### PR TITLE
Make jenkins test merge result of branches

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -2,6 +2,11 @@
 
 set -e
 
+# Try to merge master into the current branch, and abort if it doesn't exit
+# cleanly (ie there are conflicts). This will be a noop if the current branch
+# is master.
+git merge --no-commit origin/master || git merge --abort
+
 bundle install --path "/home/jenkins/bundles/${JOB_NAME}" --deployment --without=development
 export GOVUK_APP_DOMAIN=dev.gov.uk
 export GOVUK_ASSET_HOST=http://static.dev.gov.uk


### PR DESCRIPTION
As we do in manyother repos, eg;
- https://github.com/alphagov/rummager/commit/698c2c896f9aa227dbd7dc8600c043008f084db7

'Almost all of the time we are writing code to be merged into master
sooner rather than later. Rather than testing the HEAD of the branch in
Jenkins this commit adds a command to the build script which merges the
branch with master before building it.'

This will help us catch some test failures on master that
had passed on branch builds. Catch errors earlier.
