### PR TITLE
Update holiday entitlement calculator to restore 'leaving' option

### DIFF
--- a/lib/flows/calculate-your-holiday-entitlement-v2.rb
+++ b/lib/flows/calculate-your-holiday-entitlement-v2.rb
@@ -16,13 +16,16 @@ end
 multiple_choice :calculation_period? do
   option "full-year"
   option "starting"
+  option "leaving"
   option "starting-and-leaving"
   save_input_as :holiday_period
 
   next_node do |response|
     case response
     when "starting", "starting-and-leaving"
-      :what_is_your_starting_date?      
+      :what_is_your_starting_date?
+    when "leaving"
+      :what_is_your_leaving_date?
     else
       calculation_basis == "days-worked-per-week" ? :how_many_days_per_week? : :how_many_hours_per_week?
     end
@@ -226,6 +229,7 @@ end
 multiple_choice :shift_worker_basis? do
   option "full-year" => :shift_worker_hours_per_shift?
   option "starting" => :what_is_your_starting_date?
+  option "leaving" => :what_is_your_leaving_date?
   option "starting-and-leaving" => :what_is_your_starting_date?
   save_input_as :holiday_period
 end
@@ -241,7 +245,7 @@ end
 
 value_question :shift_worker_shifts_per_shift_pattern? do
   calculate :shifts_per_shift_pattern do
-    shifts = responses.last.to_i
+    shifts = Integer(responses.last)
     raise InvalidResponse if shifts <=0
     shifts
   end

--- a/lib/flows/locales/en/calculate-your-holiday-entitlement-v2.yml
+++ b/lib/flows/locales/en/calculate-your-holiday-entitlement-v2.yml
@@ -7,7 +7,7 @@ en-GB:
       body: |
         Calculate statutory holiday entitlement in days or hours for a full leave year or work out holiday someone is entitled to when they start or leave a job part way through a leave year.
       phrases:
-         
+
         answer_days: |
           $!The statutory holiday entitlement is %{holiday_entitlement_days} days holiday.$!
 
@@ -53,12 +53,13 @@ en-GB:
         "shift-worker": "shifts"
         "full-year": "for a full leave year"
         "starting": "for someone starting part way through a leave year"
+        "leaving": "for someone leaving part way through a leave year"
         "starting-and-leaving": "for someone starting and leaving part way through a leave year"
         "5-days": "5 days per week"
         "6-days": "6 days per week"
         "6-or-7-days": "6 or 7 days per week"
         "7-days": "7 days per week"
-      
+
       # Q1
       basis_of_calculation?:
         title: "Is the holiday entitlement based on:"
@@ -94,6 +95,7 @@ en-GB:
         title: Number of days per week worked?
         label: Days per week
         error_message: Please check and enter a correct value. Don't enter fractions. If you work half-days, enter .5 for half. eg 4.5
+
       # Q11
       casual_or_irregular_hours?:
         title: How many hours have been worked in this leave year?
@@ -106,9 +108,11 @@ en-GB:
         hint: This is calculated by excluding statutory entitlement. This calculation isn't suitable for term-time workers.
         label: Hours per year
         error_message: You need to enter a number greater than 0. Don't enter fractions. If you work half-hours, enter .5 for half. eg 340.5
+
       # Q15
       shift_worker_basis?:
         title: "Do you want to calculate the holiday:"
+
       shift_worker_hours_per_shift?:
         title: How many hours in each shift?
         label: Hours per shift
@@ -118,6 +122,7 @@ en-GB:
         title: How many shifts will be worked per shift pattern?
         label: Shifts per pattern
         error_message: You need to enter a number greater than 0
+
       # Q20
       shift_worker_days_per_shift_pattern?:
         title: How many days in the shift pattern?

--- a/lib/smart_answer/calculators/holiday_entitlement_v2.rb
+++ b/lib/smart_answer/calculators/holiday_entitlement_v2.rb
@@ -117,6 +117,8 @@ module SmartAnswer::Calculators
       
       if start_date and leaving_date
         (Date.parse(leaving_date) - Date.parse(start_date) + 1) / days_divide
