### PR TITLE
Add rel=nofollow to get started button

### DIFF
--- a/app/views/smart_answers/_landing.html.erb
+++ b/app/views/smart_answers/_landing.html.erb
@@ -24,7 +24,7 @@
           <%= @presenter.body %>
         <% end %>
         <p class="get-started">
-          <a href="<%= smart_answer_path(@name, started: 'y') %>" class="big button">Start now</a>
+          <a rel="nofollow" href="<%= smart_answer_path(@name, started: 'y') %>" class="big button">Start now</a>
         </p>
       </div>
       <%= @presenter.devolved_body if @presenter.has_devolved_body? %>


### PR DESCRIPTION
To reduce the chances of search bots trying to index smart answers.
