### PR TITLE
Fix pension credit date phrase list bug

### DIFF
--- a/lib/flows/calculate-state-pension-v2.rb
+++ b/lib/flows/calculate-state-pension-v2.rb
@@ -80,10 +80,20 @@ date_question :dob_age? do
     phrases = PhraseList.new
     if state_pension_date > Date.today
       if state_pension_date >= Date.parse('2016-04-06')
-        phrases << :state_pension_age_is_a << :pension_credit_future
+        phrases << :state_pension_age_is_a
+        if Date.parse(pension_credit_date) > Date.today
+          phrases << :pension_credit_future
+        else
+          phrases << :pension_credit_past
+        end
         phrases << :pension_age_review
       else
-        phrases << :state_pension_age_is << :pension_credit_future
+        phrases << :state_pension_age_is
+        if Date.parse(pension_credit_date) > Date.today
+          phrases << :pension_credit_future
+        else
+          phrases << :pension_credit_past
+        end
       end
     else
       phrases << :state_pension_age_was << :pension_credit_past

--- a/test/integration/flows/calculate_state_pension_v2_test.rb
+++ b/test/integration/flows/calculate_state_pension_v2_test.rb
@@ -150,6 +150,20 @@ class CalculateStatePensionV2Test < ActiveSupport::TestCase
       end
     end
 
+    context "male with different state pension and pension credit dates" do
+      setup do
+        Timecop.travel('2014-05-07')
+      end
+      should "go to correct outcome with pension_credit_past" do
+        add_response :male
+        add_response Date.parse('3 February 1952')
+        assert_current_node :age_result
+        assert_state_variable :formatted_state_pension_date, ' 3 February 2017'
+        assert_state_variable :pension_credit_date, ' 6 November 2013'
+        assert_phrase_list :state_pension_age_statement, [:state_pension_age_is_a, :pension_credit_past, :pension_age_review, :bus_pass]
+      end
+    end
+
     context "test correct state pension age" do
       setup do
         Timecop.travel('2014-05-08')


### PR DESCRIPTION
- Wrong phrase was being shown for people who had a pension credit date before their state pension date.
- Additional test coverage for edge cases.
