### PR TITLE
Use ICSRenderer to render iCalendar format

### DIFF
--- a/lib/ics_renderer.rb
+++ b/lib/ics_renderer.rb
@@ -1,0 +1,47 @@
+class ICSRenderer
+  def initialize(events, cal_path)
+    @events = events
+    @cal_path = cal_path
+  end
+
+  def render
+    output =  "BEGIN:VCALENDAR\r\n"
+    output << "VERSION:2.0\r\n"
+    output << "METHOD:PUBLISH\r\n"
+    output << "PRODID:-//uk.gov/GOVUK smart-answers//EN\r\n"
+    output << "CALSCALE:GREGORIAN\r\n"
+    @events.each_with_index do |event,i|
+      output << render_event(event,i)
+    end
+    output << "END:VCALENDAR\r\n"
+  end
+
+  def render_event(event, sequence)
+    output =  "BEGIN:VEVENT\r\n"
+    if event.date.is_a?(Range)
+      output << "DTEND;VALUE=DATE:#{ event.date.last.strftime("%Y%m%d") }\r\n"
+      output << "DTSTART;VALUE=DATE:#{ event.date.first.strftime("%Y%m%d") }\r\n"
+    else
+      output << "DTEND;VALUE=DATE:#{ event.date.strftime("%Y%m%d") }\r\n"
+      output << "DTSTART;VALUE=DATE:#{ event.date.strftime("%Y%m%d") }\r\n"
+    end
+    output << "SUMMARY:#{ event.title }\r\n"
+    output << "UID:#{uid(sequence)}\r\n"
+    output << "SEQUENCE:0\r\n"
+    output << "DTSTAMP:#{dtstamp}\r\n"
+    output << "END:VEVENT\r\n"
+  end
+
+  def uid(sequence)
+    @path_hash ||= Digest::MD5.hexdigest(@cal_path)
+    "#{@path_hash}-#{sequence}@gov.uk"
+  end
+
+  def dtstamp
+    unless @dtstamp
+      time = File.mtime( Rails.root.join('REVISION') ) rescue Time.now
+      @dtstamp = time.utc.strftime("%Y%m%dT%H%M%SZ")
+    end
+    @dtstamp
+  end
+end

--- a/lib/smart_answer/calendar.rb
+++ b/lib/smart_answer/calendar.rb
@@ -1,3 +1,5 @@
+require 'ics_renderer'
+
 module SmartAnswer
   class Calendar
 
@@ -9,31 +11,17 @@ module SmartAnswer
     end
 
     def evaluate(state)
+      @path = state.path.join('/')
       instance_exec(state, &@block) if @block and !@dates.any?
       return self
     end
 
     def date(name, date_or_range)
-      @dates << [name, date_or_range]
+      @dates << OpenStruct.new(:title => name, :date => date_or_range)
     end
 
     def to_ics
-      output = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\n"
-      output << "PRODID:-//uk.gov/GOVUK smart-answers//EN\r\n"
-      output << "CALSCALE:GREGORIAN\r\n"
-      @dates.each do |(title,date_or_range)|
-        output << "BEGIN:VEVENT\r\n"
-        if date_or_range.is_a?(Range)
-          output << "DTEND;VALUE=DATE:#{ date_or_range.last.strftime("%Y%m%d") }\r\n"
-          output << "DTSTART;VALUE=DATE:#{ date_or_range.first.strftime("%Y%m%d") }\r\n"
-        elsif date_or_range.is_a?(Date)
-          output << "DTEND;VALUE=DATE:#{ date_or_range.strftime("%Y%m%d") }\r\n"
-          output << "DTSTART;VALUE=DATE:#{ date_or_range.strftime("%Y%m%d") }\r\n"
-        end
-        output << "SUMMARY:#{ title }\r\n"
-        output << "END:VEVENT\r\n"
-      end
-      output << "END:VCALENDAR\r\n"
+      ICSRenderer.new(dates, @path).render
     end
 
   end

--- a/test/integration/flows/flow_test_helper.rb
+++ b/test/integration/flows/flow_test_helper.rb
@@ -43,6 +43,6 @@ module FlowTestHelper
 
   def assert_calendar_date(expected_date_or_range)
     calendar = @flow.node(current_state.current_node).evaluate_calendar(current_state)
