### PR TITLE
Use the last smp lower earning limit as the default

### DIFF
--- a/lib/smart_answer/calculators/maternity_paternity_calculator.rb
+++ b/lib/smart_answer/calculators/maternity_paternity_calculator.rb
@@ -95,7 +95,7 @@ module SmartAnswer::Calculators
 
     def lower_earning_limit_birth
       earning_limit_rate = earning_limit_rates_birth.find { |c| c[:min] <= @due_date and c[:max] >= @due_date }
-      (earning_limit_rate ? earning_limit_rate[:lower_earning_limit_rate] : 107)
+      (earning_limit_rate ? earning_limit_rate[:lower_earning_limit_rate] : earning_limit_rates_birth.last[:lower_earning_limit_rate])
     end
 
     def earning_limit_rates_adoption

--- a/test/unit/calculators/maternity_paternity_calculator_test.rb
+++ b/test/unit/calculators/maternity_paternity_calculator_test.rb
@@ -138,7 +138,13 @@ module SmartAnswer::Calculators
           @calculator = MaternityPaternityCalculator.new(@due_date)
           assert_equal @calculator.lower_earning_limit, 109
         end
-
+        
+        should "return 109 for due dates after 14/07/2014" do
+          @due_date = Date.parse("14 July 2015")
+          @calculator = MaternityPaternityCalculator.new(@due_date)
+          assert_equal @calculator.lower_earning_limit, 109
+        end
+        
         should "return lower_earning_limit 107" do
           @due_date = Date.parse("15 July 2012")
           @calculator = MaternityPaternityCalculator.new(@due_date)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/52870305
Ensures that future dates not accounted for in lower earning limit ranges default to using the latest amount.
