### PR TITLE
Update overseas passports Pakistan outcomes

### DIFF
--- a/lib/data/passport_data.yml
+++ b/lib/data/passport_data.yml
@@ -1370,6 +1370,7 @@ pakistan:
   type: ips_application_3
   group: ips_documents_group_3
   app_form: hmpo_1_application_form
+  application_office: true
   renewing_new: 8_weeks
   renewing_old: 6_months
   applying: 6_months

--- a/lib/flows/locales/en/overseas-passports.yml
+++ b/lib/flows/locales/en/overseas-passports.yml
@@ -459,12 +459,12 @@ en-GB:
 
         how_long_additional_info_replacing: |
           If you haven’t already reported the loss or theft, you must include [form LS01](/government/publications/lost-or-stolen-passport-notification--2) with your declaration form.
-          
+
         how_long_additional_info_renewing_old: |
           You may have to attend an interview for a first adult passport.
         how_long_additional_info_renewing_new: |
           You may have to attend an interview for a first adult passport.
-          
+
         how_long_it_takes_ips1: |
           Applications may take longer if:
 
@@ -598,10 +598,7 @@ en-GB:
 
           You must post your completed form and supporting documents to the British High Commission in New Delhi.
 
-        send_application_ips3_pakistan: |
-          ## Making your application
 
-          You must post your completed form and supporting documents to the British High Commission in Islamabad.
 
         send_application_uk_visa_renew_new: |
           ## Making your application
@@ -956,6 +953,48 @@ en-GB:
           $C
           Email: <KathmanduHMPO@vfshelpline.com>
           Opening hours: Monday to Friday 2pm to 4pm (local time)
+          $C
+
+        send_application_address_pakistan: |
+
+          $A
+          UK Visa Application Centre
+          14-B, Sadiq Plaza G-9 Markaz
+          Islamabad
+          $A
+          $C
+          Email:<islamabad.hmpo@gerrys.com.pk>
+          $C
+
+          $A
+          UK Visa Application Centre
+          43/1/D, Razi Road PECHS
+          Shaharah-e-Faisal
+          Karachi
+          $A
+          $C
+          Email: <karachi.hmpo@gerrys.com.pk>
+          $C
+
+          $A
+          UK Visa Application Centre
+          20, Ex American Centre Building
+          Opp. Ganga Ram Hospital
+          Queens Road
+          Lahore
+          $A
+          $C
+          Email: <lahore.hmpo@gerrys.com.pk>
+          $C
+
+          $A
+          UK Visa Application Centre
+          Nau Mahal Plaza, Near Foot Ball Square,
+          Defense Road
+          Mirpur
+          $A
+          $C
+          Email: <mirpur.hmpo@gerrys.com.pk>
           $C
 
         send_application_address_pitcairn-island: |

--- a/lib/flows/overseas-passports.rb
+++ b/lib/flows/overseas-passports.rb
@@ -193,7 +193,7 @@ outcome :ips_application_result do
   end
 
   precalculate :cost do
-    uk_visa_application_centre_countries = %w(algeria azerbaijan belarus china georgia indonesia kazakhstan laos lebanon mauritania morocco nepal russia thailand ukraine venezuela western-sahara)
+    uk_visa_application_centre_countries = %w(algeria azerbaijan belarus china georgia indonesia kazakhstan laos lebanon mauritania morocco nepal pakistan russia thailand ukraine venezuela western-sahara)
     pay_at_appointment_countries = %(venezuela)
 
     if application_action == 'replacing' and ips_number == '1' and ips_docs_number == '1'
@@ -239,8 +239,8 @@ outcome :ips_application_result do
   end
 
   precalculate :send_your_application do
-    uk_visa_application_centre_countries = %w(afghanistan algeria azerbaijan belarus burundi china gaza georgia indonesia kazakhstan laos lebanon mauritania morocco nepal russia thailand ukraine western-sahara venezuela)
-    uk_visa_application_with_colour_pictures = %w(azerbaijan algeria belarus china georgia indonesia kazakhstan laos lebanon mauritania morocco nepal thailand ukraine russia venezuela)
+    uk_visa_application_centre_countries = %w(afghanistan algeria azerbaijan belarus burundi china gaza georgia indonesia kazakhstan laos lebanon mauritania morocco nepal pakistan russia thailand ukraine western-sahara venezuela)
+    uk_visa_application_with_colour_pictures = %w(azerbaijan algeria belarus china georgia indonesia kazakhstan laos lebanon mauritania morocco nepal pakistan thailand ukraine russia venezuela)
     non_uk_visa_application_with_colour_pictures = %w(burma cuba sudan tajikistan turkmenistan uzbekistan)
     phrases = PhraseList.new
     if application_address
@@ -285,10 +285,10 @@ outcome :ips_application_result do
       end
     elsif %w(timor-leste).include?(current_location)
       phrases << :"send_application_#{current_location}" << :"send_application_address_#{current_location}"
-    elsif %w(bangladesh india pakistan).include?(current_location)
+    elsif %w(bangladesh india).include?(current_location)
       phrases << :"send_application_ips3_#{current_location}"
-      phrases << :send_application_ips3_must_post unless %w(india bangladesh pakistan).include?(current_location)
-      phrases << :send_application_ips3_must_post_colour_photo if %w(india pakistan).include?(current_location)
+      phrases << :send_application_ips3_must_post unless %w(india bangladesh).include?(current_location)
+      phrases << :send_application_ips3_must_post_colour_photo if %w(india).include?(current_location)
       phrases << :send_application_embassy_address
     elsif general_action == 'renewing' and data_query.renewing_countries?(current_location)
       if passport_data['application_office']
