### PR TITLE
Remove reference to `govuk_setenv`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Testing
 ------------
 Run unit tests by executing the following:
 
-    govuk_setenv smartanswers bundle exec rake
+    bundle exec rake
 
 
 Issues/todos


### PR DESCRIPTION
This internal script shouldn't be required for development test runs.

Fixes #263.