-    assert calendar.dates.select {|(title, date)| date == expected_date_or_range }.any?
+    assert calendar.dates.select {|event| event.date == expected_date_or_range }.any?
   end
 end

--- a/test/unit/calendar_test.rb
+++ b/test/unit/calendar_test.rb
@@ -6,7 +6,7 @@ module SmartAnswer
   class CalendarTest < ActiveSupport::TestCase
 
     setup do
-      @state = State.new(:example)
+      @state = State.new(:example).transition_to(:result, 'y')
     end
 
     test "a calendar has no dates when initialized" do
@@ -19,7 +19,7 @@ module SmartAnswer
         date :event_date, Date.parse("17 October 2012")
       end
 
-      assert_equal [[:event_date, Date.parse("17 October 2012")]], calendar.evaluate(@state).dates
+      assert_equal [ OpenStruct.new(:title => :event_date, :date => Date.parse("17 October 2012")) ], calendar.evaluate(@state).dates
     end
 
     test "can initialize a calendar with a range" do
@@ -27,21 +27,19 @@ module SmartAnswer
         date :event_range, Date.parse("20 October 2012")..Date.parse("21 October 2012")
       end
 
-      assert_equal [[:event_range, Date.parse("20 October 2012")..Date.parse("21 October 2012")]], calendar.evaluate(@state).dates
+      assert_equal [ OpenStruct.new(:title => :event_range, :date => Date.parse("20 October 2012")..Date.parse("21 October 2012")) ], calendar.evaluate(@state).dates
     end
 
-    test "will output ics for given dates" do
-      calendar = Calendar.new do
-        date :event_one, Date.parse("13 October 2012")..Date.parse("14 October 2012")
-        date :event_two, Date.parse("20 October 2012")..Date.parse("21 October 2012")
-        date :event_three, Date.parse("4 November 2012")
-      end
+    test "can create an ics renderer with the dates and the path" do
+      calendar = Calendar.new
+      calendar.stubs(:dates).returns([:date_one, :date_two])
 
-      output = calendar.evaluate(@state).to_ics
+      stub_renderer = stub(:render => "calendar output")
 
-      assert_match "BEGIN:VEVENT\r\nDTEND;VALUE=DATE:20121014\r\nDTSTART;VALUE=DATE:20121013\r\nSUMMARY:event_one\r\nEND:VEVENT", output
-      assert_match "BEGIN:VEVENT\r\nDTEND;VALUE=DATE:20121021\r\nDTSTART;VALUE=DATE:20121020\r\nSUMMARY:event_two\r\nEND:VEVENT", output
-      assert_match "BEGIN:VEVENT\r\nDTEND;VALUE=DATE:20121104\r\nDTSTART;VALUE=DATE:20121104\r\nSUMMARY:event_three\r\nEND:VEVENT", output
+      ICSRenderer.any_instance.stubs(:dtstamp).returns("20121017T0100Z")
+      ICSRenderer.expects(:new).with([:date_one, :date_two], "example").returns(stub_renderer)
+
+      assert_equal "calendar output", calendar.evaluate(@state).to_ics
     end
   end
 end

