### PR TITLE
Manually track pushState pageviews with GA

### DIFF
--- a/app/assets/javascripts/smart-answers.js
+++ b/app/assets/javascripts/smart-answers.js
@@ -91,6 +91,7 @@ $(document).ready(function() {
   // manage the URL
   function addToHistory(data) {
     history.pushState(data, data['title'], data['url']);
+    window._gaq && window._gaq.push(['_trackPageview', data['url']]);
   }
 
   // add an indicator of loading


### PR DESCRIPTION
The version of GA we're using doesn't do this automatically, so ensure we capture all the steps in Smart Answers
