### PR TITLE
Precompile print.css

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -56,6 +56,7 @@ module SmartAnswers
       joint.js
       joint.layout.DirectedGraph.js
       joint.css
+      print.css
       dagre.js
       visualise.js
       visualise.css


### PR DESCRIPTION
This was added in 27c5ae2d5ea276fef59608be08ac40796663c518, but this file won't pre-compile in production environments because it's not on the list. This commit fixes that.
