### PR TITLE
Cache flows in production and by config switch

### DIFF
--- a/app/controllers/smart_answers_controller.rb
+++ b/app/controllers/smart_answers_controller.rb
@@ -107,7 +107,7 @@ private
   end
 
   def smartdown_question(name)
-    SmartdownAdapter::Registry.check(name.to_s)
+    SmartdownAdapter::Registry.instance.check(name.to_s)
   end
 
 end

--- a/lib/smartdown_adapter/graph_presenter.rb
+++ b/lib/smartdown_adapter/graph_presenter.rb
@@ -2,7 +2,7 @@ module SmartdownAdapter
   class GraphPresenter
     def initialize(name)
       @name = name
-      @flow = SmartdownAdapter::Registry.build_flow(name)
+      @flow = SmartdownAdapter::Registry.instance.find(name)
     end
 
     def labels

--- a/lib/smartdown_adapter/graphviz_presenter.rb
+++ b/lib/smartdown_adapter/graphviz_presenter.rb
@@ -2,7 +2,7 @@ module SmartdownAdapter
   class GraphvizPresenter < SmartdownAdaptor::GraphPresenter
     def initialize(name)
       @name = name
-      @flow = SmartdownAdapter::Registry.build_flow(name)
+      @flow = SmartdownAdapter::Registry.instance.find(name)
     end
 
     def to_gv

--- a/lib/smartdown_adapter/presenter.rb
+++ b/lib/smartdown_adapter/presenter.rb
@@ -25,7 +25,7 @@ module SmartdownAdapter
       @name = name
       @started = request[:started]
       @processed_responses = process_inputs(responses_from_request(request))
-      @smartdown_flow = SmartdownAdapter::Registry.build_flow(name)
+      @smartdown_flow = SmartdownAdapter::Registry.instance.find(name)
       @smartdown_state = @smartdown_flow.state(started, @processed_responses)
     end
 

--- a/lib/tasks/panopticon.rake
+++ b/lib/tasks/panopticon.rake
@@ -30,7 +30,7 @@ namespace :panopticon do
   end
 
   def smartdown_registrables
