### PR TITLE
Updating smart answers to have maslow need ids

### DIFF
--- a/lib/flows/appeal-a-benefits-decision.rb
+++ b/lib/flows/appeal-a-benefits-decision.rb
@@ -1,4 +1,4 @@
-satisfies_need "845"
+satisfies_need "100492"
 status :draft
 
 decision_appeal_limit_in_months = 13

--- a/lib/flows/apply-for-probate.rb
+++ b/lib/flows/apply-for-probate.rb
@@ -1,5 +1,5 @@
 status :draft
-satisfies_need "131"
+satisfies_need "100321"
 
 ## Q1
 multiple_choice :where_did_deceased_live? do

--- a/lib/flows/benefits-abroad.rb
+++ b/lib/flows/benefits-abroad.rb
@@ -1,4 +1,4 @@
-satisfies_need "392"
+satisfies_need "100405"
 status :draft
 
 situations = ['going_abroad','already_abroad']

--- a/lib/flows/calculate-night-work-hours.rb
+++ b/lib/flows/calculate-night-work-hours.rb
@@ -1,4 +1,5 @@
 status :draft
+satisfies_need "100986"
 
 multiple_choice :how_old? do
   option '18-or-over' => :exception_to_limits?

--- a/lib/flows/calculate-state-pension-v2.rb
+++ b/lib/flows/calculate-state-pension-v2.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 status :draft
-satisfies_need "564"
+satisfies_need "100245"
 
 # Q1
 multiple_choice :which_calculation? do

--- a/lib/flows/calculate-state-pension.rb
+++ b/lib/flows/calculate-state-pension.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 status :published
-satisfies_need "564"
+satisfies_need "100245"
 
 # Q1
 multiple_choice :which_calculation? do

--- a/lib/flows/can-i-get-a-british-passport.rb
+++ b/lib/flows/can-i-get-a-british-passport.rb
@@ -1,4 +1,5 @@
 status :draft
+satisfies_need "100983"
 
 multiple_choice :do_you_have? do
   option :british_citizenship => :is_one_of_these_true?

--- a/lib/flows/check-uk-visa-v2.rb
+++ b/lib/flows/check-uk-visa-v2.rb
@@ -1,5 +1,5 @@
 status :draft
-satisfies_need "2969"
+satisfies_need "100982"
 
 additional_countries = UkbaCountry.all
 

--- a/lib/flows/check-uk-visa.rb
+++ b/lib/flows/check-uk-visa.rb
@@ -1,5 +1,5 @@
 status :published
-satisfies_need "2969"
+satisfies_need "100982"
 
 additional_countries = UkbaCountry.all
 

--- a/lib/flows/energy-grants-calculator.rb
+++ b/lib/flows/energy-grants-calculator.rb
@@ -1,4 +1,5 @@
 status :published
+satisfies_need "100259"
 
 # Q1
 multiple_choice :what_are_you_looking_for? do

--- a/lib/flows/estimate-self-assessment-penalties.rb
+++ b/lib/flows/estimate-self-assessment-penalties.rb
@@ -1,5 +1,5 @@
 status :draft
-satisfies_need "B692"
+satisfies_need "100615"
 
 calculator_dates = {
   :online_filing_deadline => {

--- a/lib/flows/find-a-british-embassy.rb
+++ b/lib/flows/find-a-british-embassy.rb
@@ -1,4 +1,5 @@
 status :draft
+satisfies_need "100987"
 
 data_query = SmartAnswer::Calculators::MarriageAbroadDataQuery.new
 i18n_prefix = "flow.find-a-british-embassy"

--- a/lib/flows/inherits-someone-dies-without-will-v2.rb
+++ b/lib/flows/inherits-someone-dies-without-will-v2.rb
@@ -1,4 +1,4 @@
-satisfies_need 2006
+satisfies_need "100988"
 status :draft
 
 # The case & if blocks in this file are organised to be read in the same order

--- a/lib/flows/inherits-someone-dies-without-will.rb
+++ b/lib/flows/inherits-someone-dies-without-will.rb
@@ -1,4 +1,4 @@
-satisfies_need 2006
+satisfies_need "100988"
 status :published
 
 # The case & if blocks in this file are organised to be read in the same order

--- a/lib/flows/maternity-paternity-calculator-v2.rb
+++ b/lib/flows/maternity-paternity-calculator-v2.rb
@@ -1,5 +1,5 @@
 status :draft
-satisfies_need "B1012"
+satisfies_need "100990"
 
 
 

--- a/lib/flows/maternity-paternity-calculator.rb
+++ b/lib/flows/maternity-paternity-calculator.rb
@@ -1,5 +1,5 @@
 status :published
-satisfies_need "B1012"
+satisfies_need "100990"
 
 days_of_the_week = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
 

--- a/lib/flows/overseas-passports.rb
+++ b/lib/flows/overseas-passports.rb
@@ -1,5 +1,5 @@
 status :published
-satisfies_need 2820
+satisfies_need "100131"
 
 
 data_query = Calculators::PassportAndEmbassyDataQuery.new

--- a/lib/flows/request-for-flexible-working.rb
+++ b/lib/flows/request-for-flexible-working.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 status :draft
-satisfies_need "357"
+satisfies_need "100992"
 
 ## Q1
 multiple_choice :are_you_an_employee_or_employer? do

--- a/lib/flows/uk-benefits-abroad.rb
+++ b/lib/flows/uk-benefits-abroad.rb
@@ -1,4 +1,4 @@
-satisfies_need "392"
+satisfies_need "100490"
 status :draft
 
 exclude_countries = %w(holy-see british-antarctic-territory)

--- a/lib/flows/vat-payment-deadlines.rb
+++ b/lib/flows/vat-payment-deadlines.rb
@@ -1,5 +1,5 @@
 status :draft
-satisfies_need 2834
+satisfies_need "100624"
 
 date_question :when_does_your_vat_accounting_period_end? do
   default_day -1

--- a/lib/flows/vehicles-you-can-drive.rb
+++ b/lib/flows/vehicles-you-can-drive.rb
@@ -1,4 +1,4 @@
-satisfies_need 1625
+satisfies_need "100242"
 status :published
 
 ## Q1


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/67206140

using needotron need_ids was causing deploy
builds to break when registering smart answers
as an artefact in panopticon. this is because
there is now a validation for need_ids to be
six-digit integers.
