### PR TITLE
Updating overseas passports smart-answer to avoid 500 errors

### DIFF
--- a/lib/data/passport_data.yml
+++ b/lib/data/passport_data.yml
@@ -143,9 +143,9 @@ brazil:
   app_form: hmpo_2_application_form
   online_application: true
 british-indian-ocean-territory:
-  type:
-  group:
-  app_form:
+  type: ips_application_1
+  group: ips_documents_group_1
+  app_form: hmpo_1_application_form
 british-virgin-islands:
   type: ips_application_1
   group: ips_documents_group_2
@@ -538,9 +538,9 @@ kuwait:
   app_form: hmpo_1_application_form
   online_application: true
 kyrgyzstan:
-  type:
-  group:
-  app_form:
+  type: ips_application_3
+  group: ips_documents_group_3
+  app_form: hmpo_1_application_form
 laos:
   type: ips_application_3
   group: ips_documents_group_3
@@ -743,9 +743,9 @@ nigeria:
   app_form: hmpo_1_application_form
   address: durham
 north-korea:
-  type:
-  group:
-  app_form:
+  type: ips_application_3
+  group: ips_documents_group_2
+  app_form: hmpo_1_application_form
 norway:
   type: ips_application_1
   group: ips_documents_group_1
@@ -903,9 +903,9 @@ south-africa:
   app_form: hmpo_1_application_form
   online_application: true
 south-georgia-and-south-sandwich-islands:
-  type:
-  group:
-  app_form:
+  type: ips_application_1
+  group: ips_documents_group_1
+  app_form: hmpo_1_application_form
 south-korea:
   type: ips_application_1
   group: ips_documents_group_1


### PR DESCRIPTION
Reinstating the type, group and app_form values for apply_in_neighbouring_countries countries. This will prevent the 500 erros we're currently seeing.
