### PR TITLE
Change flat weekly rate of child maintenance

### DIFF
--- a/lib/smart_answer/calculators/child_maintenance_calculator.rb
+++ b/lib/smart_answer/calculators/child_maintenance_calculator.rb
@@ -5,7 +5,7 @@ module SmartAnswer::Calculators
     attr_accessor :income, :number_of_other_children, :number_of_shared_care_nights
     
     OLD_SCHEME_BASE_AMOUNT = 5
-    NEW_SCHEME_BASE_AMOUNT = 5
+    NEW_SCHEME_BASE_AMOUNT = 7
     OLD_SCHEME_MINIMUM_REDUCED_BASIC = 5
     REDUCED_RATE_THRESHOLD = 100
     BASIC_PLUS_RATE_THRESHOLD = 800

--- a/test/integration/flows/calculate_child_maintenance_test.rb
+++ b/test/integration/flows/calculate_child_maintenance_test.rb
@@ -135,7 +135,7 @@ class CalculateChildMaintentanceTest < ActiveSupport::TestCase
       context "answer 100" do
         should "give flat rate result" do
           add_response 100
-          assert_state_variable "flat_rate_amount", 5
+          assert_state_variable "flat_rate_amount", 7
           assert_current_node :flat_rate_result
         end
 

--- a/test/unit/calculators/child_maintenance_calculator_test.rb
+++ b/test/unit/calculators/child_maintenance_calculator_test.rb
@@ -94,7 +94,7 @@ module SmartAnswer::Calculators
         @calculator.number_of_shared_care_nights = 0
         assert_equal 0.235, @calculator.reduced_rate_multiplier
         assert_equal 0, @calculator.shared_care_multiplier
-        assert_equal 22, @calculator.calculate_reduced_rate_payment ##22.15 unrounded
+        assert_equal 24, @calculator.calculate_reduced_rate_payment ##22.15 unrounded
       end
     end
     


### PR DESCRIPTION
Note that the rate for the old scheme (2003) has not been increased as this scheme logic will be removed as part of https://www.pivotaltracker.com/s/projects/537731/stories/60858218 which is also to be deployed on November 25.
