### PR TITLE
Ensure the `rm` command completes without error

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -8,7 +8,7 @@ export GOVUK_ASSET_HOST=http://static.dev.gov.uk
 
 # DELETE STATIC SYMLINKS AND RECONNECT...
 for d in images javascripts templates stylesheets; do
-  rm public/$d
+  rm -f public/$d
   ln -s ../../Static/public/$d public/
 done
 


### PR DESCRIPTION
There are sporadic build failures on CI of the form:

```
+ export GOVUK_APP_DOMAIN=dev.gov.uk
+ GOVUK_APP_DOMAIN=dev.gov.uk
+ export GOVUK_ASSET_HOST=http://static.dev.gov.uk
+ GOVUK_ASSET_HOST=http://static.dev.gov.uk
+ for d in images javascripts templates stylesheets
+ rm public/images
rm: cannot remove `public/images': No such file or directory
```

Passing the `-f` flag to `rm` ensures that it will swallow errors like
that and continue fine (since we don't care if the directory doesn't exist).
