### PR TITLE
Fix state pension bug, update logic and content

### DIFF
--- a/lib/data/state_pension_query_v2.rb
+++ b/lib/data/state_pension_query_v2.rb
@@ -61,8 +61,12 @@ class StatePensionQueryV2 < Struct.new(:dob, :gender)
       StatePensionDateV2.new(:both, Date.new(1961,1,6), Date.new(1961, 2, 5), 66.years.since(dob) + 10.months),
       StatePensionDateV2.new(:both, Date.new(1961,2,6), Date.new(1961, 3, 5), 66.years.since(dob) + 11.months),
       StatePensionDateV2.new(:both, Date.new(1961,3,6), Date.new(1977, 4, 5), 67.years.since(dob)),
-      StatePensionDateV2.new(:both, Date.new(1978,4,6), Date.today + 1, 68.years.since(dob))
+      StatePensionDateV2.new(:both, Date.new(1977,4,6), Date.today + 1, 68.years.since(dob))
     ]
+  end
+  
+  def self.has_month_offset?(dob) 
+    dob >= Date.new(1960,4,6) and dob <= Date.new(1961,3,5)
   end
 
   def pension_dates_static

--- a/lib/flows/calculate-state-pension-v2.rb
+++ b/lib/flows/calculate-state-pension-v2.rb
@@ -85,7 +85,7 @@ date_question :dob_age? do
   calculate :state_pension_age_statement do
     phrases = PhraseList.new
     if state_pension_date > Date.today
-      if state_pension_date > Date.parse('2016-04-06')
+      if state_pension_date >= Date.parse('2016-04-06')
         phrases << :state_pension_age_is_a << :pension_credit_future
       else
         phrases << :state_pension_age_is << :pension_credit_future
@@ -506,13 +506,13 @@ outcome :amount_result do
       phrases << (enough_qualifying_years ? :within_4_months_enough_qy_years_more : :within_4_months_not_enough_qy_years_more)
       phrases << :automatic_years_phrase if auto_years_entitlement and !enough_qualifying_years
     elsif calculator.state_pension_date >= Date.parse('2016-04-06')
-      phrases << :too_few_qy_enough_remaining_years_a
-      if qualifying_years_total > 10
-        phrases << :ni_table
+      phrases << :too_few_qy_enough_remaining_years_a_intro
+      if qualifying_years_total >= 10
+        phrases << :ten_and_greater
       else
         phrases << :less_than_ten
       end
-      phrases << :too_few_qy_enough_remaining_years_a_outro
+      phrases << :too_few_qy_enough_remaining_years_a
       phrases << :automatic_years_phrase if auto_years_entitlement
     elsif !enough_qualifying_years
       phrases << (enough_remaining_years ? :too_few_qy_enough_remaining_years : :too_few_qy_not_enough_remaining_years)
@@ -521,7 +521,6 @@ outcome :amount_result do
       phrases << :you_get_full_state_pension
       phrases << :automatic_years_phrase if auto_years_entitlement
     end
-
     phrases
   end
 

--- a/lib/flows/locales/en/calculate-state-pension-v2.yml
+++ b/lib/flows/locales/en/calculate-state-pension-v2.yml
@@ -9,7 +9,7 @@ en-GB:
       devolved_body: |
         ##What you need to know:
 
-        This calculator gives an estimate of your basic State pension or information about the [new State Pension](/new-state-pension) if you retire after 6 April 2016.
+        This calculator gives an estimate of your basic State pension and information about the [new State Pension](/new-state-pension) if you reach State Pension age after 6 April 2016.
 
         It doesn’t estimate any [Additional State Pension.](/additional-state-pension)
 
@@ -41,24 +41,6 @@ en-GB:
           + Scotland, Wales or Northern Ireland - it's usually when you turn 60
 
           [Check with your council](/find-your-local-council) as the date may be sooner.
