### PR TITLE
Don't throw an uncaught error for unparseable responses

### DIFF
--- a/lib/flows/calculate-state-pension.rb
+++ b/lib/flows/calculate-state-pension.rb
@@ -371,7 +371,7 @@ value_question :years_of_work? do
   save_input_as :years_of_work_entered
 
   calculate :qualifying_years do
-    work_years = Integer(responses.last)
+    work_years = responses.last.to_i
     qy = (work_years + qualifying_years)
     raise InvalidResponse if (work_years < 0 or work_years > 3)
     qy


### PR DESCRIPTION
@brenetic this should be updated in the draft version of this smart answer.
