### PR TITLE
Fix a typo in module names

### DIFF
--- a/lib/smartdown_adapter/date_question_presenter.rb
+++ b/lib/smartdown_adapter/date_question_presenter.rb
@@ -1,5 +1,5 @@
 module SmartdownAdapter
-  class DateQuestionPresenter < SmartdownAdaptor::QuestionPresenter
+  class DateQuestionPresenter < SmartdownAdapter::QuestionPresenter
     #TODO: range should be specified in smartdown and taken from there
     #these are only defaults
     #in the future we will want to specify in smartdown start/end etc,,,

--- a/lib/smartdown_adapter/graphviz_presenter.rb
+++ b/lib/smartdown_adapter/graphviz_presenter.rb
@@ -1,5 +1,5 @@
 module SmartdownAdapter
-  class GraphvizPresenter < SmartdownAdaptor::GraphPresenter
+  class GraphvizPresenter < SmartdownAdapter::GraphPresenter
     def initialize(name)
       @name = name
       @flow = SmartdownAdapter::Registry.build_flow(name)


### PR DESCRIPTION
Typo from https://github.com/alphagov/smart-answers/pull/1113

Sigh.
