### PR TITLE
Remove clickbooks from register a birth and death

### DIFF
--- a/lib/smart_answer_flows/locales/en/register-a-birth-v2.yml
+++ b/lib/smart_answer_flows/locales/en/register-a-birth-v2.yml
@@ -176,18 +176,6 @@ en-GB:
           **British Embassy Tokyo**
           <consular.tokyo@fco.gov.uk>
           $C
-        registering_clickbooks: |
-          Book an appointment online at the British embassy or consulate in:
-
-          +[data_partial:clickbooks:clickbook_data]
-
-          Bring the registration form, supporting documents and the fee.
-        clickbook_link: |
-          - [%{city}](%{url})
-        registering_clickbook: |
-          [Book an appointment online](%{clickbook_data}) at the %{embassy_high_commission_or_consulate}.
-
-          Bring the registration form, supporting documents and the fee.
         consular_service_fees: |
           You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees](/government/organisations/foreign-commonwealth-office/series/consular-fees).
         consular_service_fees_libya: |

--- a/lib/smart_answer_flows/locales/en/register-a-death-v2.yml
+++ b/lib/smart_answer_flows/locales/en/register-a-death-v2.yml
@@ -232,14 +232,6 @@ en-GB:
 
           ##Go to the %{embassy_high_commission_or_consulate}
 
-        clickbooks: |
-          You can book an appointment at the British embassy or consulate in:
-
-          +[data_partial:clickbooks:clickbook_data]
-
-        clickbook: |
-          [Book an appointment online](%{clickbook_data})
-
         booking_text_embassy_hong_kong: |
           Register at consulate-general - bring the registration form, supporting documents and the fee.
 
@@ -434,8 +426,6 @@ en-GB:
           %{go_to_the_embassy_heading}
 
           %{booking_text_embassy_result}
-
-          %{clickbook}
 
           %{postal}
 

--- a/lib/smart_answer_flows/register-a-birth-v2.rb
+++ b/lib/smart_answer_flows/register-a-birth-v2.rb
@@ -139,12 +139,7 @@ outcome :embassy_result do
     end
     PhraseList.new(key.to_sym)
   end
-  precalculate :clickbook_data do
-    reg_data_query.clickbook(registration_country)
-  end
-  precalculate :multiple_clickbooks do
-    clickbook_data and clickbook_data.class == Hash
-  end
+
   precalculate :fees_for_consular_services do
     phrases = PhraseList.new
     if registration_country == 'libya'
@@ -162,11 +157,7 @@ outcome :embassy_result do
   precalculate :go_to_the_embassy do
     unless reg_data_query.post_only_countries?(registration_country)
       phrases = PhraseList.new
-      if multiple_clickbooks
-        phrases << :registering_clickbooks
-      elsif clickbook_data
-        phrases << :registering_clickbook
-      elsif %w(hong-kong japan).include?(registration_country)
+      if %w(hong-kong japan).include?(registration_country)
         phrases << :"registering_#{registration_country}"
       else
         phrases << :registering_all

--- a/lib/smart_answer_flows/register-a-death-v2.rb
+++ b/lib/smart_answer_flows/register-a-death-v2.rb
@@ -214,22 +214,6 @@ outcome :embassy_result do
     end
   end
 
-  precalculate :clickbook_data do
-    reg_data_query.clickbook(current_location)
-  end
-
-  precalculate :clickbook do
-    if clickbook_data.nil? || modified_card_only_countries.include?(current_location)
-      ''
-    else
-      if clickbook_data.class == Hash
-        PhraseList.new :clickbooks
-      else
-        PhraseList.new :clickbook
-      end
-    end
-  end
-
   precalculate :post_only do
     if reg_data_query.post_only_countries?(current_location)
       PhraseList.new(:"post_only_#{current_location}")

--- a/test/integration/smart_answer_flows/register_a_birth_v2_test.rb
+++ b/test/integration/smart_answer_flows/register_a_birth_v2_test.rb
@@ -176,7 +176,7 @@ class RegisterABirthV2Test < ActiveSupport::TestCase
       assert_state_variable :british_national_parent, 'mother_and_father'
       assert_phrase_list :documents_you_must_provide, [:documents_you_must_provide_bangladesh]
       assert_phrase_list :fees_for_consular_services, [:consular_service_fees]
-      assert_phrase_list :go_to_the_embassy, [:registering_clickbooks, :registering_either_parent]
+      assert_phrase_list :go_to_the_embassy, [:registering_all, :registering_either_parent]
       assert_state_variable :postal_form_url, nil
       assert_state_variable :postal, ""
       assert_phrase_list :footnote, [:footnote_another_country]

--- a/test/integration/smart_answer_flows/register_a_death_v2_test.rb
+++ b/test/integration/smart_answer_flows/register_a_death_v2_test.rb
@@ -239,7 +239,6 @@ class RegisterADeathTestV2 < ActiveSupport::TestCase
         assert_phrase_list :documents_required_embassy_result, [:documents_list_embassy]
         assert_state_variable :embassy_high_commission_or_consulate, "British embassy"
         assert_phrase_list :booking_text_embassy_result, [:booking_text_embassy]
-        assert_phrase_list :clickbook, [:clickbook]
         expected_location = WorldLocation.find('argentina')
         assert_state_variable :location, expected_location
         assert_state_variable :organisation, expected_location.fco_organisation
@@ -255,7 +254,6 @@ class RegisterADeathTestV2 < ActiveSupport::TestCase
         assert_current_node :embassy_result
         assert_phrase_list :documents_required_embassy_result, [:documents_list_embassy]
         assert_state_variable :embassy_high_commission_or_consulate, "British embassy"
-        assert_state_variable :clickbook, ''
         assert_phrase_list :booking_text_embassy_result, [:booking_text_embassy]
         assert_phrase_list :fees_for_consular_services, [:consular_service_fees]
         assert_state_variable :postal_form_url, "/government/publications/passport-credit-debit-card-payment-authorisation-slip-austria"


### PR DESCRIPTION
The service that allowed to book appointments at embassies and consulates is not active anymore. I removed every reference to it from Register a Birth and Register a Death Smartanswers.

https://www.agileplannerapp.com/boards/105200/cards/8811
