### PR TITLE
Smartanswers: marriage abroad - Lithuania update

### DIFF
--- a/lib/flows/marriage-abroad-v2.rb
+++ b/lib/flows/marriage-abroad-v2.rb
@@ -26,7 +26,7 @@ country_select :country_of_ceremony?, exclude_countries: exclude_countries do
   end
 
   calculate :marriage_and_partnership_phrases do
-    if data_query.ss_marriage_countries?(ceremony_country)
+    if data_query.ss_marriage_countries?(ceremony_country) | data_query.ss_marriage_countries_when_couple_british?(ceremony_country)
       "ss_marriage"
     elsif data_query.ss_marriage_and_partnership?(ceremony_country)
       "ss_marriage_and_partnership"
@@ -240,6 +240,9 @@ multiple_choice :partner_opposite_or_same_sex? do
   define_predicate(:ss_marriage_countries?) {
     data_query.ss_marriage_countries?(ceremony_country)
   }
+  define_predicate(:ss_marriage_countries_when_couple_british?) {
+    data_query.ss_marriage_countries_when_couple_british?(ceremony_country) & %w(partner_british).include?(partner_nationality)
+  }
   define_predicate(:ss_marriage_and_partnership?) {
     data_query.ss_marriage_and_partnership?(ceremony_country)
   }
@@ -251,10 +254,7 @@ multiple_choice :partner_opposite_or_same_sex? do
   next_node_if(:outcome_ss_marriage_not_possible, ss_marriage_not_possible?)
 
   next_node_if(:outcome_ss_marriage,
-    (
-      variable_matches(:residency_uk_region, %w(uk_england uk_scotland uk_ni uk_wales uk_iom uk_ci)) |
-      variable_matches(:resident_of, "other")
-    ) & ( ss_marriage_countries? | ss_marriage_and_partnership?)
+    ss_marriage_countries? | ss_marriage_countries_when_couple_british? | ss_marriage_and_partnership?
   )
 
   next_node_if(:outcome_os_consular_cni, variable_matches(:ceremony_country, "spain"))

--- a/lib/smart_answer/calculators/marriage_abroad_data_query_v2.rb
+++ b/lib/smart_answer/calculators/marriage_abroad_data_query_v2.rb
@@ -40,7 +40,9 @@ module SmartAnswer::Calculators
 
     COUNTRIES_WITHOUT_CONSULAR_FACILITIES = %w(aruba slovakia curacao bonaire-st-eustatius-saba st-maarten taiwan czech-republic argentina cote-d-ivoire)
 
-    SS_MARRIAGE_COUNTRIES = %w(australia azerbaijan bolivia chile china colombia dominican-republic estonia kosovo latvia lithuania mongolia montenegro nicaragua russia san-marino hungary serbia)
+    SS_MARRIAGE_COUNTRIES = %w(australia azerbaijan bolivia chile china colombia dominican-republic estonia kosovo latvia mongolia montenegro nicaragua russia san-marino hungary serbia)
+
+    SS_MARRIAGE_COUNTRIES_WHEN_COUPLE_BRITISH = %w(lithuania)
 
     SS_MARRIAGE_AND_PARTNERSHIP_COUNTRIES = %w(cambodia costa-rica peru philippines vietnam japan)
 
@@ -58,6 +60,10 @@ module SmartAnswer::Calculators
 
     def ss_marriage_countries?(country_slug)
       SS_MARRIAGE_COUNTRIES.include?(country_slug)
+    end
+
+    def ss_marriage_countries_when_couple_british?(country_slug)
+      SS_MARRIAGE_COUNTRIES_WHEN_COUPLE_BRITISH.include?(country_slug)
     end
 
     def ss_marriage_and_partnership?(country_slug)

--- a/test/integration/flows/marriage_abroad_v2_test.rb
+++ b/test/integration/flows/marriage_abroad_v2_test.rb
@@ -1960,7 +1960,7 @@ class MarriageAbroadV2Test < ActiveSupport::TestCase
       assert_phrase_list :affirmation_os_outcome, [:affirmation_os_local_resident, :gulf_states_os_consular_cni, :gulf_states_os_consular_cni_local_resident_partner_not_irish, :affirmation_os_all_what_you_need_to_do, :what_you_need_to_do_may_ask, :appointment_for_affidavit, :affirmation_os_translation_in_local_language, :docs_decree_and_death_certificate, :divorced_or_widowed_evidences, :change_of_name_evidence, :affirmation_os_partner_not_british, :fee_table_45_70_55, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
     end
   end
-  context "Now Lithuania allows same sex marriage" do
+  context "ceremony in Lithuania, partner same sex, partner british" do
     setup do
       worldwide_api_has_organisations_for_location('lithuania', read_fixture_file('worldwide/lithuania_organisations.json'))
       add_response 'lithuania'
@@ -1972,6 +1972,19 @@ class MarriageAbroadV2Test < ActiveSupport::TestCase
     should "go to outcome_ss_marriage" do
       assert_current_node :outcome_ss_marriage
       assert_phrase_list :ss_ceremony_body, [:able_to_ss_marriage, :contact_embassy_or_consulate, :embassies_data, :documents_needed_ss_british, :what_to_do_ss_marriage, :will_display_in_14_days, :no_objection_in_14_days_ss_marriage, :provide_two_witnesses_ss_marriage, :ss_marriage_footnote, :partner_naturalisation_in_uk, :fees_table_ss_marriage, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  context "ceremony in Lithuania, partner same sex, partner not british" do
+    setup do
+      worldwide_api_has_organisations_for_location('lithuania', read_fixture_file('worldwide/lithuania_organisations.json'))
+      add_response 'lithuania'
+      add_response 'other'
+      add_response 'lithuania'
+      add_response 'partner_local'
+      add_response 'same_sex'
+    end
+    should "go to outcome 'no same sex marriage allowed' because partner is not british" do
+      assert_current_node :outcome_cp_all_other_countries
     end
   end
   context "Testing if the address box shows the Belarus one" do


### PR DESCRIPTION
Only same sex british couples can marry in Lithuania

https://www.pivotaltracker.com/s/projects/1008986/stories/74592704
