### PR TITLE
Delete redundant asset/symlink removal on Jenkins

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -6,12 +6,6 @@ bundle install --path "/home/jenkins/bundles/${JOB_NAME}" --deployment --without
 export GOVUK_APP_DOMAIN=dev.gov.uk
 export GOVUK_ASSET_HOST=http://static.dev.gov.uk
 
-# DELETE STATIC SYMLINKS AND RECONNECT...
-for d in images javascripts templates stylesheets; do
-  rm public/$d
-  ln -s ../../Static/public/$d public/
-done
-
 export DISPLAY=:99
 bundle exec rake stats
 RAILS_ENV=test bundle exec rake test


### PR DESCRIPTION
The asset pipeline should take care of this for us.

Leaving this code in causes errors of the form:

```
+ export GOVUK_APP_DOMAIN=dev.gov.uk
+ GOVUK_APP_DOMAIN=dev.gov.uk
+ export GOVUK_ASSET_HOST=http://static.dev.gov.uk
+ GOVUK_ASSET_HOST=http://static.dev.gov.uk
+ for d in images javascripts templates stylesheets
+ rm public/images
rm: cannot remove `public/images': No such file or directory
```

Replaces #1024
