### PR TITLE
Fix ics output to do all-day and multi-day events correctly.

### DIFF
--- a/lib/ics_renderer.rb
+++ b/lib/ics_renderer.rb
@@ -18,11 +18,12 @@ class ICSRenderer
 
   def render_event(event, sequence)
     output =  "BEGIN:VEVENT\r\n"
+    # The end date is defined as non-inclusive in the RFC (2445 section 4.6.1)
     if event.date.is_a?(Range)
-      output << "DTEND;VALUE=DATE:#{ event.date.last.strftime("%Y%m%d") }\r\n"
+      output << "DTEND;VALUE=DATE:#{ (event.date.last + 1.day).strftime("%Y%m%d") }\r\n"
       output << "DTSTART;VALUE=DATE:#{ event.date.first.strftime("%Y%m%d") }\r\n"
     else
-      output << "DTEND;VALUE=DATE:#{ event.date.strftime("%Y%m%d") }\r\n"
+      output << "DTEND;VALUE=DATE:#{ (event.date + 1.day).strftime("%Y%m%d") }\r\n"
       output << "DTSTART;VALUE=DATE:#{ event.date.strftime("%Y%m%d") }\r\n"
     end
     output << "SUMMARY:#{ event.title }\r\n"

--- a/test/integration/engine/calendar_export_test.rb
+++ b/test/integration/engine/calendar_export_test.rb
@@ -30,6 +30,7 @@ class CalendarExportTest < EngineIntegrationTest
 
   def assert_calendar_has_event(start_date, stop_date = nil)
     stop_date = start_date if stop_date.nil?
+    stop_date = stop_date + 1.day
     assert_match "DTEND;VALUE=DATE:#{stop_date.strftime('%Y%m%d')}\r\nDTSTART;VALUE=DATE:#{start_date.strftime('%Y%m%d')}", page.body
   end
 end

--- a/test/unit/ics_renderer_test.rb
+++ b/test/unit/ics_renderer_test.rb
@@ -48,7 +48,7 @@ class ICSRendererTest < ActiveSupport::TestCase
       @r.expects(:uid).with(2).returns("sdaljksafd-2@gov.uk")
 
       expected =  "BEGIN:VEVENT\r\n"
-      expected << "DTEND;VALUE=DATE:20120414\r\n"
+      expected << "DTEND;VALUE=DATE:20120415\r\n"
       expected << "DTSTART;VALUE=DATE:20120414\r\n"
       expected << "SUMMARY:An Event\r\n"
       expected << "UID:sdaljksafd-2@gov.uk\r\n"
@@ -65,7 +65,7 @@ class ICSRendererTest < ActiveSupport::TestCase
       @r.expects(:uid).with(2).returns("sdaljksafd-2@gov.uk")
 
       expected =  "BEGIN:VEVENT\r\n"
-      expected << "DTEND;VALUE=DATE:20120418\r\n"
+      expected << "DTEND;VALUE=DATE:20120419\r\n"
       expected << "DTSTART;VALUE=DATE:20120414\r\n"
       expected << "SUMMARY:An Event\r\n"
       expected << "UID:sdaljksafd-2@gov.uk\r\n"


### PR DESCRIPTION
RFC 2445 (section 4.6.1) specifies that a VEVENT end date is
non-inclusive, therefore for all-day or multi-day events, the end date should be the
following day.