+      elsif leaving_date
+        (Date.parse(leaving_date) - leave_year_start + 1) / days_divide
       else
         (leave_year_end - Date.parse(start_date) + 1) / days_divide
       end

--- a/test/integration/flows/calculate_your_holiday_entitlement_v2_test.rb
+++ b/test/integration/flows/calculate_your_holiday_entitlement_v2_test.rb
@@ -140,6 +140,75 @@ class CalculateYourHolidayEntitlementV2Test < ActiveSupport::TestCase
       end # with a start date
     end # starting this year
 
+    context "leaving this year" do
+      setup do
+        add_response 'leaving'
+      end
+
+      should "ask when you are leaving" do
+        assert_current_node :what_is_your_leaving_date?
+      end
+
+      context "with a date" do
+        setup do
+          add_response "#{Date.today.year}-07-14"
+        end
+
+        should "ask when your leave year starts" do
+          assert_current_node :when_does_your_leave_year_start?
+        end
+
+        context "with a leave year start date" do
+          setup do
+            add_response "#{Date.today.year}-01-01"
+          end
+
+          should "ask how many days per week you work" do
+            assert_current_node :how_many_days_per_week?
+          end
+
+          should "calculate and be done part year when 5 days" do
+            SmartAnswer::Calculators::HolidayEntitlementV2.
+              expects(:new).
+              with(
+                :days_per_week => 5,
+                :start_date => nil,
+                :leaving_date => "#{Date.today.year}-07-14",
+                :leave_year_start_date => "#{Date.today.year}-01-01"
+              ).
+              returns(@stubbed_calculator)
+            @stubbed_calculator.expects(:formatted_full_time_part_time_days).returns('formatted days')
+
+            add_response '5'
+            assert_current_node :done
+            assert_state_variable :holiday_entitlement_days, 'formatted days'
+            assert_phrase_list :content_sections, [:answer_days, :your_employer_with_rounding]
+            assert_state_variable :days_per_week, 5
+          end
+
+          should "calculate and be done part year when 6 days" do
+            SmartAnswer::Calculators::HolidayEntitlementV2.
+              expects(:new).
+              with(
+                :days_per_week => 5,
+                :start_date => nil,
+                :leaving_date => "#{Date.today.year}-07-14",
+                :leave_year_start_date => "#{Date.today.year}-01-01"
+              ).
+              returns(@stubbed_calculator)
+            @stubbed_calculator.expects(:formatted_full_time_part_time_days).returns('formatted days')
+            @stubbed_calculator.expects(:full_time_part_time_days).returns(29)
+
+            add_response '6'
+            assert_current_node :done
+            assert_state_variable :holiday_entitlement_days, 'formatted days'
+            assert_phrase_list :content_sections, [:answer_days, :maximum_days_calculated, :your_employer_with_rounding]
+            assert_state_variable :days_per_week, 6
+          end
+        end # with a leave year start date
+      end # with a start date
+    end # leaving this year
+
     context "starting and leaving within a leave year" do
       setup do
         add_response 'starting-and-leaving'
@@ -260,6 +329,53 @@ class CalculateYourHolidayEntitlementV2Test < ActiveSupport::TestCase
               assert_current_node :done
               assert_state_variable "holiday_entitlement_hours", 79
               assert_state_variable "holiday_entitlement_minutes", 30
