### PR TITLE
Swap order of contact elements & add mailto

### DIFF
--- a/lib/flows/data_partials/_embassies.erb
+++ b/lib/flows/data_partials/_embassies.erb
@@ -2,14 +2,9 @@
 <%- embassies.each do |embassy| -%>
 ### <%= embassy.title %>
 
-$A
-<%= embassy.address.label.value %>
-$A
-
-
 $C
 <%- if embassy.details.email.present? -%>
-Email: <%= embassy.details.email %>
+Email: <<%= embassy.details.email.strip %>>
 
 <%- end -%>
 <%- embassy.contact_numbers.each do |contact| -%>
@@ -18,6 +13,10 @@ Email: <%= embassy.details.email %>
 
 <%- end -%>
 $C
+
+$A
+<%= embassy.address.label.value %>
+$A
 
 <%- end -%>
 <%- else -%>


### PR DESCRIPTION
The use of govspeak to generate the embassy finder result restricts the CSS we can apply but changing the order of the contact elements gives some separation between embassy blocks.
