### PR TITLE
Fix calculate state pension bug

### DIFF
--- a/lib/flows/calculate-state-pension-v2.rb
+++ b/lib/flows/calculate-state-pension-v2.rb
@@ -436,7 +436,7 @@ value_question :years_of_work? do
   end
 
   define_predicate(:new_rules_and_less_than_10_ni?) {
-    (ni < 10) && (calculator.state_pension_date > Date.parse('6 April 2016'))
+    (ni < 10) && (calculator.state_pension_date >= Date.parse('6 April 2016'))
   }
 
   next_node_if(:lived_or_worked_outside_uk?, new_rules_and_less_than_10_ni?)

--- a/test/integration/flows/calculate_state_pension_v2_test.rb
+++ b/test/integration/flows/calculate_state_pension_v2_test.rb
@@ -1315,5 +1315,20 @@ class CalculateStatePensionV2Test < ActiveSupport::TestCase
         assert_phrase_list :result_text, [:too_few_qy_enough_remaining_years_a_intro, :less_than_ten, :reduced_rate_election, :lived_or_worked_overseas, :too_few_qy_enough_remaining_years_a]
       end
     end
+
+    context "male and new state pension - should ask lived or worked outside uk" do
+      setup do
+        add_response :male
+        add_response Date.parse('6 April 1951')
+        add_response 5
+        add_response 0
+        add_response :no
+        add_response 0
+        add_response :yes # lived or worked outside uk
+      end
+      should "go to amount_result" do
+        assert_current_node :amount_result
+      end
+    end
   end #amount calculation
 end #ask which calculation


### PR DESCRIPTION
- The lived or worked outside of the uk question was not being asked as the logic was checking for dates later than 6th April 2016
- Updated to >= 6th April 2016 and later
- Additional test coverage

https://www.pivotaltracker.com/story/show/76136180
