### PR TITLE
Revert Student finance form finder copy changes...

### DIFF
--- a/lib/flows/locales/en/student-finance-forms.yml
+++ b/lib/flows/locales/en/student-finance-forms.yml
@@ -37,7 +37,7 @@ en-GB:
 
         The forms are different for students from [Scotland](http://www.saas.gov.uk), [Wales](http://www.studentfinancewales.co.uk) and [Northern Ireland.](http://www.studentfinanceni.co.uk)
 
-        For braille or alternative formats contact the helpline. If you email, include your contact details and the format you need.
+        For braille or alternative formats contact the helpline. If you email, include your contact details and the format needed.
 
 
         $C
@@ -145,44 +145,10 @@ en-GB:
           [How to apply for student finance](/apply-for-student-finance)
 
       outcome_uk_ft_1415_continuing:
-        title: Student finance - application form
-        body: |
-          You should [apply online](/apply-online-for-student-finance) for help with your tuition and living costs.
-
-          If you can't apply online, use form PR1.
-
-          Academic Year | Form for new students
-          - | -
-          2014 to 2015 | [Apply online](/apply-online-for-student-finance "Apply for student finance online")
-          2014 to 2015 | [PR1 - form (PDF, 814KB)](http://www.sfengland.slc.co.uk/media/682895/sfe_pr1_form_1415_d.pdf)
-          2014 to 2015 | [PR1 - guidance notes (PDF, 556KB)](http://www.sfengland.slc.co.uk/media/682919/sfe_pr1_notes_1415_d.pdf)
-
-          ^You can apply up to 9 months after the start of your course.^
-
-          %{form_destination}
-
-        next_steps: |
-          [How to apply for student finance](/apply-for-student-finance)
+        title: You can't apply yet. Forms will be available early 2014.
 
       outcome_uk_ft_1415_new:
-        title: Student finance - application form
-        body: |
-          You should [apply online](/apply-online-for-student-finance) for help with your tuition and living costs.
-
-          If you can't apply online, use form PN1.
-
-          Academic Year | Form for new students
-          - | -
-          2014 to 2015 | [Apply online](/apply-online-for-student-finance)
-          2014 to 2015 | [PN1 - form (PDF, 801KB)](http://www.sfengland.slc.co.uk/media/682892/sfe_pn1_form_1415_d.pdf)
-          2014 to 2015 | [PN1 - guidance notes (PDF, 527KB)](http://www.sfengland.slc.co.uk/media/682916/sfe_pn1_notes_1415_d.pdf)
-
-          ^You can apply up to 9 months after the start of your course.^
-
-          %{form_destination}
-
-        next_steps: |
-          [How to apply for student finance](/apply-for-student-finance)
+        title: You can't apply yet. Forms will be available early 2014.
 
       outcome_uk_pt_1314_new:
         title: Student finance – application form
@@ -262,9 +228,9 @@ en-GB:
 
           You must send your income details for the 2011 to 2012 tax year. Do this online as part of the student's [online application](/apply-online-for-student-finance). If you can't do it online, use form PFF2.
 
-          If you think your income has dropped by 15% or more since the 2011 to 2012 tax year you’ll need to do both of the following:
+          If you think your income has dropped by 15% or more since the 2011 to 2012 tax year:
 
-          + submit your 2011 to 2012 income details online or using form PFF2
+          + send your 2011 to 2012 income details (as above), and
           + complete a CYI form (to ask for the student finance to be based on your expected 2013 to 2014 tax year income)
 
           Academic year | Form
@@ -276,30 +242,8 @@ en-GB:
 
         next_steps: |
           [How to support an application](/apply-for-student-finance/parents-and-partners)
-
       outcome_parent_partner_1415:
-        title: Parents and partners - forms
-        body: |
-          Some student finance (eg a Maintenance Grant) is based on income.
-
-          You must send your income details for the 2012 to 2013 tax year. Do this online as part of the student's [online application](/apply-online-for-student-finance). If you can't do it online, use form PFF2.
-
-          If you think your income has dropped by 15% or more since the 2012 to 2013 tax year you’ll need to do both of the following:
-
-          + submit your 2012 to 2013 income details online or using form PFF2
-          + complete a CYI form (to ask for the student finance to be based on your expected 2014 to 2015 tax year income)
-
-          Academic year | Form
-          - | -
-          2014 to 2015 | [PFF2 - income details form (PDF, 212 KB)](http://www.sfengland.slc.co.uk/media/682907/sfe_pff2_1415_d.pdf)
-          2014 to 2015 | CYI - current tax year income details form (not available yet)
-
-          %Income means your [household income](/apply-for-student-finance/household-income).%
-
-          %{form_destination}
-
-        next_steps: |
-          [How to support an application](/apply-for-student-finance/parents-and-partners)
+        title: Applications aren't open yet. Forms will be available early 2014.
 
       outcome_proof_identity_1314:
         title: Proof of identity
@@ -333,24 +277,9 @@ en-GB:
 
         next_steps: |
           [How to apply for student finance](/apply-for-student-finance)
-
       outcome_proof_identity_1415:
-        title: Proof of identity
-        body: |
-          To prove your identity, include your UK passport details in your application. If you forget, use the passport details form. If you don't have a passport  (or it has expired), send your birth or adoption certificate using the certificate form.
-
-          Academic year | Form
-          - | -
-          2014 to 2015 | [UK passport details form (PDF, 47KB)](http://www.sfengland.slc.co.uk/media/685458/sfe_uk_passport_details_1415_d.pdf)
-          2014 to 2015 | [Birth or adoption certificate form (PDF, 105KB)](http://www.sfengland.slc.co.uk/media/682913/sfe_birth_adopt_cert_form_1415_d.pdf)
-
-          ^Don't send your UK passport.^
-
-          %{form_destination}
-
-        next_steps: |
-          [How to apply for student finance](/apply-for-student-finance)
-
+        title: Applications aren't open yet. Forms will be available early 2014.
+      
       outcome_uk_ft_change_application: |
         title: change application full-time
       outcome_uk_pt_change_application: |
@@ -390,24 +319,8 @@ en-GB:
 
         next_steps: |
           [Disabled Student's Allowances](/disabled-students-allowances-dsas)
-
       outcome_dsa_1415:
-        title: Disabled Students' Allowances
-        body: |
-          To apply, use one of the DSA1 forms. If you’ve applied for student finance use form 'DSA1 short'. If you’re only applying for DSAs use form 'DSA1 full'.
-
-          Academic Year | Form
-          - | -
-          2014 to 2015 | [DSA1 - short form (PDF, 128KB)](http://www.sfengland.slc.co.uk/media/682901/sfe_dsa_slim_form_1415_d.pdf)
-          2014 to 2015 | [DSA1 - full form (PDF, 642KB)](http://www.sfengland.slc.co.uk/media/682898/sfe_dsa1_form_1415_d.pdf)
-          2014 to 2015 | [DSA1 - guidance notes (PDF, 150KB)](http://www.sfengland.slc.co.uk/media/682922/sfe_dsa1_notes_1415_d.pdf)
-
-          ^Open University (OU) students apply to the OU for Disabled Students' Allowances.^
-
-          %{form_destination}
-
-        next_steps: |
-          [Disabled Student's Allowances](/disabled-students-allowances-dsas)
+        title: Applications aren't open yet. Forms will be available early 2014.
 
       outcome_ccg_1314:
         title: Childcare Grant
@@ -422,20 +335,8 @@ en-GB:
 
         next_steps: |
           [Childcare Grant](/childcare-grant)
-
       outcome_ccg_1415:
-        title: Childcare Grant
-        body: |
-          To apply, estimate your childcare costs on form CCG1 after you've completed your main student finance application.
-
-          Academic year | Form
-          - | -
-          2014 to 2015 | [CCG1 - form (PDF, 107KB)](http://www.sfengland.slc.co.uk/media/682910/sfe_ccg1_1415_d.pdf)
-
-          %{form_destination}
-
-        next_steps: |
-          [Childcare Grant](/childcare-grant)
+        title: Applications aren't open yet. Forms will be available early 2014.
 
       outcome_dsa_expenses:
         title: Disabled Students' Allowances – expenses


### PR DESCRIPTION
Please merge [this pull request](https://github.com/alphagov/smart-answers/pull/664) beforehand.

Revert "Change copy on Start page"

This reverts commit d3976f96ff5d17cdfd085a64fddb7c533c3054e0.

Revert "Add application forms for 2014/15 (UK FT)"

This reverts commit 1b3825e1d108677deb9e2fe8dfd4dc01e230c641.

Revert "Add copy for 2014/15 (parents and partners)"

This reverts commit 380800127980b8b6dbf7346a201ca56740dc14d1.

Revert "Change copy for 2013/14 (parents and partners)"

This reverts commit f3dfcef44d2da4f2943cf399c499a3a64cc4d326.

Revert "Add missing Next steps section."

This reverts commit f52f9f30c1b3d25977aa5ceeeb4984f06adfb3c8.

Revert "Add copy for 2014/14 (proof of identity)"

This reverts commit 6aaef892bef5017b8709b682665a501d5d87e75e.

Revert "Add copy for 2014/15 (disabled students allowance)"

This reverts commit a022e8d8f4c5aca85cc3f5c0da0f87b2ad2a1b00.

Revert "Add copy for 2014/15 (childcare grant)"

This reverts commit 9b827ce750dcec01123bf219ea53ff10d2ee708f.