-        ni_table: |
-          National Insurance | Your results 
-          - | - 
-          Years of contributions you already have | %{qualifying_years_total}
-          Years you can still make contributions | %{remaining_years}
-        less_than_ten: |
-          ^You need at least 10 years of National Insurance contributions to get the [new State Pension](/state-pension).^
-        too_few_qy_enough_remaining_years_a_outro: |
-          ##Get a pension statement
-          Find out how you can [get for a State Pension statement](/state-pension-statement) and when you get an estimate of your full State Pension.
-
-          ##More about the State Pension
-          Read about:
-
-          - [the new State Pension or how to top it up](/new-state-pension)
-          - [voluntary contributions](/voluntary-national-insurance-contributions)
-          -  [increasing your basic State Pension with your partner’s (or late or former partner’s) National Insurance contributions](/state-pension-through-partner)
-          - [State Pension if you retire abroad](/state-pension-if-you-retire-abroad)
         remaining_contributions_years_callout: |
           You still need to pay National Insurance contributions for %{remaining_contribution_years} to get the full State Pension.
         automatic_years_phrase: |
@@ -88,7 +70,7 @@ en-GB:
 
           Once you claim your State Pension, the Pension Service will work out how much exactly you get. You need at least 10 years of National Insurance contributions or credits to get the State Pension.
 
-          ^You will claim the [new State Pension](/new-state-pension) when you reach your State Pension age.^
+          ^The State Pension has changed. You will claim the [new State Pension](/new-state-pension) when you reach your State Pension age.^
 
           ##Pension Credit
           If you're on a low income, you might be eligible to claim [Pension Credit](/pension-credit).
@@ -149,24 +131,46 @@ en-GB:
           - [increasing your basic State Pension with your partner’s (or late or former partner’s) National Insurance contributions](/state-pension-through-partner)
           - [State Pension if you retire abroad](/state-pension-if-you-retire-abroad)
         
-        too_few_qy_enough_remaining_years_a: |
+        ##Estimate Result 1a
+        too_few_qy_enough_remaining_years_a_intro: |
 
 
           $C
-          The State Pension has changed. When you reach State Pension age you’ll claim the [new State Pension](/new-state-pension).
+          The State Pension has changed. When you reach State Pension age you’ll claim the [new State Pension](/new-state-pension). This is an estimate of your basic State Pension under the current rules.
           $C
           
-          The estimate of how much you will get is based on the current State Pension rules and will be the least amount you will get under the new State Pension rules.
-
+        ten_and_greater: |
+          The estimate of how much you will get is based on the current basic State Pension rules and will be the least amount you will get under the new State Pension rules.
+        less_than_ten: |
+          ^You don’t have the 10 years of National Insurance contributions you need to get the [new State Pension](/state-pension/eligibility).^
+        too_few_qy_enough_remaining_years_a: |
           State Pension | Your results
           - | - 
           Your State Pension age | %{state_pension_age}
           When you’ll reach State Pension age | %{formatted_state_pension_date}
           How much per week you may get | £%{pension_amount}
+          
+          The State Pension age is regularly reviewed.
 
-          This amount doesn’t include an [Additional State Pension](/additional-state-pension) you built up before 6 April 2016. It will change if you make more [National Insurance contributions](/national-insurance) before you reach State Pension age.
+          This estimate doesn’t include an [Additional State Pension](/additional-state-pension) you built up before 6 April 2016. It may change if you make more [National Insurance contributions](/national-insurance) before you reach State Pension age.
 
-          How much State Pension you get depends on how many years of [National Insurance contributions](/national-insurance) you have. 
+          How much State Pension you get depends on how many years of [National Insurance contributions](/national-insurance) you have.
+          
+          National Insurance | Your results 
+          - | - 
+          Years of contributions you already have | %{qualifying_years_total}
+          Years you can still make contributions | %{remaining_years}
+  
+          ##Get a pension statement
+          Find out how you can [get for a State Pension statement](/state-pension-statement) and when you get an estimate of your full State Pension.
+
+          ##More about the State Pension
+          Read about:
+
+          - [the new State Pension or how to top it up](/new-state-pension)
+          - [voluntary contributions](/voluntary-national-insurance-contributions)
+          -  [increasing your basic State Pension with your partner’s (or late or former partner’s) National Insurance contributions](/state-pension-through-partner)
+          - [State Pension if you retire abroad](/state-pension-if-you-retire-abroad)
 
         ## Result 2
         too_few_qy_not_enough_remaining_years: |
