### PR TITLE
State pension calculator v2 copy updates

### DIFF
--- a/lib/flows/locales/en/calculate-state-pension-v2.yml
+++ b/lib/flows/locales/en/calculate-state-pension-v2.yml
@@ -71,8 +71,6 @@ en-GB:
           ##Pension Credit
           If you&rsquo;re on a low income, you might be eligible to claim [Pension Credit](/pension-credit "Pension Credit").
 
-          You may have been entitled to receive Pension Credit from %{pension_credit_date}
-          
           ##Bus pass
           You may also apply for an [elderly person’s bus pass](/apply-for-elderly-person-bus-pass "Elderly person’s bus pass") from %{pension_credit_date}.
 


### PR DESCRIPTION
Remove pension credit copy for people who have reached state pension age.
Factcheck response for https://www.pivotaltracker.com/story/show/46105341
