### PR TITLE
Refactor - DRY the worldwide org office selection

### DIFF
--- a/app/models/worldwide_organisation.rb
+++ b/app/models/worldwide_organisation.rb
@@ -22,4 +22,13 @@ class WorldwideOrganisation
   def fco_sponsored?
     @data.sponsors.any? {|s| s.details.acronym == "FCO" }
   end
+
+  def offices_with_service(service_title)
+    return [] unless all_offices.any?
+    embassies = all_offices.select do |o|
+      o.services.any? { |s| s.title.include?(service_title) }
+    end
+    embassies << main_office if embassies.empty?
+    embassies
+  end
 end

--- a/lib/flows/overseas-passports.rb
+++ b/lib/flows/overseas-passports.rb
@@ -53,17 +53,13 @@ multiple_choice :renewing_replacing_applying? do
   end
 
   calculate :overseas_passports_embassies do
-    if organisation && organisation.all_offices.any?
-      embassies = organisation.all_offices.select do |o| 
-        o.services.any? { |s| s.title.include?('Overseas Passports Service') }
-      end
-      embassies << organisation.main_office if embassies.empty?
-      embassies
+    if organisation
+      organisation.offices_with_service 'Overseas Passports Service'
     else
       []
     end
   end
-  
+
   calculate :general_action do
     responses.last =~ /^renewing_/ ? 'renewing' : responses.last
   end
@@ -482,12 +478,8 @@ outcome :cannot_apply do
   end
 
   precalculate :overseas_passports_embassies do
-    if organisation && organisation.all_offices.any?
-      embassies = organisation.all_offices.select do |o| 
-        o.services.any? { |s| s.title.include?('Overseas Passports Service') }
-      end
-      embassies << organisation.main_office if embassies.empty?
-      embassies
+    if organisation
+      organisation.offices_with_service 'Overseas Passports Service'
     else
       []
     end

--- a/lib/flows/register-a-birth.rb
+++ b/lib/flows/register-a-birth.rb
@@ -234,12 +234,8 @@ outcome :embassy_result do
     location.fco_organisation
   end
   precalculate :overseas_passports_embassies do
-    if organisation && organisation.all_offices.any?
-      embassies = organisation.all_offices.select do |o| 
-        o.services.any? { |s| s.title.include?('Births and Deaths registration service') }
-      end
-      embassies << organisation.main_office if embassies.empty?
-      embassies
+    if organisation
+      organisation.offices_with_service 'Births and Deaths registration service'
     else
       []
     end

--- a/lib/flows/register-a-death.rb
+++ b/lib/flows/register-a-death.rb
@@ -252,12 +252,8 @@ outcome :embassy_result do
     location.fco_organisation
   end
   precalculate :overseas_passports_embassies do
-    if organisation && organisation.all_offices.any?
-      embassies = organisation.all_offices.select do |o| 
-        o.services.any? { |s| s.title.include?('Births and Deaths registration service') }
-      end
-      embassies << organisation.main_office if embassies.empty?
-      embassies
+    if organisation
+      organisation.offices_with_service 'Births and Deaths registration service'
     else
       []
     end


### PR DESCRIPTION
This is to simplify further work.
I noticed there was repetition of code for finding an office based on
the services it provides so have made this available as a method of the
worldwide_organisation model.

Also adds tests for new method and DRY's the loading of the test data
(aka fixture).

I was looking at this because the lost/stolen passport tool will need
to reuse this functionality when it starts using the API to get embassy
information.
