### PR TITLE
Fix spacing in screenreader previous link change description

### DIFF
--- a/app/views/smart_answers/_collapsed_question.html.erb
+++ b/app/views/smart_answers/_collapsed_question.html.erb
@@ -8,11 +8,11 @@
     <td class="link-right">
       <% if question_page.questions.count == 1 %>
         <%= link_to @presenter.change_collapsed_question_link(number_questions_so_far + 1) do %>
-          Change<span class="visuallyhidden"> answer(s) to "<%=question_page.title%>"</span>
+          Change<span class="visuallyhidden"> answer to "<%=question_page.title%>"</span>
         <% end %>
       <% else %>
         <%= link_to @presenter.change_collapsed_question_link(number_questions_so_far + 1, question_page.questions.count) do %>
-          Change<span class="visuallyhidden"> answer(s) to "<%=question_page.title%>"</span>
+          Change<span class="visuallyhidden"> answer to "<%=question_page.title%>"</span>
         <% end %>
       <% end %>
     </td>
@@ -41,12 +41,12 @@
       <td class="link-right">
         <% if question_page.questions.count == 1 %>
           <%= link_to @presenter.change_collapsed_question_link(number_questions_so_far + 1) do %>
-            Change<span class="visuallyhidden"> answer(s) to "<%=question_page.questions.first.title%>"</span>
+            Change<span class="visuallyhidden"> answer to "<%=question_page.questions.first.title%>"</span>
           <% end %>
         <% else %>
           <%= link_to @presenter.change_collapsed_question_link(number_questions_so_far + 1, question_page.questions.count) do %>
             <% titles = question_page.questions.map { |question| "\"#{question.title}\"" }.join(",") %>
-            Change<span class="visuallyhidden"> answer(s) to <%=titles%></span>
+            Change<span class="visuallyhidden"> answer to <%=titles%></span>
           <% end %>
         <% end %>
       </td>


### PR DESCRIPTION
Without this change of spacing, VoiceOver would read as 'Changeanswer(s)'
instead of 'Change answers(s)'
