### PR TITLE
Fire javascript event when an outcome is reached

### DIFF
--- a/app/assets/javascripts/smart-answers.js
+++ b/app/assets/javascripts/smart-answers.js
@@ -68,8 +68,8 @@ $(document).ready(function() {
   // update the content (i.e. plonk in the html fragment)
   function updateContent(fragment){
     $('.smart_answer section').html(fragment);
-    if($(".results").length !== 0){
-      //_gaq.push(['_trackEvent', 'Citizen-Format-Smartanswer', 'Success-results']);
+    if ($(".outcome").length !== 0) {
+      $.event.trigger('smartanswerOutcome');
     }
   }
 

--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -89,6 +89,11 @@ class SmartAnswersControllerTest < ActionController::TestCase
       assert_select "input[name=response][value=no]"
     end
 
+    should "show outcome when smart answer is complete so that 'smartanswerOutcome' JS event is fired" do
+      get :show, id: 'sample', started: 'y', responses: ['yes']
+      assert_select ".outcome"
+    end
+
     should "have meta robots noindex on question pages" do
       get :show, id: 'sample', started: 'y'
       assert_select "head meta[name=robots][content=noindex]"


### PR DESCRIPTION
Includes a test that an element with a class of 'outcome' exists when an
outcome is reached.

This is required for success tracking.
