### PR TITLE
Add previewable amended maternity paternity calculator

### DIFF
--- a/lib/flows/locales/en/maternity-paternity-calculator-preview.yml
+++ b/lib/flows/locales/en/maternity-paternity-calculator-preview.yml
@@ -1,0 +1,434 @@
+en-GB:
+  flow:
+    maternity-paternity-calculator-preview:
+      meta:
+        description: Statutory maternity, paternity and adoption leave or pay - calculate the qualifying week, relevant period, pay rate, notice period and the start and end dates 
+      title:
+        Employers' maternity and paternity calculator
+      options:
+        "no": "No"
+        "yes": "Yes"
+        "maternity": "Maternity"
+        "paternity": "Paternity"
+        "adoption": "Adoption"
+      body: |
+
+        Calculate the qualifying week, ‘relevant employment period,’ notice period and check an employee’s eligibility for statutory maternity, paternity and adoption leave or pay. 
+        
+        
+        ##What you need
+
+        You’ll need:
+
+        + the baby’s due date
+        + date of birth - for paternity
+        + your employee's salary details - eg weekly rates of pay
+        + the dates for adoption - eg match date or date of placement 
+
+        % You can’t use the calculator for [Additional Paternity Leave or Pay](/additional-paternity-leave-pay-employees "Additional paternity leave or pay") and paternity leave for [overseas adoptions](/paternity-leave-pay-employees "Paternity leave for adoptions") or births 15 weeks before the due date. %
+      phrases:
+        not_worked_long_enough: + they must have started working for you on or before %{employment_start}
+        must_be_on_payroll: + you must be liable for their secondary Class 1 National Insurance contributions - ie you will be if they’re on your payroll
+        must_earn_over_threshold: + their average weekly earnings between %{relevant_period} must be at least £%{lower_earning_limit}
+        pa_must_be_employed_by_you: + they must still be employed by you on %{ap_adoption_date_formatted}
+        must_be_employed_by_you: + they must still be employed by you on %{due_date}
+        not_responsible_for_upbringing: + aren’t responsible for the child’s upbringing or the adopter’s partner
+        maternity_leave_table: |
+          ##Statutory Maternity Leave 
+
+          The employee is entitled to up to 52 weeks Statutory Maternity Leave.
+          
+          |Leave                         | Key dates                    |
+          |------------------------------|------------------------------|
+          |Start                         | %{leave_start_date}          |
+          |End                           | %{leave_end_date}            |
+          |Latest date to give notice    | %{notice_of_leave_deadline}  |
+          |Earliest date leave can start | %{leave_earliest_start_date} |
+        
+        not_entitled_to_statutory_maternity_leave: |
+          ##Statutory Maternity Leave
+
+          The employee is not entitled to Statutory Maternity Leave because they don’t have an employment contract with you.
+
+          Write to them within 28 days of their leave request confirming this.
+
+        maternity_pay_table: |
+          ##Statutory Maternity Pay
+
+          The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP).
+          
+          |Pay                                  | Key facts                   |
+          |-------------------------------------|-----------------------------|
+          |Average weekly earnings              | £%{average_weekly_earnings} |
+          |Weekly rate - first 6 weeks          | £%{smp_a}                   |
+          |Weekly rate - for remaining 33 weeks | £%{smp_b}                   |
+          |Total SMP                            | £%{total_smp}               |
+          |Start date                           | %{pay_start_date}           |
+          |End date                             | %{pay_end_date}             |
+          |Latest date to give notice           | %{notice_request_pay}       |
+          |Proof of pregnancy                   | Usually 28 days before SMP starts (or as soon as possible if baby born early)  |
+          |Start date due to pregnancy related illness| %{ssp_stop}           |
+
+
+        not_entitled_to_smp_intro: |
+          ##Statutory maternity pay
+      
+          The employee is not entitled to statutory maternity pay. To qualify:
+
+        not_entitled_to_smp_intro_with_awe: |
+          ##Statutory maternity pay
+      
+          The employee is not entitled to statutory maternity pay. 
+          Their average weekly earnings are £%{average_weekly_earnings}. To qualify:
+
+        not_entitled_to_smp_outro: |
+          You must write confirming this within 28 days of their maternity pay request.
+
+          Send them form SMP1 within 7 days of your decision. They must get this form within 28 days of their pay request or the birth (whichever is earlier).
+
+
+          $D
+            [Download Form SMP1, Non-payment of Statutory Maternity Pay (PDF, 59KB)](http://www.dwp.gov.uk/advisers/claimforms/smp1_print.pdf "Download Form SMP1, Non-payment of Statutory Maternity Pay (PDF, 59KB)"){:rel="external"}
+          $D
+
+        paternity_entitled_to_leave: |
+          ##Statutory Paternity Leave
+
+          The employee is entitled to either 1 or 2 weeks Statutory Paternity leave. Notice should be given by %{p_notice_leave}. 
+
+          The leave can’t start before the birth and should be taken within 56 days of the birth (or the due date if the baby is born early). 
+
+        paternity_not_entitled_to_leave: |
+          ##Statutory Paternity Leave
+
+          The employee is not entitled to Statutory Paternity Leave because they don’t have an employment contract with you.
+
+          Write to them within 28 days of their leave request confirming this.  
+
+        paternity_entitled_to_pay: |
+          ##Statutory Paternity Pay
+
+          If the employee is still employed by you on the date of birth, they’re entitled to Statutory Paternity Pay - £%{spp_rate} a week.
+
+          They should request this using form SC3 (or your own version) usually 28 days before it is due to start.
+
+
+          $D
+            [Download Form SC3, notice for Statutory Paternity Pay and or Leave (PDF, 100KB)](http://www.hmrc.gov.uk/forms/sc3.pdf "Download Form SC3, notice for Statutory Paternity Pay and or Leave (PDF, 100KB)")
+          $D
+
+        paternity_not_entitled_to_pay_intro: |
+          ##Statutory Paternity Pay
+
+          The employee is not entitled to Statutory Paternity Pay. To qualify:
+
+        paternity_not_entitled_to_pay_outro: |
+
+          Send them form OSPP1 confirming this within 28 days of their pay request. 
+
+
+          $D [Download Form OSPP1, refusing Statutory Paternity Pay (PDF, 100KB)](http://www.hmrc.gov.uk/forms/spp1.pdf "Download Form OSPP1, refusing Statutory Paternity Pay (PDF, 100KB)") $D 
+
+        padoption_entitled_to_leave: |   
+          ##Statutory Paternity Leave
+
+          The employee is entitled to either 1 or 2 weeks Statutory Paternity Leave.
+
+          They should request this using form SC4 or SC5, the deadlines for this are explained on the forms.
+
+          Usually, paternity leave can’t start before %{ap_adoption_date_formatted} and should be taken within 56 days of this date.
+
+        padoption_entitled_to_pay: |
+          ##Statutory Paternity Pay
+
+          The employee is entitled to Statutory Paternity Pay - £%{sapp_rate} a week.
+
+          They should request this using form SC4 or SC5 usually 28 days before it is due to start.
+
+        padoption_leave_and_pay_forms: |
+        
+
+          $D
+          [Download Form SC4 - paternity pay and or leave request (UK adoption) (PDF, 50 KB)](http://www.hmrc.gov.uk/forms/sc4.pdf "Download Form SC4 - paternity pay and or leave request (UK adoption) (PDF, 50 KB)"){:rel="external"}
+          [Download Form SC5 - paternity pay and or leave request (overseas adoptions) (PDF, 70KB)](http://www.hmrc.gov.uk/forms/sc5.pdf "Download Form SC5 - paternity pay and or leave request (overseas adoptions) (PDF, 70KB)"){:rel="external"}
+          $D
+
+        padoption_not_entitled_to_leave: |
+          ##Statutory Paternity Leave
+
+          The employee is not entitled to Statutory Paternity Leave because they don’t have an employment contract with you.
+
+          You must write to them confirming this within 28 days of their request for paternity leave.
+
+        padoption_not_entitled_to_pay_intro: |
+          ##Statutory Paternity Pay
+
+          The employee is not entitled to Statutory Paternity Pay. To qualify:
+
+        padoption_not_entitled_to_pay_outro: |
+          Send them form OSPP1 confirming this within 28 days of their pay request.
+
+
+          $D [Download Form OSPP1, refusing Statutory Paternity Pay (PDF, 100KB)](http://www.hmrc.gov.uk/forms/spp1.pdf "Download Form OSPP1, refusing Statutory Paternity Pay (PDF, 100KB)") $D
+
+        adoption_leave_table: |
+          ##Statutory Adoption Leave 
+
+          The employee is entitled to up to 52 weeks Statutory Adoption Leave.
+          
+          |Leave                         | Key dates                   |
+          |------------------------------|-----------------------------|
+          |Start                         | %{leave_start_date}         |
+          |End                           | %{leave_end_date}           |
+          |Earliest date leave can start for UK adoptions | %{a_leave_earliest_start} |
+          |Earliest date leave can start for overseas adoptions | %{adoption_placement_date} or within 28 days from this date |
+          |Latest date to give notice | %{a_notice_leave} (the rules are different for [overseas adoptions](/adoption-leave-pay-employees/notice-period "Notice for overseas adoptions")) |
+
+        adoption_not_entitled_to_leave: |
+          ##Statutory Adoption Leave 
+
+          The employee is not entitled to Statutory Adoption Leave because they don’t have an employment contract with you. 
+
+          Write to them within 28 days of their leave request confirming this. 
+
+        adoption_pay_table: |
+          ##Statutory Adoption Pay
+
+          The employee is entitled to 39 weeks Statutory Adoption Pay (SAP).
+          
+          |Pay                            | Key facts                 |
+          |-------------------------------|---------------------------|
+          |Start                          | %{pay_start_date}         |
+          |End                            | %{pay_end_date}           |
+          |Weekly rate                    | £%{sap_rate}              |
+          |Proof of adoption              | You’ll need [proof of the adoption](/adoption-leave-pay-employees/proof-of-adoption "Proof of adoption")  before you can pay SAP usually 28 days before SAP starts |
+
+          *[SAP]: Statutory Adoption Pay
+      
+        adoption_not_entitled_to_pay_intro: |
+          ##Statutory Adoption Pay
+
+          The employee is not entitled to Statutory Adoption Pay. To qualify:
+          
+        adoption_not_entitled_to_pay_outro: |
+          Send them form SAP1 within 7 days of your decision. They must get this form within 28 days of their pay request or the date they were matched with the child (whichever is earlier).
+
+
+          $D [Download Form SAP1, Non-payment of Statutory Adoption Pay (PDF, 59KB)](http://www.hmrc.gov.uk/forms/sap1.pdf "Download Form SAP1, Non-payment of Statutory Adoption Pay (PDF, 59KB)"){:rel="external"} $D
+
+      ## Q1
+      what_type_of_leave?:
+        title: What do you want to check?          
+      ## QM1    
+      baby_due_date_maternity?:
+        title: What is the baby’s due date?
+      ## QM2
+      employment_contract?:
+        title: Does the employee have an employment contract with you?
+      ## QM3
+      date_leave_starts?:
+        title: When does the employee want to start their leave?
+        hint: Usually, leave can't start before %{leave_earliest_start_date}
+        error_message: Please enter a valid date
+      ## QM4
+      did_the_employee_work_for_you?:
+        title: Did the employee work for you on or before %{employment_start}?
+      ## QM5
+      is_the_employee_on_your_payroll?:
+        title: Is the employee on your payroll?
+      ## QM5.2
+      last_normal_payday?:
+        title: What was the last normal payday on or before %{to_saturday}?
+        error_message: You must enter a date on or before %{to_saturday}
+      ## QM5.3
+      payday_eight_weeks?:
+        title: What was the last normal payday on or before %{payday_offset}?
+        error_message: You must enter a date on or before %{payday_offset}
+      ## QM5.4
+      pay_frequency?:
+        title: How often do you pay the employee?
+        options: 
+          "every_2_weeks": "every 2 weeks"
+          "every_4_weeks": "every 4 weeks"
+          "none_of_the_above": "none of the above"
+      ## QM5.5
+      earnings_for_pay_period?:
+        title: What were the employee’s earnings between %{relevant_period}?  
+      ## QM6
+      employees_average_weekly_earnings?:
+        title: What were the employee’s average weekly earnings between %{relevant_period}?
+        hint: Enter the average weekly amount. The dates are the 8 week 'relevant period'.
+        suffix_label: per week
+        error_message: Please enter a number greater than 0
+      ## Combined result for maternity leave and pay.
+      maternity_leave_and_pay_result:
+        next_steps: |
+          Read the [guide to Statutory Maternity Pay and Leave](/maternity-leave-pay-employees "Maternity leave and pay")
+        body: |   
+          %{maternity_leave_info}
+
+          %{maternity_pay_info}
+
+          *[SMP]: Statutory Maternity Pay
+
+      ## QP0
+      leave_or_pay_for_adoption?:
+        title: Is the paternity leave or pay for an adoption? 
+      ## QP1
+      baby_due_date_paternity?:
+        title: What is the baby’s due date?
+      ## QP2
+      employee_responsible_for_upbringing?:
+        title: Is the employee responsible for the child’s upbringing and either the biological father or the mother’s husband or partner?
+      ## QP3
+      employee_work_before_employment_start?:
+        title: Did the employee work for you on or before %{employment_start}?
+      ## QP4
+      employee_has_contract_paternity?:
+        title: Does the employee have an employment contract with you?
+      ## QP5 
+      employee_employed_at_employment_end_paternity?:
+        title: Will the employee be employed by you on %{employment_end}?
+      ## QP6
+      employee_on_payroll_paternity?:
+        title: Is the employee on your payroll?
+      ## QP7
+      employees_average_weekly_earnings_paternity?:
+        title: What were the employee’s average weekly earnings between %{relevant_period}?
+        hint: Enter the average weekly amount. The dates are the 8 week 'relevant period'.
+        suffix_label: per week
+        error_message: Please enter a number greater than 0
+      ## Paternity Results:
+      paternity_leave_and_pay:
+        next_steps: |
+          Read the [guide to Statutory Paternity Pay and Leave](/paternity-leave-pay-employees "Paternity leave and pay")
+        body: |
+          %{paternity_leave_info}
+
+          %{paternity_pay_info}
+
+      paternity_not_entitled_to_leave_or_pay:
+        next_steps: |
+          Read the [guide to Statutory Paternity Pay and Leave](/paternity-leave-pay-employees "Paternity leave and pay")
+        body: |
+          ##Not entitled to paternity leave or pay
+
+          The employee is not entitled to statutory paternity leave or pay because they: 
+
+          %{not_entitled_reason}
+          
+          You must write confirming this. Also, send them form OSP1 confirming they’re not entitled to pay within 28 days of their pay request.
+
+
+          $D [Download Form OSPP1, refusing Statutory Paternity Pay (PDF, 100KB)](http://www.hmrc.gov.uk/forms/spp1.pdf "Download Form OSPP1, refusing Statutory Paternity Pay (PDF, 100KB)") $D 
+
+      ## Paternity Adoption
+      ## QAP1
+      employee_date_matched_paternity_adoption?:
+        title: When was the child matched with the employee?
+      ## QAP2
+      padoption_date_of_adoption_placement?:
+        title: When will the child be placed with the employee?
+        error_message: Placement date can't be before matching date
+      ## QAP3
+      padoption_employee_responsible_for_upbringing?:
+        title: Is the employee responsible for the child's upbringing and the husband or partner of the adopter or the child's adopter?
+      ## QAP4
+      padoption_employee_start_on_or_before_employment_start?:
+        title: Did the employee work for you on or before %{employment_start}?
+      ## QAP5
+      padoption_have_employee_contract?:
+        title: Does the employee have an employment contract with you?
+      ## QAP6
+      padoption_employed_at_employment_end?:
+        title: Will the employee be employed by you on %{ap_adoption_date_formatted}?
+      ## QAP7
+      padoption_employee_on_payroll?:
+        title: Is the employee on your payroll?
+      ## QAP8
+      padoption_employee_avg_weekly_earnings?:
+        title: What were the employee’s average weekly earnings between %{relevant_period}?
+        hint: Enter the average weekly amount. The dates are the 8 week 'relevant period'.
+        suffix_label: per week
+        error_message: Please enter a number greater than 0
+
+        
+      ## Paternity Adoption Results
+      padoption_leave_and_pay:
+        next_steps: |
+          Read the [guide to Statutory Paternity Pay and Leave](/paternity-leave-pay-employees "Paternity leave and pay")
+        body: |
+          %{padoption_leave_info}
+
+          %{padoption_pay_info}
+      
+      padoption_not_entitled_to_leave_or_pay:
+        next_steps: |
+          Read the [guide to Statutory Paternity Pay and Leave](/paternity-leave-pay-employees "Paternity leave and pay")
+        body: |
+          ##Not entitled to Statutory Paternity Leave and Pay
+          
+          The employee is not entitled to statutory paternity leave or pay because they: 
+
+          %{not_entitled_reason}
+          
+          You must write confirming this. Also, send them form OSP1 confirming they’re not entitled to pay within 28 days of their pay request. 
+
+
+          $D [Download Form OSPP1, refusing Statutory Paternity Pay (PDF, 100KB)](http://www.hmrc.gov.uk/forms/spp1.pdf "Download Form OSPP1, refusing Statutory Paternity Pay (PDF, 100KB)") $D
+
+      ## QA0
+      taking_paternity_leave_for_adoption?:
+        title: Is the employee taking paternity leave to adopt a child?
+      ## QA1
+      date_of_adoption_match?:
+        title: When was the child matched with the employee?
+        hint: For overseas adoptions, enter the official notification date (the permission to adopt from abroad).
+      ## QA2
+      date_of_adoption_placement?:
+        title: When will the child be placed with the employee?
+        hint: For overseas adoptions enter the date of arrival in the UK.
+        error_message: Placement date can't be before matching date
+      ## QA3
+      adoption_employment_contract?:
+        title: Does the employee have an employment contract with you?
+      ## QA4
+      adoption_date_leave_starts?:
+        title: When does the employee want to start their leave?
+        hint: Leave can't start before %{a_leave_earliest_start} or within 28 days of the child arriving in the UK (overseas adoptions only).
+        error_message: Please enter a valid date
+      ## QA5
+      adoption_did_the_employee_work_for_you?:
+        title: Did the employee work for you on or before %{employment_start}?
+      ## QA6
+      adoption_is_the_employee_on_your_payroll?:
+        title: Is the employee on your payroll?
+      ## QA7
+      adoption_employees_average_weekly_earnings?:
+         title: What were the employee’s average weekly earnings between %{relevant_period}?
+         hint: Enter the average weekly amount. The dates are the 8 week 'relevant period'.
+         suffix_label: per week
+         error_message: Please enter a number greater than 0
+      ## Adoption outcomes
+      adoption_leave_and_pay:
+        next_steps: |
+          Read the [guide to Statutory Adoption Pay and Leave](/adoption-leave-pay-employees "Adoption leave and pay")
+        body: |
+          %{adoption_leave_info}
+
+          %{adoption_pay_info}
+
+      adoption_not_entitled_to_leave_or_pay:
+        next_steps: |
+          Read the [guide to Statutory Adoption Pay and Leave](/adoption-leave-pay-employees "Adoption leave and pay")
+        body: |
+          ##Not entitled to Statutory Adoption Leave and Pay
+          
+          The employee is not entitled to statutory adoption leave or pay because they must have started working for you on %{employment_start}
+
+          You must write confirming this. Also, send them form SAP1 confirming they’re not entitled to pay within 28 days of their pay request. 
+
+          
+          $D [Download Form SAP1, Non-payment of Statutory Adoption Pay (PDF, 59KB)](http://www.hmrc.gov.uk/forms/sap1.pdf "Download Form SAP1, Non-payment of Statutory Adoption Pay (PDF, 59KB)"){:rel="external"} $D 
+
+      

--- a/lib/flows/maternity-paternity-calculator-preview.rb
+++ b/lib/flows/maternity-paternity-calculator-preview.rb
@@ -1,0 +1,646 @@
+status :draft
+satisfies_need "B1012"
+
+## Q1
+multiple_choice :what_type_of_leave? do
+  save_input_as :leave_type
+  option :maternity => :baby_due_date_maternity?
+  option :paternity => :leave_or_pay_for_adoption?
+  option :adoption => :taking_paternity_leave_for_adoption?
+end
+
+## QM1
+date_question :baby_due_date_maternity? do
+  calculate :calculator do
+    Calculators::MaternityPaternityCalculatorPreview.new(Date.parse(responses.last))
+  end
+  next_node :employment_contract?
+end
+
+## QM2
+multiple_choice :employment_contract? do
+  option :yes 
+  option :no
+  calculate :maternity_leave_info do
+    if responses.last == 'yes'
+      PhraseList.new(:maternity_leave_table)
+    else
+      PhraseList.new(:not_entitled_to_statutory_maternity_leave)
+    end
+  end
+  next_node :date_leave_starts?
+end
+
+## QM3
+date_question :date_leave_starts? do
+  precalculate :leave_earliest_start_date do
+    calculator.leave_earliest_start_date
+  end
+
+  calculate :leave_start_date do
+    ls_date = Date.parse(responses.last)
+    raise SmartAnswer::InvalidResponse if ls_date < leave_earliest_start_date
+    calculator.leave_start_date = ls_date
+    calculator.leave_start_date
+  end
+  
+  calculate :leave_end_date do
+    calculator.leave_end_date
+  end
+  calculate :leave_earliest_start_date do
+    calculator.leave_earliest_start_date
+  end
+  calculate :notice_of_leave_deadline do
+    calculator.notice_of_leave_deadline
+  end
+
+  calculate :pay_start_date do
+    calculator.pay_start_date
+  end
+  calculate :pay_end_date do
+    calculator.pay_end_date
+  end
+  calculate :employment_start do
+    calculator.employment_start
+  end
+  calculate :ssp_stop do
+    calculator.ssp_stop
+  end
+  next_node :did_the_employee_work_for_you?
+end
+
+## QM4
+multiple_choice :did_the_employee_work_for_you? do
+  option :yes => :is_the_employee_on_your_payroll?
+  option :no => :maternity_leave_and_pay_result
+  calculate :not_entitled_to_pay_reason do
+    :not_worked_long_enough
+  end
+  #not yet eligible for pay, keep asking questions
+  calculate :eligible_for_maternity_pay do
+    false
+  end
+end
+
+## QM5
+multiple_choice :is_the_employee_on_your_payroll? do
+  option :yes => :last_normal_payday? # NOTE: goes to shared questions 
+  option :no => :maternity_leave_and_pay_result
+  
+  calculate :not_entitled_to_pay_reason do
+    :must_be_on_payroll
+  end
+  #not yet eligible for pay, keep asking questions
+  calculate :eligible_for_maternity_pay do
+    false
+  end
+
+  calculate :payday_exit do
+    'maternity'
+  end
+  calculate :to_saturday do
+    calculator.format_date_day calculator.qualifying_week.last
+  end
+end
+
+## QM5.2 && QP6.2 && QA6.2 
+date_question :last_normal_payday? do
+  calculate :last_payday do
+    calculator.last_payday = Date.parse(responses.last)
+    raise SmartAnswer::InvalidResponse if calculator.last_payday > Date.parse(to_saturday)
+    calculator.last_payday
+  end
+
+  next_node :payday_eight_weeks?
+end
+
+## QM5.3 && P6.3 && A6.3
+date_question :payday_eight_weeks? do
+  precalculate :payday_offset do
+    calculator.format_date_day calculator.payday_offset
+  end
+
+  calculate :last_payday_eight_weeks do
+    payday = Date.parse(responses.last)
+    payday += 1 if leave_type == 'maternity'
+    raise SmartAnswer::InvalidResponse if payday > Date.parse(payday_offset)
+    calculator.pre_offset_payday = payday
+    payday
+  end
+
+  calculate :relevant_period do
+    calculator.formatted_relevant_period
+  end
+
+  next_node do |response|
+    case payday_exit
+    when 'maternity'
+      :pay_frequency?
+    when 'paternity'
+      :employees_average_weekly_earnings_paternity?
+    when 'paternity_adoption'
+      :padoption_employee_avg_weekly_earnings?
+    when 'adoption'
+      :adoption_employees_average_weekly_earnings?
+    end
+  end
+end
+
+## QM5.4
+multiple_choice :pay_frequency? do
+  save_input_as :pay_pattern
+  option :weekly => :earnings_for_pay_period? ## QM5.5
+  option :every_2_weeks => :earnings_for_pay_period? ## QM5.5
+  option :every_4_weeks => :earnings_for_pay_period? ## QM5.5
+  option :monthly => :earnings_for_pay_period? ## QM5.5
+  option :irregularly => :earnings_for_pay_period? ## QM5.5
+  option :none_of_the_above => :employees_average_weekly_earnings? ## QM6
+end
+
+## QM5.5
+money_question :earnings_for_pay_period? do
+  calculate :calculator do
+    raise SmartAnswer::InvalidNode if responses.last < 1
+    calculator.calculate_average_weekly_pay(pay_pattern, responses.last)
+    calculator
+  end
+  calculate :average_weekly_earnings do
+    calculator.average_weekly_earnings
+  end
+  next_node :maternity_leave_and_pay_result
+end
+
+## QM6
+money_question :employees_average_weekly_earnings? do
+  calculate :average_weekly_earnings do
+    raise SmartAnswer::InvalidNode if responses.last < 1
+    calculator.average_weekly_earnings = responses.last
+  end
+  calculate :not_entitled_to_pay_reason do
+    :must_earn_over_threshold
+  end
+  next_node :maternity_leave_and_pay_result
+end
+
+## Maternity outcomes
+outcome :maternity_leave_and_pay_result do
+  precalculate :smp_a do
+    sprintf("%.2f", calculator.statutory_maternity_rate_a)
+  end
+  precalculate :smp_b do
+    sprintf("%.2f", calculator.statutory_maternity_rate_b)
+  end
+  precalculate :lower_earning_limit do
+    sprintf("%.2f", calculator.lower_earning_limit)
+  end
+  precalculate :total_smp do
+    sprintf("%.2f", calculator.total_statutory_pay)
+  end
+  precalculate :notice_request_pay do
+    calculator.notice_request_pay
+  end
+
+  precalculate :eligible_for_maternity_pay do
+    if calculator.average_weekly_earnings and 
+      calculator.average_weekly_earnings >= calculator.lower_earning_limit
+      true
+    else
+      false
+    end
+  end
+  
+  precalculate :maternity_pay_info do
+    if eligible_for_maternity_pay
+      pay_info = PhraseList.new(:maternity_pay_table)
+    else
+      pay_info = PhraseList.new(calculator.average_weekly_earnings ? 
+                                :not_entitled_to_smp_intro_with_awe : :not_entitled_to_smp_intro)
+      pay_info << not_entitled_to_pay_reason
+      pay_info << :not_entitled_to_smp_outro
+    end
+    pay_info
+  end
+
+  calendar do |responses|
+    date "Statutory Maternity Leave", responses.leave_start_date..responses.leave_end_date
+    date "Latest date to give notice", responses.notice_of_leave_deadline
+    date "Earliest date maternity leave can start", responses.leave_earliest_start_date
+  end
+end
+
+
+## Paternity
+
+## QP0
+multiple_choice :leave_or_pay_for_adoption? do
+	option :yes => :employee_date_matched_paternity_adoption?
+	option :no => :baby_due_date_paternity?
+end
+
+## QP1
+date_question :baby_due_date_paternity? do
+  calculate :due_date do
+    Date.parse(responses.last)
+  end
+  calculate :calculator do
+    Calculators::MaternityPaternityCalculatorPreview.new(due_date)
+  end
+	next_node :employee_responsible_for_upbringing?  
+end
+
+## QP2
+multiple_choice :employee_responsible_for_upbringing? do
+
+  calculate :employment_start do
+    calculator.employment_start
+  end
+  calculate :employment_end do
+    due_date
+  end
+  calculate :p_notice_leave do
+    calculator.notice_of_leave_deadline
+  end
+  calculate :not_entitled_reason do
+    PhraseList.new :not_responsible_for_upbringing
+  end
+	option :yes => :employee_work_before_employment_start?
+	option :no => :paternity_not_entitled_to_leave_or_pay # result 5P DP
+end
+
+## QP3
+multiple_choice :employee_work_before_employment_start? do
+	calculate :not_entitled_reason do
+    PhraseList.new :not_worked_long_enough
+  end
+  option :yes => :employee_has_contract_paternity?
+	option :no => :paternity_not_entitled_to_leave_or_pay # result 5P EP
+end
+
+## QP4
+multiple_choice :employee_has_contract_paternity? do
+	option :yes 
+	option :no 
+	calculate :paternity_leave_info do
+    if responses.last == 'yes'
+      PhraseList.new(:paternity_entitled_to_leave)
+    else
+      PhraseList.new(:paternity_not_entitled_to_leave)
+    end
+  end
+  next_node :employee_employed_at_employment_end_paternity?
+end
+
+## QP5
+multiple_choice :employee_employed_at_employment_end_paternity? do
+	option :yes => :employee_on_payroll_paternity?
+  option :no => :paternity_leave_and_pay #4P_AP
+  calculate :paternity_pay_info do
+    if responses.last == 'no'
+      pay_info = PhraseList.new (:paternity_not_entitled_to_pay_intro)
+      pay_info << :must_be_employed_by_you
+      pay_info << :paternity_not_entitled_to_pay_outro
+    end
+    pay_info
+  end 
+end
+
+
+## QP6
+multiple_choice :employee_on_payroll_paternity? do
+	option :yes => :last_normal_payday? # NOTE: this goes to a shared question => QM5.2
+  option :no => :paternity_leave_and_pay # 4P BP
+  calculate :paternity_pay_info do
+    if responses.last == 'no'
+      pay_info = PhraseList.new (:paternity_not_entitled_to_pay_intro)
+      pay_info << :must_be_on_payroll
+      pay_info << :paternity_not_entitled_to_pay_outro
+    end
+    pay_info 
+  end
+
+  calculate :payday_exit do
+    'paternity'
+  end
+  calculate :to_saturday do
+    calculator.format_date_day calculator.qualifying_week.last
+  end
+end
+
+## QP7
+money_question :employees_average_weekly_earnings_paternity? do
+	calculate :spp_rate do
+    calculator.average_weekly_earnings = responses.last
+    sprintf("%.2f",calculator.statutory_paternity_rate)
+  end
+  calculate :lower_earning_limit do
+    sprintf("%.2f",calculator.lower_earning_limit)
+  end
+  calculate :paternity_pay_info do
+    if responses.last >= calculator.lower_earning_limit
+			pay_info = PhraseList.new(:paternity_entitled_to_pay)
+		else
+			pay_info = PhraseList.new(:paternity_not_entitled_to_pay_intro)
+			pay_info << :must_earn_over_threshold
+      pay_info << :paternity_not_entitled_to_pay_outro
+    end
+    pay_info 
+	end
+  next_node :paternity_leave_and_pay
+end
+
+# Paternity outcomes
+outcome :paternity_leave_and_pay
+outcome :paternity_not_entitled_to_leave_or_pay
+
+
+
+## Paternity Adoption
+
+## QAP1
+date_question :employee_date_matched_paternity_adoption? do
+	calculate :matched_date do
+    Date.parse(responses.last)
+  end
+  calculate :calculator do
+    Calculators::MaternityPaternityCalculatorPreview.new(matched_date, Calculators::MaternityPaternityCalculatorPreview::LEAVE_TYPE_ADOPTION)
+  end
+  next_node :padoption_date_of_adoption_placement?
+end
+
+## QAP2
+date_question :padoption_date_of_adoption_placement? do
+
+  calculate :ap_adoption_date do
+    placement_date = Date.parse(responses.last)
+    raise SmartAnswer::InvalidResponse if placement_date < matched_date
+    calculator.adoption_placement_date = placement_date
+    placement_date
+  end
+  calculate :ap_adoption_date_formatted do
+    calculator.format_date_day ap_adoption_date
+  end
+
+  calculate :employment_start do 
+    calculator.a_employment_start
+  end
+  calculate :matched_date_formatted do
+    calculator.format_date_day matched_date
+  end
+  calculate :employment_end do 
+    matched_date
+  end
+  next_node :padoption_employee_responsible_for_upbringing?
+end
+
+## QAP3
+multiple_choice :padoption_employee_responsible_for_upbringing? do
+	calculate :not_entitled_reason do
+    PhraseList.new :not_responsible_for_upbringing
+  end
+  option :yes => :padoption_employee_start_on_or_before_employment_start?
+	option :no => :padoption_not_entitled_to_leave_or_pay #5AP DP
+end
+
+## QAP4
+multiple_choice :padoption_employee_start_on_or_before_employment_start? do
+	calculate :not_entitled_reason do
+    PhraseList.new :not_worked_long_enough
+  end
+  option :yes => :padoption_have_employee_contract?
+	option :no => :padoption_not_entitled_to_leave_or_pay #5AP EP
+end
+
+## QAP5
+multiple_choice :padoption_have_employee_contract? do
+	option :yes 
+	option :no
+
+  calculate :padoption_leave_info do
+    if responses.last == 'yes'
+      PhraseList.new(:padoption_entitled_to_leave)
+    else
+      PhraseList.new(:padoption_not_entitled_to_leave)
+    end
+  end
+
+  next_node :padoption_employed_at_employment_end?
+end
+
+## QAP6
+multiple_choice :padoption_employed_at_employment_end? do
+  option :yes => :padoption_employee_on_payroll?
+  option :no => :padoption_leave_and_pay # 4AP AP
+	calculate :padoption_pay_info do
+    if responses.last == 'no'
+      pay_info = PhraseList.new (:padoption_not_entitled_to_pay_intro)
+      pay_info << :pa_must_be_employed_by_you
+      pay_info << :padoption_not_entitled_to_pay_outro
+      #not entitled to pay so add form download links to end of leave info if they were entitled to leave
+      if padoption_leave_info.phrase_keys.include?(:padoption_entitled_to_leave)
+        padoption_leave_info << :padoption_leave_and_pay_forms
+      end
+    end
+    pay_info
+  end
+end
+
+## QAP7
+multiple_choice :padoption_employee_on_payroll? do
+  option :yes => :last_normal_payday? # NOTE: goes to shared questions 
+  option :no => :padoption_leave_and_pay # 4AP BP
+	calculate :padoption_pay_info do
+    if responses.last == 'no'
+      pay_info = PhraseList.new(:padoption_not_entitled_to_pay_intro)
+      pay_info << :must_be_on_payroll
+      pay_info << :padoption_not_entitled_to_pay_outro
+      #not entitled to pay so add form download links to end of leave info if they were entitled to leave
+      if padoption_leave_info.phrase_keys.include?(:padoption_entitled_to_leave)
+        padoption_leave_info << :padoption_leave_and_pay_forms
+      end
+    end
+    pay_info
+  end
+
+  calculate :payday_exit do
+    'paternity_adoption'
+  end
+  calculate :to_saturday do
+    calculator.format_date_day calculator.matched_week.last
+  end
+end
+
+
+## QAP8
+money_question :padoption_employee_avg_weekly_earnings? do
+  calculate :sapp_rate do
+    calculator.average_weekly_earnings = responses.last
+    sprintf("%.2f", calculator.statutory_paternity_rate)
+  end
+  calculate :lower_earning_limit do
+    sprintf("%.2f", calculator.lower_earning_limit)
+  end
+  calculate :padoption_pay_info do
+    if responses.last >= calculator.lower_earning_limit
+      pay_info = PhraseList.new(:padoption_entitled_to_pay)
+      pay_info << :padoption_leave_and_pay_forms
+    else
+      pay_info = PhraseList.new(:padoption_not_entitled_to_pay_intro)
+      pay_info << :must_earn_over_threshold
+      pay_info << :padoption_not_entitled_to_pay_outro
+      #not entitled to pay so add form download links to end of leave info if they were entitled to leave
+      if padoption_leave_info.phrase_keys.include?(:padoption_entitled_to_leave)
+        padoption_leave_info << :padoption_leave_and_pay_forms
+      end
+    end
+    pay_info
+  end
+
+  next_node :padoption_leave_and_pay
+end
+
+## Paternity Adoption Results
+outcome :padoption_leave_and_pay
+outcome :padoption_not_entitled_to_leave_or_pay
+
+
+
+## Adoption
+## QA0
+multiple_choice :taking_paternity_leave_for_adoption? do
+  option :yes => :employee_date_matched_paternity_adoption? #QAP1
+  option :no => :date_of_adoption_match? # QA1
+end
+
+## QA1
+date_question :date_of_adoption_match? do
+  calculate :match_date do
+    Date.parse(responses.last)
+  end
+  calculate :calculator do
+    Calculators::MaternityPaternityCalculatorPreview.new(match_date, Calculators::MaternityPaternityCalculatorPreview::LEAVE_TYPE_ADOPTION)
+  end
+  next_node :date_of_adoption_placement?
+end
+
+## QA2
+date_question :date_of_adoption_placement? do
+  calculate :adoption_placement_date do
+    placement_date = Date.parse(responses.last)
+    raise SmartAnswer::InvalidResponse if placement_date < match_date
+    calculator.adoption_placement_date = placement_date
+    placement_date
+  end
+  calculate :a_leave_earliest_start do
+    calculator.format_date (adoption_placement_date - 14)
+  end
+  next_node :adoption_employment_contract?
+end
+
+## QA3
+multiple_choice :adoption_employment_contract? do
+  option :yes
+  option :no
+
+  save_input_as :employee_has_contract_adoption
+
+  #not entitled to leave if no contract; keep asking questions to check eligibility
+  calculate :adoption_leave_info do
+    if responses.last == 'no'
+      PhraseList.new(:adoption_not_entitled_to_leave)
+    end
+  end
+  next_node :adoption_date_leave_starts?
+end
+
+## QA4
+date_question :adoption_date_leave_starts? do
+  calculate :adoption_date_leave_starts do
+    ald_start = Date.parse(responses.last)
+    raise SmartAnswer::InvalidResponse if ald_start < Date.parse(a_leave_earliest_start)
+    calculator.adoption_leave_start_date = ald_start 
+  end
+
+  calculate :leave_start_date do
+    calculator.leave_start_date
+  end
+  calculate :leave_end_date do
+    calculator.leave_end_date
+  end
+ 
+  calculate :pay_start_date do
+    calculator.pay_start_date
+  end
+  calculate :pay_end_date do
+    calculator.pay_end_date
+  end
+  calculate :employment_start do
+    calculator.a_employment_start
+  end
+  
+  calculate :a_notice_leave do
+    calculator.format_date calculator.a_notice_leave
+  end
+
+  next_node :adoption_did_the_employee_work_for_you?
+end
+
+## QA5
+multiple_choice :adoption_did_the_employee_work_for_you? do
+  option :yes => :adoption_is_the_employee_on_your_payroll?
+  option :no => :adoption_not_entitled_to_leave_or_pay
+  #at this point we know for sure if employee is entitled to leave
+  calculate :adoption_leave_info do
+    if (responses.last == 'yes') and (employee_has_contract_adoption == 'yes')
+      PhraseList.new(:adoption_leave_table)
+    else
+      PhraseList.new(:adoption_not_entitled_to_leave)
+    end
+  end
+end
+
+## QA6
+multiple_choice :adoption_is_the_employee_on_your_payroll? do
+  option :yes => :last_normal_payday? # NOTE: this goes to a shared question => QM5.2
+  option :no => :adoption_leave_and_pay
+  calculate :adoption_pay_info do
+    if responses.last == 'no'
+      pay_info = PhraseList.new(:adoption_not_entitled_to_pay_intro)
+      pay_info << :must_be_on_payroll
+      pay_info << :adoption_not_entitled_to_pay_outro
+    end
+    pay_info
+  end
+
+
+  calculate :payday_exit do
+    'adoption'
+  end
+  calculate :to_saturday do
+    calculator.format_date_day calculator.matched_week.last
+  end
+end
+
+## QA7
+money_question :adoption_employees_average_weekly_earnings? do
+ calculate :sap_rate do
+  calculator.average_weekly_earnings = responses.last
+  sprintf("%.2f", calculator.statutory_adoption_rate)
+ end
+ calculate :lower_earning_limit do
+   sprintf("%.2f", calculator.lower_earning_limit)
+ end
+ calculate :adoption_pay_info do
+    if responses.last >= calculator.lower_earning_limit
+      PhraseList.new(:adoption_pay_table)
+    else
+      pay_info = PhraseList.new(:adoption_not_entitled_to_pay_intro)
+      pay_info << :must_earn_over_threshold
+      pay_info << :adoption_not_entitled_to_pay_outro
+      pay_info
+    end
+  end
+  next_node :adoption_leave_and_pay
+end
+
+outcome :adoption_leave_and_pay
+outcome :adoption_not_entitled_to_leave_or_pay

--- a/lib/smart_answer/calculators/maternity_paternity_calculator_preview.rb
+++ b/lib/smart_answer/calculators/maternity_paternity_calculator_preview.rb
@@ -1,0 +1,165 @@
+module SmartAnswer::Calculators
+  class MaternityPaternityCalculatorPreview
+
+    attr_reader :due_date, :expected_week, :qualifying_week, :employment_start, :notice_of_leave_deadline,
+      :leave_earliest_start_date, :adoption_placement_date, :ssp_stop,
+      :notice_request_pay, :matched_week, :a_employment_start
+
+    attr_accessor :employment_contract, :leave_start_date, :average_weekly_earnings, :a_notice_leave,
+      :last_payday, :pre_offset_payday
+
+    MATERNITY_RATE = PATERNITY_RATE = 135.45
+    LEAVE_TYPE_BIRTH = "birth"
+    LEAVE_TYPE_ADOPTION = "adoption"
+
+    # def initialize(match_or_due_date)
+    def initialize(match_or_due_date, birth_or_adoption = LEAVE_TYPE_BIRTH)
+      @due_date = @match_date = match_or_due_date
+      @leave_type = birth_or_adoption
+      expected_start = match_or_due_date - match_or_due_date.wday
+      @expected_week = @matched_week = expected_start .. expected_start + 6.days
+      @notice_of_leave_deadline = qualifying_start = 15.weeks.ago(expected_start)
+      @qualifying_week = qualifying_start .. qualifying_start + 6.days
+      @employment_start = 25.weeks.ago(@qualifying_week.last)
+      @a_employment_start = 25.weeks.ago(@matched_week.last)
+      @leave_earliest_start_date = 11.weeks.ago(@expected_week.first)
+      @ssp_stop = 4.weeks.ago(@expected_week.first)
+      @notice_request_pay = 27.days.ago(@due_date)
+
+      # Adoption instance vars
+      @a_notice_leave = @match_date + 7
+    end
+
+    def format_date(date)
+      date.strftime("%e %B %Y")
+    end
+
+    def format_date_day(date)
+      date.strftime("%A, %d %B %Y")
+    end
+
+    def payday_offset
+      8.weeks.ago(last_payday) + 1
+    end
+
+    def relevant_period
+      [pre_offset_payday, last_payday]
+    end
+
+    def formatted_relevant_period
+      relevant_period_from, relevant_period_to = relevant_period
+      "#{format_date_day(relevant_period_from)} and #{format_date_day(relevant_period_to)}"
+    end
+
+    def leave_end_date
+      52.weeks.since(@leave_start_date)
+    end
+
+    def pay_start_date
+      @leave_start_date
+    end
+
+    def pay_end_date
+      39.weeks.since(pay_start_date)
+    end
+
+    def statutory_maternity_rate
+      (@average_weekly_earnings.to_f * 0.9).round(2)
+    end
+
+    def statutory_maternity_rate_a
+      statutory_maternity_rate
+    end
+
+    def statutory_maternity_rate_b
+      (MATERNITY_RATE < statutory_maternity_rate ? MATERNITY_RATE : statutory_maternity_rate)
+    end
+
+    def earning_limit_rates_birth
+      [
+        {min: Date.parse("17 July 2009"), max: Date.parse("16 July 2010"), lower_earning_limit_rate: 95},
+        {min: Date.parse("17 July 2010"), max: Date.parse("16 July 2011"), lower_earning_limit_rate: 97},
+        {min: Date.parse("17 July 2011"), max: Date.parse("14 July 2012"), lower_earning_limit_rate: 102},
+        {min: Date.parse("15 July 2012"), max: Date.parse("13 July 2013"), lower_earning_limit_rate: 107}
+      ]
+    end
+
+    def lower_earning_limit_birth
+      earning_limit_rate = earning_limit_rates_birth.find { |c| c[:min] <= @due_date and c[:max] >= @due_date }
+      (earning_limit_rate ? earning_limit_rate[:lower_earning_limit_rate] : 107)
+    end
+
+    def earning_limit_rates_adoption
+      [
+        {min: Date.parse("3 April 2010"), max: Date.parse("2 April 2011"), lower_earning_limit_rate: 97},
+        {min: Date.parse("3 April 2011"), max: Date.parse("31 March 2012"), lower_earning_limit_rate: 102},
+        {min: Date.parse("1 April 2012"), max: Date.parse("30 March 2013"), lower_earning_limit_rate: 107}
+      ]
+    end
+
+    def lower_earning_limit_adoption
+      earning_limit_rate = earning_limit_rates_adoption.find { |c| c[:min] <= @due_date and c[:max] >= @due_date }
+      (earning_limit_rate ? earning_limit_rate[:lower_earning_limit_rate] : 107)
+    end
+
+    def lower_earning_limit
+      if @leave_type == LEAVE_TYPE_BIRTH
+        lower_earning_limit_birth
+      else
+        lower_earning_limit_adoption
+      end
+    end
+
+    def employment_end
+      @due_date
+    end
+
+    def adoption_placement_date=(date)
+      @adoption_placement_date = date
+      @leave_earliest_start_date = 14.days.ago(date)
+    end
+
+    def adoption_leave_start_date=(date)
+      @leave_start_date = date
+    end
+
+    ## Paternity
+    ##
+    ## Statutory paternity rate
+    def statutory_paternity_rate
+      awe = (@average_weekly_earnings.to_f * 0.9).round(2)
+      (PATERNITY_RATE < awe ? PATERNITY_RATE : awe)
+    end
+
+    ## Adoption
+    ##
+    ## Statutory adoption rate
+    def statutory_adoption_rate
+      statutory_maternity_rate_b
+    end
+
+    def pay_period_in_days
+      (last_payday + 1 - pre_offset_payday).to_i
+    end
+
+    def calculate_average_weekly_pay(pay_pattern, pay)
+      @average_weekly_earnings = (
+        case pay_pattern
+        when "irregularly"
+          pay.to_f / pay_period_in_days * 7
+        when "monthly"
+          pay.to_f / 2 * 12 / 52
+        else
+          pay.to_f / 8
+        end
+      ).round(5) # HMRC rounding to 5 places.
+    end
+
+    # Total SMP is the sum of 6 weeks at the potentially higher rate A
+    # and 33 weeks at the maximum statutory rate (B)
+    #
+    def total_statutory_pay
+      ((statutory_maternity_rate_a * 6) + (statutory_maternity_rate_b * 33)).round(2)
+    end
+  end
+end

--- a/test/integration/flows/maternity_paternity_calculator_preview_test.rb
+++ b/test/integration/flows/maternity_paternity_calculator_preview_test.rb
@@ -1,0 +1,1012 @@
+# encoding: UTF-8
+require_relative '../../test_helper'
+require_relative 'flow_test_helper'
+
+class MaternityPaternityCalculatorPreviewTest < ActiveSupport::TestCase
+  include FlowTestHelper
+
+  setup do
+    setup_for_testing_flow 'maternity-paternity-calculator-preview'
+  end
+  ## Q1
+  should "ask what type of leave or pay you want to check" do
+    assert_current_node :what_type_of_leave?
+  end
+  
+  ##
+  ## Maternity flow
+  ##
+  context "answer maternity" do
+    setup do
+      add_response :maternity
+    end
+    ## QM1
+    should "ask when the baby due date is" do
+      assert_current_node :baby_due_date_maternity?
+    end
+
+    context "test lower earning limits returned" do
+      should "return lower_earning_limit of £107" do
+        dd =Date.parse("1 January 2013")
+        add_response dd
+        add_response :yes
+        add_response 1.month.ago(dd)
+        add_response :yes
+        add_response :yes
+        add_response Date.parse("10 September 2012")
+        add_response Date.parse("10 July 2012")
+        add_response "weekly"
+        add_response "200"
+        assert_state_variable "lower_earning_limit", sprintf("%.2f",107) 
+      end
+      should "return lower_earning_limit of £102" do
+        dd =Date.parse("1 January 2012")
+        add_response dd
+        add_response :yes
+        add_response 1.month.ago(dd)
+        add_response :yes
+        add_response :yes
+        add_response Date.parse("10 September 2011")
+        add_response Date.parse("10 July 2011")
+        add_response "weekly"
+        add_response "200"
+        assert_state_variable "lower_earning_limit", sprintf("%.2f",102) 
+      end
+    end
+
+    context "answer 21 November 2012" do
+      setup do
+        @dd = Date.parse("21 November 2012")
+        #FIXME qw should be 15 weeks before due date...
+        @qw = 15.weeks.ago(@dd - @dd.wday)..15.weeks.ago((@dd-@dd.wday)+6)
+        add_response @dd
+      end
+      ## QM2
+      should "ask if the employee has a contract with you" do
+        assert_current_node :employment_contract?
+      end
+      context "answer yes" do
+        setup do
+          add_response :yes
+        end
+        ## QM3
+        should "ask when the employee wants to start their leave" do
+          assert_current_node :date_leave_starts?
+        end
+        context "answer 21 November 2012" do
+          setup do
+            add_response Date.parse("21 November 2012")
+          end
+          ## QM4
+          should "ask if the employee worked for you before or on this date" do
+            assert_current_node :did_the_employee_work_for_you?
+          end
+          context "answer yes" do
+            setup do
+              add_response :yes
+            end
+            ## QM5
+            should "ask if the employee is on your payroll" do
+              assert_current_node :is_the_employee_on_your_payroll?
+            end
+            context "answer yes" do
+              setup do
+                add_response :yes
+              end
+              
+              ## QM5.2
+              should "ask when the last normal payday" do
+                assert_current_node :last_normal_payday?
+              end
+              should "be wrong as lastpayday is after" do
+                add_response @qw.last+2
+                assert_current_node_is_error
+              end
+              context "answer 2 days before Saturday of qualifying week" do
+                setup do
+                  add_response @qw.last-2
+                end
+                ## QM5.3
+                should "ask when before lastpayday I was paid" do
+                  assert_current_node :payday_eight_weeks?
+                end
+
+                context "answer 8 weeks before qualifying week" do
+                  setup do
+                    add_response 8.weeks.ago(@qw.last - 2)
+                  end
+                 
+                  ## QM5.4
+                  should "ask how often you pay the employee" do
+                    assert_current_node :pay_frequency?
+                  end
+                  
+                  context "answer weekly" do
+                    setup do
+                      add_response 'weekly'
+                    end
+                    ## QM5.5
+                    should "ask what the employees earnings are for the period" do
+                      assert_current_node :earnings_for_pay_period?
+                      ##TODO relevant period calculation
+                    end
+                    context "answer 1083.20" do
+                      setup do
+                        add_response 1083.20
+                      end
+                      should "calculate dates and pay amounts" do
+                        leave_start = Date.parse("21 November 2012")
+                        start_of_week = leave_start - leave_start.wday
+                        assert_state_variable "leave_start_date", leave_start
+                        assert_state_variable "leave_end_date", 52.weeks.since(leave_start)
+                        assert_state_variable "notice_of_leave_deadline", 15.weeks.ago(start_of_week)
+                        assert_state_variable "pay_start_date", leave_start
+                        assert_state_variable "pay_end_date", 39.weeks.since(leave_start)
+                        assert_state_variable "average_weekly_earnings", 135.4
+                        assert_state_variable "smp_a", (135.40 * 0.9).round(2).to_s
+                        assert_state_variable "smp_b", (135.40 * 0.9).round(2).to_s
+                        assert_state_variable "total_smp", "4752.54"
+                      end
+                      should "calculate and present the result" do
+                        assert_phrase_list :maternity_leave_info, [:maternity_leave_table]
+                        assert_current_node :maternity_leave_and_pay_result
+                      end
+                      should "output a calendar" do
+                        assert_calendar
+                        assert_calendar_date Date.parse("21 November 2012")..Date.parse("20 November 2013")
+                        assert_calendar_date Date.parse("5 August 2012")
+                      end
+                    end #answer 135.40
+                  end
+                end
+              end
+
+            end #answer yes to QM5 on payroll
+
+            context "answer no" do
+              should "state that you they are not entitled to pay" do
+                add_response :no
+                assert_state_variable "not_entitled_to_pay_reason", :must_be_on_payroll
+                assert_current_node :maternity_leave_and_pay_result
+              end
+            end #answer no to QM5 on payroll
+
+          end #answer yes to QM4
+          context "answer no" do
+            should "state that you they are not entitled to pay" do
+              add_response :no
+              assert_state_variable "not_entitled_to_pay_reason", :not_worked_long_enough
+              assert_current_node :maternity_leave_and_pay_result
+            end
+          end
+        end
+      end # answer Yes to QM2 employee has contract?
+
+      context "no contract" do # means they can't get leave but they may still be able to get pay.
+        setup do
+          add_response :no
+        end
+        should "ask when the employee wants to start their leave" do
+          assert_current_node :date_leave_starts?
+        end
+        context "answer 21 November 2012" do
+          setup do
+            ld = Date.parse("21 November 2012")
+            add_response ld
+          end
+          ## QM4
+          should "ask if the employee worked for you before or on this date" do
+            assert_current_node :did_the_employee_work_for_you?
+          end
+          context "answer yes" do
+            setup do
+              add_response :yes
+            end
+            ## QM5
+            should "ask if the employee is on your payroll" do
+              assert_current_node :is_the_employee_on_your_payroll?
+            end
+            context "answer yes" do
+              setup do
+                add_response :yes
+              end
+              ## QM5.2
+              should "ask when the last normal payday" do
+                assert_current_node :last_normal_payday?
+              end
+
+              context "answer 2 days before Saturday of qualifying week" do
+                setup do
+                  add_response @qw.last-2
+                end
+                ## QM5.3
+                should "ask the date of the pay before the 8 week offset" do 
+                  assert_current_node :payday_eight_weeks?
+                end
+
+                context "answer 8 weeks before qualifying week" do
+                  setup do
+                    add_response 8.weeks.ago(@qw.last - 2)
+                  end
+                  #QM5.4
+                  should "ask how often you pay the employee" do
+                    assert_current_node :pay_frequency?
+                  end
+                  
+                  context "answer weekly" do
+                    setup { add_response :weekly }
+                    ##QM5.5
+                    should "ask how much the employee was paid in this period" do
+                      assert_current_node :earnings_for_pay_period?
+                    end
+                    context "answer 1083.20" do
+                      setup { add_response '1083.20' }
+                      should "calculate the dates and payment amounts" do
+                        leave_start = Date.parse("21 November 2012")
+                        start_of_week = leave_start - leave_start.wday
+                        assert_state_variable "average_weekly_earnings", 135.40
+                        assert_state_variable "leave_start_date", leave_start
+                        assert_state_variable "leave_end_date", 52.weeks.since(leave_start)
+                        assert_state_variable "notice_of_leave_deadline", 15.weeks.ago(start_of_week)
+                        assert_state_variable "pay_start_date", leave_start
+                        assert_state_variable "pay_end_date", 39.weeks.since(leave_start)
+                        assert_state_variable "smp_a", (135.40 * 0.9).round(2).to_s
+                        assert_state_variable "smp_b", (135.40 * 0.9).round(2).to_s
+                        assert_state_variable "total_smp", "4752.54"
+                      end
+                      # no contract means no leave
+                      should "calculate and present the result" do
+                        assert_phrase_list :maternity_leave_info, [:not_entitled_to_statutory_maternity_leave]
+                        assert_current_node :maternity_leave_and_pay_result
+                      end
+                      should "output a calendar" do
+                        assert_calendar
+                        assert_calendar_date Date.parse("21 November 2012")..Date.parse("20 November 2013")
+                        assert_calendar_date Date.parse("5 August 2012")
+                      end
+                    end # answer 135.40
+                  end
+                  context "answer every 2 weeks" do
+                    setup { add_response :every_2_weeks }
+                    ##QM5.5
+                    should "ask how much the employee was paid in this period" do
+                      assert_current_node :earnings_for_pay_period?
+                    end
+                    context "answer 2601.60" do
+                      setup { add_response '2601.60' }
+                      should "calculate the dates and payment amounts" do
+                        assert_state_variable "average_weekly_earnings", 325.20
+                        assert_state_variable "smp_a", (325.20 * 0.9).round(2).to_s
+                        assert_state_variable "smp_b", "135.45" # Uses the statutory maternity rate 
+                      end
+                    end
+                  end
+                  context "answer every 4 weeks" do
+                    setup { add_response :every_4_weeks }
+                    ##QM5.5
+                    should "ask how much the employee was paid in this period" do
+                      assert_current_node :earnings_for_pay_period?
+                    end
+                    context "answer 2100.80" do
+                      setup { add_response '2100.80' }
+                      should "calculate the dates and payment amounts" do
+                        assert_state_variable "average_weekly_earnings", 262.60 
+                        assert_state_variable "smp_a", (262.60 * 0.9).round(2).to_s
+                        assert_state_variable "smp_b", "135.45" # Uses the statutory maternity rate 
+                      end
+                    end
+                  end
+                  context "answer every month" do
+                    setup { add_response :monthly }
+                    ##QM5.5
+                    should "ask how much the employee was paid in this period" do
+                      assert_current_node :earnings_for_pay_period?
+                    end
+                    context "answer 1807.78" do
+                      setup { add_response '1807.78' }
+                      should "calculate the dates and payment amounts" do
+                        assert_state_variable "average_weekly_earnings", 208.59 
+                        assert_state_variable "smp_a", (208.59 * 0.9).round(2).to_s
+                        assert_state_variable "smp_b", "135.45" # Uses the statutory maternity rate 
+                      end
+                    end
+                  end
+                  context "answer irregularly" do
+                    setup { add_response :irregularly }
+                    ##QM5.5
+                    should "ask how much the employee was paid in this period" do
+                      assert_current_node :earnings_for_pay_period?
+                    end
+                    context "answer 7463.19" do
+                      setup { add_response '7463.19' }
+                      should "calculate the dates and payment amounts" do
+                        assert_state_variable "average_weekly_earnings", 932.89875
+                      end
+                    end
+                  end
+                  context "answer none of the above" do
+                    setup { add_response :none_of_the_above }
+                    ##QM6
+                    should "ask the weekly average paid" do
+                      assert_current_node :employees_average_weekly_earnings?
+                    end
+                    context "answer 239.79" do
+                      setup { add_response '239.79' }
+                      should "calculate the dates and payment amounts" do
+                        leave_start = Date.parse("21 November 2012")
+                        start_of_week = leave_start - leave_start.wday
+                        assert_state_variable "average_weekly_earnings", 239.79 
+                        assert_state_variable "leave_start_date", leave_start
+                        assert_state_variable "leave_end_date", 52.weeks.since(leave_start)
+                        assert_state_variable "notice_of_leave_deadline", 15.weeks.ago(start_of_week)
+                        assert_state_variable "pay_start_date", leave_start
+                        assert_state_variable "pay_end_date", 39.weeks.since(leave_start)
+                        assert_state_variable "smp_a", (239.79 * 0.9).round(2).to_s
+                        assert_state_variable "smp_b", "135.45" # the statutory rate
+                        assert_state_variable "total_smp", "5764.71" 
+                      end
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end 
+      end # no to QM2 employee has contract?
+    end
+  end # Maternity flow
+  
+  
+  ##
+  ## Paternity flow
+  ##
+  context "answer paternity" do
+    setup { add_response :paternity }
+
+    ## QP0
+    should "ask whether to check for leave or pay for adoption" do
+      assert_current_node :leave_or_pay_for_adoption?
+    end
+
+    context "answer no" do
+      setup { add_response :no }
+      ## QP1
+      should "ask for the due date" do
+        assert_current_node :baby_due_date_paternity?
+      end
+
+      context "due date given as 12 June 2013" do
+        setup do
+          @pat_due_date = Date.parse ("12 June 2013")
+          add_response @pat_due_date
+        end
+
+        ## QP2 
+        should "ask if and what context the employee is responsible for the childs upbringing" do
+          assert_current_node :employee_responsible_for_upbringing?
+        end
+
+        context "is biological father or partner and responsible for upbringing" do
+          setup { add_response :yes }
+          
+          ## QP3
+          should "ask if employee worked for you before employment_start" do
+            assert_current_node :employee_work_before_employment_start? 
+          end
+
+          context "answer yes" do
+            setup { add_response :yes }
+
+            # QP4
+            should "ask if employee has an employee contract" do
+              assert_current_node :employee_has_contract_paternity?
+            end
+
+            context "answer yes" do
+              setup { add_response :yes }
+
+              # QP5
+              should "be entitled to leave" do
+                assert_phrase_list :paternity_leave_info, [:paternity_entitled_to_leave]
+              end
+
+              should "ask if employee will be employed at employment_end" do
+                assert_current_node :employee_employed_at_employment_end_paternity?
+              end
+
+              context "answer yes" do
+                setup { add_response :yes }
+
+                # QP6
+                should "ask if employee is on payroll" do
+                  assert_current_node :employee_on_payroll_paternity?
+                end
+
+                context "answer yes" do
+                  setup { add_response :yes }
+
+                  #QP6.2
+                  should "ask for last normal payday before ..." do
+                    assert_current_node :last_normal_payday?
+                  end
+
+                  context "answer 1 March 2013" do
+                    setup { add_response Date.parse("1 March 2013") }
+
+                    #QP6.3
+                    should "ask for payday eight weeks before" do
+                      assert_current_node :payday_eight_weeks?
+                    end
+
+                    context "answer 1 January 2013" do
+                      setup { add_response Date.parse("1 January 2013") }
+
+                      # QP7
+                      should "ask for average weekly earnings" do
+                        assert_current_node :employees_average_weekly_earnings_paternity?
+                      end
+
+                      context "answer 500.55" do
+                        setup do 
+                          add_response 500.55
+                          @leave_notice = @pat_due_date - @pat_due_date.wday
+                        end
+
+                        should "have p_notice_leave qualify" do
+                          assert_state_variable "p_notice_leave", 15.weeks.ago(@leave_notice)
+                        end
+
+                        should "calculate dates and pay amounts" do
+                          expected_start = @leave_notice
+                          @expected_week = expected_start .. expected_start + 6.days
+                          @notice_of_leave_deadline = qualifying_start = 15.weeks.ago(expected_start)
+                          @qualifying_week = qualifying_start .. qualifying_start + 6.days
+                          #FIXME@relevant_period = "#{8.weeks.ago(qualifying_start).to_s(:long)} and #{qualifying_start.to_s(:long)}"
+                      
+                          #FIXME assert_state_variable "relevant_period", @relevant_period
+                          #FIXME assert_state_variable "employment_start", 26.weeks.ago(expected_start)
+                          assert_state_variable "employment_end", @pat_due_date 
+                          assert_state_variable "spp_rate", sprintf("%.2f",135.45) 
+                        end
+
+                        should "display employee is entitled to pay" do
+                          assert_phrase_list :paternity_pay_info, [:paternity_entitled_to_pay]
+                          assert_current_node :paternity_leave_and_pay
+                        end
+                      end #answer 500.55
+
+                      context "answer 120.25" do
+                        setup { add_response 120.25 }
+
+                        should "calculate dates and pay amounts" do
+                          assert_state_variable "spp_rate", sprintf("%.2f",108.23) 
+                          assert_current_node :paternity_leave_and_pay
+                        end 
+                      end
+
+                      context "answer 102.25" do
+                        setup { add_response 102.25 }
+
+                        should "paternity not entitled to pay because earnings too low" do
+                          assert_phrase_list :paternity_pay_info, [:paternity_not_entitled_to_pay_intro, :must_earn_over_threshold, :paternity_not_entitled_to_pay_outro]
+                          assert_current_node :paternity_leave_and_pay
+                        end 
+                      end
+                    end #QP6.3
+                  end #QP6.2
+                end  # yes - QP6 on payroll  
+
+                #QP6 - not on payroll:
+                context "answer no" do
+                  setup { add_response :no }
+
+                  should "state that they are not entitled for pay because not on payroll" do
+                    assert_phrase_list :paternity_pay_info, [:paternity_not_entitled_to_pay_intro, :must_be_on_payroll, :paternity_not_entitled_to_pay_outro]
+                    assert_current_node :paternity_leave_and_pay
+                  end
+                end
+              end
+              #QP5 - not employed at end of relevant period
+              context "answer no" do
+                setup { add_response :no }
+                
+                should "state that they are not entitled to pay because not employed at end date" do  
+                  assert_phrase_list :paternity_pay_info, [:paternity_not_entitled_to_pay_intro, :must_be_employed_by_you, :paternity_not_entitled_to_pay_outro]
+                  assert_current_node :paternity_leave_and_pay
+                end
+              end
+            end
+            #QP4 - no employment contract
+            context "answer no" do
+              setup { add_response :no }
+
+              should "not be entitled to leave" do
+                assert_phrase_list :paternity_leave_info, [:paternity_not_entitled_to_leave]
+              end
+              #QP5
+              should "ask if employee will be employed at employment_end" do
+                assert_current_node :employee_employed_at_employment_end_paternity?
+              end
+
+              context "answer yes" do
+                setup { add_response :yes }
+
+                # QP6
+                should "ask if employee is on payroll" do
+                  assert_current_node :employee_on_payroll_paternity?
+                end
+
+                context "answer yes" do
+                  setup { add_response :yes }
+
+                  #QP6.2
+                  should "ask for last normal payday before ..." do
+                    assert_current_node :last_normal_payday?
+                  end
+
+                  context "answer 1 March 2013" do
+                    setup { add_response Date.parse("1 March 2013") }
+
+                    #QP6.3
+                    should "ask for payday eight weeks before" do
+                      assert_current_node :payday_eight_weeks?
+                    end
+
+                    context "answer 1 January 2013" do
+                      setup { add_response Date.parse("1 January 2013") }
+
+                      # QP7
+                      should "ask for average weekly earnings" do
+                        assert_current_node :employees_average_weekly_earnings_paternity?
+                      end
+
+                      context "answer 107.00" do
+                        setup { add_response 107.00 }
+
+                        should "display employee is entitled to pay" do
+                          assert_phrase_list :paternity_pay_info, [:paternity_entitled_to_pay]
+                          assert_current_node :paternity_leave_and_pay
+                        end 
+                      end #answer 107
+                    end
+                  end
+                end
+              end
+            end # no employment contract
+          end # worked for you before employment start
+          # Q3 - did not work for you
+          context "answer no" do
+            setup { add_response :no }
+
+            should "state that they are not entitled to leave or pay because not worked long enough" do  
+              assert_phrase_list :not_entitled_reason, [:not_worked_long_enough]
+              assert_current_node :paternity_not_entitled_to_leave_or_pay
+            end
+          end
+        end 
+        #Q2 - not a father, partner nor husband
+        context "answer no" do
+          setup { add_response :no }
+
+          should "state that they are not entitled to leave or pay because they're not responsible for upbringing" do
+            assert_phrase_list :not_entitled_reason, [:not_responsible_for_upbringing]
+            assert_current_node :paternity_not_entitled_to_leave_or_pay
+          end
+        end
+      end #due date 3 months from now
+    end #QP0 - no
+  
+
+    ##
+    ## Paternity - Adoption
+    ##
+    context "answer yes" do
+      setup { add_response :yes }
+      ## QAP1
+      should "ask for date the child was matched with employee" do
+        assert_current_node :employee_date_matched_paternity_adoption?
+      end
+
+      context "date matched date given as 21 June 2012" do
+        setup do 
+          @pat_adoption_match = Date.parse("21 June 2012")
+          add_response @pat_adoption_match
+        end
+
+        # QAP2
+        should "ask for the date the adoption placement will start" do
+          assert_current_node :padoption_date_of_adoption_placement?
+        end
+
+        context "placement date given as 21 November 2012" do
+          setup { add_response Date.parse("21 November 2012") }
+
+          # QAP3
+          should "ask if employee is responsible for upbringing" do
+            assert_current_node :padoption_employee_responsible_for_upbringing?
+          end
+
+          context "answer yes" do
+            setup { add_response :yes }
+
+            # QAP4
+            should "ask if employee started on or before employment_start" do
+              assert_current_node :padoption_employee_start_on_or_before_employment_start?
+            end
+
+            context "answer yes" do
+              setup { add_response :yes }
+              
+              # QAP5
+              should "ask if employee has an employment contract" do
+                 assert_current_node :padoption_have_employee_contract?
+              end
+
+              context "answer yes" do
+                setup { add_response :yes }
+
+                should "be entitled to leave" do
+                  assert_phrase_list :padoption_leave_info, [:padoption_entitled_to_leave]
+                end
+                
+                # QAP6
+                should "ask if employee will be employed at employment_end" do
+                   assert_current_node :padoption_employed_at_employment_end?
+                end
+
+                context "answer yes" do
+                  setup { add_response :yes }
+                  
+                  # QAP7
+                  should "ask if employee is on payroll" do
+                     assert_current_node :padoption_employee_on_payroll?
+                  end
+
+                  context "answer yes" do
+                    setup { add_response :yes }
+
+                    #QAP7.2
+                    should "ask when the last normal payday" do
+                      assert_current_node :last_normal_payday?
+                    end
+
+                    context "answer 1 June 2012" do
+                      setup { add_response Date.parse("1 June 2012") }
+
+                      #QAP7.3
+                      should "ask for payday eight weeks" do
+                        assert_current_node :payday_eight_weeks?
+                      end
+
+                      context "answer 1 April 2012" do
+                        setup { add_response Date.parse("1 April 2012") }
+
+                        # QAP8
+                        should "ask for employee avg weekly earnings" do
+                          assert_current_node :padoption_employee_avg_weekly_earnings?
+                        end  
+
+                        context "answer 500.55" do
+                          setup do 
+                            add_response 500.55
+                            @leave_notice = @pat_adoption_match - @pat_adoption_match.wday
+                          end
+
+                          should "calculate dates and pay amounts" do
+                            expected_start = @leave_notice
+                            @expected_week = expected_start .. expected_start + 6.days
+                            @notice_of_leave_deadline = qualifying_start = 15.weeks.ago(expected_start)
+                            #@qualifying_week = qualifying_start .. qualifying_start + 6.days
+                            #FIXME@relevant_period = "#{8.weeks.ago(qualifying_start).to_s(:long)} and #{qualifying_start.to_s(:long)}"
+                        
+                            #FIXME assert_state_variable "ap_qualifying_week", @qualifying_week
+                            #FIXME assert_state_variable "relevant_period", @relevant_period
+                            #FIXME assert_state_variable "employment_start", 26.weeks.ago(expected_start)
+                            assert_state_variable "employment_end", @pat_adoption_match 
+                            assert_state_variable "sapp_rate", sprintf("%.2f",135.45) 
+                          end
+
+                          should "display pay info" do
+                            assert_phrase_list :padoption_pay_info, [:padoption_entitled_to_pay, :padoption_leave_and_pay_forms]
+                            assert_current_node :padoption_leave_and_pay
+                          end
+                        end
+
+                        context "answer 120.25" do
+                          setup { add_response 120.25 }
+
+                          should "calculate dates and pay amounts" do
+                            assert_state_variable "sapp_rate", 108.23.to_s 
+                          end 
+                        end
+
+                        context "answer 90" do
+                          setup { add_response 90.25 }
+
+                          should "paternity adoption not entitled to pay because earn too little" do
+                            assert_phrase_list :padoption_pay_info, [:padoption_not_entitled_to_pay_intro, :must_earn_over_threshold, :padoption_not_entitled_to_pay_outro]
+                            assert_current_node :padoption_leave_and_pay
+                          end 
+                        end
+                      end #QAP7.3
+                    end #QAP7.2
+                  end # is on payroll
+
+                  context "answer no" do
+                    # outcome 4AP
+                    setup { add_response :no }
+                    
+                    should "paternity adoption not entitled to pay because not on payroll" do
+                      assert_phrase_list :padoption_pay_info, [:padoption_not_entitled_to_pay_intro, :must_be_on_payroll, :padoption_not_entitled_to_pay_outro]
+                      assert_current_node :padoption_leave_and_pay
+                    end
+                  end
+
+                end #yes to employed at end
+
+                context "answer no" do
+                  # outcome 4AP
+                  setup { add_response :no }
+
+                  should "paternity adoption not entitled to pay because not employed at end" do
+                    assert_phrase_list :padoption_pay_info, [:padoption_not_entitled_to_pay_intro, :pa_must_be_employed_by_you, :padoption_not_entitled_to_pay_outro]
+                    assert_current_node :padoption_leave_and_pay
+                  end
+                end
+
+              end
+
+              context "answer no" do
+                # outcome 3AP
+                setup { add_response :no }
+
+                should "paternity adoption not entitled to leave because no contract" do
+                  assert_phrase_list :padoption_leave_info, [:padoption_not_entitled_to_leave] 
+                end
+                #TODO: complete this flow with different pay scenarios
+              end
+
+
+            end
+
+            context "answer no" do
+              # outcome 5AP
+              setup { add_response :no } 
+
+              should "not entitled to paternity adoption leave nor pay because not employed long enough" do
+                assert_phrase_list :not_entitled_reason, [:not_worked_long_enough]
+                assert_current_node :padoption_not_entitled_to_leave_or_pay
+              end
+            end
+          end
+
+          context "answer no" do
+            # outcome 5AP
+            setup { add_response :no }
+            should "not entitled to leave or pay because not responsible for upbringing" do
+              assert_phrase_list :not_entitled_reason, [:not_responsible_for_upbringing]
+              assert_current_node :padoption_not_entitled_to_leave_or_pay
+            end
+          end
+        end
+      end # Paternity Adoption flow
+
+    end #QP0 - yes
+  end # Paternity flow
+  
+  
+
+  ##
+  ## Adoption flow
+  ##
+  context "answer adoption" do
+    setup do
+      add_response :adoption
+    end
+    ## QA0
+    should "ask if the check is for maternity or paternity leave" do
+      assert_current_node :taking_paternity_leave_for_adoption?
+    end
+    context "answer no (i.e taking maternity leave)" do
+      setup do
+        add_response :no
+      end
+      ## QA1
+      should "ask the date of the adoption match" do
+        assert_current_node :date_of_adoption_match?
+      end
+      context "answer 15 July 2012" do
+        setup do
+          add_response Date.parse("15 July 2012")
+        end
+        ## QA2
+        should "ask the date of the adoption placement" do
+          assert_current_node :date_of_adoption_placement?
+        end
+        context "answer 17 October 2012" do
+          setup do
+            add_response Date.parse("17 October 2012")
+          end
+          ## QA3
+          should "ask if the employee has a contract" do
+            assert_current_node :adoption_employment_contract?
+          end
+          context "answer yes to contract" do
+            setup do
+              add_response :yes
+            end
+            ## QA4
+            should "ask when the employee wants to start their leave" do
+              assert_state_variable "employee_has_contract_adoption", 'yes'
+              assert_current_node :adoption_date_leave_starts?
+            end
+            context "answer 17 October 2012" do
+              setup do
+                add_response Date.parse("17 October 2012")
+              end
+              ## QA5
+              should "ask if the employee worked for you before ..." do
+                assert_current_node :adoption_did_the_employee_work_for_you?
+              end
+              should "return employment_start" do
+                assert_state_variable "employment_start", Date.parse("2012 Jan 28")
+              end
+              context "answer yes" do
+                setup do
+                  add_response :yes
+                end
+                ## QA6
+                should "ask if the employee is on your payroll" do
+                  assert_current_node :adoption_is_the_employee_on_your_payroll?
+                end
+                context "answer yes" do
+                  setup do
+                    add_response :yes
+                  end
+                  ## QA6.2
+                  should "ask for last normal payday" do
+                    assert_current_node :last_normal_payday?
+                  end
+
+                  context "answer 21 July" do
+                    setup { add_response Date.parse("21 July 2012") }
+
+                    ## QA6.3
+                    should "ask for payday eight weeks" do
+                      assert_current_node :payday_eight_weeks?
+                    end
+
+                    context "answer 21 May " do
+                      setup { add_response Date.parse ("21 May 2012")}
+
+                      ## QA7
+                      should "ask what the average weekly earnings of the employee" do
+                        assert_current_node :adoption_employees_average_weekly_earnings?
+                      end
+                      context "answer below the lower earning limit" do
+                        should "state they are entitled to leave but not entitled to pay" do
+                          add_response 100
+                          assert_phrase_list :adoption_leave_info, [:adoption_leave_table]
+                          assert_phrase_list :adoption_pay_info, [:adoption_not_entitled_to_pay_intro, :must_earn_over_threshold, :adoption_not_entitled_to_pay_outro]
+                          assert_current_node :adoption_leave_and_pay
+                        end
+                      end
+                      context "answer above the earning limit" do
+                        should "give adoption leave and pay details" do
+                          add_response 200
+                          assert_phrase_list :adoption_leave_info, [:adoption_leave_table]
+                          assert_phrase_list :adoption_pay_info, [:adoption_pay_table]
+                          assert_current_node :adoption_leave_and_pay
+                        end
+                      end
+                    end
+                  end
+                end # yes to QA6 - on payroll
+                context "answer no" do
+                  should " state they are entitled to leave but not entitled to pay" do
+                    add_response :no
+                    assert_phrase_list :adoption_leave_info, [:adoption_leave_table]
+                    assert_phrase_list :adoption_pay_info, [:adoption_not_entitled_to_pay_intro, :must_be_on_payroll, :adoption_not_entitled_to_pay_outro]
+                    assert_current_node :adoption_leave_and_pay
+                  end
+                end
+              end # yes to QA5 - worked for you before
+              context "answer no" do
+                should "state they are not entitled to leave or pay" do
+                  add_response :no
+                  assert_current_node :adoption_not_entitled_to_leave_or_pay
+                end
+              end
+            end
+          end # yes to QA3 - has a contract
+          # now run through the branch where there is no contract as that means not entitled to leave
+          context "answer no to contract" do
+            setup do
+              add_response :no
+            end
+            should "ask when the employee wants to start their leave" do
+              assert_state_variable "employee_has_contract_adoption", 'no'
+              assert_current_node :adoption_date_leave_starts?
+            end
+            context "answer 17 October 2012" do
+              setup do
+                add_response Date.parse("17 October 2012")
+              end
+              ## QA5
+              should "ask if the employee worked for you before ..." do
+                assert_current_node :adoption_did_the_employee_work_for_you?
+              end
+              context "answer yes" do
+                setup do
+                  add_response :yes
+                end
+                ## QA6
+                should "ask if the employee is on your payroll" do
+                  assert_current_node :adoption_is_the_employee_on_your_payroll?
+                end
+                context "answer yes" do
+                  setup do
+                    add_response :yes
+                  end
+
+                  ## QA6.2
+                  should "ask for last normal payday" do
+                    assert_current_node :last_normal_payday?
+                  end
+
+                  context "answer 1 July" do
+                    setup { add_response Date.parse("1 July 2012") }
+
+                    ## QA6.3
+                    should "ask for payday eight weeks" do
+                      assert_current_node :payday_eight_weeks?
+                    end
+
+                    context "answer 1 May " do
+                      setup { add_response Date.parse ("1 May 2012")}
+
+                      ## QA7
+                      should "ask what the average weekly earnings of the employee" do
+                        assert_current_node :adoption_employees_average_weekly_earnings?
+                      end
+                      context "answer below the lower earning limit" do
+                        should "state they are not entitled to leave and not entitled to pay" do
+                         add_response 100
+                          assert_phrase_list :adoption_leave_info, [:adoption_not_entitled_to_leave]
+                          assert_phrase_list :adoption_pay_info, [:adoption_not_entitled_to_pay_intro, :must_earn_over_threshold, :adoption_not_entitled_to_pay_outro]
+                          assert_current_node :adoption_leave_and_pay
+                        end
+                      end
+                      context "answer above the earning limit" do
+                        should "not entitled to leave but entitled to pay" do
+                          add_response 200
+                          assert_phrase_list :adoption_leave_info, [:adoption_not_entitled_to_leave]
+                          assert_phrase_list :adoption_pay_info, [:adoption_pay_table]
+                          assert_current_node :adoption_leave_and_pay
+                        end
+                      end
+                    end
+                  end
+                end # yes to QA6 - on payroll
+                context "answer no" do
+                  should " state they are not entitled to leave nor pay" do
+                    add_response :no
+                    assert_phrase_list :adoption_leave_info, [:adoption_not_entitled_to_leave]
+                    assert_phrase_list :adoption_pay_info, [:adoption_not_entitled_to_pay_intro, :must_be_on_payroll, :adoption_not_entitled_to_pay_outro]
+                    assert_current_node :adoption_leave_and_pay
+                  end
+                end
+              end # yes to QA5 - worked for you before
+              context "answer no" do
+                should "state they are not entitled to leave or pay" do
+                  add_response :no
+                  assert_current_node :adoption_not_entitled_to_leave_or_pay
+                end
+              end
+            end
+          end # no to contract (QA3)
+        end
+      end
+    end
+  end # adoption
+end

--- a/test/unit/calculators/maternity_paternity_calculator_preview_test.rb
+++ b/test/unit/calculators/maternity_paternity_calculator_preview_test.rb
@@ -1,0 +1,301 @@
+require_relative "../../test_helper"
+
+module SmartAnswer::Calculators
+  class MaternityPaternityCalculatorPreviewTest < ActiveSupport::TestCase
+    
+    context MaternityPaternityCalculatorPreview do
+      context "due date 4 months in future" do
+        setup do
+          @due_date = 4.months.since(Date.today)
+          @start_of_week_in_four_months = @due_date - @due_date.wday
+          @calculator = MaternityPaternityCalculatorPreview.new(@due_date)
+        end
+        
+        should "calculate expected birth week" do
+          assert_equal @start_of_week_in_four_months, @calculator.expected_week.first
+        end
+        
+
+        should "calculate qualifying week" do
+          assert_equal 15.weeks.ago(@start_of_week_in_four_months), @calculator.qualifying_week.first
+        end
+        
+        should "calculate notice of leave deadline" do
+          assert_equal 15.weeks.ago(@start_of_week_in_four_months), @calculator.notice_of_leave_deadline
+        end
+        
+        should "calculate the earliest leave start date" do
+          assert_equal 11.weeks.ago(@start_of_week_in_four_months), @calculator.leave_earliest_start_date
+        end
+
+        should "calculate the relevant period" do
+          @dd = Date.parse("2012-10-12")
+          @calculator = MaternityPaternityCalculatorPreview.new(@dd)
+          @calculator.last_payday = @calculator.qualifying_week.last
+          payday = @calculator.last_payday.julian - (7 * 9)
+          @calculator.pre_offset_payday = payday
+          assert_equal "Saturday, 15 April 2012 and Saturday, 30 June 2012", @calculator.formatted_relevant_period
+        end
+
+        should "calculate payday offset" do
+          @calculator.last_payday = Date.parse("2012-03-28")
+          assert_equal Date.parse("2012-02-02"), @calculator.payday_offset
+        end
+
+        should "calculate the ssp_stop date anda the notice request date" do
+          @calculator = MaternityPaternityCalculatorPreview.new(Date.parse("2012 Oct 12"))
+          expected_week = @calculator.expected_week.first
+          assert_equal expected_week.julian - (7 * 4), @calculator.ssp_stop
+          assert_equal Date.parse("2012 Oct 12") - 27, @calculator.notice_request_pay
+        end
+        
+        context "with a requested leave date in one month's time" do
+          setup do
+            @leave_start_date = 1.month.since(Date.today)
+            @calculator.leave_start_date = @leave_start_date
+          end
+          
+          should "make the leave end date 52 weeks from the leave start date" do
+            assert_equal 52.weeks.since(@leave_start_date), @calculator.leave_end_date
+          end
+          
+          should "make the leave end date after the leave start date" do
+            assert @calculator.leave_end_date > @calculator.leave_start_date, "Leave end date should come after leave start date"
+          end
+          
+          should "make the pay start date the same date" do
+            assert_equal @leave_start_date, @calculator.pay_start_date
+          end
+          
+          should "make the pay end date 39 weeks from the start date" do
+            assert_equal 39.weeks.since(@leave_start_date), @calculator.pay_end_date
+          end
+        end
+        
+        context "with a weekly income of 193.00" do
+          setup do
+            @calculator.average_weekly_earnings = 193.00
+          end
+          
+          should "calculate the statutory maternity rate" do
+            assert_equal (193.00 * 0.9).round(2), @calculator.statutory_maternity_rate
+          end
+          
+          should "calculate the maternity pay at rate A" do
+            assert_equal (193.00 * 0.9).round(2), @calculator.statutory_maternity_rate_a
+          end
+          
+          should "calculate the maternity pay at rate B using the base rate" do
+            assert_equal 135.45, @calculator.statutory_maternity_rate_b
+          end
+          
+          should "calculate the maternity pay at rate B using the percentage of weekly income" do
+            @calculator.average_weekly_earnings = 135.40
+            assert_equal (135.40 * 0.9).round(2), @calculator.statutory_maternity_rate_b
+          end
+
+        end
+
+        should "calculate the paternity rate as the standard rate" do
+          @calculator.average_weekly_earnings = 500.55
+          assert_equal 135.45, @calculator.statutory_paternity_rate 
+        end
+
+        should "calculate the paternity rate as 90 percent of weekly earnings" do
+          @calculator.average_weekly_earnings = 120.55
+          assert_equal ((120.55 * 0.9).to_f).round(2), @calculator.statutory_paternity_rate 
+        end
+        
+        context "with an adoption placement date of a week ago" do
+          setup do
+            @one_week_ago = 1.week.ago(Date.today)
+            @calculator.adoption_placement_date = @one_week_ago
+          end
+          
+          should "make the earliest leave start date 14 days before the placement date" do
+            assert_equal 1.fortnight.ago(@one_week_ago), @calculator.leave_earliest_start_date
+          end
+        end
+      end
+
+      context "specific date tests (for lower_earning_limits) for birth" do
+        should "return lower_earning_limit 107" do
+          @due_date = Date.parse("1 January 2013")
+          @calculator = MaternityPaternityCalculatorPreview.new(@due_date)
+          assert_equal @calculator.lower_earning_limit, 107
+        end
+        should "return lower_earning_limit 107" do
+          @due_date = Date.parse("15 July 2012")
+          @calculator = MaternityPaternityCalculatorPreview.new(@due_date)
+          assert_equal @calculator.lower_earning_limit, 107
+        end
+        should "return lower_earning_limit 102" do
+          @due_date = Date.parse("14 July 2012")
+          @calculator = MaternityPaternityCalculatorPreview.new(@due_date)
+          assert_equal @calculator.lower_earning_limit, 102
+        end
+        should "return lower_earning_limit 102" do
+          @due_date = Date.parse("1 January 2012")
+          @calculator = MaternityPaternityCalculatorPreview.new(@due_date)
+          assert_equal @calculator.lower_earning_limit, 102
+        end
+        should "return lower_earning_limit 97" do
+          @due_date = Date.parse("1 January 2011")
+          @calculator = MaternityPaternityCalculatorPreview.new(@due_date)
+          assert_equal @calculator.lower_earning_limit, 97
+        end
+        should "return lower_earning_limit 95" do
+          @due_date = Date.parse("1 January 2010")
+          @calculator = MaternityPaternityCalculatorPreview.new(@due_date)
+          assert_equal @calculator.lower_earning_limit, 95
+        end
+      end
+
+      context "specific date tests (for lower_earning_limits) for adoption" do
+        should "return lower_earning_limit 107" do
+          @match_date = Date.parse("1 April 2012")
+          @calculator = MaternityPaternityCalculatorPreview.new(@match_date, MaternityPaternityCalculatorPreview::LEAVE_TYPE_ADOPTION)
+          assert_equal @calculator.lower_earning_limit, 107
+        end
+        should "return lower_earning_limit 102" do
+          @match_date = Date.parse("31 March 2012")
+          @calculator = MaternityPaternityCalculatorPreview.new(@match_date, MaternityPaternityCalculatorPreview::LEAVE_TYPE_ADOPTION)
+          assert_equal @calculator.lower_earning_limit, 102
+        end
+        should "return lower_earning_limit 97" do
+          @match_date = Date.parse("2 April 2011")
+          @calculator = MaternityPaternityCalculatorPreview.new(@match_date, MaternityPaternityCalculatorPreview::LEAVE_TYPE_ADOPTION)
+          assert_equal @calculator.lower_earning_limit, 97
+        end
+      end
+
+      context "qualifying_week tests" do
+        # due, qualifying_week, latest employment start, start of 11th week before due, start of 4th week
+        # 08/04/12 to 14/04/12 25/12/11 to 31/12/11 09/07/2011 22/01/2012 11/03/2012
+        should "due Monday 9th April 2012" do
+          @due_date = Date.parse("2012 Apr 09")
+          @calculator = MaternityPaternityCalculatorPreview.new(@due_date)
+          assert_equal Date.parse("09 Apr 2012"), @calculator.employment_end 
+          assert_equal Date.parse("08 Apr 2012")..Date.parse("14 Apr 2012"), @calculator.expected_week 
+          assert_equal Date.parse("25 Dec 2011"), 15.weeks.ago(@calculator.expected_week.first)
+          assert_equal Date.parse("31 Dec 2011"), 15.weeks.ago(@calculator.expected_week.first) + 6
+          assert_equal Date.parse("25 Dec 2011")..Date.parse("31 Dec 2011"), @calculator.qualifying_week
+          # assert_equal 26, (Date.parse(" Dec 2011").julian - Date.parse("09 Jul 2011").julian).to_i / 7
+          # assert_equal 26, (Date.parse("14 Apr 2012").julian - Date.parse("15 Oct 2011").julian).to_i / 7
+          # FIXME: this should work but 25 weeks rather than 26
+          assert_equal Date.parse("09 Jul 2011"), @calculator.employment_start
+          assert_equal Date.parse("22 Jan 2012"), @calculator.leave_earliest_start_date
+          assert_equal Date.parse("11 Mar 2012"), @calculator.ssp_stop
+        end
+        # 15/07/12 to 21/07/12 01/04/12 to 07/04/12 15/10/2011 29/04/2012 17/06/2012
+        should "due Wednesday 18 July 2012" do
+          @due_date = Date.parse("2012 Jul 18")
+          @calculator = MaternityPaternityCalculatorPreview.new(@due_date)
+          assert_equal Date.parse("18 Jul 2012"), @calculator.employment_end 
+          assert_equal Date.parse("15 Jul 2012")..Date.parse("21 Jul 2012"), @calculator.expected_week
+          assert_equal Date.parse("01 Apr 2012")..Date.parse("07 Apr 2012"), @calculator.qualifying_week
+          # DEBUG test
+          # assert_equal 26, (Date.parse("21 Jul 2012").julian - Date.parse("15 Oct 2011").julian).to_i / 7
+          # FIXME: ...
+          assert_equal Date.parse("15 Oct 2011"), @calculator.employment_start
+          assert_equal Date.parse("29 Apr 2012"), @calculator.leave_earliest_start_date
+          assert_equal Date.parse("17 Jun 2012"), @calculator.ssp_stop
+        end
+        # 09/09/12 to 15/09/12 27/05/12 to 02/06/12 10/12/2011 24/06/2012 12/08/2012
+        should "due Wednesday 14 Sep 2012" do
+          @due_date = Date.parse("2012 Sep 14")
+          @calculator = MaternityPaternityCalculatorPreview.new(@due_date)
+          assert_equal Date.parse("14 Sep 2012"), @calculator.employment_end 
+          assert_equal Date.parse("09 Sep 2012")..Date.parse("15 Sep 2012"), @calculator.expected_week
+          assert_equal Date.parse("27 May 2012")..Date.parse("02 Jun 2012"), @calculator.qualifying_week
+          assert_equal Date.parse("10 Dec 2011"), @calculator.employment_start
+          assert_equal Date.parse("24 Jun 2012"), @calculator.leave_earliest_start_date
+          assert_equal Date.parse("12 Aug 2012"), @calculator.ssp_stop
+        end
+        # 07/04/13 to 13/04/13 23/12/12 to 29/12/12 07/07/2012 20/01/2013 10/03/2013
+        # 27/01/13 to 02/02/13 14/10/12 to 20/10/12 28/04/2012 11/11/2012 30/12/2012
+        # 03/02/13 to 09/02/13 21/10/12 to 27/10/12 05/05/2012 18/11/2012 06/01/2013
+      end
+
+      context "adoption employment start tests" do
+        # 27/05/12 to 02/06/12 10/12/11
+        should "matched_date Monday 28th May 2012" do
+          @matched_date = Date.parse("2012 May 28")
+          @calculator = MaternityPaternityCalculatorPreview.new(@matched_date, MaternityPaternityCalculatorPreview::LEAVE_TYPE_ADOPTION)
+          assert_equal Date.parse("2012 May 27")..Date.parse("2012 Jun 02"), @calculator.matched_week
+          assert_equal Date.parse("2011 Dec 10"), @calculator.a_employment_start
+        end
+        # 15/07/12 to 21/07/12 28/01/12
+        should "matched_date Wednesday 18th July 2012" do
+          @matched_date = Date.parse("2012 Jul 18")
+          @calculator = MaternityPaternityCalculatorPreview.new(@matched_date, MaternityPaternityCalculatorPreview::LEAVE_TYPE_ADOPTION)
+          assert_equal Date.parse("2012 Jul 15")..Date.parse("2012 Jul 21"), @calculator.matched_week
+          assert_equal Date.parse("2012 Jan 28"), @calculator.a_employment_start
+          assert_equal 25, (Date.parse("2012 Jul 21").julian - Date.parse("2012 Jan 28").julian).to_i / 7 
+        end
+        # 16/09/12 to 22/09/12 31/03/12
+        # 09/12/12 to 15/12/12 23/06/12
+        # 10/03/13 to 16/03/13 22/09/12
+      end
+      
+      context "calculate_average_weekly_pay" do
+        setup do
+          @calculator = MaternityPaternityCalculatorPreview.new(4.months.since(Date.today))
+        end
+        should "make no calculation for a weekly pay pattern" do
+          assert_equal 665.15, @calculator.calculate_average_weekly_pay("weekly", 5321.20)
+        end
+        should "work out the weekly average for a fortnightly pay pattern" do
+          assert_equal 399.32, @calculator.calculate_average_weekly_pay("every_2_weeks", 3194.56)
+        end
+        should "work out the weekly average for a four week pay pattern" do
+          assert_equal 382.06, @calculator.calculate_average_weekly_pay("every_4_weeks", 3056.48)
+        end
+        should "work out the weekly average for a monthly pay pattern" do
+          assert_equal 1846.15385, @calculator.calculate_average_weekly_pay("monthly", 16000)
+        end
+        should "work out the weekly average for a irregular pay pattern" do
+          @calculator.last_payday = 15.days.ago(Date.today)
+          @calculator.pre_offset_payday = 55.days.ago(@calculator.last_payday)
+          assert_equal 56, @calculator.pay_period_in_days
+          assert_equal 974.82875, @calculator.calculate_average_weekly_pay("irregularly", 7798.63)
+        end
+      end
+      context "HMRC scenarios" do
+        setup do
+          @calculator = MaternityPaternityCalculatorPreview.new(Date.parse('2013-02-22'))
+        end
+        should "calculate AWE for weekly pay patterns" do
+          assert_equal 200, @calculator.calculate_average_weekly_pay("weekly", 1600) 
+          assert_equal 151, @calculator.calculate_average_weekly_pay("weekly", 1208)
+          assert_equal 150, @calculator.calculate_average_weekly_pay("weekly", 1200)
+        end
+        should "calculate AWE for monthly pay patterns" do
+          @calculator.last_payday = Date.parse('2012-10-31')
+          assert_equal 184.61538, @calculator.calculate_average_weekly_pay("monthly", 1600)
+          @calculator.last_payday = Date.parse('2012-10-26')
+          assert_equal 144.31731, @calculator.calculate_average_weekly_pay("monthly", 1250.75)
+        end
+        should "calculate AWE for irregular pay patterns" do
+          @calculator.last_payday = Date.parse('2012-11-06')
+          @calculator.pre_offset_payday = Date.parse('2012-08-01')
+          assert_equal 214.28571, @calculator.calculate_average_weekly_pay("irregularly", 3000)
+        end
+      end
+
+      context "total_statutory_pay" do
+        setup do
+          @calculator = MaternityPaternityCalculatorPreview.new(4.months.since(Date.today))
+        end
+        should "be statutory leave times statutory rates A and B" do
+          @calculator.average_weekly_earnings = 120.40
+          assert_equal 4226.04, @calculator.total_statutory_pay
+        end
+        should "be statutory leave times statutory higher rate A and statutory rate B" do
+          @calculator.average_weekly_earnings = 235.40
+          assert_equal 5741.01, @calculator.total_statutory_pay
+        end
+      end
+    end    
+  end
+end


### PR DESCRIPTION
Allows HMRC to preview the amends without affecting live calculators.

slug: /maternity-paternity-calculator-preview
