### PR TITLE
Add start of leave week threshold

### DIFF
--- a/lib/flows/plan-maternity-leave.rb
+++ b/lib/flows/plan-maternity-leave.rb
@@ -20,7 +20,9 @@ date_question :leave_start? do
     start_date = responses.last
     start_date_p = Date.parse(start_date)
     due_date_p = Date.parse(due_date)
-    raise SmartAnswer::InvalidResponse if start_date_p > due_date_p or start_date_p < 11.weeks.ago(due_date_p) 
+    if start_date_p > due_date_p or start_date_p < calculator.leave_earliest_start_date 
+      raise SmartAnswer::InvalidResponse 
+    end
     calculator.enter_start_date(start_date)
     start_date
   end

--- a/lib/smart_answer/calculators/plan_maternity_leave.rb
+++ b/lib/smart_answer/calculators/plan_maternity_leave.rb
@@ -2,10 +2,12 @@ module SmartAnswer::Calculators
 	class PlanMaternityLeave
 		include ActionView::Helpers::DateHelper
 
-		attr_reader :formatted_due_date, :formatted_start_date
+		attr_reader :formatted_due_date, :formatted_start_date, :leave_earliest_start_date 
 
 		def initialize(options = {})
 			@due_date = Date.parse(options[:due_date])
+      due_date_week_start = @due_date - @due_date.wday
+      @leave_earliest_start_date = 11.weeks.ago(due_date_week_start)
 			@formatted_due_date = @due_date.strftime("%A, %d %B %Y")
 		end
 

--- a/test/integration/flows/plan_maternity_leave_test.rb
+++ b/test/integration/flows/plan_maternity_leave_test.rb
@@ -47,7 +47,19 @@ class PlanMaternityLeaveTest < ActiveSupport::TestCase
           add_response 2.days.since(3.months.since)
           assert_current_node_is_error
         end
+        should "fail if leave date is over 11 weeks before due date (leave date week start)" do
+          leave_start_date = 11.weeks.ago(3.months.since)
+          week_start_for_leave_date = leave_start_date.to_date - leave_start_date.wday
+          add_response 1.day.ago(week_start_for_leave_date)
+          assert_current_node_is_error
+        end
+        should "proceed if leave date is under 11 weeks before due date (leave date week start)" do
+          leave_start_date = 11.weeks.ago(3.months.since)
+          week_start_for_leave_date = leave_start_date - leave_start_date.wday
+          add_response week_start_for_leave_date
+          assert_current_node :maternity_leave_details     
+        end
   		end
-	  end
+    end
   end
 end


### PR DESCRIPTION
https://govuk.zendesk.com/agent/#/tickets/20308 11 week leave start date threshold should actually be calculated from the start of the week the leave start date falls in.
