### PR TITLE
Bump therubyracer.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ end
 
 group :assets do
   gem 'sass-rails', '3.2.3'
-  gem 'therubyracer', '~> 0.9.4'
+  gem 'therubyracer', '~> 0.12.1'
   gem 'uglifier'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,7 +98,7 @@ GEM
     kramdown (0.13.8)
     launchy (2.1.0)
       addressable (~> 2.2.6)
-    libv8 (3.3.10.4)
+    libv8 (3.16.14.3)
     link_header (0.0.8)
     logstash-event (1.1.5)
     logstasher (0.4.8)
@@ -150,6 +150,7 @@ GEM
     rake (10.1.1)
     rdoc (3.12.2)
       json (~> 1.4)
+    ref (1.0.5)
     rest-client (1.6.7)
       mime-types (>= 1.16)
     sanitize (2.0.3)
@@ -184,8 +185,9 @@ GEM
       multi_json (~> 1.0)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
-    therubyracer (0.9.10)
-      libv8 (~> 3.3.10)
+    therubyracer (0.12.1)
+      libv8 (~> 3.16.14.0)
+      ref
     thor (0.18.1)
     tilt (1.4.1)
     timecop (0.5.1)
@@ -235,7 +237,7 @@ DEPENDENCIES
   simplecov (~> 0.6.4)
   simplecov-rcov (~> 0.2.3)
   slimmer (= 3.25.0)
-  therubyracer (~> 0.9.4)
+  therubyracer (~> 0.12.1)
   timecop
   uglifier
   unicorn (= 4.3.1)


### PR DESCRIPTION
To prevent install errors when a newer version of libv8 is installed
