### PR TITLE
Add two missing questions to the SPL flow

### DIFF
--- a/lib/smartdown_flows/employee-parental-leave/questions/employment_1_more.txt
+++ b/lib/smartdown_flows/employee-parental-leave/questions/employment_1_more.txt
@@ -8,37 +8,39 @@
 
 * single_parent is 'yes'
   * employment_status_1 is 'employee'
-    * job_after_y_1 is 'yes' => leave_1
+    * job_after_y_1 is 'yes' => employment_1_more_salary
     * job_after_y_1 is 'no'
       * circumstance is 'birth'
-        * earnings_employment_1 is 'yes' => outcome_mat-allowance
+        * earnings_employment_1 is 'yes' => employment_1_more_salary
         * earnings_employment_1 is 'no' => outcome_birth-nothing
       * circumstance is 'adoption' => outcome_adopt-nothing
   * employment_status_1 in {worker agency}
     * circumstance is 'birth'
-      * earnings_employment_1 is 'yes' => outcome_mat-allowance
+      * earnings_employment_1 is 'yes' => employment_1_more_salary
       * earnings_employment_1 is 'no' => outcome_birth-nothing
     * circumstance is 'adoption' => outcome_adopt-nothing
   * employment_status_1 in {self-employed unemployed}
     * circumstance is 'birth'
-      * earnings_employment_1 is 'yes' => outcome_mat-allowance
+      * earnings_employment_1 is 'yes' => employment_1_more_salary
       * earnings_employment_1 is 'no' => outcome_birth-nothing
     * circumstance is 'adoption' => outcome_adopt-nothing
 * single_parent is 'no'
-  * employment_status_2 in {employee worker agency} => employment_2
+  * employment_status_2 in {employee worker agency}
+    * earnings_employment_1 is 'yes' => employment_1_more_salary
+    * earnings_employment_1 is 'no' => employment_2
   * employment_status_2 in {self-employed unemployed}
     * employment_status_1 in {employee worker agency}
       * circumstance is 'adoption' => outcome_adopt-nothing
       * circumstance is 'birth'
-        * earnings_employment_1 is 'yes' => outcome_mat-allowance
+        * earnings_employment_1 is 'yes' => employment_1_more_salary
         * earnings_employment_1 is 'no' => outcome_birth-nothing
     * employment_status_1 is 'self-employed'
       * circumstance is 'birth'
-        * earnings_employment_1 is 'yes' => outcome_mat-allowance
+        * earnings_employment_1 is 'yes' => employment_1_more_salary
         * earnings_employment_1 is 'no' => outcome_birth-nothing
       * circumstance is 'adoption' => outcome_adopt-nothing
     * employment_status_1 is 'unemployed'
       * circumstance is 'birth'
-        * earnings_employment_1 is 'yes' => outcome_mat-allowance
+        * earnings_employment_1 is 'yes' => employment_1_more_salary
         * earnings_employment_1 is 'no' => outcome_mat-allowance-14-weeks
       * circumstance is 'adoption' => outcome_adopt-nothing

--- a/lib/smartdown_flows/employee-parental-leave/questions/employment_1_more_salary.txt
+++ b/lib/smartdown_flows/employee-parental-leave/questions/employment_1_more_salary.txt
@@ -1,0 +1,10 @@
+# Salary details mother/principal adopter
+
+How much did you earn between X and Y (66 weeks range before due_date or match_date)?
+
+[salary: salary_1_66_weeks]
+
+* single_parent is 'yes' => outcome_mat-allowance
+* single_parent is 'no'
+  * employment_status_2 in {employee worker agency} => employment_2
+  * employment_status_2 in {self-employed unemployed} => outcome_mat-allowance

--- a/lib/smartdown_flows/employee-parental-leave/questions/leave_2.txt
+++ b/lib/smartdown_flows/employee-parental-leave/questions/leave_2.txt
@@ -4,6 +4,12 @@
 
 [date:date_leave_2]
 
+# How much paternity leave is the mother's or primary adopter's partner planning on taking?
+
+[choice: amount_leave_2]
+* 1-week: 1 week
+* 2-weeks: 2 weeks
+
 * circumstance is 'adoption'
   * employment_status_1 in {agency worker}
     * job_before_x_1 is 'yes' AND job_after_y_1 is 'yes' AND ler_1 is 'yes'

--- a/lib/smartdown_flows/employee-parental-leave/questions/leave_both.txt
+++ b/lib/smartdown_flows/employee-parental-leave/questions/leave_both.txt
@@ -8,6 +8,12 @@
 
 [date:date_leave_2]
 
