### PR TITLE
Remove Karachi from secondary embassy detail output

### DIFF
--- a/lib/flows/overseas-passports.rb
+++ b/lib/flows/overseas-passports.rb
@@ -51,7 +51,7 @@ country_select :which_country_are_you_in? do
   end
   calculate :embassy_details do
     if embassies_details
-      responses.last =~ /^(russian-federation|pakistan)$/ ? embassies_details.join : embassies_details.first
+      responses.last == 'russian-federation' ? embassies_details.join : embassies_details.first
     end
   end
 


### PR DESCRIPTION
Related to https://govuk.zendesk.com/agent/#/tickets/69470 Karachi should not be shown for the second set of embassy details when applying from Pakistan.
