### PR TITLE
Fix smart answer visualiser toggle button text

### DIFF
--- a/app/assets/javascripts/visualise.js
+++ b/app/assets/javascripts/visualise.js
@@ -123,9 +123,9 @@
           rankSep: 100
         });
         if (rankDir == 'LR') {
-          toggleButton.text('Show in portrait');
-        } else {
           toggleButton.text('Show in landscape');
+        } else {
+          toggleButton.text('Show in portrait');
         }
         var padding = 400;
         paper.fitToContent(10, 10, padding);

--- a/app/views/smart_answers/visualise.html.erb
+++ b/app/views/smart_answers/visualise.html.erb
@@ -33,7 +33,7 @@
     </header>
 
     <p>Having problems reading the visualisation? Changing the orientation may help.</p>
-    <button id="btn-toggle-rankdir" class="big button">Show in landscape</button>
+    <button id="btn-toggle-rankdir" class="big button">Show in portrait</button>
 
   </div>
 </main>


### PR DESCRIPTION
- Swapped the text in the toggle button of the visualiser to say "Show in portrait" initially.
- Adjusted js file to accommodate.

https://www.pivotaltracker.com/story/show/73195900