+              assert_phrase_list :content_sections, [:answer_hours, :your_employer_with_rounding]
+            end
+          end
+        end
+      end
+    end
+
+    context "answer leaving part way through the leave year" do
+      setup do
+        add_response "leaving"
+      end
+      should "ask for the employment end date" do
+        assert_current_node :what_is_your_leaving_date?
+      end
+      context "answer 2012-06-15" do
+        setup do
+          add_response '2012-06-15'
+        end
+        should "ask when the leave year started" do
+          assert_current_node :when_does_your_leave_year_start?
+        end
+        context "answer 2012-01-01" do
+          setup do
+            add_response '2012-01-01'
+          end
+          should "ask the number of hours worked per week" do
+            assert_current_node :how_many_hours_per_week?
+          end
+          context "answer 26.5" do
+            setup do
+              add_response '26.5'
+            end
+            should "calculate the holiday entitlement" do
+              SmartAnswer::Calculators::HolidayEntitlementV2.
+                expects(:new).
+                with(
+                  :hours_per_week => 26.5,
+                  :start_date => nil,
+                  :leaving_date => "2012-06-15",
+                  :leave_year_start_date => "2012-01-01"
+                ).
+                returns(@stubbed_calculator)
+              @stubbed_calculator.expects(:full_time_part_time_hours).returns(19.75)
+
+              assert_current_node :done
+              assert_state_variable "holiday_entitlement_hours", 19
+              assert_state_variable "holiday_entitlement_minutes", 45
               assert_phrase_list :content_sections, [:answer_hours, :your_employer_with_rounding]
             end
           end
@@ -564,6 +680,80 @@ class CalculateYourHolidayEntitlementV2Test < ActiveSupport::TestCase
         end # with a leave year start date
       end # with a date
     end # starting this year
+
+    context "leaving this year" do
+      setup do
+        add_response 'leaving'
+      end
+
+      should "ask your leaving date" do
+        assert_current_node :what_is_your_leaving_date?
+      end
+
+      context "with a date" do
+        setup do
+          add_response "#{Date.today.year}-02-16"
+        end
+
+        should "ask when your leave year starts" do
+          assert_current_node :when_does_your_leave_year_start?
+        end
+
+        context "with a leave year start date" do
+          setup do
+            add_response "#{Date.today.year}-08-01"
+          end
+
+          should "ask how many hours in each shift" do
+            assert_current_node :shift_worker_hours_per_shift?
+          end
+
+          should "ask how many shifts per shift pattern" do
+            add_response '8'
+            assert_current_node :shift_worker_shifts_per_shift_pattern?
+          end
+
+          should "ask how many days per shift pattern" do
+            add_response '8'
+            add_response '4'
+            assert_current_node :shift_worker_days_per_shift_pattern?
+          end
+
+          should "be done when all entered" do
+            add_response '7'
+            add_response '4'
+            add_response '8'
+
+            SmartAnswer::Calculators::HolidayEntitlementV2.
+              expects(:new).
+              with(
+                :start_date => nil,
+                :leaving_date => "#{Date.today.year}-02-16",
+                :leave_year_start_date => "#{Date.today.year}-08-01",
+                :hours_per_shift => 7,
+                :shifts_per_shift_pattern => 4,
+                :days_per_shift_pattern => 8
+            ).
+              returns(@stubbed_calculator)
+            @stubbed_calculator.expects(:formatted_shifts_per_week).returns('shifts per week')
+            @stubbed_calculator.expects(:formatted_shift_entitlement).returns('some shifts')
+            @stubbed_calculator.expects(:formatted_fraction_of_year).returns('fraction of year')
+
+            assert_current_node :done
+
+            assert_state_variable :hours_per_shift, '7'
+            assert_state_variable :shifts_per_shift_pattern, 4
+            assert_state_variable :days_per_shift_pattern, 8
+
+            assert_state_variable :shifts_per_week, 'shifts per week'
+            assert_state_variable :holiday_entitlement_shifts, 'some shifts'
+            assert_state_variable :fraction_of_year, 'fraction of year'
+
+            assert_phrase_list :content_sections, [:answer_shift_worker, :your_employer_with_rounding]
+          end
+        end # with a leave year start date
+      end # with a date
+    end # leaving this year
 
     context "starting and leaving this year" do
       setup do


### PR DESCRIPTION
We removed the 'leaving partway through a leave year' as part of a previous story. 
Now we're putting it back. 
Also adding the fraction parsing fix.
