### PR TITLE
Update register-death-abroad cash and card countries

### DIFF
--- a/lib/data/registrations.yml
+++ b/lib/data/registrations.yml
@@ -117,6 +117,7 @@ postal_return:
 postal_form:
   austria: /government/publications/passport-credit-debit-card-payment-authorisation-slip-austria
   bangladesh: /government/publications/passport-credit-debit-card-payment-authorisation-slip-bangladesh
+  belgium: /government/publications/credit-card-payment-authorisation-form-belgium
   brazil: /government/publications/credit-card-authorization-form
   czech-republic: /government/publications/czech-republic-credit-card-payment-authorization-form
   chile: /government/publications/passport-credit-debit-card-payment-authorisation-slip-chile
@@ -126,6 +127,7 @@ postal_form:
   france: /government/publications/passport-credit-debit-card-payment-authorisation-slip-france
   germany: /government/publications/passport-credit-debit-card-payment-authorisation-slip-germany
   greece: /government/publications/passport-credit-debit-card-payment-authorisation-slip-greece
+  hungary: /government/publications/credit-card-payment-authorisation-form-hungary
   india: /government/publications/passport-credit-debit-card-payment-authorisation-slip-india
   israel: /government/publications/passport-credit-debit-card-payment-authorisation-slip-israel
   italy: /government/publications/passport-credit-debit-card-payment-authorisation-slip-italy
@@ -133,9 +135,12 @@ postal_form:
   japan: /government/publications/passport-credit-debit-card-payment-authorisation-slip-japan
   korea: /government/publications/passport-credit-debit-card-payment-authorisation-slip-korea
   mexico: /government/publications/passport-credit-debit-card-payment-authorisation-slip-mexico
+  netherlands: /government/publications/credit-card-payment-authorisation-form-netherlands
   norway: /government/publications/creditdebit-card-payment-authorisation-slip-norway
+  poland: /government/publications/credit-card-payment-authorisation-form-poland
   portugal: /government/publications/passport-credit-debit-card-payment-authorisation-slip-portugal
   russia: /government/publications/passport-credit-debit-card-payment-authorisation-slip-russia
+  slovakia: /government/publications/credit-card-authorisation-form--2
   spain: /government/publications/passport-credit-debit-card-payment-authorisation-slip-spain
   switzerland: /government/publications/passport-credit-debit-card-payment-authorisation-slip-switzerland
   vietnam: /government/publications/creditdebit-card-payment-authorisation-slip-vietnam
@@ -147,7 +152,6 @@ death:
     usa: /government/publications/usa-birth-registration-application
   postal_no_form:
   - barbados
-  - belgium
   - costa-rica
   - malaysia
   - papua-new-guinea

--- a/lib/flows/register-a-death.rb
+++ b/lib/flows/register-a-death.rb
@@ -254,10 +254,10 @@ outcome :embassy_result do
       PhraseList.new(:cheque_only)
     elsif reg_data_query.cash_only?(current_location)
       PhraseList.new(:cash_only)
-    elsif reg_data_query.modified_card_only_countries?(current_location)
-      ''
-    else
+    elsif reg_data_query.cash_and_card_only?(current_location)
       PhraseList.new(:cash_and_card)
+    else
+      ''
     end
   end
 

--- a/lib/smart_answer/calculators/registrations_data_query.rb
+++ b/lib/smart_answer/calculators/registrations_data_query.rb
@@ -22,6 +22,8 @@ module SmartAnswer::Calculators
     COUNTRIES_WITH_TRADE_CULTURAL_OFFICES = %w(taiwan)
 
     MODIFIED_CARD_ONLY_COUNTRIES = %w(belgium netherlands czech-republic slovakia hungary poland portugal italy spain switzerland)
+    
+    CASH_AND_CARD_COUNTRIES = %w(estonia)
 
     attr_reader :data
 
@@ -67,6 +69,10 @@ module SmartAnswer::Calculators
 
     def cheque_only?(country_slug)
       CHEQUE_ONLY_COUNTRIES.include?(country_slug)
