### PR TITLE
Fix a relative URL in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Smart Answers
 =============
 
 Toolkit for building smart answers. Have a look at
-[`test/unit/flow_test.rb`](smart-answers/blob/master/test/unit/flow_test.rb) for example usage.
+[`test/unit/flow_test.rb`](test/unit/flow_test.rb) for example usage.
 
 This application supports two styles of writing and executing smart answers:
 


### PR DESCRIPTION
The URL is relative and appends unnecessary path components before
`test/unit`. The repo and branch names are already in the current URL
and threfore must not be included in the relative URL.