@@ -300,7 +304,7 @@ en-GB:
         title: What would you like to calculate?
         options:
           age: State Pension age - including pension credit age and when you’ll get free bus travel
-          amount: Amount - estimate of your State Pension amount (including your State Pension age)
+          amount: Amount - estimate of your basic State Pension amount (including your State Pension age)
       ## Q2
       gender?:
         title: Are you a man or a woman?
@@ -408,6 +412,8 @@ en-GB:
           Your State Pension age is %{state_pension_age}.
 
           You’ll reach State Pension age on %{formatted_state_pension_date}
+          
+          The State Pension age is regularly reviewed.
 
           How much State Pension you get depends on how many years of [National Insurance contributions](/national-insurance/overview) you have.
 

--- a/lib/smart_answer/calculators/state_pension_amount_calculator_v2.rb
+++ b/lib/smart_answer/calculators/state_pension_amount_calculator_v2.rb
@@ -76,35 +76,18 @@ module SmartAnswer::Calculators
     end
 
     def state_pension_age
-      syear = state_pension_date.year - dob.year
-
-      pension_age = syear.years.since(dob)
-      years = syear
-
-      if pension_age > state_pension_date
-        pension_age = 1.year.ago(pension_age)
-        years -= 1
-      end
-
-      month_and_day = friendly_time_diff(pension_age, state_pension_date)
-      month_and_day = month_and_day.empty? ? month_and_day : ", " + month_and_day
-      "#{pluralize(years, 'year')}#{month_and_day}"
+      year_month = pension_date_from_dob_diff
+      if StatePensionQueryV2.has_month_offset?(dob)
+        year_month[0] -= 1 if year_month[0] > 66
+        "#{year_month[0]} years, #{year_month[1]} #{year_month[1] > 1 ? "month".pluralize : "month"}"
+      else
+        "#{year_month[0]} years"
+      end 
     end
-
-    def friendly_time_diff(from_time, to_time)
-      from_time = from_time.to_time if from_time.respond_to?(:to_time)
-      to_time = to_time.to_time if to_time.respond_to?(:to_time)
-      components = []
-
-      %w(year month day).map do |interval|
-        distance_in_seconds = (to_time.to_i - from_time.to_i).round(1)
-        delta = (distance_in_seconds / 1.send(interval)).floor
-        delta -= 1 if from_time + delta.send(interval) > to_time
-        from_time += delta.send(interval)
-        components << pluralize(delta, interval) if distance_in_seconds >= 1.send(interval)
-      end
-
-      components.join(", ")
+    
+    def pension_date_from_dob_diff
+      months = (state_pension_date.year * 12 + state_pension_date.month) - (dob.year * 12 + dob.month)
+      [(months.to_f / 12).round, months % 12]
     end
 
     def before_state_pension_date?

--- a/test/integration/flows/calculate_state_pension_v2_test.rb
+++ b/test/integration/flows/calculate_state_pension_v2_test.rb
@@ -150,6 +150,60 @@ class CalculateStatePensionV2Test < ActiveSupport::TestCase
         assert_phrase_list :state_pension_age_statement, [:state_pension_age_is_a, :pension_credit_future, :bus_pass]
       end
     end
+    
+    context "test correct state pension age" do
+      setup do
+        Timecop.travel('2014-05-08')
+      end
+      should "show state pension age of 60 years" do
+        add_response :female
+        add_response Date.parse('23 April 1949')
+        assert_current_node :age_result
+        assert_state_variable :state_pension_age, "60 years"
+      end
+      
+      should "show state pension age of 65 years" do
+        add_response :male
+        add_response Date.parse('23 April 1951')
+        assert_current_node :age_result
+        assert_state_variable :state_pension_age, "65 years"
+      end
+      
+      should "show state pension age of 66 years" do
+        add_response :male
+        add_response Date.parse('23 October 1954')
+        assert_current_node :age_result
+        assert_state_variable :state_pension_age, "66 years"
+      end
+      
+      should "show state pension age of 66 years, 1 month" do
+        add_response :male
+        add_response Date.parse('23 April 1960')
+        assert_current_node :age_result
+        assert_state_variable :state_pension_age, "66 years, 1 month"
+      end
+      
+      should "show state pension age of 66 years, 10 month" do
+        add_response :male
+        add_response Date.parse('23 January 1961')
+        assert_current_node :age_result
+        assert_state_variable :state_pension_age, "66 years, 10 months"
+      end
+      
+      should "show state pension age of 67" do
+        add_response :male
+        add_response Date.parse('23 March 1969')
+        assert_current_node :age_result
+        assert_state_variable :state_pension_age, "67 years"
+      end
+      
+      should "show state pension age of 68" do
+        add_response :male
+        add_response Date.parse('23 March 1978')
+        assert_current_node :age_result
+        assert_state_variable :state_pension_age, "68 years"
+      end
+    end 
   end # age calculation
 
   #Amount
