### PR TITLE
Removing Spain trial from overseas passports tool

### DIFF
--- a/lib/flows/locales/en/overseas-passports.yml
+++ b/lib/flows/locales/en/overseas-passports.yml
@@ -74,16 +74,6 @@ en-GB:
           $D
           [Download 'Form LS01 - Lost or stolen passport notification' (PDF, 236KB)](http://www.direct.gov.uk/prod_consum_dg/groups/dg_digitalassets/@dg/@en/@travel/documents/digitalasset/dg_175799.pdf)
           $D
-        spain_pay_online_trial: |
-
-          ###Apply online
-
-          From 9 September 2013, you can [apply and pay for a passport online](https://www.smartsurvey.co.uk/s/applicationtrial) for a limited period of time.
-
-          This is while a new service is being trialled, making it easier to apply.
-
-          ###Apply by post
-
         passport_courier_costs_wellington_new_zealand: |
 
         adult_passport_costs_wellington_new_zealand: |
@@ -2771,8 +2761,6 @@ en-GB:
           %{cost}
 
           ## How to apply
-
-          %{apply_online_spain_trial}
 
           %{how_to_apply}
 

--- a/lib/flows/overseas-passports.rb
+++ b/lib/flows/overseas-passports.rb
@@ -278,14 +278,6 @@ outcome :ips_application_result do
     end
   end
 
-  precalculate :apply_online_spain_trial do
-    if %w(spain).include?(current_location)
-      if child_or_adult == 'adult' and general_action == 'applying' or application_action == 'renewing_new'
-        PhraseList.new(:spain_pay_online_trial)
-      end
-    end
-  end
-
   precalculate :how_to_apply do
     PhraseList.new(:"how_to_apply_ips#{ips_number}",
                    application_form.to_sym,

--- a/test/integration/flows/overseas_passports_test.rb
+++ b/test/integration/flows/overseas_passports_test.rb
@@ -992,19 +992,4 @@ class OverseasPassportsTest < ActiveSupport::TestCase
     end
   end # Djibouti
 
-  context "answer Spain, renewing_new, child passport" do
-    should "give the spain apply online trial phrase" do
-      worldwide_api_has_organisations_for_location('spain', read_fixture_file('worldwide/spain_organisations.json'))
-      add_response 'spain'
-      add_response 'renewing_new'
-      add_response 'child'
-      assert_current_node :ips_application_result
-      assert_phrase_list :apply_online_spain_trial, [:spain_pay_online_trial]
-      expected_location = WorldLocation.find('spain')
-      assert_state_variable :location, expected_location
-      assert_state_variable :organisation, expected_location.fco_organisation
-      assert_match /Law Society House/, outcome_body
-    end
-  end # Spain
-
 end


### PR DESCRIPTION
The paying online trial ends this week so this change will be deployed on Monday.
