### PR TITLE
Fix calendar date leaks

### DIFF
--- a/app/controllers/smart_answers_controller.rb
+++ b/app/controllers/smart_answers_controller.rb
@@ -21,7 +21,7 @@ class SmartAnswersController < ApplicationController
       format.ics {
         if @presenter.current_node.respond_to?(:calendar) and @presenter.current_node.has_calendar?
           response.headers['Content-Disposition'] = "attachment; filename=\"#{@name.to_s}.ics\""
-          render :text => @presenter.current_node.calendar_as_ics, :layout => false
+          render :text => @presenter.current_node.calendar.to_ics, :layout => false
         else
           render_404
         end

--- a/app/presenters/outcome_presenter.rb
+++ b/app/presenters/outcome_presenter.rb
@@ -18,15 +18,11 @@ class OutcomePresenter < NodePresenter
   end
 
   def calendar
-    @node.defined_calendar
+    @node.evaluate_calendar(@state)
   end
 
   def has_calendar?
     calendar.present?
-  end
-
-  def calendar_as_ics
-    calendar.to_ics @node.evaluate_calendar(@state)
   end
 
   private

--- a/lib/smart_answer/calendar.rb
+++ b/lib/smart_answer/calendar.rb
@@ -10,10 +10,5 @@ module SmartAnswer
     def evaluate(state)
       return CalendarState.new(state, &@block)
     end
-
-    def to_ics(calendar_state)
-      ICSRenderer.new(calendar_state.dates, calendar_state.path).render
-    end
-
   end
 end

--- a/lib/smart_answer/calendar_state.rb
+++ b/lib/smart_answer/calendar_state.rb
@@ -17,5 +17,8 @@ module SmartAnswer
       @state.path.join('/')
     end
 
+    def to_ics
+      ICSRenderer.new(self.dates, self.path).render
+    end
   end
 end

--- a/lib/smart_answer/outcome.rb
+++ b/lib/smart_answer/outcome.rb
@@ -12,10 +12,6 @@ module SmartAnswer
       @calendar = Calendar.new(&block)
     end
 
-    def defined_calendar
-      @calendar
-    end
-
     def evaluate_calendar(state)
       @calendar.evaluate(state) if @calendar
     end

--- a/test/unit/calendar_state_test.rb
+++ b/test/unit/calendar_state_test.rb
@@ -34,5 +34,17 @@ module SmartAnswer
       calendar_state = CalendarState.new(state)
       assert_equal "example/result/question", calendar_state.path
     end
+
+    test "can create an ics renderer with a calendar state" do
+      calendar_state = CalendarState.new(@state)
+      calendar_state.stubs(:dates).returns([:date_one, :date_two])
+
+      stub_renderer = stub(:render => "calendar output")
+
+      ICSRenderer.any_instance.stubs(:dtstamp).returns("20121017T0100Z")
+      ICSRenderer.expects(:new).with([:date_one, :date_two], "example").returns(stub_renderer)
+
+      assert_equal "calendar output", calendar_state.to_ics
+    end
   end
 end

--- a/test/unit/calendar_test.rb
+++ b/test/unit/calendar_test.rb
@@ -18,18 +18,5 @@ module SmartAnswer
 
       assert_equal "Calendar state", calendar_state
     end
-
-    test "can create an ics renderer with a calendar state" do
-      calendar = Calendar.new
-      calendar_state = CalendarState.new(@state)
-      calendar_state.stubs(:dates).returns([:date_one, :date_two])
-
-      stub_renderer = stub(:render => "calendar output")
-
-      ICSRenderer.any_instance.stubs(:dtstamp).returns("20121017T0100Z")
-      ICSRenderer.expects(:new).with([:date_one, :date_two], "example").returns(stub_renderer)
-
-      assert_equal "calendar output", calendar.to_ics(calendar_state)
-    end
   end
 end


### PR DESCRIPTION
We found a bug in the calendar class which persists the dates from one request in the calendar output of another. 

It feels cleaner to separate out the definition of the calendar and the state of the calendar in each request. This pull request creates a new class, `CalendarState`, which contains the dates and a pointer to the wider state of the flow.
