### PR TITLE
Correct display of maternity pay page

### DIFF
--- a/lib/smartdown_flows/employee-parental-leave/snippets/mat-pay.txt
+++ b/lib/smartdown_flows/employee-parental-leave/snippets/mat-pay.txt
@@ -17,8 +17,10 @@ Tax and National Insurance will be deducted.
 ###Extra help
 
 The mother could also get:
+
 - a £500 [Sure Start Maternity Grant](/sure-start-maternity-grant) (usually if it’s her first child)
 - benefits while she’s not working
 - Child Tax Credits - after the baby is born
 - Child Benefit - after the baby is born
+
 Use the [benefits calculators](/benefits-calculators) to check what benefits or tax credits the mother can get.


### PR DESCRIPTION
The bulleted list was not displaying as a list due to spacing error