+    end
+    
+    def cash_and_card_only?(country_slug)
+      CASH_AND_CARD_COUNTRIES.include?(country_slug)
     end
 
     def caribbean_alt_embassies?(country_slug)

--- a/test/integration/flows/register_a_death_test.rb
+++ b/test/integration/flows/register_a_death_test.rb
@@ -199,7 +199,7 @@ class RegisterADeathTest < ActiveSupport::TestCase
         end
         should "give the embassy result and be done" do
           assert_current_node :embassy_result
-          assert_phrase_list :cash_only, [:cash_and_card]
+          assert_phrase_list :postal, [:post_only_pay_by_card_countries]
           assert_phrase_list :footnote, [:footnote]
           expected_location = WorldLocation.find('spain')
           assert_state_variable :location, expected_location
@@ -304,10 +304,10 @@ class RegisterADeathTest < ActiveSupport::TestCase
         assert_phrase_list :documents_required_embassy_result, [:documents_list_embassy]
         assert_state_variable :embassy_high_commission_or_consulate, "British embassy"
         assert_phrase_list :fees_for_consular_services, [:consular_service_fees]
-        assert_state_variable :postal_form_url, nil
+        assert_state_variable :postal_form_url, "/government/publications/credit-card-authorisation-form--2"
         assert_phrase_list :postal, [:post_only_pay_by_card_countries]
       end
-    end # Answer Belgium
+    end # Answer Slovakia
     context "answer Italy" do
       setup do
       worldwide_api_has_organisations_for_location('italy', read_fixture_file('worldwide/italy_organisations.json'))
@@ -535,8 +535,8 @@ class RegisterADeathTest < ActiveSupport::TestCase
         assert_phrase_list :documents_required_embassy_result, [:documents_list_embassy_netherlands]
         assert_state_variable :embassy_high_commission_or_consulate, "British consulate general"
         assert_phrase_list :fees_for_consular_services, [:consular_service_fees]
-        assert_state_variable :postal_form_url, nil
-        assert_phrase_list :cash_only, [:cash_and_card]
+        assert_state_variable :postal_form_url, "/government/publications/credit-card-payment-authorisation-form-netherlands"
+        assert_phrase_list :postal, [:post_only_pay_by_card_countries]
         expected_location = WorldLocation.find('netherlands')
         assert_state_variable :location, expected_location
         assert_state_variable :organisation, expected_location.fco_organisation
@@ -557,7 +557,7 @@ class RegisterADeathTest < ActiveSupport::TestCase
         assert_state_variable :clickbook, ''
         assert_phrase_list :fees_for_consular_services, [:consular_service_fees]
         assert_state_variable :postal_form_url, nil
-        assert_phrase_list :cash_only, [:cash_and_card]
+        assert_state_variable :cash_only, ''
         assert_phrase_list :footnote, [:footnote_caribbean]
         expected_location = WorldLocation.find('barbados')
         assert_state_variable :location, expected_location
@@ -578,7 +578,7 @@ class RegisterADeathTest < ActiveSupport::TestCase
         assert_state_variable :clickbook, ''
         assert_phrase_list :fees_for_consular_services, [:consular_service_fees]
         assert_state_variable :postal_form_url, nil
-        assert_phrase_list :cash_only, [:cash_and_card]
+        assert_state_variable :cash_only, ''
         assert_phrase_list :footnote, [:footnote]
         expected_location = WorldLocation.find('malaysia')
         assert_state_variable :location, expected_location
@@ -599,7 +599,7 @@ class RegisterADeathTest < ActiveSupport::TestCase
         assert_state_variable :clickbook, ''
         assert_phrase_list :fees_for_consular_services, [:consular_service_fees]
         assert_state_variable :postal_form_url, nil
-        assert_phrase_list :cash_only, [:cash_and_card]
+        assert_state_variable :cash_only, ''
         assert_phrase_list :footnote, [:footnote]
         assert_match /British Embassy Jakarta/, outcome_body
         expected_location = WorldLocation.find('indonesia')


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/63704814

Fixed the authorisation slip links and updated cash_only logic for Malaysia, Indonesia and Dominica.
