### PR TITLE
Quietening the I18n locale error in smart-answers

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -34,6 +34,7 @@ module SmartAnswers
     # config.time_zone = 'Central Time (US & Canada)'
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
+    config.i18n.enforce_available_locales = false
     config.i18n.load_path += Dir[Rails.root.join(*%w{lib flows locales * *.{rb,yml}}).to_s]
     config.i18n.default_locale = :"en-GB"
 


### PR DESCRIPTION
We only (currently) use one locale so don't need to validate it.
