### PR TITLE
Limit number of children in calculation

### DIFF
--- a/lib/flows/child-benefit-tax-calculator.rb
+++ b/lib/flows/child-benefit-tax-calculator.rb
@@ -133,6 +133,8 @@ value_question :how_many_children_claiming_for? do
   calculate :number_of_children do
     if ! (responses.last.to_s =~ /\A\d+\z/)
       raise SmartAnswer::InvalidResponse
+    elsif responses.last.to_i > 30
+      raise SmartAnswer::InvalidResponse, :error_max_children
     else
       responses.last.to_i
     end

--- a/lib/flows/locales/en/child-benefit-tax-calculator.yml
+++ b/lib/flows/locales/en/child-benefit-tax-calculator.yml
@@ -84,6 +84,7 @@ en-GB:
         title: How many children will you or your partner be getting paid Child Benefit for from %{formatted_start_of_tax_year}?
         hint: If you’re expecting your first child enter 0. Don’t count any children that you start getting paid Child Benefit for after %{formatted_start_of_tax_year}.
         error_message: Please enter a number
+        error_max_children: You can only use this calculator for up to 30 children.
       ## Q8
       do_you_expect_to_start_or_stop_claiming?:
         title: Do you or your partner expect to start getting Child Benefit for a new child or stop getting Child Benefit for an existing child before %{formatted_end_of_tax_year}?

--- a/test/integration/flows/child_benefit_tax_calculator_test.rb
+++ b/test/integration/flows/child_benefit_tax_calculator_test.rb
@@ -55,6 +55,14 @@ class ChildBenefitTaxCalculatorV2Test < ActiveSupport::TestCase
           end
         end
       end
+      context "excessive number of children" do
+        setup do
+          add_response 31
+        end
+        should "give an error" do
+          assert_current_node_is_error
+        end
+      end
     end
 
     context "enter 2012-13" do


### PR DESCRIPTION
Impose a sensible cap on the number of children that user can be receiving child benefit for in the coming year.
Related to the problem mentioned in https://www.pivotaltracker.com/story/show/39612751
