### PR TITLE
Fix Smartdown title in JSON response

### DIFF
--- a/lib/smartdown_adapter/node.rb
+++ b/lib/smartdown_adapter/node.rb
@@ -8,7 +8,7 @@ module SmartdownAdapter
       headings = node_elements.select {
           |element| element.is_a? Smartdown::Model::Element::MarkdownHeading
       }
-      @title = headings.first.content if headings.first
+      @title = headings.first.content.to_s if headings.first
       node_elements.delete(headings.first) #Remove page title
       @elements = node_elements
       @front_matter = node.front_matter


### PR DESCRIPTION
This was returning a Parslet:Slice object, which acts like a string in most cases, like
templates, but not in the JSON response. Force it to string in the adaptor layer as
Parslet &c should never be exposed to the app

https://www.agileplannerapp.com/boards/203504/cards/5619
