### PR TITLE
Parse flow only once

### DIFF
--- a/app/controllers/smart_answers_controller.rb
+++ b/app/controllers/smart_answers_controller.rb
@@ -72,7 +72,7 @@ private
   def find_smart_answer
     @name = params[:id].to_sym
     if smartdown_question(@name)
-      @presenter = SmartdownAdapter::Presenter.new(@name.to_s, request)
+      @presenter = SmartdownAdapter::Presenter.new(smartdown_flow(@name), request)
     else
       @smart_answer = flow_registry.find(@name.to_s)
       @presenter = SmartAnswerPresenter.new(request, @smart_answer)
@@ -106,8 +106,16 @@ private
     set_slimmer_headers(template: 'header_footer_only')
   end
 
+  def smartdown_registry
+    @registry ||= SmartdownAdapter::Registry.instance
+  end
+
   def smartdown_question(name)
-    SmartdownAdapter::Registry.instance.check(name.to_s)
+    smartdown_registry.check(name.to_s)
+  end
+
+  def smartdown_flow(name)
+    smartdown_registry.find(name.to_s)
   end
 
 end

--- a/lib/smartdown_adapter/presenter.rb
+++ b/lib/smartdown_adapter/presenter.rb
@@ -7,10 +7,10 @@ module SmartdownAdapter
     extend Forwardable
     include Rails.application.routes.url_helpers
 
-    attr_accessor :name, :started, :smartdown_flow, :smartdown_state
+    attr_accessor :started, :smartdown_flow, :smartdown_state
 
     # The same for all nodes/views
-    def_delegators :@smartdown_flow, :title, :meta_description, :need_id
+    def_delegators :@smartdown_flow, :name, :title, :meta_description, :need_id
 
     # Where you are in the flow
     def_delegators :@smartdown_state, :current_question_number, :started?, :finished?
@@ -21,11 +21,10 @@ module SmartdownAdapter
     # The current node in the flow
     def_delegators :current_node, :body, :has_body?, :devolved_body, :has_devolved_body?
 
-    def initialize(name, request)
-      @name = name
+    def initialize(smartdown_flow, request)
+      @smartdown_flow = smartdown_flow
       @started = request[:started]
       @processed_responses = process_inputs(responses_from_request(request))
-      @smartdown_flow = SmartdownAdapter::Registry.instance.find(name)
       @smartdown_state = @smartdown_flow.state(started, @processed_responses)
     end
 

--- a/test/unit/smartdown_adapter/presenter_test.rb
+++ b/test/unit/smartdown_adapter/presenter_test.rb
@@ -7,7 +7,7 @@ module SmartdownAdapter
     context "initialize" do
       setup do
         silence_warnings do
-          SmartdownAdapter::Registry::FLOW_REGISTRY_OPTIONS = { 
+          SmartdownAdapter::Registry::FLOW_REGISTRY_OPTIONS = {
             show_drafts: true,
             preload_flows: true,
             load_path: Rails.root.join('test', 'fixtures', 'smartdown_flows')
@@ -18,12 +18,12 @@ module SmartdownAdapter
         setup do
           request = { started: false } 
           request.stubs(:query_parameters).returns({})
-          @presenter = SmartdownAdapter::Presenter.new('animal-example-simple', request)
+          @flow = SmartdownAdapter::Registry.instance.find('animal-example-simple')
+          @presenter = SmartdownAdapter::Presenter.new(@flow, request)
         end
         should "initialize sets internal state" do
           assert_equal "animal-example-simple", @presenter.name
           refute @presenter.started
-          assert_equal SmartdownAdapter::Registry.instance.find('animal-example-simple'), @presenter.smartdown_flow
           assert_equal Smartdown::Api::Coversheet, @presenter.smartdown_state.current_node.class
           assert_empty @presenter.smartdown_state.responses
         end
@@ -32,12 +32,12 @@ module SmartdownAdapter
         setup do
           request = { started: true, response: 'lion', params: "" } 
           request.stubs(:query_parameters).returns({})
-          @presenter = SmartdownAdapter::Presenter.new('animal-example-simple', request)
+          @flow = SmartdownAdapter::Registry.instance.find('animal-example-simple')
+          @presenter = SmartdownAdapter::Presenter.new(@flow, request)
         end
         should "initialize sets internal state" do
           assert_equal "animal-example-simple", @presenter.name
           assert @presenter.started
-          assert_equal SmartdownAdapter::Registry.instance.find('animal-example-simple'), @presenter.smartdown_flow
           assert_equal Smartdown::Api::QuestionPage, @presenter.smartdown_state.current_node.class
           assert_equal ["lion"], @presenter.smartdown_state.responses
         end
@@ -46,12 +46,12 @@ module SmartdownAdapter
         setup do
           request = { started: true, responses: 'lion', params: "" } 
           request.stubs(:query_parameters).returns({ 'response_1' => 'yes' })
-          @presenter = SmartdownAdapter::Presenter.new('animal-example-simple', request)
+          @flow = SmartdownAdapter::Registry.instance.find('animal-example-simple')
+          @presenter = SmartdownAdapter::Presenter.new(@flow, request)
         end
         should "initialize sets internal state" do
           assert_equal "animal-example-simple", @presenter.name
           assert @presenter.started
-          assert_equal SmartdownAdapter::Registry.instance.find('animal-example-simple'), @presenter.smartdown_flow
           assert_equal Smartdown::Api::Outcome, @presenter.smartdown_state.current_node.class
           assert_equal ["lion", "yes"], @presenter.smartdown_state.responses
         end


### PR DESCRIPTION
This small change stops timeouts on the largest flow (employee parental leave) from happening. This is a minimum-viable-fix for performance issues on smartdown questions. 
