### PR TITLE
Fix flow error with Q11 -> Q16

### DIFF
--- a/lib/flows/childcare-costs-for-tax-credits.rb
+++ b/lib/flows/childcare-costs-for-tax-credits.rb
@@ -90,7 +90,7 @@ end
 #Q11
 multiple_choice :pay_same_each_time? do
   option :yes => :how_often_pay_providers? #Q12
-  option :no => :weekly_costs_are_x #Q16
+  option :no => :how_much_spent_last_12_months? #Q16
 end
 
 #Q12

--- a/test/integration/flows/childcare_costs_for_tax_credits_test.rb
+++ b/test/integration/flows/childcare_costs_for_tax_credits_test.rb
@@ -318,6 +318,24 @@ class ChildcareCostsForTaxCreditsV2Test < ActiveSupport::TestCase
       end
 
     end
+  end
+
+  context "answering Q16" do
+    setup do
+      add_response :no #Q1
+      add_response :regularly_more_than_year #Q2
+      add_response :no #Q11
+    end
+
+    should "be on Q16" do
+      assert_current_node :how_much_spent_last_12_months?
+    end
+
+    should "take user to weekly outcome" do
+      add_response 52
+      assert_state_variable :weekly_cost, 1
+      assert_current_node :weekly_costs_are_x
+    end
 
   end
 end


### PR DESCRIPTION
Was causing an interpolation error, Q11 was taking user to the outcome
rather than to Q16, and then the outcome, so the expected state variable
didn't exist. Fix and write test.
