### PR TITLE
Fixed link in do_not_qualify outcome

### DIFF
--- a/lib/flows/locales/en/energy-grants-calculator.yml
+++ b/lib/flows/locales/en/energy-grants-calculator.yml
@@ -100,5 +100,5 @@ en-GB:
         body: |
           $!Based on your answers you aren’t eligible for help with your energy bills.$!
 
-          You might be able to use [Green Deal](/green-deal-energy-saving-measures “Green Deal”) - energy saving improvements to your home or business
+          You might be able to use [Green Deal](/green-deal-energy-saving-measures "Green Deal") - energy saving improvements to your home or business
 


### PR DESCRIPTION
Curly brackets around the link title were breaking markdown
