### PR TITLE
Check SASS compiles as part of Jenkins test runner

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,4 +1,7 @@
 #!/bin/bash -x
+
+set -e
+
 bundle install --path "/home/jenkins/bundles/${JOB_NAME}" --deployment --without=development
 export GOVUK_APP_DOMAIN=dev.gov.uk
 export GOVUK_ASSET_HOST=http://static.dev.gov.uk
@@ -12,5 +15,5 @@ done
 export DISPLAY=:99
 bundle exec rake stats
 RAILS_ENV=test bundle exec rake test
-RESULT=$?
-exit $RESULT
+
+bundle exec rake assets:precompile


### PR DESCRIPTION
- Running asset precompile will catch SASS syntactic/reference errors earlier.
- Use set -e, to immediately fail if any command fails,  rather than than relying
  on a manual exit, as we're running more than one 'test' command, more robust.
