### PR TITLE
Set cache headers on json format redirects

### DIFF
--- a/app/controllers/smart_answers_controller.rb
+++ b/app/controllers/smart_answers_controller.rb
@@ -57,6 +57,7 @@ private
 
   def redirect_response_to_canonical_url
     if params[:next] && ! @presenter.current_state.error
+      set_expiry
       redirect_to action: :show,
         id: @name,
         started: 'y',

--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -158,6 +158,20 @@ class SmartAnswersControllerTest < ActionController::TestCase
         assert_response :success
       end
 
+      context "valid response given" do
+        context "format=json" do
+          should "give correct canonical url" do
+            submit_json_response(day: "01", month: "01", year: "2013")
+            assert_redirected_to '/sample/y/2013-01-01.json'
+          end
+
+          should "set correct cache control headers" do
+            submit_json_response(day: "01", month: "01", year: "2013")
+            assert_equal "max-age=1800, public", @response.header["Cache-Control"]
+          end
+        end
+      end
+
       context "no response given" do
         should "redisplay question" do
           submit_response(day: "", month: "", year: "")


### PR DESCRIPTION
Right now we are not setting expiry headers on the json redirects (where there is a `next=1` parameter, which equates to every question in every flow when accessed with a JS-enabled browser.)

This will ensure expiry headers are set so that Varnish should cache these redirects.
