### PR TITLE
Trigger smartanswerOutcome at result step

### DIFF
--- a/app/assets/javascripts/smart-answers.js
+++ b/app/assets/javascripts/smart-answers.js
@@ -97,7 +97,7 @@ $(document).ready(function() {
     $('.smart_answer section').html(fragment);
     $.event.trigger('smartanswerAnswer');
     if ($(".outcome").length !== 0) {
-      $.event.trigger('smartanswerAnswer');
+      $.event.trigger('smartanswerOutcome');
     }
   }
 


### PR DESCRIPTION
The 'smartanswerAnswer' event incorrectly replaced 'smartanswerOutcome' in this commit:

https://github.com/alphagov/smart-answers/commit/18b773509702533e1ddc945b6dfe62da78a87679#L0L73

Now fixed and tested to ensure the code attached to 'smartanswerOutcome' in https://github.com/alphagov/static/blob/master/app/assets/javascripts/analytics/tracking.js works.