+# How much paternity leave is the mother's or primary adopter's partner planning on taking?
+
+[choice: amount_leave_2]
+* 1-week: 1 week
+* 2-weeks: 2 weeks
+
 * circumstance is 'birth'
   * job_before_x_1 is 'yes' AND job_after_y_1 is 'yes' AND ler_1 is 'yes'
     * due_date >= '2015-4-5' => outcome_mat-leave_mat-pay_mat-shared-leave_mat-shared-pay_pat-pay_pat-leave_pat-shared-leave_pat-shared-pay

--- a/lib/smartdown_flows/employee-parental-leave/snippets/mat-allowance.txt
+++ b/lib/smartdown_flows/employee-parental-leave/snippets/mat-allowance.txt
@@ -5,8 +5,8 @@ The mother can get Maternity Allowance from the government for up to 39 weeks.
 Maternity Allowance | Key facts
 - | -
 Maternity Allowance dates | %{start_of_maternity_allowance(due_date)} to %{end_of_maternity_allowance}(due_date)}
-Weekly rate | {rate_of_maternity_allowance(salary_1)}
-Total estimated allowance | {total_maternity_allowance(salary_1)}
+Weekly rate | %{rate_of_maternity_allowance(salary_1_66_weeks)}
+Total estimated allowance | %{total_maternity_allowance(salary_1_66_weeks)}
 Claim from | %{claim_date_maternity_allowance(due_date)}
 
 %This is an estimate, the mother must claim Maternity Allowance to find out if she qualifies and what she’ll get.%

--- a/lib/smartdown_plugins/employee-parental-leave.rb
+++ b/lib/smartdown_plugins/employee-parental-leave.rb
@@ -80,7 +80,7 @@ module SmartdownPlugins
       "TODO_rate_of_paternity_pay"
     end
 
-    def self.rate_of_maternity_allowance(salary_1)
+    def self.rate_of_maternity_allowance(salary_1_66_weeks)
       "TODO_rate_of_maternity_allowance"
     end
 
@@ -108,7 +108,7 @@ module SmartdownPlugins
       "TODO_start_of_maternity_allowance"
     end
 
-    def self.total_maternity_allowance(salary_1)
+    def self.total_maternity_allowance(salary_1_66_weeks)
       "TODO_total_maternity_allowance"
     end
 

--- a/lib/tasks/smartdown_generate_scenarios.rake
+++ b/lib/tasks/smartdown_generate_scenarios.rake
@@ -24,6 +24,7 @@ namespace :smartdown_generate_scenarios do
       :salary_1 => ["400-week"],
       :ler_1 => ["yes", "no"],
       :earnings_employment_1 => ["yes", "no"],
+      :salary_1_66_weeks => ["400-week"],
       :job_before_x_2 => ["yes", "no"],
       :job_after_y_2 => ["yes", "no"],
       :salary_2 => ["400-week"],
@@ -31,6 +32,7 @@ namespace :smartdown_generate_scenarios do
       :earnings_employment_2 => ["yes", "no"],
       :date_leave_1 => ["2015-4-5"],
       :date_leave_2 => ["2015-4-5"],
+      :amount_leave_2 => ["1-week", "2-week"]
     }
     generate("employee-parental-leave", combinations)
   end
@@ -50,6 +52,7 @@ namespace :smartdown_generate_scenarios do
       :salary_1 => ["400-week"],
       :ler_1 => ["yes", "no"],
       :earnings_employment_1 => ["yes", "no"],
+      :salary_1_66_weeks => ["400-week"],
       :job_before_x_2 => ["yes", "no"],
       :job_after_y_2 => ["yes", "no"],
       :salary_2 => ["400-week"],
@@ -57,6 +60,7 @@ namespace :smartdown_generate_scenarios do
       :earnings_employment_2 => ["yes", "no"],
       :date_leave_1 => ["2015-4-5"],
       :date_leave_2 => ["2015-4-5"],
+      :amount_leave_2 => ["1-week", "2-week"]
     }
     human_readable_snippet_names = {
       "birth-nothing" => "Nothing",


### PR DESCRIPTION
We were missing an additional question for mothers eligible for maternity allowance where we missing their 66-week salary on which the amount is based.
We were missing the amount of paternity leave planned by the mother's partner or principal adopter's partner for the paternity leave: choice between 1 or 2 weeks.
