### PR TITLE
Disable drafts by default in RAILS_ENV=production

### DIFF
--- a/config/initializers/flow_preview.rb
+++ b/config/initializers/flow_preview.rb
@@ -1,4 +1,10 @@
-FLOW_REGISTRY_OPTIONS = {show_drafts: true, show_transitions: false}
+# This file potentially overwritten on deploy
+
+if Rails.env.production?
+  FLOW_REGISTRY_OPTIONS = {}
+else
+  FLOW_REGISTRY_OPTIONS = {show_drafts: true}
+end
 
 # Uncomment the following to run smartanswers with the test flows instead of the real ones
 #


### PR DESCRIPTION
To reduce the chance of a misconfiguration revealing draft content in
production, this changes the default config to not show drafts unless
explicitly overridden.

This removes the `show_transitions: false` option because that's already
the default value for it.

**Note:** https://github.gds/gds/alphagov-deployment/pull/762 should be merged before this, or drafts will disappear from preview.

/cc @camilleldn 
