### PR TITLE
Move error method to node presenter

### DIFF
--- a/app/presenters/node_presenter.rb
+++ b/app/presenters/node_presenter.rb
@@ -53,6 +53,12 @@ class NodePresenter
     !!title
   end
 
+  def error
+    if @state.error.present?
+      translate!(@state.error.to_sym) || error_message || I18n.translate('flow.defaults.error_message')
+    end
+  end
+
   def error_message
     translate!('error_message')
   end

--- a/app/presenters/smart_answer_presenter.rb
+++ b/app/presenters/smart_answer_presenter.rb
@@ -77,13 +77,6 @@ class SmartAnswerPresenter
     @current_state ||= @flow.process(all_responses)
   end
 
-  def error
-    if current_state.error.present?
-      current_node.translate!(current_state.error.to_sym) || current_node.error_message ||
-        I18n.translate('flow.defaults.error_message')
-    end
-  end
-
   def collapsed_question_pages
     collapsed_questions.map do |collapsed_question|
       OpenStruct.new(:questions => [collapsed_question])

--- a/app/views/smart_answers/_current_question.html.erb
+++ b/app/views/smart_answers/_current_question.html.erb
@@ -14,10 +14,10 @@
       <p class="hint"><%= question.hint %></p>
     <% end %>
 
-    <div class="<%= @presenter.error && 'error' %>">
-      <% if @presenter.error %>
+    <div class="<%= question.error && 'error' %>">
+      <% if question.error %>
         <p class="error-message" id="current-error" role="alert">
-          <%= @presenter.error %>
+          <%= question.error %>
         </p>
       <% end %>
 

--- a/lib/smartdown_adapter/presenter.rb
+++ b/lib/smartdown_adapter/presenter.rb
@@ -96,12 +96,6 @@ module SmartdownAdapter
       smart_answer_path(url_hash)
     end
 
-    #TODO: implement once we have error handling
-    # Should be moved on to question nodes, only they have errors
-    def error
-      nil
-    end
-
     private
 
     def responses_from_request(request)

--- a/lib/smartdown_adapter/question_presenter.rb
+++ b/lib/smartdown_adapter/question_presenter.rb
@@ -16,6 +16,11 @@ module SmartdownAdapter
       !!hint
     end
 
+    #TODO: implement once we have error handling
+    def error
+      nil
+    end
+
     def partial_template_name
       case smartdown_question
       when Smartdown::Api::MultipleChoice


### PR DESCRIPTION
This enables being able to have different error messages for each question
in the case of multiple questions per page.
The smartdown error message is still unimplemented.
