### PR TITLE
Calculator: vat deadlines calculator: CHAPS payment calculation update

### DIFF
--- a/lib/flows/vat-payment-deadlines.rb
+++ b/lib/flows/vat-payment-deadlines.rb
@@ -18,8 +18,8 @@ multiple_choice :how_do_you_want_to_pay? do
   option :'online-debit-credit-card' => :result_online_debit_credit_card
   option :'bacs-direct-credit' => :result_bacs_direct_credit
   option :'bank-giro' => :result_bank_giro
-  option 'chaps' => :result_chaps
-  option 'cheque' => :result_cheque
+  option :'chaps' => :result_chaps
+  option :'cheque' => :result_cheque
 
   calculate :calculator do
     Calculators::VatPaymentDeadlines.new(period_end_date, responses.last)

--- a/lib/smart_answer/calculators/vat_payment_deadlines.rb
+++ b/lib/smart_answer/calculators/vat_payment_deadlines.rb
@@ -44,7 +44,9 @@ module SmartAnswer::Calculators
         # Select previous working day if not a work_day
         0.working_days.before(end_of_month_after(@period_end_date) + 7.days)
       when 'chaps'
-        5.working_days.after(end_of_month_after(@period_end_date))
+        receiving_by_date = end_of_month_after(@period_end_date) + 7.days
+        receiving_by_date -= 1 while !receiving_by_date.workday?
+        receiving_by_date
       when 'cheque'
         # Select previous working day if not a work_day
         0.working_days.before(end_of_month_after(@period_end_date))

--- a/test/unit/calculators/vat_payment_deadlines_test.rb
+++ b/test/unit/calculators/vat_payment_deadlines_test.rb
@@ -104,20 +104,46 @@ module SmartAnswer::Calculators
         @method = 'chaps'
       end
 
-      should "calculate last_payment_date as end_of_month_after(end_date) + 7 days" do
-        calc = VatPaymentDeadlines.new(Date.parse('2013-04-30'), @method)
-        assert_equal Date.parse('2013-06-07'), calc.last_payment_date
-      end
+      # should "calculate last_payment_date as end_of_month_after(end_date) + 7 days" do
+      #   calc = VatPaymentDeadlines.new(Date.parse('2013-04-30'), @method)
+      #   assert_equal Date.parse('2013-06-07'), calc.last_payment_date
+      # end
 
-      should "calculate funds_received_by as end_of_month_after(end_date) + 7 days" do
-        calc = VatPaymentDeadlines.new(Date.parse('2013-04-30'), @method)
-        assert_equal Date.parse('2013-06-07'), calc.funds_received_by
-      end
+      # should "calculate funds_received_by as end_of_month_after(end_date) + 7 days" do
+      #   calc = VatPaymentDeadlines.new(Date.parse('2013-04-30'), @method)
+      #   assert_equal Date.parse('2013-06-07'), calc.funds_received_by
+      # end
 
-      #date falling in weekend
-      should "calculate funds_received_by as end_of_month_after(end_date) + 7 days = falls in weekend therefore result is preceding working day" do
-        calc = VatPaymentDeadlines.new(Date.parse('2015-04-30'), @method)
-        assert_equal Date.parse('2015-06-05'), calc.funds_received_by
+      # #date falling in weekend
+      # should "calculate funds_received_by as end_of_month_after(end_date) + 7 days = falls in weekend therefore result is preceding working day" do
+      #   calc = VatPaymentDeadlines.new(Date.parse('2015-04-30'), @method)
+      #   assert_equal Date.parse('2015-06-05'), calc.funds_received_by
+      # end
+
+      should "The last date you can pay is [period_end_date + 1 calendar month + 7 calendar days. If the 7th is a BH or WE go back to the last preceding working day. Same for either payment date and funds_received_by date" do
+        calc = VatPaymentDeadlines.new(Date.parse('2013-11-30'), @method)
+        assert_equal Date.parse('2014-01-07'), calc.last_payment_date
+        assert_equal Date.parse('2014-01-07'), calc.funds_received_by
+
+        calc = VatPaymentDeadlines.new(Date.parse('2014-03-31'), @method)
+        assert_equal Date.parse('2014-05-07'), calc.last_payment_date
+        assert_equal Date.parse('2014-05-07'), calc.funds_received_by
+
+        calc = VatPaymentDeadlines.new(Date.parse('2014-11-30'), @method)
+        assert_equal Date.parse('2015-01-07'), calc.last_payment_date
+        assert_equal Date.parse('2015-01-07'), calc.funds_received_by
+
+        calc = VatPaymentDeadlines.new(Date.parse('2015-02-28'), @method)
+        assert_equal Date.parse('2015-04-07'), calc.last_payment_date
+        assert_equal Date.parse('2015-04-07'), calc.funds_received_by
+
+        calc = VatPaymentDeadlines.new(Date.parse('2015-03-31'), @method)
+        assert_equal Date.parse('2015-05-07'), calc.last_payment_date
+        assert_equal Date.parse('2015-05-07'), calc.funds_received_by
+
+        calc = VatPaymentDeadlines.new(Date.parse('2015-11-30'), @method)
+        assert_equal Date.parse('2016-01-07'), calc.last_payment_date
+        assert_equal Date.parse('2016-01-07'), calc.funds_received_by
       end
     end
 


### PR DESCRIPTION
CHAPS payment is received by HMRC on the same day that it is made, hence the two dates should always be the same

https://www.pivotaltracker.com/story/show/73131588
