### PR TITLE
Reverting the latest PIP changes as they aren't ready to be published yet

### DIFF
--- a/lib/flows/locales/en/pip-checker.yml
+++ b/lib/flows/locales/en/pip-checker.yml
@@ -59,30 +59,35 @@ en-GB:
 
       result_4:
         body: |
-          $!You shouldn't be affected by Personal Independence Payment (PIP) until 2015 or later, but there are some exceptions.$!
+          $!You can continue to claim Disability Living Allowance (DLA) for the child until they turn 16.$!
 
-          You don't need to do anything now - you'll get a letter in 2015 or later explaining:
+          ##After they turn 16
 
-          + what will happen to your Disability Living Allowance (DLA)
-          + how you can claim PIP
+          Their claim probably won't be affected by Personal Independence Payment (PIP) until 2015 or later, but there are some exceptions.
 
-          ##Exceptions
+          They'll be asked to make a claim for PIP if after October 2013:
 
-          You'll be asked to make a claim for PIP if after 28 October 2013 you live in Wales, East Midlands, West Midlands or East Anglia and one of the following happen:
+          * there’s a change in how their condition affects them
+          * their DLA is due to end and they haven't received a renewal letter
 
-          + there’s a change in how your condition affects you
-          + your DLA is due to end and you haven't received a renewal letter
+          Unless either of these happen – you don't need to do anything. You'll get a letter in 2015 or later explaining:
+
+          * what will happen to their DLA
+          * how they can claim PIP
 
           *[PIP]: Personal Independence Payment
           *[DLA]: Disability Living Allowance
 
       result_5:
         body: |
-          $!You can continue to claim Disability Living Allowance (DLA) for the child for now – but there are some exceptions.$!
- 
-          ##Exceptions
- 
-          If they live in Wales, East Midlands, West Midlands or East Anglia they will be invited to claim Personal Independence Payment on or shortly after they turn 16.
+          $!You can continue to claim Disability Living Allowance (DLA) for the child until they turn 16.$!
+
+          You don't have to do anything now.
+
+          Closer to their 16th birthday you'll get a letter explaining:
+
+          * what will happen to their DLA
+          * how they can claim Personal Independence Payment
 
           *[DLA]: Disability Living Allowance
 
@@ -96,17 +101,15 @@ en-GB:
         body: |
           $!You shouldn't be affected by Personal Independence Payment (PIP) until 2015 or later, but there are some exceptions.$!
 
-          You don't need to do anything now - you'll get a letter in 2015 or later explaining:
+          You'll be asked to make a claim for PIP if after October 2013:
 
-          + what will happen to your Disability Living Allowance (DLA)
-          + how you can claim PIP
+          * there’s a change in how your condition affects you
+          * your Disability Living Allowance (DLA) is due to end and you haven't received a renewal letter
 
-          ##Exceptions
+          Unless either of these happen – you don't need to do anything. You'll get a letter in 2015 or later explaining:
 
-          You'll be asked to make a claim for PIP if after 28 October 2013 you live in Wales, East Midlands, West Midlands or East Anglia and one of the following happen:  
-
-          + there’s a change in how your condition affects you
-          + your DLA is due to end and you haven't received a renewal letter
+          * what will happen to your DLA
+          * how you can claim PIP
 
           *[PIP]: Personal Independence Payment
           *[DLA]: Disability Living Allowance


### PR DESCRIPTION
The Student Finance changes need to go out today but they are behind the PIP changes in the Smart-answers pipeline. This will take the PIP changes out.
