### PR TITLE
Add visuallyhidden description of previous answers Change link

### DIFF
--- a/app/views/smart_answers/_collapsed_question.html.erb
+++ b/app/views/smart_answers/_collapsed_question.html.erb
@@ -7,9 +7,13 @@
     </td>
     <td class="link-right">
       <% if question_page.questions.count == 1 %>
-        <%= link_to "Change", @presenter.change_collapsed_question_link(number_questions_so_far + 1) %>
+        <%= link_to @presenter.change_collapsed_question_link(number_questions_so_far + 1) do %>
+          Change <span class="visuallyhidden">answer(s) to "<%=question_page.title%>"</span>
+        <% end %>
       <% else %>
-        <%= link_to "Change", @presenter.change_collapsed_question_link(number_questions_so_far + 1, question_page.questions.count) %>
+        <%= link_to @presenter.change_collapsed_question_link(number_questions_so_far + 1, question_page.questions.count) do %>
+          Change <span class="visuallyhidden">answer(s) to "<%=question_page.title%>"</span>
+        <% end %>
       <% end %>
     </td>
   </tr>
@@ -36,9 +40,14 @@
     <%- if !question_page.title -%>
       <td class="link-right">
         <% if question_page.questions.count == 1 %>
-          <%= link_to "Change", @presenter.change_collapsed_question_link(number_questions_so_far + 1) %>
+          <%= link_to @presenter.change_collapsed_question_link(number_questions_so_far + 1) do %>
+            Change <span class="visuallyhidden">answer(s) to "<%=question_page.questions.first.title%>"</span>
+          <% end %>
         <% else %>
-          <%= link_to "Change", @presenter.change_collapsed_question_link(number_questions_so_far + 1, question_page.questions.count) %>
+          <%= link_to @presenter.change_collapsed_question_link(number_questions_so_far + 1, question_page.questions.count) do %>
+            <% titles = question_page.questions.map { |question| "\"#{question.title}\"" }.join(",") %>
+            Change <span class="visuallyhidden">answer(s) to <%=titles%></span>
+          <% end %>
         <% end %>
       </td>
     <% end %>


### PR DESCRIPTION
By adding a human readable description of what the question page
or question titles are for each Change link, screenreader users
get a less confusing experience in the previous answers section of
smart answers
