### PR TITLE
Check for empty organisations, fix error for commonwealth countries

### DIFF
--- a/lib/flows/register-a-birth.rb
+++ b/lib/flows/register-a-birth.rb
@@ -247,7 +247,7 @@ outcome :embassy_result do
     end
   end
   precalculate :overseas_passports_embassies do
-    if organisations
+    if organisations and organisations.any?
       service_title = 'Births and Deaths registration service'
       if registration_country == 'united-arab-emirates'
         all_offices = []


### PR DESCRIPTION
Make sure that organsations is not empty before attempting to pick the correct embassy details.
https://www.pivotaltracker.com/story/show/68883854
