### PR TITLE
Marriage Abroad Amends

### DIFF
--- a/lib/smart_answer/calculators/marriage_abroad_data_query_v2.rb
+++ b/lib/smart_answer/calculators/marriage_abroad_data_query_v2.rb
@@ -23,7 +23,7 @@ module SmartAnswer::Calculators
 
     OS_OTHER_COUNTRIES = %w(burma north-korea iran somalia syria yemen saudi-arabia)
 
-    OS_NOTICE_OF_MARRIAGE_7_DAY_WAIT_CEREMONY_COUNTRY = %w(albania algeria angola armenia austria azerbaijan bahrain bolivia bosnia-and-herzegovina bulgaria croatia cuba ecuador estonia georgia greece hong-kong iceland iran italy japan kazakhstan kuwait kyrgyzstan libya lithuania luxembourg macedonia mexico)
+    OS_NOTICE_OF_MARRIAGE_7_DAY_WAIT_CEREMONY_COUNTRY = %w(albania algeria angola armenia austria azerbaijan bahrain bolivia bosnia-and-herzegovina bulgaria croatia cuba ecuador estonia georgia greece hong-kong iceland iran italy japan kazakhstan kuwait kyrgyzstan libya lithuania luxembourg macedonia mexico moldova montenegro nicaragua norway poland russia serbia spain sweden tajikistan tunisia turkmenistan ukraine uzbekistan venezuela)
 
     OS_AFFIRMATION_COUNTRIES = %w(cambodia colombia china ecuador egypt lebanon finland mongolia morocco peru philippines portugal qatar south-korea thailand turkey united-arab-emirates vietnam)
 

--- a/lib/smart_answer_flows/locales/en/marriage-abroad-v2.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad-v2.yml
@@ -762,7 +762,7 @@ en-GB:
           $C
 
           %You can't book an appointment to get advice at the embassy in person.%
-
+        consular_cni_os_foreign_resident_3_days_macedonia_giving_notice: |
           ###Giving notice of marriage
 
           You need to have been living in your country of residence for 3 days.

--- a/lib/smart_answer_flows/marriage-abroad-v2.rb
+++ b/lib/smart_answer_flows/marriage-abroad-v2.rb
@@ -569,10 +569,12 @@ outcome :outcome_os_consular_cni do
     end
 
     if ceremony_country == residency_country
-      if ceremony_country == 'croatia'
-        phrases << :consular_cni_os_local_resident_table
-      elsif %w(germany italy kazakhstan russia).exclude?(ceremony_country)
-        phrases << :consular_cni_os_foreign_resident_ceremony_not_germany_italy << :check_with_embassy_or_consulate
+      unless ceremony_country == 'macedonia'
+        if ceremony_country == 'croatia'
+          phrases << :consular_cni_os_local_resident_table
+        elsif %w(germany italy kazakhstan russia).exclude?(ceremony_country)
+          phrases << :consular_cni_os_foreign_resident_ceremony_not_germany_italy << :check_with_embassy_or_consulate
+        end
       end
       phrases << :"#{ceremony_country}_os_local_resident" if %w(kazakhstan russia).include?(ceremony_country)
       unless %w(germany italy japan russia spain).include?(ceremony_country)
@@ -585,6 +587,8 @@ outcome :outcome_os_consular_cni do
         end
         if ceremony_country == 'croatia'
           phrases << :make_appointment_online_croatia
+        elsif ceremony_country == 'macedonia'
+          phrases << :consular_cni_os_foreign_resident_3_days_macedonia
         elsif not reg_data_query.clickbook(ceremony_country)
           phrases << :embassies_data
         end
@@ -602,6 +606,7 @@ outcome :outcome_os_consular_cni do
         if cni_posted_after_7_days_countries.include?(ceremony_country)
           if ceremony_country == 'macedonia'
             phrases << :consular_cni_os_foreign_resident_3_days_macedonia
+            phrases << :consular_cni_os_foreign_resident_3_days_macedonia_giving_notice
           else
             phrases << :consular_cni_os_foreign_resident_3_days
           end

--- a/test/integration/smart_answer_flows/marriage_abroad_v2_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_v2_test.rb
@@ -1188,10 +1188,25 @@ class MarriageAbroadV2Test < ActiveSupport::TestCase
     should "go to consular cni os outcome" do
       assert_current_node :outcome_os_consular_cni
       assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :consular_cni_os_other_resident_ceremony_not_italy, :consular_cni_os_naturalisation, :consular_cni_os_fees_not_italy_not_uk, :consular_cni_os_fees_foreign_commonwealth_roi_resident, :pay_by_cash_or_credit_card_no_cheque]
-      assert_phrase_list :consular_cni_os_start, [:other_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :consular_cni_os_foreign_resident_ceremony_not_germany_italy, :consular_cni_os_foreign_resident_3_days_macedonia, :consular_cni_variant_local_resident_not_germany_or_spain_or_foreign_resident, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :consular_cni_os_local_resident_not_germany_or_spain_or_foreign_resident_not_germany, :consular_cni_os_foreign_resident_ceremony_7_days]
+      assert_phrase_list :consular_cni_os_start, [:other_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :consular_cni_os_foreign_resident_ceremony_not_germany_italy, :consular_cni_os_foreign_resident_3_days_macedonia, :consular_cni_os_foreign_resident_3_days_macedonia_giving_notice, :consular_cni_variant_local_resident_not_germany_or_spain_or_foreign_resident, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :consular_cni_os_local_resident_not_germany_or_spain_or_foreign_resident_not_germany, :consular_cni_os_foreign_resident_ceremony_7_days]
     end
   end
 
+  #testing for ceramony in macedonia
+  context "user lives in macedonia, ceremony in macedonia" do
+    setup do
+      worldwide_api_has_organisations_for_location('macedonia', read_fixture_file('worldwide/macedonia_organisations.json'))
+      add_response 'macedonia'
+      add_response 'other'
+      add_response 'macedonia'
+      add_response 'partner_other'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:local_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :consular_cni_os_foreign_resident_3_days_macedonia, :living_in_residence_country_3_days, :consular_cni_variant_local_resident_not_germany_or_spain_or_foreign_resident, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :consular_cni_os_local_resident_not_germany_or_spain_or_foreign_resident_not_germany, :display_notice_of_marriage_7_days]
+    end
+  end
 
   #testing for ceremony in usa
   context "ceremony in usa, resident in poland, partner irish" do


### PR DESCRIPTION
- If the enquirer lives in Macedonia we must also show the bespoke Macedonian embassy details.
- Add missing countries to notice of marriage 7 day wait.
