### PR TITLE
Prevent Ruby error if input to Q4 is nil

### DIFF
--- a/lib/flows/calculate-your-child-maintenance.rb
+++ b/lib/flows/calculate-your-child-maintenance.rb
@@ -101,7 +101,10 @@ end
 ## Q4
 value_question :how_many_other_children_in_payees_household? do
   calculate :calculator do
-    calculator.number_of_other_children = Integer(responses.last)
+    # if converting to int messes things up, raise invalid response
+    # this deals with nil input through the API
+    raise SmartAnswer::InvalidResponse if responses.last.to_i.to_s != responses.last
+    calculator.number_of_other_children = responses.last.to_i
     calculator
   end
   next_node :how_many_nights_children_stay_with_payee?

--- a/test/integration/flows/calculate_child_maintenance_test.rb
+++ b/test/integration/flows/calculate_child_maintenance_test.rb
@@ -83,6 +83,13 @@ class CalculateChildMaintentanceTest < ActiveSupport::TestCase
         should "ask how many other children there are in the payees household" do
           assert_current_node :how_many_other_children_in_payees_household?
         end
+
+        should "not raise error if given nil" do
+          # add_response converts to string, we explicitly want to test nil here
+          @responses << nil
+          assert_current_node :how_many_other_children_in_payees_household?
+          assert_current_node_is_error
+        end
       
         context "answer 3" do
           setup do


### PR DESCRIPTION
This fixes nil being passed to this Q through the API and it then erroring.