-    Hash[SmartdownAdapter::Registry.flows.collect { |flow|
+    Hash[SmartdownAdapter::Registry.instance.flows.collect { |flow|
       [flow.name, SmartdownAdapter::FlowRegistrationPresenter.new(flow)]
     }]
   end

--- a/lib/tasks/smartanswer-smartdown-compare.rake
+++ b/lib/tasks/smartanswer-smartdown-compare.rake
@@ -4,7 +4,8 @@ namespace :smartanswer_smartdown do
   desc "Compare the HTML for all listed scenarios of two questions"
   task :compare => :environment do
     result = {}
-    SmartdownAdapter::Registry.smartdown_transition_questions.each do |smartdown_transition_question|
+    SmartdownAdapter::Registry::FLOW_REGISTRY_OPTIONS = { preload_flows: true }
+    SmartdownAdapter::Registry.instance.flows.select { |f| f.transition? }.each do |smartdown_transition_question|
       errors = 0
       helper = SmartdownAdapter::SmartAnswerCompareHelper.new(smartdown_transition_question)
 

--- a/test/fixtures/smartdown_flows/animal-example-simple/animal-example-simple.txt
+++ b/test/fixtures/smartdown_flows/animal-example-simple/animal-example-simple.txt
@@ -1,0 +1,25 @@
+meta_description: Animals eh?
+satisfies_need: 100982
+status: draft
+
+# A simple example of smartdown
+
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+consequat.
+
+Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+## Before you start, you will need
+
+* To know the kind of feline you have
+* Any animal training certification documents
+
+[start: question_1]
+
+## Devolved body
+
+Which is really just body content after the start button

--- a/test/fixtures/smartdown_flows/animal-example-simple/outcomes/outcome_safe_pet.txt
+++ b/test/fixtures/smartdown_flows/animal-example-simple/outcomes/outcome_safe_pet.txt
@@ -1,0 +1,69 @@
+# You picked a safe pet
+
+Good call.
+
+# Markdown/Govspeak examples
+
+## H2 example
+
+With answers, that are smart. Down with that?
+
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+
+### H3 example
+
+consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+## List
+
+* one
+* two
+* three
+
+## List 2
+
+- A
+- B
+- C
+
+## List 3
+
++ Up
++ Down
++ Left
++ Right
+
+^This is an information callout.^
+
+%This is a warning callout - use it when there’s a risk of getting a fine or going to prison.%
+
+$E
+**Example**
+Your income for the last tax year was £30,000. You think your income will drop to £20,000 this tax year. Enter £22,500 into the calculator.
+$E
+
+{::highlight-answer}
+The VAT rate is *20%*
+{:/highlight-answer}
+
+
+$C
+**Student Finance England**
+Telephone: 0845 300 5090
+Minicom: 0845 604 4434
+[Find out about call charges](http://www.gov.uk/call-charges)
+$C
+
+$A
+Hercules House
+Hercules Road
+London SE1 7DU
+$A
+
+$D
+[Download the 'Example application form' (PDF, 35KB)](http://example.com/ "Example form")
+$D

--- a/test/fixtures/smartdown_flows/animal-example-simple/outcomes/outcome_tigers_are_fine.txt
+++ b/test/fixtures/smartdown_flows/animal-example-simple/outcomes/outcome_tigers_are_fine.txt
@@ -1,0 +1,9 @@
+# Tigers are fine
+
+You haven't trained with tigers, but you'll be alright, probably.
+
+[next_steps]
+###You bought a tiger? Seriously?
+
+[Your nearest hospital](https://gov.uk/hospital)
+[end_next_steps]

--- a/test/fixtures/smartdown_flows/animal-example-simple/outcomes/outcome_trained_with_lions.txt
+++ b/test/fixtures/smartdown_flows/animal-example-simple/outcomes/outcome_trained_with_lions.txt
@@ -1,0 +1,3 @@
+# You've trained with lions
+
+You'll be alright, I think.

--- a/test/fixtures/smartdown_flows/animal-example-simple/outcomes/outcome_untrained_with_lions.txt
+++ b/test/fixtures/smartdown_flows/animal-example-simple/outcomes/outcome_untrained_with_lions.txt
@@ -1,0 +1,3 @@
+# You're not trained with lions
+
+Nice to know you.

--- a/test/fixtures/smartdown_flows/animal-example-simple/questions/question_1.txt
+++ b/test/fixtures/smartdown_flows/animal-example-simple/questions/question_1.txt
@@ -1,0 +1,13 @@
+# Amazing page title
+
+# What type of feline do you have?
+
+Check the serial number by the tail.
+
+[choice: question_1]
+* lion: Lion
+* tiger: Tiger
+* cat: Cat
+
+* question_1 in {lion tiger} => question_2
+* otherwise => outcome_safe_pet

--- a/test/fixtures/smartdown_flows/animal-example-simple/questions/question_2.txt
+++ b/test/fixtures/smartdown_flows/animal-example-simple/questions/question_2.txt
@@ -1,0 +1,10 @@
+# Are you trained for lions?
+
+[choice: trained_for_lions]
+* yes: Yes
+* no: No
+
+* question_1 is 'lion'
+  * trained_for_lions is 'yes' => outcome_trained_with_lions
+  * otherwise => outcome_untrained_with_lions
+* otherwise => outcome_tigers_are_fine

--- a/test/unit/smartdown_adapter/presenter_test.rb
+++ b/test/unit/smartdown_adapter/presenter_test.rb
@@ -1,0 +1,61 @@
+# coding:utf-8
+
+require_relative '../../test_helper'
+
+module SmartdownAdapter
+  class PresenterTest < ActiveSupport::TestCase
+    context "initialize" do
+      setup do
+        silence_warnings do
+          SmartdownAdapter::Registry::FLOW_REGISTRY_OPTIONS = { 
+            show_drafts: true,
+            preload_flows: true,
+            load_path: Rails.root.join('test', 'fixtures', 'smartdown_flows')
+          }
+        end
+      end
+      context "an unstarted flow" do
+        setup do
+          request = { started: false } 
+          request.stubs(:query_parameters).returns({})
+          @presenter = SmartdownAdapter::Presenter.new('animal-example-simple', request)
+        end
+        should "initialize sets internal state" do
+          assert_equal "animal-example-simple", @presenter.name
+          refute @presenter.started
+          assert_equal SmartdownAdapter::Registry.instance.find('animal-example-simple'), @presenter.smartdown_flow
+          assert_equal Smartdown::Api::Coversheet, @presenter.smartdown_state.current_node.class
+          assert_empty @presenter.smartdown_state.responses
+        end
+      end
+      context "a started flow with a response" do
+        setup do
+          request = { started: true, response: 'lion', params: "" } 
+          request.stubs(:query_parameters).returns({})
+          @presenter = SmartdownAdapter::Presenter.new('animal-example-simple', request)
+        end
+        should "initialize sets internal state" do
+          assert_equal "animal-example-simple", @presenter.name
+          assert @presenter.started
+          assert_equal SmartdownAdapter::Registry.instance.find('animal-example-simple'), @presenter.smartdown_flow
+          assert_equal Smartdown::Api::QuestionPage, @presenter.smartdown_state.current_node.class
+          assert_equal ["lion"], @presenter.smartdown_state.responses
+        end
+      end
+      context "a started flow with responses" do
+        setup do
+          request = { started: true, responses: 'lion', params: "" } 
+          request.stubs(:query_parameters).returns({ 'response_1' => 'yes' })
+          @presenter = SmartdownAdapter::Presenter.new('animal-example-simple', request)
+        end
+        should "initialize sets internal state" do
+          assert_equal "animal-example-simple", @presenter.name
+          assert @presenter.started
+          assert_equal SmartdownAdapter::Registry.instance.find('animal-example-simple'), @presenter.smartdown_flow
+          assert_equal Smartdown::Api::Outcome, @presenter.smartdown_state.current_node.class
+          assert_equal ["lion", "yes"], @presenter.smartdown_state.responses
+        end
+      end
+    end
+  end
+end

--- a/test/unit/smartdown_adapter/registry_test.rb
+++ b/test/unit/smartdown_adapter/registry_test.rb
@@ -1,0 +1,39 @@
+# coding:utf-8
+
+require_relative '../../test_helper'
+
+module SmartdownAdapter
+  class RegistryTest < ActiveSupport::TestCase
+    setup do
+      @registry_options = { load_path: Rails.root.join("test", "fixtures", "smartdown_flows").to_s, show_drafts: true }
+    end
+
+    test "constructor is private" do
+      assert_raises NoMethodError do
+        SmartdownAdapter::Registry.new
+      end
+    end
+    test "registry is a singleton" do
+      a, b = SmartdownAdapter::Registry.instance, SmartdownAdapter::Registry.instance
+      assert_equal a, b
+    end
+    test "flows are loaded dynamically depending on registry options" do
+      SmartdownAdapter::Registry.reset_instance
+      silence_warnings do
+        SmartdownAdapter::Registry::FLOW_REGISTRY_OPTIONS = @registry_options      
+      end
+      flow1 = SmartdownAdapter::Registry.instance.find("animal-example-simple")            
+      flow2 = SmartdownAdapter::Registry.instance.find("animal-example-simple")
+      refute_equal flow1, flow2
+    end
+    test "flows are cacheable depending on registry options" do
+      SmartdownAdapter::Registry.reset_instance
+      silence_warnings do
+        SmartdownAdapter::Registry::FLOW_REGISTRY_OPTIONS = @registry_options.merge(preload_flows: true)      
+      end
+      flow1 = SmartdownAdapter::Registry.instance.find("animal-example-simple")            
+      flow2 = SmartdownAdapter::Registry.instance.find("animal-example-simple")
+      assert_equal flow1, flow2
+    end
+  end
+end


### PR DESCRIPTION
Adopts a similar pattern used in the existing `SmartAnswer::FlowRegistry`
class whereby production defaults to caching flows and options passed to
registry control the caching of flows.
See https://www.agileplannerapp.com/boards/105200/cards/5843