@@ -357,7 +411,7 @@ class CalculateStatePensionV2Test < ActiveSupport::TestCase
                         assert_state_variable "state_pension_age", "65 years"
                         assert_state_variable "remaining_years", 5
                         assert_state_variable "pension_loss", "14.69"
-                        assert_phrase_list :result_text, [:too_few_qy_enough_remaining_years_a, :ni_table, :too_few_qy_enough_remaining_years_a_outro, :automatic_years_phrase]
+                        assert_phrase_list :result_text, [:too_few_qy_enough_remaining_years_a_intro,:ten_and_greater, :too_few_qy_enough_remaining_years_a, :automatic_years_phrase]
                         assert_state_variable "state_pension_date", Date.parse("2018 Oct 4th")
                         assert_current_node :amount_result
                       end
@@ -1080,7 +1134,7 @@ class CalculateStatePensionV2Test < ActiveSupport::TestCase
         add_response 0
         add_response 'no'
         assert_current_node :amount_result
-        assert_phrase_list :result_text, [:too_few_qy_enough_remaining_years_a, :less_than_ten, :too_few_qy_enough_remaining_years_a_outro]
+        assert_phrase_list :result_text, [:too_few_qy_enough_remaining_years_a_intro, :less_than_ten, :too_few_qy_enough_remaining_years_a]
       end # less than 10 years NI
       
       should "show results for not enough qualifyting but enough remaining years" do
@@ -1091,7 +1145,7 @@ class CalculateStatePensionV2Test < ActiveSupport::TestCase
         add_response 'no'
         add_response 0
         assert_current_node :amount_result
-        assert_phrase_list :result_text, [:too_few_qy_enough_remaining_years_a, :ni_table, :too_few_qy_enough_remaining_years_a_outro, :automatic_years_phrase]
+        assert_phrase_list :result_text, [:too_few_qy_enough_remaining_years_a_intro, :ten_and_greater, :too_few_qy_enough_remaining_years_a, :automatic_years_phrase]
       end
       
       should "show results for not enough qualifying years and not enough remaining years" do
@@ -1135,7 +1189,7 @@ class CalculateStatePensionV2Test < ActiveSupport::TestCase
         assert_current_node :amount_result
         assert_state_variable :qualifying_years_total, 39
         assert_state_variable :remaining_years, 2
-        assert_phrase_list :result_text, [:too_few_qy_enough_remaining_years_a, :ni_table, :too_few_qy_enough_remaining_years_a_outro, :automatic_years_phrase]
+        assert_phrase_list :result_text, [:too_few_qy_enough_remaining_years_a_intro, :ten_and_greater, :too_few_qy_enough_remaining_years_a, :automatic_years_phrase]
       end
       
       should "show results for female and 40 available years" do
@@ -1149,7 +1203,7 @@ class CalculateStatePensionV2Test < ActiveSupport::TestCase
         assert_current_node :amount_result
         assert_state_variable :qualifying_years_total, 42
         assert_state_variable :remaining_years, 6
-        assert_phrase_list :result_text, [:too_few_qy_enough_remaining_years_a, :ni_table, :too_few_qy_enough_remaining_years_a_outro]
+        assert_phrase_list :result_text, [:too_few_qy_enough_remaining_years_a_intro, :ten_and_greater, :too_few_qy_enough_remaining_years_a]
       end
       
       should "show results for female and 29 available years" do
@@ -1160,7 +1214,7 @@ class CalculateStatePensionV2Test < ActiveSupport::TestCase
         assert_current_node :amount_result
         assert_state_variable :qualifying_years_total, 32
         assert_state_variable :remaining_years, 18
