### PR TITLE
Centralise more passport costs

### DIFF
--- a/lib/flows/locales/en/overseas-passports.yml
+++ b/lib/flows/locales/en/overseas-passports.yml
@@ -1733,7 +1733,7 @@ en-GB:
           -|-|-
           Renewal of adult standard 32-page passport | 7,100 Dalasi | 8,200 Dalasi
           First adult passport or replacement of lost or stolen adult passport | 7,100 Dalasi | 9,000 Dalasi
-          48-page adult passport | 8,500 Dalasi | 9,600
+          48-page adult passport | 8,500 Dalasi | 9,600 Dalasi
           Renewal of child passport | 4,500 Dalasi | 6,400 Dalasi
           First child passport | 4,500 Dalasi | 5,600 Dalasi
 


### PR DESCRIPTION
More housekeeping to keep passport costs in one place.
