### PR TITLE
Always return an array of flows

### DIFF
--- a/lib/smartdown_adapter/registry.rb
+++ b/lib/smartdown_adapter/registry.rb
@@ -37,7 +37,7 @@ module SmartdownAdapter
 
     def flows
       if @preloaded
-        @preloaded
+        @preloaded.values
       else
         available_flows.map { |f| build_flow(f) }
       end


### PR DESCRIPTION
Unbreak panopticon registration when Rails.env.production