-        assert_phrase_list :result_text, [:too_few_qy_enough_remaining_years_a, :ni_table, :too_few_qy_enough_remaining_years_a_outro]
+        assert_phrase_list :result_text, [:too_few_qy_enough_remaining_years_a_intro, :ten_and_greater, :too_few_qy_enough_remaining_years_a]
       end
       
       should "show results for male and 35 available years" do
@@ -1175,7 +1229,7 @@ class CalculateStatePensionV2Test < ActiveSupport::TestCase
         assert_current_node :amount_result
         assert_state_variable :qualifying_years_total, 31
         assert_state_variable :remaining_years, 11
-        assert_phrase_list :result_text, [:too_few_qy_enough_remaining_years_a, :ni_table, :too_few_qy_enough_remaining_years_a_outro]
+        assert_phrase_list :result_text, [:too_few_qy_enough_remaining_years_a_intro, :ten_and_greater, :too_few_qy_enough_remaining_years_a]
       end
     end # end timecop 30-04-2014
     

--- a/test/unit/calculators/state_pension_amount_calculator_v2_test.rb
+++ b/test/unit/calculators/state_pension_amount_calculator_v2_test.rb
@@ -579,39 +579,39 @@ module SmartAnswer::Calculators
       end
 
       context "testing set pension dates from data file" do
-        should "67 years, 1 day; 2044-05-06" do
+        should "67 years; 2044-05-06" do
           @calculator = SmartAnswer::Calculators::StatePensionAmountCalculatorV2.new(
               gender: "male", dob: "1977-05-05", qualifying_years: nil)
           assert_equal Date.parse("2044-05-06"), @calculator.state_pension_date
-          assert_equal "67 years, 1 day", @calculator.state_pension_age
+          assert_equal "67 years", @calculator.state_pension_age
         end
 
-        should "65 years, 10 months and 23 days; dob: 1968-02-29; pension date: 2034-03-01 " do
+        should "67 years; dob: 1968-02-29; pension date: 2034-03-01 " do
           @calculator = SmartAnswer::Calculators::StatePensionAmountCalculatorV2.new(
               gender: "male", dob: "1968-02-29", qualifying_years: nil)
           # assert_equal "65 years, 10 months and 23 days", @calculator.state_pension_age
-          assert_equal "67 years, 1 day", @calculator.state_pension_age
+          assert_equal "67 years", @calculator.state_pension_age
           assert_equal Date.parse("2035-03-01"), @calculator.state_pension_date
         end
 
-        should "66 years, 7 months; 2035-05-06" do
+        should "67 years; 2035-05-06" do
           @calculator = SmartAnswer::Calculators::StatePensionAmountCalculatorV2.new(
               gender: "male", dob: "1968-10-06", qualifying_years: nil)
-          assert_equal "66 years, 7 months", @calculator.state_pension_age
+          assert_equal "67 years", @calculator.state_pension_age
           assert_equal Date.parse("2035-05-06"), @calculator.state_pension_date
         end
 
-        should "66 years, 6 months, 1 day; 2035-05-06" do
+        should "67 years; 2035-05-06" do
           @calculator = SmartAnswer::Calculators::StatePensionAmountCalculatorV2.new(
               gender: "male", dob: "1968-11-05", qualifying_years: nil)
-          assert_equal "66 years, 6 months, 1 day", @calculator.state_pension_age
+          assert_equal "67 years", @calculator.state_pension_age
           assert_equal Date.parse("2035-05-06"), @calculator.state_pension_date
         end
 
-        should "66 years, 8 months; 2035-05-06" do
+        should "67 years; 2035-05-06" do
           @calculator = SmartAnswer::Calculators::StatePensionAmountCalculatorV2.new(
               gender: "male", dob: "1968-11-06", qualifying_years: nil)
-          assert_equal "66 years, 8 months", @calculator.state_pension_age
+          assert_equal "67 years", @calculator.state_pension_age
           assert_equal Date.parse("2035-07-06"), @calculator.state_pension_date
         end
       end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/70924770

Fixed bug which was showing incorrect state pension age.
Fixed missing output table in outcome.
Additional test coverage.
Updated logic and content.