@@ -320,7 +320,7 @@ outcome :ips_application_result do
     collect_in_person_countries = %w(angola benin cameroon chad congo eritrea ethiopia gambia ghana guinea jamaica kenya nigeria somalia south-sudan zambia zimbabwe)
     collect_in_person_variant_countries = %w(burundi india jordan pitcairn-island)
     collect_in_person_renewing_new_variant_countries = %(burma nepal north-korea)
-    uk_visa_application_centre_countries = %w(algeria azerbaijan belarus china georgia indonesia kazakhstan lebanon mauritania morocco russia thailand ukraine venezuela western-sahara)
+    uk_visa_application_centre_countries = %w(algeria azerbaijan belarus china georgia indonesia kazakhstan lebanon mauritania morocco pakistan russia thailand ukraine venezuela western-sahara)
     uk_visa_application_centre_variant_countries = %w(cambodia egypt iraq libya rwanda sierra-leone tunisia uganda yemen)
     collect_with_photo_id_countries = %w(cambodia egypt iraq libya rwanda sierra-leone tunisia uganda yemen)
     passport_delivered_by_courier_countries = %w(laos)

--- a/test/integration/flows/overseas_passports_test.rb
+++ b/test/integration/flows/overseas_passports_test.rb
@@ -850,24 +850,6 @@ class OverseasPassportsTest < ActiveSupport::TestCase
     end
   end # Bangladesh
 
-  context "answer Pakistan" do
-    setup do
-      worldwide_api_has_organisations_for_location('pakistan', read_fixture_file('worldwide/pakistan_organisations.json'))
-      add_response 'pakistan'
-    end
-    context "applying for a new adult passport" do
-      should "give the ips result" do
-        add_response 'applying'
-        add_response 'adult'
-        add_response 'pakistan'
-        assert_current_node :ips_application_result
-        assert_phrase_list :how_long_it_takes, [:how_long_6_months, :how_long_it_takes_ips3]
-        assert_phrase_list :send_your_application, [:send_application_ips3_pakistan, :send_application_ips3_must_post_colour_photo, :send_application_embassy_address]
-        assert_phrase_list :how_to_apply, [:how_to_apply_ips3, :send_application_ips1_pakistan, :hmpo_1_application_form, :ips_documents_group_3]
-      end
-    end
-  end # Pakistan
-
   context "answer Uzbekistan" do
     setup do
       worldwide_api_has_organisations_for_location('uzbekistan', read_fixture_file('worldwide/uzbekistan_organisations.json'))
@@ -1149,4 +1131,36 @@ class OverseasPassportsTest < ActiveSupport::TestCase
       end
     end
   end
+  # Testing for Pakistan
+  context "testing for pakistan outcome variations" do
+    setup do
+      worldwide_api_has_organisations_for_location('pakistan', read_fixture_file('worldwide/pakistan_organisations.json'))
+      add_response 'pakistan'
+    end
+    context "renewing_new pakistan adult passport" do
+      should "go to outcome with correct phrases" do
+        add_response 'renewing_new'
+        add_response 'adult'
+        assert_current_node :ips_application_result
+        assert_phrase_list :how_long_it_takes, [:how_long_8_weeks, :how_long_it_takes_ips3]
+        assert_phrase_list :cost, [:passport_courier_costs_ips3_uk_visa, :adult_passport_costs_ips3, :passport_costs_ips3]
+        assert_phrase_list :send_your_application, [:send_application_uk_visa_renew_new_colour, :send_application_address_pakistan]
+        assert_phrase_list :how_to_apply, [:how_to_apply_ips3, :send_application_ips1_pakistan, :hmpo_1_application_form, :ips_documents_group_3]
+        assert_phrase_list :getting_your_passport, [:getting_your_passport_uk_visa_centre, :getting_your_passport_contact, :getting_your_passport_id_renew_new]
+      end
+    end # renewing_new adult
+    context "replacing adult passport" do
+      should "give the ips result" do
+        add_response 'replacing'
+        add_response 'child'
+        assert_current_node :ips_application_result
+        assert_phrase_list :how_long_it_takes, [:how_long_14_weeks,:report_loss_or_theft, :how_long_it_takes_ips3]
+        assert_phrase_list :cost, [:passport_courier_costs_ips3_uk_visa, :child_passport_costs_ips3, :passport_costs_ips3]
+        assert_phrase_list :send_your_application, [:send_application_uk_visa_apply_renew_old_replace_colour,
+          :send_application_address_pakistan]
+        assert_phrase_list :how_to_apply, [:how_to_apply_ips3, :send_application_ips1_pakistan, :hmpo_1_application_form, :ips_documents_group_3]
+        assert_phrase_list :getting_your_passport, [:getting_your_passport_uk_visa_centre, :getting_your_passport_contact_and_id]
+      end
+    end # replacing child
+  end # Pakistan tests
 end


### PR DESCRIPTION
- Changed logic flow to allow for Pakistan to get UK visa application centre outcomes.
- Updated yml files with come extra Pakistan specific content.
- Additional test coverage for new Pakistan phrases.

https://www.pivotaltracker.com/story/show/74776660
