### PR TITLE
Rebuild find-an-embassy smartanswer using Worldwide API

### DIFF
--- a/lib/flows/data_partials/_embassies.html.erb
+++ b/lib/flows/data_partials/_embassies.html.erb
@@ -1,0 +1,20 @@
+<%# This goes through markdown afterwards, so can't be indented too far %>
+<%- if embassies.any? -%>
+  <%- embassies.each do |embassy| -%>
+<h3><%= embassy.title %></h3>
+<div class="address">
+  <%= simple_format embassy.address.label.value %>
+</div>
+<div class="contact">
+  <%- if embassy.details.email.present? -%>
+  <p>Email: <%= embassy.details.email %></p>
+  <%- end -%>
+  <%- embassy.contact_numbers.each do |contact| -%>
+  <%# Some labels have a trailing :, some don't %>
+  <p><%= contact.label.sub(/:\s*\z/, '') %>: <%= contact.number %></p>
+  <%- end -%>
+</div>
+  <%- end -%>
+<%- else -%>
+<p>No embassy details found</p>
+<%- end -%>

--- a/lib/flows/find-a-british-embassy.rb
+++ b/lib/flows/find-a-british-embassy.rb
@@ -3,59 +3,29 @@ status :draft
 data_query = SmartAnswer::Calculators::MarriageAbroadDataQuery.new
 i18n_prefix = "flow.find-a-british-embassy"
 
-#Question
-country_select :choose_embassy_country, :use_legacy_data => true do
+country_select :choose_embassy_country do
   save_input_as :embassy_country
 
-  calculate :embassy_country_name do
-    LegacyCountry.all.find { |c| c.slug == responses.last }.name
+  calculate :location do
+    loc = WorldLocation.find(embassy_country)
+    raise InvalidResponse unless loc
+    loc
   end
-  calculate :country_name_lowercase_prefix do
-    case embassy_country
-    when 'bahamas','british-virgin-islands','cayman-islands','czech-republic','dominican-republic','falkland-islands','gambia','maldives','marshall-islands','philippines','russian-federation','seychelles','solomon-islands','south-georgia-and-south-sandwich-islands','turks-and-caicos-islands','united-states'
-      "the #{embassy_country_name}"
-    when 'korea'
-      "South #{embassy_country_name}"
+  calculate :country_name do
+    if %w(bahamas british-virgin-islands cayman-islands central-african-republic czech-republic democratic-republic-of-congo dominican-republic
+          falkland-islands gambia maldives marshall-islands netherlands philippines seychelles solomon-islands united-arab-emirates).include?(location.slug)
+      "the #{location.name}"
     else
-      embassy_country_name
+      location.name
     end
   end
-
-
-  calculate :embassies_data do
-    data_query.find_embassy_data(embassy_country)
-  end
-
-  calculate :embassies_details do
-    details = []
-    embassies_data.each do |e|
-      details << I18n.translate!("#{i18n_prefix}.phrases.embassy_details",
-                                embassy_location: e['location_name'],
-                                address: e['address'], phone: e['phone'],
-                                email: e['email'], office_hours: e['office_hours'])
-    end if embassies_data
-    details
-  end
-
-  calculate :embassies_details_single do
-    bananas = []
-    embassies_data.each do |e|
-      bananas << I18n.translate!("#{i18n_prefix}.phrases.embassy_details",
-                                embassy_location: e[''],
-                                address: e['address'], phone: e['phone'],
-                                email: e['email'], office_hours: e['office_hours'])
-    end if embassies_data
-    bananas
-  end
-
-  calculate :embassy_details do
-    if embassies_details.count{'location_name'} == 1 
-      embassies_details_single.first
+  calculate :embassies do
+    if org = location.fco_organisation
+      org.all_offices
     else
-      embassies_details.join
+      []
     end
   end
-
 
   next_node :embassy_outcome
 end

--- a/lib/flows/locales/en/find-a-british-embassy.yml
+++ b/lib/flows/locales/en/find-a-british-embassy.yml
@@ -23,31 +23,13 @@ en-GB:
         - certifying documents (like a passport or birth certificate)
         - witnessing a signature or affidavit
 
-      phrases:
-        embassy_details: |
-          %{embassy_location}
-
-
-          $A
-            %{address}
-          $A
-
-          $C
-            %{email}
-
-            %{phone}
-
-            %{office_hours}
-          $C
 #Q1
       choose_embassy_country:
         title: |
           Which country would you like details for?
-        body: |
-
 
 #outcome
       embassy_outcome:
-        title: Embassy details for %{country_name_lowercase_prefix}
+        title: Embassy details for %{country_name}
         body: |
-            %{embassy_details}
+          +[data_partial:embassies:embassies]

--- a/test/integration/flows/flow_test_helper.rb
+++ b/test/integration/flows/flow_test_helper.rb
@@ -17,6 +17,13 @@ module FlowTestHelper
     end
   end
 
+  def outcome_body
+    @outcome_body ||= begin
+      presenter = OutcomePresenter.new("flow.#{@flow.name}", @flow.node(current_state.current_node), current_state)
+      Nokogiri::HTML::DocumentFragment.parse(presenter.body)
+    end
+  end
+
   def assert_current_node(node_name, opts = {})
     opts[:error] ? assert_current_node_is_error : assert_not_error
     assert_equal node_name, current_state.current_node


### PR DESCRIPTION
There will need to be some tweaks, but it would be good to get this up on preview.

Particularly, we need to think about what happens if there are no embassy details in the API (e.g. Bahamas)
