### PR TITLE
Really memoize the FlowRegistry.

### DIFF
--- a/app/controllers/smart_answers_controller.rb
+++ b/app/controllers/smart_answers_controller.rb
@@ -52,7 +52,7 @@ private
   end
 
   def flow_registry
-    @flow_registry ||= SmartAnswer::FlowRegistry.new(FLOW_REGISTRY_OPTIONS)
+    @flow_registry = SmartAnswer::FlowRegistry.instance
   end
 
   def redirect_response_to_canonical_url

--- a/lib/smart_answer/flow_registry.rb
+++ b/lib/smart_answer/flow_registry.rb
@@ -2,6 +2,14 @@ module SmartAnswer
   class FlowRegistry
     class NotFound < StandardError; end
 
+    def self.instance
+      @instance ||= new(FLOW_REGISTRY_OPTIONS)
+    end
+
+    def self.reset_instance
+      @instance = nil
+    end
+
     def initialize(options={})
       @load_path = Pathname.new(options[:load_path] || Rails.root.join('lib', 'flows'))
       @show_drafts = options[:show_drafts]

--- a/test/integration/engine/engine_test_helper.rb
+++ b/test/integration/engine/engine_test_helper.rb
@@ -7,11 +7,13 @@ class EngineIntegrationTest < ActionDispatch::IntegrationTest
   setup do
     fixture_flows_path = Rails.root.join(*%w{test fixtures flows})
     FLOW_REGISTRY_OPTIONS[:load_path] = fixture_flows_path
+    SmartAnswer::FlowRegistry.reset_instance
 
     stub_content_api_default_artefact
   end
 
   teardown do
     FLOW_REGISTRY_OPTIONS.delete(:load_path)
+    SmartAnswer::FlowRegistry.reset_instance
   end
 end

--- a/test/integration/flows/flow_test_helper.rb
+++ b/test/integration/flows/flow_test_helper.rb
@@ -2,8 +2,7 @@
 
 module FlowTestHelper
   def setup_for_testing_flow(flow_slug)
-    @flow_registry ||= SmartAnswer::FlowRegistry.new(:show_drafts => true)
-    @flow = @flow_registry.find(flow_slug)
+    @flow = SmartAnswer::FlowRegistry.instance.find(flow_slug)
     @responses = []
   end
 


### PR DESCRIPTION
Previously a new FlowRegistry instance was created for each request, this meant parsing all the flows (even draft ones) on each request.

I've done some crude benchmarks with apachebench against my dev vm with RAILS_ENV=production, this change reduced the response time from c. 160ms to c. 60 ms for an outcome 3 questions deep.
