### PR TITLE
Fix calculate statutory sick pay bug

### DIFF
--- a/lib/flows/calculate-statutory-sick-pay-v2.rb
+++ b/lib/flows/calculate-statutory-sick-pay-v2.rb
@@ -26,8 +26,8 @@ multiple_choice :employee_tell_within_limit? do
   option :yes
   option :no
 
-  calculate :notice_of_absence do
-    responses.last == 'no'
+  calculate :enough_notice_of_absence do
+    responses.last == 'yes'
   end
 
   next_node(:employee_work_different_days?)
@@ -279,11 +279,11 @@ outcome :entitled_to_sick_pay do
   precalculate :pattern_days_total do calculator.pattern_days * 28 end
 
   precalculate :proof_of_illness do
-    PhraseList.new(:enough_notice) if notice_of_absence
+    PhraseList.new(:enough_notice) unless enough_notice_of_absence
   end
 
   precalculate :entitled_to_esa do
-    PhraseList.new(:esa) if notice_of_absence
+    PhraseList.new(:esa) if enough_notice_of_absence
   end
 
   precalculate :paternity_adoption_warning do

--- a/test/integration/flows/calculate_statutory_sick_pay_v2_test.rb
+++ b/test/integration/flows/calculate_statutory_sick_pay_v2_test.rb
@@ -127,7 +127,6 @@ class CalculateStatutorySickPayV2Test < ActiveSupport::TestCase
                           should "go to entitled_to_sick_pay outcome" do
                             assert_current_node :entitled_to_sick_pay
                             assert_phrase_list :proof_of_illness, [:enough_notice]
-                            assert_phrase_list :entitled_to_esa, [:esa]
                             assert_phrase_list :paternity_adoption_warning, [:paternity_warning]
                           end
                         end
@@ -283,6 +282,8 @@ class CalculateStatutorySickPayV2Test < ActiveSupport::TestCase
                               end
                               should "take you to result 6 without first days (no PIW)" do
                                 assert_current_node :entitled_to_sick_pay
+                                assert_phrase_list :entitled_to_esa, [:esa]
+                                assert_phrase_list :paternity_adoption_warning, [:paternity_warning]
                               end
                             end
                           end


### PR DESCRIPTION
- Fixed bug which was showing the wrong phrase dependent upon an answer to a question in the flow.
- Adjusted tests to cover the correct phrases in the outcome.

Relates to https://www.pivotaltracker.com/story/show/74588798