--- a/test/unit/ics_renderer_test.rb
+++ b/test/unit/ics_renderer_test.rb
@@ -1,0 +1,121 @@
+# encoding: utf-8
+require_relative '../test_helper'
+require 'ics_renderer'
+
+class ICSRendererTest < ActiveSupport::TestCase
+
+  context "generating complete ics file" do
+    should "generate correct ics header and footer" do
+      r = ICSRenderer.new([], "/foo/ics")
+
+      expected =  "BEGIN:VCALENDAR\r\n"
+      expected << "VERSION:2.0\r\n"
+      expected << "METHOD:PUBLISH\r\n"
+      expected << "PRODID:-//uk.gov/GOVUK smart-answers//EN\r\n"
+      expected << "CALSCALE:GREGORIAN\r\n"
+      expected << "END:VCALENDAR\r\n"
+
+      assert_equal expected, r.render
+    end
+
+    should "generate an event for each given event" do
+      r = ICSRenderer.new([:e1, :e2], "/foo/ics")
+      r.expects(:render_event).with(:e1, 0).returns("Event1 ics\r\n")
+      r.expects(:render_event).with(:e2, 1).returns("Event2 ics\r\n")
+
+      expected =  "BEGIN:VCALENDAR\r\n"
+      expected << "VERSION:2.0\r\n"
+      expected << "METHOD:PUBLISH\r\n"
+      expected << "PRODID:-//uk.gov/GOVUK smart-answers//EN\r\n"
+      expected << "CALSCALE:GREGORIAN\r\n"
+      expected << "Event1 ics\r\n"
+      expected << "Event2 ics\r\n"
+      expected << "END:VCALENDAR\r\n"
+
+      assert_equal expected, r.render
+    end
+  end
+
+  context "generating an event" do
+    setup do
+      @r = ICSRenderer.new([], "/foo/ics")
+      ICSRenderer.any_instance.stubs(:dtstamp).returns("20121017T0100Z")
+    end
+
+    should "render an event with a date" do
+      e = OpenStruct.new("title" => "An Event", "date" => Date.parse("2012-04-14") )
+
+      @r.expects(:uid).with(2).returns("sdaljksafd-2@gov.uk")
+
+      expected =  "BEGIN:VEVENT\r\n"
+      expected << "DTEND;VALUE=DATE:20120414\r\n"
+      expected << "DTSTART;VALUE=DATE:20120414\r\n"
+      expected << "SUMMARY:An Event\r\n"
+      expected << "UID:sdaljksafd-2@gov.uk\r\n"
+      expected << "SEQUENCE:0\r\n"
+      expected << "DTSTAMP:20121017T0100Z\r\n"
+      expected << "END:VEVENT\r\n"
+
+      assert_equal expected, @r.render_event(e, 2)
+    end
+
+    should "render an event with a range" do
+      e = OpenStruct.new("title" => "An Event", "date" => Date.parse("2012-04-14")..Date.parse("2012-04-18") )
+
+      @r.expects(:uid).with(2).returns("sdaljksafd-2@gov.uk")
+
+      expected =  "BEGIN:VEVENT\r\n"
+      expected << "DTEND;VALUE=DATE:20120418\r\n"
+      expected << "DTSTART;VALUE=DATE:20120414\r\n"
+      expected << "SUMMARY:An Event\r\n"
+      expected << "UID:sdaljksafd-2@gov.uk\r\n"
+      expected << "SEQUENCE:0\r\n"
+      expected << "DTSTAMP:20121017T0100Z\r\n"
+      expected << "END:VEVENT\r\n"
+
+      assert_equal expected, @r.render_event(e, 2)
+    end
+
+  end
+
+  context "generating a uid" do
+    setup do
+      @r = ICSRenderer.new([], "/foo/bar.ics")
+    end
+
+    should "use the calendar path, and sequence to create a uid" do
+      hash = Digest::MD5.hexdigest("/foo/bar.ics")
+      assert_equal "#{hash}-2@gov.uk", @r.uid(2)
+    end
+
+    should "cache the hash generation" do
+      Digest::MD5.expects(:hexdigest).with("/foo/bar.ics").once.returns("hash")
+      @r.uid(1)
+      assert_equal "hash-2@gov.uk", @r.uid(2)
+    end
+  end
+
+  context "generating dtstamp" do
+    setup do
+      @r = ICSRenderer.new([], "/foo/ics")
+    end
+
+    should "return the mtime of the REVISION file" do
+      File.expects(:mtime).with(Rails.root.join("REVISION")).returns(Time.parse('2012-04-06 14:53:54'))
+      assert_equal "20120406T145354Z", @r.dtstamp
+    end
+
+    should "return now if the file doesn't exist" do
+      Timecop.freeze(Time.parse('2012-11-27 16:13:27')) do
+        File.expects(:mtime).with(Rails.root.join("REVISION")).raises(Errno::ENOENT)
+        assert_equal "20121127T161327Z", @r.dtstamp
+      end
+    end
+
+    should "cache the result" do
+      File.expects(:mtime).with(Rails.root.join("REVISION")).once.returns(Time.parse('2012-04-06 14:53:54'))
+      @r.dtstamp
+      assert_equal "20120406T145354Z", @r.dtstamp
+    end
+  end
+end


### PR DESCRIPTION
Ported @alext's ICSRenderer class from Calendars into SmartAnswers to keep calendar rendering consistent. Modifications made to support date ranges.

This will support Outlook XP/2003 for importing a calendar.

We may extract ICSRenderer into a gem in the future, if there is a need for it in another app.
