### PR TITLE
Prevent Ruby error if the country can't be found

### DIFF
--- a/lib/smart_answer/calculators/arrested_abroad.rb
+++ b/lib/smart_answer/calculators/arrested_abroad.rb
@@ -8,7 +8,10 @@ module SmartAnswer::Calculators
     end
 
     def generate_url_for_download(country, field, text)
-      url = @data.select { |c| c["slug"] == country }.first[field]
+      country_data = @data.select { |c| c["slug"] == country }.first
+      return "" unless country_data
+
+      url = country_data[field]
       output = []
       if url
         urls = url.split(" ")

--- a/test/unit/calculators/arrested_abroad_calculator_test.rb
+++ b/test/unit/calculators/arrested_abroad_calculator_test.rb
@@ -7,6 +7,19 @@ module SmartAnswer::Calculators
         @calc = ArrestedAbroad.new
       end
 
+      context "generating a URL" do
+        should "not error if the country doesn't exist" do
+          assert_nothing_raised do
+            @calc.generate_url_for_download("doesntexist", "pdf", "hello world")
+          end
+        end
+
+        should "generate link if country exists" do
+          link = @calc.generate_url_for_download("argentina", "pdf", "Prisoner pack")
+          assert_equal "- [Prisoner pack](http://ukinargentina.fco.gov.uk/resources/en/pdf/pdf1/prisoners-abroad){:rel=\"external\"}", link
+        end
+      end
+
       context "countries with regions" do
         should "pull the regions out of the YML for Australia" do
           resp = @calc.get_country_regions("australia")["new_south_wales"]


### PR DESCRIPTION
If generate_url_for_download is called with a country that doesn't
exist, it was raising a Ruby error. This prevents that.
