### PR TITLE
Make GET requests, not POST requests, when JS is disabled

### DIFF
--- a/app/views/smart_answers/_current_question.html.erb
+++ b/app/views/smart_answers/_current_question.html.erb
@@ -1,5 +1,5 @@
 <div class="step current" data-step="employment-status">
-  <%= form_tag calculate_current_question_path(@presenter), :method => :get, :authenticity_token => false %>
+  <%= form_tag calculate_current_question_path(@presenter), :method => :get %>
     <div class="current-question" id="current-question">
       <h2>
         <span class="question-number"><%= @presenter.current_question_number %> </span><%= question.title %>


### PR DESCRIPTION
This means we can cache all requests to smart answers, as we won't be making any post requests at all.
