### PR TITLE
Ssp v2 - refactored and updated to work across tax years

### DIFF
--- a/lib/flows/calculate-statutory-sick-pay.rb
+++ b/lib/flows/calculate-statutory-sick-pay.rb
@@ -40,8 +40,8 @@ end
 date_question :sickness_start_date? do
 	# should really add options to date_question to specify formatting
 	calculate :sick_start_date do
-		# currently no support for sickness periods that start before 6 April 2012
-		raise SmartAnswer::InvalidResponse if Date.parse(responses.last) < Date.parse("6 April 2012")
+		# no support for sickness periods that start before 6 April 2011
+		raise SmartAnswer::InvalidResponse if Date.parse(responses.last) < Date.parse("6 April 2011")
 		Date.parse(responses.last).strftime("%e %B %Y")
 	end
 	next_node :sickness_end_date?
@@ -81,8 +81,8 @@ money_question :what_was_average_weekly_pay? do
 		end
 	end
 	next_node do |response|
-		## TODO: look up LEL at sickness start date for this test
-		if response.to_f < Calculators::StatutorySickPayCalculator::LOWER_EARNING_LIMIT
+		## TODO: check if it's LEL at sickness start date or start of earliest linked period?
+		if response.to_f < Calculators::StatutorySickPayCalculator.lower_earning_limit_on(Date.parse(sick_start_date))
 			:not_earned_enough												## A5
 		else
 			:related_illness?										## Q11
@@ -101,8 +101,8 @@ money_question :what_was_average_weekly_earnings? do
 		end
 	end
 	next_node do |response|
-		## TODO: look up LEL at sickness start date for this test
-		if response.to_f < Calculators::StatutorySickPayCalculator::LOWER_EARNING_LIMIT
+		## TODO: check if it's LEL at sickness start date or start of earliest linked period?
+		if response.to_f < Calculators::StatutorySickPayCalculator.lower_earning_limit_on(Date.parse(sick_start_date))
 			:not_earned_enough											## A5
 		else
 			:related_illness?									## Q11

--- a/lib/flows/locales/en/calculate-statutory-sick-pay.yml
+++ b/lib/flows/locales/en/calculate-statutory-sick-pay.yml
@@ -76,7 +76,7 @@ en-GB:
       ## Q6
       sickness_start_date?:
         title: On what date did your employee first become sick during the most recent period of illness (including weekends, bank holidays and non-working days)?
-        error_message: This calculator currently doesn't support periods of sickness that start before 6 April 2012
+        error_message: This calculator currently doesn't support periods of sickness that start before 6 April 2011
         body: |
           Note: This is the first day of their ‘Period of Incapacity for Work (PIW)’
 

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -1,13 +1,13 @@
 module SmartAnswer::Calculators
   class StatutorySickPayCalculator
   
-    attr_reader :daily_rate, :waiting_days, :normal_workdays, :lower_earning_limit, :ssp_weekly_rate, :pattern_days
+    attr_reader :waiting_days, :normal_workdays, :pattern_days
 
     # LEL changes on 1 April each year - update when we know the April 2013 rate
     LOWER_EARNING_LIMIT = 107.00
     SSP_WEEKLY_RATE = 85.85
 
-    def earning_limit_rates
+    def self.earning_limit_rates
       [
         {min: Date.parse("6 April 2010"), max: Date.parse("5 April 2011"), lower_earning_limit_rate: 97},
         {min: Date.parse("6 April 2011"), max: Date.parse("5 April 2012"), lower_earning_limit_rate: 102},
@@ -15,9 +15,9 @@ module SmartAnswer::Calculators
       ]
     end
 
-    # default to current limit if we don't find it
-    def lower_earning_limit
-      earning_limit_rate = earning_limit_rates.find { |c| c[:min] <= @sick_start_date and c[:max] >= @sick_start_date }
+    # define as static so we don't have to instantiate the calculator too early in the flow
+    def self.lower_earning_limit_on(date)
+      earning_limit_rate = earning_limit_rates.find { |c| c[:min] <= date and c[:max] >= date }
       (earning_limit_rate ? earning_limit_rate[:lower_earning_limit_rate] : LOWER_EARNING_LIMIT)
     end
 
