### PR TITLE
Proposal: Could we remove hint, and replace it with body?

### DIFF
--- a/lib/tasks/hint_and_body_finder.rake
+++ b/lib/tasks/hint_and_body_finder.rake
@@ -1,8 +1,11 @@
 namespace :hint_and_body_finder do
+
+    registry_options = {show_drafts: false, show_transitions: false}
+
     desc "todo"
     task :find => :environment do
 
-        flow_registry = SmartAnswer::FlowRegistry.new(FLOW_REGISTRY_OPTIONS)
+        flow_registry = SmartAnswer::FlowRegistry.new(registry_options)
         flow_registry.flows.each do |flow|
             flow.questions.each do |question|
                 question = QuestionPresenter.new("flow.#{flow.name}", question)
@@ -20,7 +23,7 @@ namespace :hint_and_body_finder do
     desc "todo"
     task :find_raw => :environment do
 
-        flow_registry = SmartAnswer::FlowRegistry.new(FLOW_REGISTRY_OPTIONS)
+        flow_registry = SmartAnswer::FlowRegistry.new(registry_options)
         flow_registry.flows.each do |flow|
             file_path = "lib/smart_answer_flows/locales/en/#{flow.name}.yml"
             if !File.exists?(file_path)


### PR DESCRIPTION
In ruby/YML Smart Answer questions there is mixed use of `body` and `hint` as explanatory text. The majority of which only use one of these fields.

Visually they're treated more or less the same, and the kind of content used in each is almost identical. Where only one field is present and usage is identical we should standardise on one of those fields - this should be `body` as `hint` is semantically different (IMO).

There are some Smart Answers questions that do use both fields, which make standardising usage harder. This PR adds a couple of rake tasks to programatically detect how common usage of both is. From there we can decide if it's possible to reword the two fields in to one, or if there is a distinct need for a semantically different `hint` field.

Both tasks take a different approach to parsing the question data to detect mixed usage and both miss some cases but combined should cover all questions.

**Flow questions with mixed usage of hint and body**
- [am-i-getting-minimum-wage.how_often_do_you_get_paid?](https://github.com/alphagov/smart-answers/blob/master/lib/smart_answer_flows/locales/en/am-i-getting-minimum-wage.yml)
  - [Example](https://www.gov.uk/am-i-getting-minimum-wage/y/current_payment/no/30) - This seems to be used a proxy for `label`, as a question can only have one of `suffix_label` or a `label` (see https://github.com/alphagov/smart-answers/blob/master/app/views/smart_answers/_value_question.html.erb#L2). Even then I think the copy could be re-written to work with just a `body` and `label`
- [am-i-getting-minimum-wage.how_often_did_you_get_paid?](https://github.com/alphagov/smart-answers/blob/master/lib/smart_answer_flows/locales/en/am-i-getting-minimum-wage.yml)
  - [Example](https://www.gov.uk/am-i-getting-minimum-wage/y/past_payment/2008-10-01/no/30) - same as above
- [calculate-married-couples-allowance.how_much_expected_contributions_before_tax?](https://github.com/alphagov/smart-answers/blob/master/lib/smart_answer_flows/locales/en/calculate-married-couples-allowance.yml)
  - Hint clarifies edge case, could be part of the body
- [calculate-state-pension.years_of_benefit?](https://github.com/alphagov/smart-answers/blob/master/lib/smart_answer_flows/locales/en/calculate-married-couples-allowance.yml#L49)
  - could be part of body
- [calculate-state-pension.years_of_caring?](https://github.com/alphagov/smart-answers/blob/master/lib/smart_answer_flows/locales/en/calculate-state-pension.yml#L365)
  - same as above
- [calculate-your-child-maintenance.gets_benefits?](https://github.com/alphagov/smart-answers/blob/master/lib/smart_answer_flows/locales/en/calculate-your-child-maintenance.yml#L67)
  - Could be part of body, similar to above
- [energy-grants-calculator.what_are_your_circumstances_without_bills_help?](https://github.com/alphagov/smart-answers/blob/master/lib/smart_answer_flows/locales/en/energy-grants-calculator.yml#L101)
- [minimum-wage-calculator-employers.how_often_do_you_get_paid?](https://github.com/alphagov/smart-answers/blob/master/lib/smart_answer_flows/locales/en/minimum-wage-calculator-employers.yml)
  - Same as `am-i-getting-minimum-wage` examples
- [minimum-wage-calculator-employers.how_often_did_you_get_paid?](https://github.com/alphagov/smart-answers/blob/master/lib/smart_answer_flows/locales/en/minimum-wage-calculator-employers.yml)
  - Same as `am-i-getting-minimum-wage` examples
