### PR TITLE
Add simple text field question.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'diffy', '3.0.6'
 if ENV['SMARTDOWN_DEV']
   gem 'smartdown', :path => '../smartdown'
 else
-  gem 'smartdown', '0.5.4'
+  gem 'smartdown', '0.6.0'
 end
 
 if ENV['API_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,7 @@ GEM
       erubis (>= 2.6.6)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
-    blankslate (2.1.2.4)
+    blankslate (3.1.3)
     builder (3.0.4)
     capybara (2.1.0)
       mime-types (>= 1.16)
@@ -126,8 +126,8 @@ GEM
     parser (2.1.9)
       ast (>= 1.1, < 3.0)
       slop (~> 3.4, >= 3.4.5)
-    parslet (1.6.1)
-      blankslate (~> 2.0)
+    parslet (1.6.2)
+      blankslate (>= 2.0, <= 4.0)
     plek (1.7.0)
     poltergeist (1.3.0)
       capybara (~> 2.1.0)
@@ -207,7 +207,7 @@ GEM
       rack (>= 1.3.5)
       rest-client
     slop (3.4.5)
-    smartdown (0.5.4)
+    smartdown (0.6.0)
       parslet (~> 1.6.1)
     sprockets (2.2.2)
       hike (~> 1.2)
@@ -272,7 +272,7 @@ DEPENDENCIES
   simplecov (~> 0.6.4)
   simplecov-rcov (~> 0.2.3)
   slimmer (= 4.1.0)
-  smartdown (= 0.5.4)
+  smartdown (= 0.6.0)
   therubyracer (~> 0.12.1)
   timecop
   uglifier

--- a/app/views/smart_answers/_text_question.html.erb
+++ b/app/views/smart_answers/_text_question.html.erb
@@ -1,0 +1,4 @@
+<% identifier = number ? "response_#{number}" : "response" %>
+<label for="<%= identifier %>"><% if question.has_hint? %><%= question.hint %><% end -%>
+  <%= text_field_tag(identifier, prefill_value_for(question)) %>
+</label>

--- a/lib/smartdown_adapter/previous_question_presenter.rb
+++ b/lib/smartdown_adapter/previous_question_presenter.rb
@@ -24,6 +24,8 @@ module SmartdownAdapter
         when Smartdown::Api::SalaryQuestion
           salary_array = response_key.split("-")
           "#{salary_array[0]} per #{salary_array[1]}"
+        when Smartdown::Api::TextQuestion
+          response_key
       end
     end
 

--- a/lib/smartdown_adapter/question_page_presenter.rb
+++ b/lib/smartdown_adapter/question_page_presenter.rb
@@ -15,6 +15,8 @@ module SmartdownAdapter
           SmartdownAdapter::DateQuestionPresenter.new(smartdown_question)
         when Smartdown::Api::SalaryQuestion
           SmartdownAdapter::SalaryQuestionPresenter.new(smartdown_question)
+        when Smartdown::Api::TextQuestion
+          SmartdownAdapter::TextQuestionPresenter.new(smartdown_question)
         else
           SmartdownAdapter::QuestionPresenter.new(smartdown_question)
         end

--- a/lib/smartdown_adapter/question_presenter.rb
+++ b/lib/smartdown_adapter/question_presenter.rb
@@ -22,8 +22,10 @@ module SmartdownAdapter
         "multiple_choice_question"
       when Smartdown::Api::DateQuestion
         "date_question"
-        when Smartdown::Api::SalaryQuestion
+      when Smartdown::Api::SalaryQuestion
         "salary_question"
+      when Smartdown::Api::TextQuestion
+        "text_question"
       end
     end
 

--- a/lib/smartdown_adapter/text_question_presenter.rb
+++ b/lib/smartdown_adapter/text_question_presenter.rb
@@ -1,0 +1,8 @@
+module SmartdownAdapter
+  class TextQuestionPresenter < SmartdownAdapter::QuestionPresenter
+    def to_response(input)
+      input.strip
+    end
+  end
+end
+

--- a/test/fixtures/smartdown_flows/animal-example-simple/outcomes/outcome_can_outrun_a_lion.txt
+++ b/test/fixtures/smartdown_flows/animal-example-simple/outcomes/outcome_can_outrun_a_lion.txt
@@ -1,0 +1,3 @@
+# You can outrun a lion
+
+You'll be alright, I think.

--- a/test/fixtures/smartdown_flows/animal-example-simple/questions/question_2.txt
+++ b/test/fixtures/smartdown_flows/animal-example-simple/questions/question_2.txt
@@ -6,5 +6,5 @@
 
 * question_1 is 'lion'
   * trained_for_lions is 'yes' => outcome_trained_with_lions
-  * otherwise => outcome_untrained_with_lions
+  * otherwise => question_3
 * otherwise => outcome_tigers_are_fine

--- a/test/fixtures/smartdown_flows/animal-example-simple/questions/question_3.txt
+++ b/test/fixtures/smartdown_flows/animal-example-simple/questions/question_3.txt
@@ -1,0 +1,7 @@
+# How fast can you run?
+
+[text: how_fast]
+
+* how_fast is 'fast' => outcome_can_outrun_a_lion
+* otherwise => outcome_untrained_with_lions
+

--- a/test/integration/smartdown_flows/question_types_test.rb
+++ b/test/integration/smartdown_flows/question_types_test.rb
@@ -1,0 +1,37 @@
+# encoding: utf-8
+require 'integration_test_helper'
+
+class QuestionTypesTest < ActionDispatch::IntegrationTest
+  def setup
+    use_test_smartdown_flow_fixtures
+    stub_content_api_default_artefact
+
+    visit smart_answer_path(id: "animal-example-simple")
+    click_on "Start now"
+  end
+
+  def teardown
+    stop_using_test_smartdown_flow_fixtures
+  end
+
+  test "a text field question" do
+    choose "Lion"
+    click_on "Next step"
+    choose "No"
+    click_on "Next step"
+    fill_in "response", with: "fast"
+    click_on "Next step"
+
+    assert page.has_content?("You can outrun a lion")
+  end
+
+  test "a multiple choice question" do
+    choose "Lion"
+    click_on "Next step"
+    choose "Yes"
+    click_on "Next step"
+
+    assert page.has_content?("You've trained with lions")
+  end
+end
+ 

--- a/test/unit/smartdown_adapter/text_question_presenter_test.rb
+++ b/test/unit/smartdown_adapter/text_question_presenter_test.rb
@@ -1,0 +1,19 @@
+# coding:utf-8
+
+require_relative '../../test_helper'
+#require_relative '../../helpers/test_fixtures_helper'
+
+module SmartdownAdapter
+  class TextQuestionPresenterTest < ActiveSupport::TestCase
+    setup do
+ #     use_test_smartdown_flow_fixtures
+    end
+    context "to_response" do
+      should "strip leading and trailing whitespace" do
+        presenter = SmartdownAdapter::TextQuestionPresenter.new("foo")
+        assert_equal "blah blah blah", presenter.to_response(" blah blah blah  ")
+      end
+    end
+  end
+end
+ 


### PR DESCRIPTION
A precursor to [this story](https://www.agileplannerapp.com/boards/105200/cards/5222), adds a simple text field question to smart-answers using [Smartdown](https://github.com/alphagov/smartdown).