@@ -29,9 +29,14 @@ module SmartAnswer::Calculators
       ]
     end
 
-    def ssp_weekly_rate
-      ssp_rate = ssp_rates.find { |c| c[:min] <= @sick_start_date and c[:max] >= @sick_start_date }
-      (ssp_rate ? ssp_rate[:ssp_weekly_rate] : SSP_WEEKLY_RATE)
+    
+    def daily_rate_on(date, pattern_days)
+      rate = ssp_rates.find { |c| c[:min] <= date and c[:max] >= date }
+      weekly_rate = (rate ? rate[:ssp_weekly_rate] : SSP_WEEKLY_RATE)
+      # we need to calculate the daily rate by truncating to four decimal places to match unrounded daily rates used by HMRC 
+      # doing .round(6) after multiplication to avoid float precision issues
+      # Simply using .round(4) on ssp_weekly_rate/@pattern_days will be off by 0.0001 for 3 and 7 pattern days and lead to 1p difference in some statutory amount calculations
+      pattern_days > 0 ? ((((weekly_rate / pattern_days) * 10000).round(6).floor)/10000.0) : 0.0000
     end
 
     
@@ -43,10 +48,7 @@ module SmartAnswer::Calculators
       @pattern_days = days_of_the_week_worked.length
       @normal_workdays_missed = init_normal_workdays_missed(days_of_the_week_worked)
       @normal_workdays = @normal_workdays_missed.length
-      # we need to calculate the daily rate by truncating to four decimal places to match unrounded daily rates used by HMRC 
-      # doing .round(6) after multiplication to avoid float precision issues
-      # Simply using .round(4) on ssp_weekly_rate/@pattern_days will be off by 0.0001 for 3 and 7 pattern days and lead to 1p difference in some statutory amount calculations
-      @daily_rate = @pattern_days > 0 ? ((((ssp_weekly_rate / @pattern_days) * 10000).round(6).floor)/10000.0) : 0.0000 
+      @payable_days = init_payable_days 
     end
 
     def max_days_that_can_be_paid
@@ -66,16 +68,39 @@ module SmartAnswer::Calculators
     end
 
     def days_to_pay
-      current_days_to_pay = @normal_workdays - @waiting_days
-      if current_days_to_pay < days_that_can_be_paid_for_this_period
-        current_days_to_pay
-      else
-        days_that_can_be_paid_for_this_period
-      end
+      @payable_days.length
     end
 
     def ssp_payment
-      (days_to_pay * @daily_rate).round(2)
+      if days_to_pay > 0
+        daily_rate_at_start = daily_rate_on(@payable_days.first, @pattern_days)
+        if days_to_pay > 1
+          daily_rate_at_end = daily_rate_on(@payable_days.last, @pattern_days)
+          if daily_rate_at_end == daily_rate_at_start
+            ## simple case - not spanning tax years
+            (days_to_pay * daily_rate_at_start).round(2)
+          else
+            days_before_6_april = 0
+            days_on_or_after_6_april = 0
+            # 6th of april after the start_date
+            higher_rate_date = find_6th_april_after(@sick_start_date)
+            ## 2. from @payable_days, count how many are before 6 April, how many after
+            @payable_days.each do |date|
+              if date < higher_rate_date
+                days_before_6_april += 1
+              else
+                days_on_or_after_6_april +=1
+              end
+            end
+            ## 3. multiply before and after by appropriate rate and add the two subtotals up
+            ((days_before_6_april * daily_rate_at_start).round(10) + (days_on_or_after_6_april * daily_rate_at_end).round(10)).round(2)
+          end    
+        else
+          daily_rate_at_start.round(2)
+        end
+      else
+        0.0
+      end
     end
 
     private
@@ -91,11 +116,21 @@ module SmartAnswer::Calculators
       normal_workdays_missed
     end
 
