### PR TITLE
Remove encodeURI call as jquery params method is enough

### DIFF
--- a/app/assets/javascripts/smart-answers.js
+++ b/app/assets/javascripts/smart-answers.js
@@ -68,7 +68,7 @@ $(document).ready(function() {
       data: params,
       timeout: 5000,
       error: function(jqXHR, textStatus, errorStr) {
-        var paramStr = encodeURI($.param(params));
+        var paramStr = $.param(params);
         redirectToNonAjax(url.replace('.json', '?' + paramStr));
       },
       success: function(data, textStatus, jqXHR) {


### PR DESCRIPTION
A couple of zendesk tickets related to this https://govuk.zendesk.com/agent/#/tickets/302399 and https://govuk.zendesk.com/agent/#/tickets/278565
The problem affects date selections in Smartanswers where the ajax error callback is triggered. This was leading to the resulting params being double encoded because of encodeURI + $.param(...).
