### PR TITLE
Add PIP DLA exceptions paragraph

### DIFF
--- a/lib/flows/locales/en/pip-checker-v2.yml
+++ b/lib/flows/locales/en/pip-checker-v2.yml
@@ -84,7 +84,10 @@ en-GB:
  
           If they live in Wales, East Midlands, West Midlands or East Anglia they will be invited to claim Personal Independence Payment on or shortly after they turn 16.
 
+          If they live in other parts of the country, DWP will write to them shortly after they turn 16 to let them know if they'll be invited to claim PIP or continue on DLA.
+
           *[DLA]: Disability Living Allowance
+          *[DWP]: Department for Work and Pensions
 
       result_6:
         body: |

--- a/test/integration/flows/pip_checker_v2_test.rb
+++ b/test/integration/flows/pip_checker_v2_test.rb
@@ -62,6 +62,7 @@ class PIPCheckerV2Test < ActiveSupport::TestCase
     should "be result 5 if born on or after 07-10-1997" do
       add_response '1997-10-07'
       assert_current_node :result_5
+      assert_match /DWP/, outcome_body
     end
 
     should "be result 7 if born between 09-04-1948 and 07-04-1997" do


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/59314248
For people who will turn 16 after 7 October 2013 and get DLA
explain that DWP will contact them shortly after their 16th birthday.
