### PR TITLE
Bump toolkit to 0.32.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'rails', '3.2.13'
 gem 'rails-i18n'
 gem 'json'
 gem 'plek', '1.1.0'
-gem 'govuk_frontend_toolkit', '0.3.3'
+gem 'govuk_frontend_toolkit', '0.32.2'
 gem 'aws-ses', :require => 'aws/ses' # Needed by exception_notification
 gem 'exception_notification', '2.6.1'
 gem 'lograge', '~> 0.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
     govspeak (0.8.15)
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
-    govuk_frontend_toolkit (0.3.3)
+    govuk_frontend_toolkit (0.32.2)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     hike (1.2.3)
@@ -217,7 +217,7 @@ DEPENDENCIES
   gds-api-adapters (= 7.2.0)
   google-api-client
   govspeak (~> 0.8.15)
-  govuk_frontend_toolkit (= 0.3.3)
+  govuk_frontend_toolkit (= 0.32.2)
   htmlentities (~> 4)
   json
   lograge (~> 0.1.0)


### PR DESCRIPTION
Continuation of this work: https://github.com/alphagov/static/pull/270

Associated with (though they don't need to be merged simultaneously):

https://github.com/alphagov/business-support-finder/pull/31
https://github.com/alphagov/calendars/pull/37
https://github.com/alphagov/design-principles/pull/47
https://github.com/alphagov/feedback/pull/53
https://github.com/alphagov/licence-finder/pull/36
https://github.com/alphagov/trade-tariff-frontend/pull/80
https://github.com/alphagov/transaction-wrappers/pull/28
