### PR TITLE
Fix module/class resolution bugs in SmartdownAdaptor

### DIFF
--- a/lib/smartdown_adapter/presenter.rb
+++ b/lib/smartdown_adapter/presenter.rb
@@ -135,16 +135,16 @@ module SmartdownAdapter
       smartdown_node = smartdown_state.current_node
       case smartdown_node
         when Smartdown::Api::QuestionPage
-          QuestionPagePresenter.new(smartdown_node)
+          SmartdownAdapter::QuestionPagePresenter.new(smartdown_node)
         else
-          NodePresenter.new(smartdown_node)
+          SmartdownAdapter::NodePresenter.new(smartdown_node)
       end
 
     end
 
     def presenters_for_previous_nodes
       smartdown_state.previous_question_pages(@processed_responses).map do |smartdown_previous_question_page|
-        PreviousQuestionPagePresenter.new(smartdown_previous_question_page)
+        SmartdownAdapter::PreviousQuestionPagePresenter.new(smartdown_previous_question_page)
       end
     end
 

--- a/lib/smartdown_adapter/previous_question_page_presenter.rb
+++ b/lib/smartdown_adapter/previous_question_page_presenter.rb
@@ -6,7 +6,7 @@ module SmartdownAdapter
 
     def questions
       @smartdown_previous_question_page.questions.map do |smartdown_previous_question|
-        PreviousQuestionPresenter.new(smartdown_previous_question)
+        SmartdownAdapter::PreviousQuestionPresenter.new(smartdown_previous_question)
       end
     end
   end

--- a/lib/smartdown_adapter/question_page_presenter.rb
+++ b/lib/smartdown_adapter/question_page_presenter.rb
@@ -12,9 +12,9 @@ module SmartdownAdapter
       @smartdown_question_page.questions.map do |smartdown_question|
         case smartdown_question
         when Smartdown::Api::DateQuestion
-          DateQuestionPresenter.new(smartdown_question)
+          SmartdownAdapter::DateQuestionPresenter.new(smartdown_question)
         else
-          QuestionPresenter.new(smartdown_question)
+          SmartdownAdapter::QuestionPresenter.new(smartdown_question)
         end
       end
     end


### PR DESCRIPTION
This was only happening in production mode, not dev, due to different class loading/caching behaviour.

Because the App presenters (for smart_answers) aren't namespaced by a module they will get picked over `SmartdownAdapter` versions, due to ruby scoping/resolution rules (related, http://techblog.thescore.com/how-you-nest-modules-matters-in-ruby/)

This commit makes sure we explicitly use `SmartdownAdapter::` classes. This will need to be done for any future use of `SmartdownAdapter` classes that share a name with top level classes, which is mostly smart_answer Presenters, as they're not namespaced into the `SmartAnswers` module, they probably should be.

For now this just fixes the instances breaking Smartdown flows in production, so we can continue testing. and  add a story to the Smartdown backlog to fix the broader name spacing issue.
