### PR TITLE
Add reasonable upper age limit to Q3

### DIFF
--- a/lib/flows/shared_logic/minimum_wage.rb
+++ b/lib/flows/shared_logic/minimum_wage.rb
@@ -57,7 +57,7 @@ value_question :how_old_are_you? do
     # Fail-hard cast to Integer here will raise
     # an exception and show the appropriate error.
     age = Integer(responses.last)
-    if age <= 0
+    if age <= 0 || age > 200
       raise SmartAnswer::InvalidResponse
     end
     age

--- a/test/integration/flows/am_i_getting_minimum_wage_test.rb
+++ b/test/integration/flows/am_i_getting_minimum_wage_test.rb
@@ -61,6 +61,19 @@ class AmIGettingMinimumWageTest < ActiveSupport::TestCase
           assert_current_node :under_school_leaving_age
         end
       end
+
+      context "answer invalid for Q3 how old" do
+        should "not accept 0 age" do
+          add_response 0
+          assert_current_node :how_old_are_you?, :error => true
+        end
+
+        should "not accept age > 200" do
+          add_response 250
+          assert_current_node :how_old_are_you?, :error => true
+        end
+
+      end
       
       context "answered 19 to 'how old are you?'" do
         setup do


### PR DESCRIPTION
Having an error further down the line with not being able to find the right rates data, due to a really high age being put in. This adds a reasonable upper age limit to Q3 to prevent errors occurring later down the line as a result.
