### PR TITLE
Register a birth overseas - amends

### DIFF
--- a/lib/flows/register-a-birth.rb
+++ b/lib/flows/register-a-birth.rb
@@ -193,6 +193,11 @@ outcome :embassy_result do
   end
 end
 outcome :fco_result do
+  precalculate :embassy_high_commission_or_consulate do
+    reg_data_query.has_high_commission?(registration_country) ? "High commission" :
+      reg_data_query.has_consulate?(registration_country) ? "British embassy or consulate" :
+        "British embassy"
+  end
   precalculate :intro do
     if exclusions.include?(registration_country)
       ''

--- a/test/integration/flows/register_a_birth_test.rb
+++ b/test/integration/flows/register_a_birth_test.rb
@@ -118,6 +118,7 @@ class RegisterABirthTest < ActiveSupport::TestCase
             assert_state_variable :registration_country, 'spain'
             assert_current_node :fco_result
             assert_phrase_list :intro, [:intro]
+            assert_state_variable :embassy_high_commission_or_consulate, "British embassy"
           end
         end
         context "answer in another country" do


### PR DESCRIPTION
Fixes FCO result missing a 'calculation' on which embassy/commission type to display.
