### PR TITLE
Updating calculate-state-pension outcome fix and extra tests

### DIFF
--- a/lib/flows/calculate-state-pension-v2.rb
+++ b/lib/flows/calculate-state-pension-v2.rb
@@ -480,17 +480,13 @@ outcome :amount_result do
       phrases << (enough_qualifying_years ? :within_4_months_enough_qy_years_more : :within_4_months_not_enough_qy_years_more)
       phrases << :automatic_years_phrase if auto_years_entitlement and !enough_qualifying_years
     elsif calculator.state_pension_date > Date.parse('2016-04-06')
-      if enough_remaining_years
-        phrases << :too_few_qy_enough_remaining_years_a
-        if qualifying_years_total > 10
-          phrases << :ni_table
-        else
-          phrases << :less_than_ten
-        end
-        phrases << :too_few_qy_enough_remaining_years_a_outro
+      phrases << :too_few_qy_enough_remaining_years_a
+      if qualifying_years_total > 10
+        phrases << :ni_table
       else
-        phrases << :too_few_qy_not_enough_remaining_years
+        phrases << :less_than_ten
       end
+      phrases << :too_few_qy_enough_remaining_years_a_outro
       phrases << :automatic_years_phrase if auto_years_entitlement
     elsif !enough_qualifying_years
       phrases << (enough_remaining_years ? :too_few_qy_enough_remaining_years : :too_few_qy_not_enough_remaining_years)

--- a/test/integration/flows/calculate_state_pension_v2_test.rb
+++ b/test/integration/flows/calculate_state_pension_v2_test.rb
@@ -992,10 +992,21 @@ class CalculateStatePensionTestV2 < ActiveSupport::TestCase
       assert_phrase_list :result_text, [:too_few_qy_enough_remaining_years_a, :less_than_ten, :too_few_qy_enough_remaining_years_a_outro]
     end # less than 10 years NI
     
-    should "show results for not enough remaining years" do
+    should "show results for not enough qualifyting but enough remaining years" do
       add_response :male
       add_response Date.parse('1 Jan 1953')
       add_response 20
+      add_response 0
+      add_response 'no'
+      add_response 0
+      assert_current_node :amount_result
+      assert_phrase_list :result_text, [:too_few_qy_enough_remaining_years_a, :ni_table, :too_few_qy_enough_remaining_years_a_outro, :automatic_years_phrase]
+    end
+    
+    should "show results for not enough qualifying years and not enough remaining years" do
+      add_response :male
+      add_response Date.parse('1 Sep 1949')
+      add_response 5
       add_response 0
       add_response 'no'
       add_response 0


### PR DESCRIPTION
Changes to logic for missed outcomes and additional test coverage.
