### PR TITLE
Fix work outcome markup in what-visa-to-visit-uk

### DIFF
--- a/lib/flows/locales/en/what-visa-to-visit-uk.yml
+++ b/lib/flows/locales/en/what-visa-to-visit-uk.yml
@@ -100,6 +100,7 @@ en-GB:
           ###'High value' workers
 
           The [high value workers visa category](http://www.ukba.homeoffice.gov.uk/visas-immigration/working/tier1/) may be suitable if you’re an investor, entrepreneur or a leader in arts or sciences.
+
           ###Commonwealth citizens
 
           You may be eligible for a [UK ancestry visa](http://www.ukba.homeoffice.gov.uk/visas-immigration/working/uk-ancestry/) if one of your grandparents was born in the UK.


### PR DESCRIPTION
This is a fix for the following markup issue:

![image](https://f.cloud.github.com/assets/23801/1925925/f7bead14-7e38-11e3-873c-be7ad74e7001.png)
