### PR TITLE
Track when a user wants to change a previous answer

### DIFF
--- a/app/assets/javascripts/smart-answers.js
+++ b/app/assets/javascripts/smart-answers.js
@@ -22,6 +22,15 @@ $(document).ready(function() {
 
     // we want to start over with whatever gets provided if someone clicks to change the answer
     $(".undo a").live('click', function() {
+      /*
+        This is short lived tracking - to help inform a design decision, should not be permanent
+
+        * Cat/Action/Label convention is taken from GOVUK.Analytics.Trackers in static
+        * Slug extraction is based on position logic in GOVUK.Analytics.Trackers.smart_answer
+      */
+      var slug = document.URL.split('/')[3].split("#")[0].split("?")[0];
+      window._gaq && window._gaq.push(['_trackEvent', "MS_smart_answer", slug, "Change Answer"]);
+
       reloadQuestions($(this).attr("href"), "");
       return false;
     });


### PR DESCRIPTION
It's possible, but very difficult, to infer this from GA flows. Explicitly track it as a custom event so we can make design decisions based on data.
- Match the existing (but broken) GOVUK.Analytics.Trackers event convention
- Using slug as action will allow looking at smart-answers by change rate
- Slug extraction is a little brittle, but:
  *\* This is a short lived change to get some data
  *\* It's based on existing logic that is working correctly.

https://www.pivotaltracker.com/story/show/66848524

CC @steventux @brenetic for review and feedback.

(My first pull request, be gentle)
