### PR TITLE
Fix for last questions out of view

### DIFF
--- a/app/assets/javascripts/smart-answers.js
+++ b/app/assets/javascripts/smart-answers.js
@@ -107,5 +107,5 @@ $(document).ready(function() {
     }
   }
 
-  contentPosition.init()
+  contentPosition.init();
 });


### PR DESCRIPTION
Some questions are so long that when the next one replaces them (and fits on-screen) the screen position is confusing.

This simply checks for this and makes sure the page is always scrolling down enough to see the last question.

Story: https://www.pivotaltracker.com/story/show/46617897
