### PR TITLE
Smartanswers: registrations data query  - Add back mistakenly removed code

### DIFF
--- a/lib/smart_answer/calculators/registrations_data_query_v2.rb
+++ b/lib/smart_answer/calculators/registrations_data_query_v2.rb
@@ -13,6 +13,8 @@ module SmartAnswer::Calculators
 
     PAY_BY_BANK_DRAFT_COUNTRIES = %w(taiwan)
 
+    CHEQUE_ONLY_COUNTRIES = %w(taiwan)
+
     EASTERN_CARIBBEAN_COUNTRIES = %w(antigua-and-barbuda barbados dominica st-kitts-and-nevis st-vincent-and-the-grenadines)
 
     NO_POSTAL_COUNTRIES = %w(barbados costa-rica malaysia papua-new-guinea sweden tanzania thailand)
@@ -87,6 +89,9 @@ module SmartAnswer::Calculators
       PAY_BY_BANK_DRAFT_COUNTRIES.include?(country_slug)
     end
 
+    def cheque_only?(country_slug)
+      CHEQUE_ONLY_COUNTRIES.include?(country_slug)
+    end
     def cash_and_card_only?(country_slug)
       CASH_AND_CARD_COUNTRIES.include?(country_slug)
     end


### PR DESCRIPTION
I put back the code that I removed in: https://github.com/alphagov/smart-answers/commit/6c0357f1c62e381a485171de4b37a6dd38942567
