### PR TITLE
Add an indication of incomplete visualisations

### DIFF
--- a/app/assets/stylesheets/visualise.css.scss
+++ b/app/assets/stylesheets/visualise.css.scss
@@ -32,6 +32,12 @@
     #btn-toggle-rankdir {
         @include button;
     }
+
+}
+
+.warning {
+  border-left: 6px solid red;
+  padding: 0.5em 2em;
 }
 
 #paper {

--- a/app/controllers/smart_answers_controller.rb
+++ b/app/controllers/smart_answers_controller.rb
@@ -38,7 +38,8 @@ class SmartAnswersController < ApplicationController
   def visualise
     respond_to do |format|
       format.html {
-        @graph_data = GraphPresenter.new(@smart_answer).to_hash
+        @graph_presenter = GraphPresenter.new(@smart_answer)
+        @graph_data = @graph_presenter.to_hash
         render layout: true
       }
       format.gv {

--- a/app/views/smart_answers/visualise.html.erb
+++ b/app/views/smart_answers/visualise.html.erb
@@ -26,6 +26,9 @@
         </h1>
       </div>
       <p>This is a visualisation of the <%= link_to @presenter.title, smart_answer_path(params[:id]) %> questions and outcomes.</p>
+      <% if ! @graph_presenter.visualisable? %>
+        <div class='warning'><p>This visualisation does not show all transitions correctly. It needs to be updated so that it can be visualised correctly.</p></div>
+      <% end %>
     </header>
 
     <p>Having problems reading the visualisation? Changing the orientation may help.</p>

--- a/lib/graph_presenter.rb
+++ b/lib/graph_presenter.rb
@@ -23,6 +23,12 @@ class GraphPresenter
     end
   end
 
+  def visualisable?
+    @flow.questions.all? do |node|
+      node.permitted_next_nodes.any?
+    end
+  end
+
   def to_hash
     {
       labels: labels,

--- a/test/fixtures/graph_presenter_test/missing_transition.rb
+++ b/test/fixtures/graph_presenter_test/missing_transition.rb
@@ -1,0 +1,12 @@
+status :draft
+
+multiple_choice :q1? do
+  option :yes
+  option :no
+
+  next_node do
+    :done
+  end
+end
+
+outcome :done

--- a/test/unit/graph_presenter_test.rb
+++ b/test/unit/graph_presenter_test.rb
@@ -39,5 +39,13 @@ module SmartAnswer
 
       assert_equal expected_adjacency_list, @presenter.adjacency_list
     end
+
+    test "indicates does not define transitions in a way which can be visualised" do
+      p = GraphPresenter.new(@registry.find('graph'))
+      assert p.visualisable?, "'graph' should be visualisable"
+
+      p = GraphPresenter.new(@registry.find('missing_transition'))
+      refute p.visualisable?, "'missing_transition' should not be visualisable"
+    end
   end
 end


### PR DESCRIPTION
Some flows haven't been updated to use the `next_node_if` syntax. Until we get around to doing that it would be nice to have a warning on flows which are incomplete. This does that.

Might need a little prettification if @dsingleton has time?
