### PR TITLE
Remove legacy 'Getting your passport' phrases

### DIFF
--- a/lib/flows/locales/en/overseas-passports.yml
+++ b/lib/flows/locales/en/overseas-passports.yml
@@ -1704,9 +1704,6 @@ en-GB:
         making_application_cameroon_replacing: |
           You must bring your application in person to the British High Commission in Yaounde.
 
-        getting_your_passport_cameroon: |
-          The British High Commission will contact you when your passport arrives using the contact details on your form. You must collect it in person.
-
         getting_your_passport_congo: |
           The Honorary Consul in Brazzaville will contact you when your passport arrives using the contact details on your form. You must collect it in person.
 
@@ -1751,9 +1748,6 @@ en-GB:
           You must make your application in person at the British embassy in Asmara.
 
           If you’re renewing a passport, you must bring your most recent passport with you.
-
-        getting_your_passport_eritrea: |
-          The British embassy will contact you when your passport and supporting documents arrive using the contact details on your form. You must collect them in person.
 
         how_long_ethiopia: |
           Action | Minimum time after you apply
@@ -1864,8 +1858,6 @@ en-GB:
 
         supporting_documents_gambia: ''
         making_application_gambia: ''
-        getting_your_passport_gambia: |
-          The British High Commission in Banjul will contact you when your passport arrives, using the contact details on your form. You must collect it in person from the High Commission.
 
         how_long_ghana: |
           Action | Minimum time after you apply


### PR DESCRIPTION
These were duplicate YAML keys which prevented new content from showing.
https://www.pivotaltracker.com/story/show/58174578
