### PR TITLE
Change IPS to Her Majesty's Passport Service

### DIFF
--- a/lib/flows/locales/en/overseas-passports.yml
+++ b/lib/flows/locales/en/overseas-passports.yml
@@ -757,16 +757,16 @@ en-GB:
           You must pay in cash using local currency - the prices above will be converted according to the exchange rate when you apply.
 
         how_long_applying_ips1: |
-          Your application will take **at least** 6 weeks from when it’s received by the Identity and Passport Service (IPS) in the UK. You may have to attend an interview for a first adult passport.
+          Your application will take **at least** 6 weeks from when it’s received by Her Majesty's Passport Service in the UK. You may have to attend an interview for a first adult passport.
 
         how_long_renewing_old_ips1: |
-          Your application will take **at least** 6 weeks from when it’s received by the Identity and Passport Service (IPS) in the UK. You may have to attend an interview for a first adult passport.
+          Your application will take **at least** 6 weeks from when it’s received by Her Majesty's Passport Service in the UK. You may have to attend an interview for a first adult passport.
 
         how_long_renewing_new_ips1: |
-          Your application will take **at least** 4 weeks from when it’s received by the Identity and Passport Service (IPS) in the UK.
+          Your application will take **at least** 4 weeks from when it’s received by Her Majesty's Passport Service in the UK.
 
         how_long_replacing_ips1: |
-          Your application will take **at least** 6 weeks from when your application is received by the Identity and Passport Service (IPS) in the UK.
+          Your application will take **at least** 6 weeks from when your application is received by Her Majesty's Passport Service in the UK.
 
           If you haven’t already reported the loss or theft, you must include form LS01 with your passport application.
 
@@ -778,7 +778,7 @@ en-GB:
         how_long_it_takes_ips1: |
           Applications may take longer if:
 
-          - the IPS needs to ask you for more information or documents
+          - Her Majesty's Passport Service needs to ask you for more information or documents
           - the photographs you send are rejected.
 
           Don’t book travel until you have a valid passport. If you need to travel more urgently, apply for an [Emergency Travel Document.](/emergency-travel-document "Get an emergency travel document")
@@ -825,11 +825,11 @@ en-GB:
         send_application_ips1: |
           ## Send your application
 
-          The IPS recommends you send your application using a secure delivery service or courier.
+          Her Majesty's Passport Service recommends you send your application using a secure delivery service or courier.
 
 
           $A
-            Identity and Passport Service
+            Her Majesty's Passport Service
             OVS-L
             101 Old Hall Street
             Liverpool
@@ -840,11 +840,11 @@ en-GB:
         send_application_ips1_belfast: |
           ## Send your application
 
-          The IPS recommends you send your application using a secure delivery service or courier.
+          Her Majesty's Passport Service recommends you send your application using a secure delivery service or courier.
 
 
           $A
-            Identity and Passport Service  
+            Her Majesty's Passport Service  
             OVS-B  
             Ground Floor  
             Law Society House  
@@ -879,16 +879,16 @@ en-GB:
           Your application will take at least **8 weeks.**
 
         how_long_renewing_new_ips2_morocco: |
-          Your application will take **at least** 4 weeks from when it’s received by the Identity and Passport Service (IPS) in the UK.
+          Your application will take **at least** 4 weeks from when it’s received by Her Majesty's Passport Service in the UK.
 
         how_long_other_ips2_morocco: |
-          Your application will take **at least** 6 weeks from when it’s received by the Identity and Passport Service (IPS) in the UK.
+          Your application will take **at least** 6 weeks from when it’s received by Her Majesty's Passport Service in the UK.
 
 
         how_long_it_takes_ips2: |
           Applications may take longer if:
 
-          - the Identity and Passport Service needs to ask you for more information or documents
+          - Her Majesty's Passport Service needs to ask you for more information or documents
           - the photographs you send are rejected
 
           Don’t book travel until you have a valid passport. If you need to travel more urgently, you may be able to apply for an [Emergency Travel Document.](/emergency-travel-document "Get an emergency travel document")
@@ -904,7 +904,7 @@ en-GB:
           $D
 
         how_long_replacing_ips2_morocco: |
-          Your application will take **at least** 6 weeks from when it’s received by the Identity and Passport Service (IPS) in the UK.
+          Your application will take **at least** 6 weeks from when it’s received by Her Majesty's Passport Service in the UK.
 
           If you haven’t already reported the loss or theft, you must include form LS01 with your passport application.
 
@@ -970,10 +970,10 @@ en-GB:
           $C
 
         how_long_applying_ips3: |
-          Your application will take **at least** 6 weeks from when it’s received by the Identity and Passport Service (IPS) in the UK. You may have to attend an interview for a first adult passport.
+          Your application will take **at least** 6 weeks from when it’s received by Her Majesty's Passport Service in the UK. You may have to attend an interview for a first adult passport.
 
         how_long_replacing_ips3: |
-          Your application will take **at least** 6 weeks from when it's received by the Identity and Passport Service (IPS) in the UK.
+          Your application will take **at least** 6 weeks from when it's received by Her Majesty's Passport Service in the UK.
 
           If you haven’t already reported the loss or theft, you must include form LS01 with your passport application.
 
@@ -983,15 +983,15 @@ en-GB:
           $D
 
         how_long_renewing_old_ips3: |
-          Your application will take **at least** 6 weeks from when it’s received by the Identity and Passport Service (IPS) in the UK. You may have to attend an interview for a first adult passport.
+          Your application will take **at least** 6 weeks from when it’s received by Her Majesty's Passport Service in the UK. You may have to attend an interview for a first adult passport.
 
         how_long_renewing_new_ips3: |
-          Your application will take **at least** 4 weeks from when it’s received by the Identity and Passport Service (IPS) in the UK.
+          Your application will take **at least** 4 weeks from when it’s received by Her Majesty's Passport Service in the UK.
 
         how_long_it_takes_ips3: |
           Applications may take longer if:
 
-          - the Identity and Passport Service needs to ask you for more information or documents
+          - Her Majesty's Passport Service needs to ask you for more information or documents
           - the photographs you send are rejected
 
           Don’t book travel until you have a valid passport. If you need to travel more urgently, you may be able to apply for an [Emergency Travel Document.](/emergency-travel-document "Get an emergency travel document")


### PR DESCRIPTION
Rename all references to IPS, Identity and Passport Service and other variants to Her Majesty's Passport Service
https://www.pivotaltracker.com/story/show/49828641