-    def init_days_payable
-      ## TODO: 
-      ## 1. remove up to 3 first dates if there are waiting days in this period
-      ## 2. take only the first days_that_can_be_paid_for_this_period
-      ## 3. work out how many of those days are before April 6 and how many after, and use appropriate daily rates
+    def init_payable_days
+      # copy not to modify the instance variable we need to keep
+      payable_days_temp = @normal_workdays_missed
+      ## 1. remove up to 3 first dates from the array if there are waiting days in this period
+      payable_days_temp.shift(@waiting_days)
+      ## 2. return only the first days_that_can_be_paid_for_this_period
+      payable_days_temp.shift(days_that_can_be_paid_for_this_period)
+    end
+
+    def find_6th_april_after(date)
+      year = date.year
+      if (date.month > 4) or (date.month == 4 and date.day > 6)
+        year +=1
+      end
+      Date.new(year, 4, 6)
     end
   end
 end

--- a/test/integration/flows/calculate_statutory_sick_pay_test.rb
+++ b/test/integration/flows/calculate_statutory_sick_pay_test.rb
@@ -84,6 +84,14 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
 	  							assert_current_node :sickness_end_date?
 	  						end
 
+	  						context "answer 13 September 2012" do
+	  							setup {add_response Date.parse('13 September 2012')}
+
+	  							should "display no pay because not enough days sick" do
+			  						assert_current_node :must_be_sick_for_at_least_4_days
+			  					end
+			  				end
+
 	  						context "answer 20 September 2012" do
 	  							setup {add_response Date.parse('20 September 2012')}
 
@@ -130,15 +138,6 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
 		  											assert_current_node :entitled_or_not_enough_days
 		  										end
 		  										
-		  										# have to handle this by dates taken off
-			  									# context "less than 4 days taken off - no pay" do
-			  									# 	setup {add_response '3'}
-
-			  									# 	should "display no pay because not enough days" do
-			  									# 		assert_phrase_list :outcome_text, [:first_three_days_not_paid]
-			  									# 		assert_current_node :entitled_or_not_enough_days
-			  									# 	end
-			  									# end
 		  									end # which days worked
 		  								end # no related illness	
 		  							end # earnings high enough
@@ -171,7 +170,6 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
 
 										  		should "should display an outcome" do
 			  										assert_state_variable "pattern_days", 5
-			  										assert_state_variable "daily_rate", 17.17
 			  										assert_state_variable "normal_workdays_out", 9
 			  										assert_current_node :entitled_or_not_enough_days
 			  									end
@@ -216,34 +214,13 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
 												  		end
 												  	end
 										  	
-											  		context "M-W worked worked" do
+											  		context "M-W worked" do
 												  		setup {add_response '1,2,3'}
 
-												  		should "ask how may sick days they had" do
+												  		should "display result" do
 												  			assert_state_variable "pattern_days", 3
-												  			assert_state_variable "daily_rate", 28.6167
 												  			assert_current_node :entitled_or_not_enough_days
 												  		end
-
-												  	# 	context "4 work days out" do
-												  	# 		setup {add_response '4'}
-
-												  	# 		should "give entitled outcome and 4 days pay" do
-													  # 			assert_state_variable "normal_workdays_out", 4
-													  # 			assert_state_variable "ssp_payment", "114.47"
-													  # 			assert_current_node :entitled_or_not_enough_days
-												  	# 		end
-												  	# 	end
-
-												  	# 	context "2 work days out" do
-												  	# 		setup {add_response '2'}
-
-												  	# 		should "give entitled outcome and 2 days' pay" do
-												  	# 			assert_state_variable "normal_workdays_out", 2
-													  # 			assert_state_variable "ssp_payment", "57.23"
-													  # 			assert_current_node :entitled_or_not_enough_days
-													  # 		end
-													  # 	end
 											  		end
 											  	end # 3 sick days	missed
 
@@ -281,6 +258,19 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
 			  					end # no to 8 weeks
 			  				end #end date
 			  			end # start date	
+
+			  			context "previous tax year LEL test" do
+			  				setup do
+			  					add_response Date.parse("1 March 2012")
+			  					add_response Date.parse("1 May 2012")
+			  					add_response 'yes'
+			  					add_response 103.00
+			  				end
+
+			  				should "ask if they had relate illness" do
+	  							assert_current_node :related_illness?
+	  						end
+	  					end
 			  		end #no to irregular schedule
 		  		end # told within 7 days
 		  	end # no to less than four days


### PR DESCRIPTION
- automatic calculation of normal workdays missed during last sickness period
- ssp calculation across tax years can now be done because it now relies on exact dates that were missed, rather than just number of days
