### PR TITLE
Removing 'not what you're looking for' link

### DIFF
--- a/app/views/smart_answers/_landing.html.erb
+++ b/app/views/smart_answers/_landing.html.erb
@@ -13,9 +13,6 @@
       <h2><%= @presenter.subtitle %></h2>
     <% end %>
   </div>
-  <nav class="skip-to-related">
-    <a href="#related">Not what you're looking for? ↓</a>
-  </nav>
 </header>
 
 <div class="article-container group">


### PR DESCRIPTION
Usage is negligible (0.352% of pageviews result in it being clicked) and it's a jarring experience

Related pull requests on other branches — 

alphagov/frontend/pull/512
alphagov/smart-answers/pull/700
alphagov/licence-finder/pull/51
alphagov/calendars/pull/57
alphagov/prototyping-v2/pull/1
alphagov/transaction-wrappers/pull/42
