### PR TITLE
Explicitly use SmartdownAdaptor module, or app Presenters get used

### DIFF
--- a/lib/smartdown_adapter/date_question_presenter.rb
+++ b/lib/smartdown_adapter/date_question_presenter.rb
@@ -1,5 +1,5 @@
 module SmartdownAdapter
-  class DateQuestionPresenter < QuestionPresenter
+  class DateQuestionPresenter < SmartdownAdaptor::QuestionPresenter
     #TODO: range should be specified in smartdown and taken from there
     #these are only defaults
     #in the future we will want to specify in smartdown start/end etc,,,

--- a/lib/smartdown_adapter/graphviz_presenter.rb
+++ b/lib/smartdown_adapter/graphviz_presenter.rb
@@ -1,5 +1,5 @@
 module SmartdownAdapter
-  class GraphvizPresenter < GraphPresenter
+  class GraphvizPresenter < SmartdownAdaptor::GraphPresenter
     def initialize(name)
       @name = name
       @flow = SmartdownAdapter::Registry.build_flow(name)


### PR DESCRIPTION
See https://github.com/alphagov/smart-answers/pull/1104.

I think this covers all cases in SmartdownAdaptor. The more robust fix is
to move the app presenters into a module (likely in lib/smart_answer), which is
on a tech debt list. This unbreaks certain questions on preview for now.
