### PR TITLE
Fix state pension top up age bug

### DIFF
--- a/lib/smart_answer/calculators/state_pension_topup_calculator.rb
+++ b/lib/smart_answer/calculators/state_pension_topup_calculator.rb
@@ -34,18 +34,25 @@ module SmartAnswer::Calculators
 
     def lump_sum_and_age(dob, weekly_amount)
       rows = []
-      age = date_difference_in_years(dob, TOPUP_START_DATE)
+      age = age_at_date(dob, TOPUP_START_DATE)
       (TOPUP_START_DATE.year..TOPUP_END_DATE.year).each do |year|
-        break if age > UPPER_AGE
+        break if age > UPPER_AGE || birthday_after_topup_end?(dob, age)
         rows << {:amount => lump_sum_amount(age, weekly_amount), :age => age} if age >= @retirement_age
         age += 1
       end
       rows
     end
 
-    def date_difference_in_years(dob, date)
+    def birthday_after_topup_end?(dob, age)
+      birthday = Date.new(TOPUP_END_DATE.year, dob.month, dob.day)
+      age_at_topup_end = age_at_date(dob, TOPUP_END_DATE)
+      (age > age_at_topup_end) && (birthday >= TOPUP_END_DATE)
+    end
+
+    def age_at_date(dob, date)
       years = date.year - dob.year
-      if (date.month < dob.month) || ((date.month == dob.month) && (date.day < dob.day))
+      birthday = Date.new(date.year, dob.month, dob.day)
+      if date < birthday
         years = years - 1
       end
       years

--- a/test/integration/flows/state_pension_topup_v2_test.rb
+++ b/test/integration/flows/state_pension_topup_v2_test.rb
@@ -66,9 +66,9 @@ class CalculateStatePensionTopupV2Test < ActiveSupport::TestCase
       add_response "male"
       add_response 1
     end
-    should "show two rates" do
+    should "show one rate" do
       assert_current_node :outcome_topup_calculations
-      assert_state_variable :amount_and_age, "- £890 when you're 65\n- £871 when you're 66"
+      assert_state_variable :amount_and_age, "- £890 when you're 65"
     end
   end
   context "Man turns 65 on 6 April 2016 = DOB 6/4/1951 = not old enough" do
@@ -86,9 +86,9 @@ class CalculateStatePensionTopupV2Test < ActiveSupport::TestCase
       add_response "female"
       add_response 1
     end
-    should "show should two rates only" do
+    should "should show one rate only" do
       assert_current_node :outcome_topup_calculations
-      assert_state_variable :amount_and_age, "- £934 when you're 63\n- £913 when you're 64"
+      assert_state_variable :amount_and_age, "- £934 when you're 63"
     end
   end
   context "Woman turns 63 on 6 April 2016 = DOB 6/4/1953 = not old enough" do
@@ -133,7 +133,7 @@ class CalculateStatePensionTopupV2Test < ActiveSupport::TestCase
   end
   context "Male born 13/10/1940 needs 3 rates" do
     setup do
-      add_response Date.parse('1940-10-13')
+      add_response Date.parse('1940-10-14')
       add_response "male"
       add_response 1
     end

--- a/test/unit/calculators/state_pension_topup_calculator_v2_test.rb
+++ b/test/unit/calculators/state_pension_topup_calculator_v2_test.rb
@@ -26,11 +26,11 @@ module SmartAnswer::Calculators
       end
 
       should "Show age of 64" do
-        assert_equal 64, @calculator.date_difference_in_years(Date.parse('1951-04-06'), Date.parse('2015-10-12'))
+        assert_equal 64, @calculator.age_at_date(Date.parse('1951-04-06'), Date.parse('2015-10-12'))
       end
 
       should "Show age of 85" do
-        assert_equal 85, @calculator.date_difference_in_years(Date.parse('1930-04-06'), Date.parse('2015-10-12'))
+        assert_equal 85, @calculator.age_at_date(Date.parse('1930-04-06'), Date.parse('2015-10-12'))
       end
     end
 
@@ -40,12 +40,12 @@ module SmartAnswer::Calculators
         @calculator.retirement_age('male')
       end
 
-      should "Show 3 rates for ages 85 to 87" do
-        assert_equal [{:amount=>3940.0, :age=>85}, {:amount=>3660.0, :age=>86}, {:amount=>3390.0, :age=>87}], @calculator.lump_sum_and_age(Date.parse('1930-04-06'), 10)
+      should "Show 2 rates for ages 85 and 86" do
+        assert_equal [{:amount=>3940.0, :age=>85}, {:amount=>3660.0, :age=>86}], @calculator.lump_sum_and_age(Date.parse('1930-04-06'), 10)
       end
 
-      should "Show 2 rates for ages 65 and 66" do
-        assert_equal [{:amount=>8900.0, :age=>65}, {:amount=>8710.0, :age=>66}], @calculator.lump_sum_and_age(Date.parse('1951-04-06'), 10)
+      should "Show rate for 65" do
+        assert_equal [{:amount=>8900.0, :age=>65}], @calculator.lump_sum_and_age(Date.parse('1951-04-06'), 10)
       end
     end
 
@@ -55,8 +55,8 @@ module SmartAnswer::Calculators
         @calculator.retirement_age('female')
       end
 
-      should "Show 2 rates for 63 and 64" do
-        assert_equal [{:amount=>9340.0, :age=>63}, {:amount=>9130.0, :age=>64}], @calculator.lump_sum_and_age(Date.parse('1953-04-06'), 10)
+      should "Show rate for 63" do
+        assert_equal [{:amount=>9340.0, :age=>63}], @calculator.lump_sum_and_age(Date.parse('1953-04-06'), 10)
       end
     end
   end


### PR DESCRIPTION
- Adjusted calculator to cover error which allowed people with their date of birth after the top up end date to be shown a rate.
- Fixed tests.

Relates to:
https://www.pivotaltracker.com/story/show/72886346
