### PR TITLE
Remove bullet point from country select element

### DIFF
--- a/app/views/smart_answers/_country_select_question.html.erb
+++ b/app/views/smart_answers/_country_select_question.html.erb
@@ -1,6 +1,1 @@
-<ul>
-  <li>
-  <%= select_tag "response", options_from_collection_for_select(question.options, :value, :label, prefill_value_for(question, :slug)) %>
-
-  </li>
-</ul>
+<%= select_tag "response", options_from_collection_for_select(question.options, :value, :label, prefill_value_for(question, :slug)) %>


### PR DESCRIPTION
Country select elements are wrapped in a single item unordered list. This adds an unwanted bullet point style to the element. This change removes the wrapping list.
