### PR TITLE
Fix YAML syntax

### DIFF
--- a/lib/flows/locales/en/marriage-abroad.yml
+++ b/lib/flows/locales/en/marriage-abroad.yml
@@ -1667,7 +1667,7 @@ en-GB:
         body: |
           It’s not possible to get legal recognition for a same-sex relationship in %{country_name_lowercase_prefix}.
       outcome_ss_marriage:
-        title: %{ss_title} in %{country_name_lowercase_prefix}
+        title: "%{ss_title} in %{country_name_lowercase_prefix}"
         body: |
           %{ss_ceremony_body}
 


### PR DESCRIPTION
when parsing with Psych I was getting an error:

```
found character that cannot start any token while scanning for the next
token at line 1670 column 16 (Psych::SyntaxError)
```
