### PR TITLE
Uprate calculate state pension for 2014/15 ***Deploy 7th April***

### DIFF
--- a/lib/flows/locales/en/calculate-state-pension.yml
+++ b/lib/flows/locales/en/calculate-state-pension.yml
@@ -201,12 +201,12 @@ en-GB:
 
           ##Your State Pension estimate
 
-          You currently don’t have the 30 qualifying years needed to get a full basic State Pension of £110.15 per week.
+          You currently don’t have the 30 qualifying years needed to get a full basic State Pension of £113.10 per week.
 
           State Pension | Your results
           - | -
           How much per week you may get | £%{pension_amount}
-          Difference to the full basic State Pension of £110.15 | £%{pension_loss}
+          Difference to the full basic State Pension of £113.10 | £%{pension_loss}
 
           How much State Pension you get depends on how many years of [National Insurance contributions](/national-insurance) you have.
 
@@ -239,7 +239,7 @@ en-GB:
 
           ##Your State Pension estimate
 
-          You have enough qualifying years to get a full basic State Pension of £110.15 per week.
+          You have enough qualifying years to get a full basic State Pension of £113.10 per week.
 
           How much State Pension you get depends on how many years of [National Insurance contributions](/national-insurance) you have.
 

--- a/lib/smart_answer/calculators/state_pension_amount_calculator.rb
+++ b/lib/smart_answer/calculators/state_pension_amount_calculator.rb
@@ -8,8 +8,9 @@ module SmartAnswer::Calculators
     attr_accessor :qualifying_years
 
     PENSION_RATES = [
-      { :min => Date.parse('7 April 2012'), :max => Date.parse('8 April 2013'), :amount => 107.45 },
-      { :min => Date.parse('7 April 2013'), :max => Date.parse('8 April 2014'), :amount => 110.15 }
+      { :min => Date.parse('7 April 2012'), :max => Date.parse('6 April 2013'), :amount => 107.45 },
+      { :min => Date.parse('7 April 2013'), :max => Date.parse('6 April 2014'), :amount => 110.15 },
+      { :min => Date.parse('7 April 2014'), :max => Date.parse('6 April 2015'), :amount => 113.10 }
     ]
 
     def initialize(answers)

--- a/test/unit/calculators/state_pension_amount_calculator_test.rb
+++ b/test/unit/calculators/state_pension_amount_calculator_test.rb
@@ -95,12 +95,38 @@ module SmartAnswer::Calculators
           assert_equal 3.67, @calculator.what_you_get
         end
       end
+      
+      should "uprate on or after 8th April 2014" do
+        Timecop.travel(Date.parse("2014-04-08")) do
+          @calculator = SmartAnswer::Calculators::StatePensionAmountCalculator.new(
+            gender: "male", dob: "1953-04-04", qualifying_years: 29)
+          assert_equal 109.33, @calculator.what_you_get
+          @calculator.qualifying_years = 28
+          assert_equal 105.56, @calculator.what_you_get
+          @calculator.qualifying_years = 27
+          assert_equal 101.79, @calculator.what_you_get
+          @calculator.qualifying_years = 26
+          assert_equal 98.02, @calculator.what_you_get
+          @calculator.qualifying_years = 15
+          assert_equal 56.55, @calculator.what_you_get
+          @calculator.qualifying_years = 10
+          assert_equal 37.70, @calculator.what_you_get
+          @calculator.qualifying_years = 5
+          assert_equal 18.85, @calculator.what_you_get
+          @calculator.qualifying_years = 4
+          assert_equal 15.08, @calculator.what_you_get
+          @calculator.qualifying_years = 2
+          assert_equal 7.54, @calculator.what_you_get
+          @calculator.qualifying_years = 1
+          assert_equal 3.77, @calculator.what_you_get
+        end
+      end
 
       should "use the last rate available" do
         Timecop.travel('2045-01-01') do
           @calculator = SmartAnswer::Calculators::StatePensionAmountCalculator.new(
             gender: "male", dob: "2000-04-04", qualifying_years: 29)
-          assert_equal 110.15, @calculator.current_weekly_rate
+          assert_equal 113.1, @calculator.current_weekly_rate
         end
       end
     end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/67770414

Change rates for 2014/2015. 
Additional tests to check for correct calculations for qualifying years. 
Change yaml to reflect new rates.
