### PR TITLE
Constrain invalid slugs in the routes.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,10 @@
 SmartAnswers::Application.routes.draw do
-  match '/:id(/:started(/*responses)).:format',
-    :to => 'smart_answers#show',
-    :as => :formatted_smart_answer,
-    :constraints => { :format => /[a-zA-Z]+/ }
+  constraints :id => /[a-z0-9-]+/i do
+    match '/:id(/:started(/*responses)).:format',
+      :to => 'smart_answers#show',
+      :as => :formatted_smart_answer,
+      :constraints => { :format => /[a-zA-Z]+/ }
 
-  match '/:id(/:started(/*responses))', :to => 'smart_answers#show', :as => :smart_answer
+    match '/:id(/:started(/*responses))', :to => 'smart_answers#show', :as => :smart_answer
+  end
 end

--- a/test/functional/routing_test.rb
+++ b/test/functional/routing_test.rb
@@ -1,0 +1,12 @@
+# encoding: UTF-8
+require_relative '../test_helper'
+
+class RoutingTest < ActionDispatch::IntegrationTest
+  include Rack::Test::Methods
+
+  should "not 404 without blowing up when given a slug with invalid UTF-8" do
+    assert_raises ActionController::RoutingError do
+      get "/non-gb-driving-licence%E2%EF%BF%BD%EF%BF%BD"
+    end
+  end
+end


### PR DESCRIPTION
This will prevent blowing up when given invalid UTF-8 etc.
