### PR TITLE
Updating married abroad smart-answer - cni outcome for russia

### DIFF
--- a/lib/flows/locales/en/marriage-abroad.yml
+++ b/lib/flows/locales/en/marriage-abroad.yml
@@ -469,7 +469,19 @@ en-GB:
           ###Applying for a CNI from the consulate
 
           You’ll normally need to have been resident in Kazakhstan for at least 21 days. You can then book an appointment at the consulate to give notice of your marriage. There’s a fee for this service (see below).
-        
+        russia_os_local_resident: |
+          If you need a CNI, you’ll first need to give notice of your intended marriage at your nearest British %{embassy_or_consulate_residency_country}.
+
+          ###Applying for a CNI from the consulate
+
+          You’ll need to have been resident in the Russian Federation for at least 21 days. You can then book an appointment at the consulate in the district you’re resident in, to give notice of your marriage.
+
+          Email <RussiaConsular@fco.gov.uk> to find out where your local consulate is.
+
+          Book an appointment online at the [British Embassy Moscow](https://www.clickbook.net/dev/bc.nsf/sub/RussiaConsular) or the [British Consulate St Petersburg](https://stpetersburgconsular.clickbook.net/sub/stpetersburgconsular).
+
+          Email <RussiaConsular@fco.gov.uk> to book an appointment at the British Consulate Ekaterinburg.
+
         consular_cni_os_no_clickbook_so_embassy_details: |
           +[data_partial:overseas_passports_embassies:overseas_passports_embassies]
         consular_cni_os_local_resident_italy: |
@@ -795,6 +807,10 @@ en-GB:
         consular_cni_os_fees_foreign_commonwealth_roi_resident: |
           You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for %{residency_country_name_lowercase_prefix}](/government/publications/%{residency_country}-consular-fees) and [consular fees for %{country_name_lowercase_prefix}](/government/publications/%{ceremony_country}-consular-fees).
 
+        consular_cni_os_fees_russia: |
+          You can pay by cash or credit card in Moscow, but not by personal cheque.
+
+          You can pay by credit card only in St Petersburg and Ekaterinburg.
 # France phrases
         fot_os_all: |
           %{country_name_uppercase_prefix} is an overseas department or territory of France. The rules and requirements for getting married there are similar to France.
@@ -1407,21 +1423,6 @@ en-GB:
           Marriage in Indonesia
         body: |
           %{indonesia_os_phraselist}
-# outcome Russia - Opposite sex
-      outcome_os_russia:
-        title: |
-          Marriage in Russia
-        body: |
-          Applying for a CNI from the consulate
-          
-          You’ll need to have been resident in the Russian Federation for at least 21 days. You can then book an appointment at the consulate in the district you’re resident in, to give notice of your marriage.
-          
-          Email <RussiaConsular@fco.gov.uk> to find out where your local consulate is.
-         
-          Book an appointment online at the [British Embassy Moscow](https://www.clickbook.net/dev/bc.nsf/sub/RussiaConsular) or the [British Consulate St Petersburg](https://stpetersburgconsular.clickbook.net/sub/stpetersburgconsular).
-          
-          Email <RussiaConsular@fco.gov.uk> to book an appointment at the British Consulate Ekaterinburg.
-
 # outcome Switzerland
       outcome_switzerland:
         title: |

--- a/lib/flows/marriage-abroad.rb
+++ b/lib/flows/marriage-abroad.rb
@@ -236,7 +236,7 @@ multiple_choice :partner_opposite_or_same_sex? do
       :"outcome_#{ceremony_country}"
     else
       if response == 'opposite_sex'
-        if %w(indonesia russia).include?(ceremony_country)
+        if %w(indonesia).include?(ceremony_country)
           :"outcome_os_#{ceremony_country}"
         elsif data_query.os_affirmation_countries?(ceremony_country)
           :outcome_os_affirmation
@@ -341,8 +341,6 @@ outcome :outcome_os_indonesia do
     phrases
   end
 end
-
-outcome :outcome_os_russia
 
 outcome :outcome_os_commonwealth do
   precalculate :commonwealth_os_outcome do
@@ -555,11 +553,13 @@ outcome :outcome_os_consular_cni do
     end
 
     if ceremony_country == residency_country
-      if %w(germany italy kazakhstan).exclude?(ceremony_country)
+      if %w(germany italy kazakhstan russia).exclude?(ceremony_country)
         phrases << :consular_cni_os_local_resident_not_italy_germany
       end
-      phrases << :kazakhstan_os_local_resident if %w(kazakhstan).include?(ceremony_country)
-      if %w(germany italy japan spain).exclude?(ceremony_country)
+      if %w(kazakhstan russia).include?(ceremony_country)
+        phrases << :"#{ceremony_country}_os_local_resident"
+      end
+      if %w(germany italy japan russia spain).exclude?(ceremony_country)
         if reg_data_query.clickbook(ceremony_country)
           if %w(vietnam).include?(ceremony_country)
             phrases << :consular_cni_os_vietnam_clickbook
@@ -759,6 +759,8 @@ outcome :outcome_os_consular_cni do
     unless data_query.countries_without_consular_facilities?(ceremony_country)
       if %w(armenia bosnia-and-herzegovina cambodia iceland kazakhstan latvia luxembourg slovenia tunisia tajikistan).include?(ceremony_country)
         phrases << :pay_in_local_currency_ceremony_country_name
+      elsif %w(russia).include?(ceremony_country)
+        phrases << :consular_cni_os_fees_russia
       elsif %w(cote-d-ivoire).exclude?(ceremony_country)
         phrases << :pay_by_cash_or_credit_card_no_cheque
       end

--- a/test/integration/flows/marriage_abroad_test.rb
+++ b/test/integration/flows/marriage_abroad_test.rb
@@ -1294,8 +1294,10 @@ class MarriageAbroadTest < ActiveSupport::TestCase
       add_response 'partner_local'
       add_response 'opposite_sex'
     end
-    should "go to russia os outcome" do
-      assert_current_node :outcome_os_russia
+    should "go to russia CNI outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:local_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :"russia_os_local_resident", :consular_cni_variant_local_resident_not_germany_or_spain_or_foreign_resident, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :consular_cni_os_local_resident_not_germany_or_spain_or_foreign_resident_not_germany, :consular_cni_os_local_resident_not_germany_or_italy_or_spain]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :consular_cni_os_other_resident_ceremony_not_italy, :consular_cni_os_naturalisation, :consular_cni_os_fees_not_italy_not_uk, :list_of_consular_fees, :consular_cni_os_fees_russia]
     end
   end
 


### PR DESCRIPTION
Russia was mistakenly given a new outcome instead of having the existing one modified. This reverts those changes and adds the updated text.
