### PR TITLE
Updating overseas-passports smart-answer for deploying 5th August.

### DIFF
--- a/lib/flows/locales/en/overseas-passports.yml
+++ b/lib/flows/locales/en/overseas-passports.yml
@@ -1332,6 +1332,13 @@ en-GB:
             Telephone: (+44) 207 008 1500
           $C
 
+        body_libya: |
+          You can’t apply for a British passport from Libya at this time.
+
+          You should apply in a neighbouring country of your choice.
+
+          If you need more information read the [Foreign Commonwealth Office travel advice](/foreign-travel-advice/libya).
+
         body_syria: |
           You can’t apply for a British passport from Syria at this time.
 

--- a/lib/smart_answer/calculators/passport_and_embassy_data_query.rb
+++ b/lib/smart_answer/calculators/passport_and_embassy_data_query.rb
@@ -1,7 +1,7 @@
 module SmartAnswer::Calculators
   class PassportAndEmbassyDataQuery
     def ineligible_country?
-      SmartAnswer::Predicate::RespondedWith.new(%w{iran syria})
+      SmartAnswer::Predicate::RespondedWith.new(%w{iran libya syria})
     end
 
     def apply_in_neighbouring_countries?


### PR DESCRIPTION
Libya is now a no-service country.
