### PR TITLE
Make state pension calculator stateless

### DIFF
--- a/lib/smart_answer/calculators/state_pension_topup_calculator.rb
+++ b/lib/smart_answer/calculators/state_pension_topup_calculator.rb
@@ -12,14 +12,12 @@ module SmartAnswer::Calculators
     FEMALE_RETIREMENT_AGE = 63
     MALE_RETIREMENT_AGE = 65
 
-    def initialize
-      @retirement_age = FEMALE_RETIREMENT_AGE
-    end
-
-    attr_accessor :retirement_age
-
     def retirement_age(gender)
-      @retirement_age = MALE_RETIREMENT_AGE if gender == 'male'
+      if gender == 'female'
+        FEMALE_RETIREMENT_AGE
+      elsif gender == 'male'
+        MALE_RETIREMENT_AGE
+      end
     end
 
     def lump_sum_amount(age, weekly_amount)
@@ -32,13 +30,13 @@ module SmartAnswer::Calculators
       SmartAnswer::Money.new(total)
     end
 
-    def lump_sum_and_age(dob, weekly_amount)
+    def lump_sum_and_age(dob, weekly_amount, gender)
       rows = []
       dob = leap_year_birthday?(dob) ? dob + 1.day : dob
       age = age_at_date(dob, TOPUP_START_DATE)
       (TOPUP_START_DATE.year..TOPUP_END_DATE.year).each do |year|
         break if age > UPPER_AGE || birthday_after_topup_end?(dob, age)
-        rows << {:amount => lump_sum_amount(age, weekly_amount), :age => age} if age >= @retirement_age
+        rows << {:amount => lump_sum_amount(age, weekly_amount), :age => age} if age >= retirement_age(gender)
         age += 1
       end
       rows

--- a/lib/smart_answer_flows/state-pension-topup.rb
+++ b/lib/smart_answer_flows/state-pension-topup.rb
@@ -1,7 +1,7 @@
 status :published
 satisfies_need "100865"
 
-calculator = Calculators::StatePensionTopupCalculator.new()
+calculator = Calculators::StatePensionTopupCalculator.new
 
 #Q1
 date_question :dob_age? do
@@ -50,10 +50,6 @@ money_question :how_much_extra_per_week? do
     end
   end
 
-  calculate :retirement_age do
-    calculator.retirement_age(gender)
-  end
-
   calculate :body_phrase do
     PhraseList.new(:body_phrase)
   end
@@ -67,7 +63,7 @@ outcome :outcome_topup_calculations do
     # Only needed for formatting amount
     self.class.send :include, ActionView::Helpers::NumberHelper
 
-    calculator.lump_sum_and_age(Date.parse(date_of_birth), weekly_amount).map do |amount_and_age|
+    calculator.lump_sum_and_age(Date.parse(date_of_birth), weekly_amount, gender).map do |amount_and_age|
       %Q(- #{number_to_currency(amount_and_age[:amount], precision: 0)} when you're #{amount_and_age[:age]})
     end.join("\n")
   end

--- a/test/unit/calculators/state_pension_topup_calculator_test.rb
+++ b/test/unit/calculators/state_pension_topup_calculator_test.rb
@@ -37,26 +37,24 @@ module SmartAnswer::Calculators
     context "check return value for lump sum amount and age male" do
       setup do
         @calculator = SmartAnswer::Calculators::StatePensionTopupCalculator.new
-        @calculator.retirement_age('male')
       end
 
       should "Show 2 rates for ages 85 and 86" do
-        assert_equal [{:amount=>3940.0, :age=>85}, {:amount=>3660.0, :age=>86}], @calculator.lump_sum_and_age(Date.parse('1930-04-06'), 10)
+        assert_equal [{:amount=>3940.0, :age=>85}, {:amount=>3660.0, :age=>86}], @calculator.lump_sum_and_age(Date.parse('1930-04-06'), 10, 'male')
       end
 
       should "Show rate for 65" do
-        assert_equal [{:amount=>8900.0, :age=>65}], @calculator.lump_sum_and_age(Date.parse('1951-04-06'), 10)
+        assert_equal [{:amount=>8900.0, :age=>65}], @calculator.lump_sum_and_age(Date.parse('1951-04-06'), 10, 'male')
       end
     end
 
     context "check return value for lump sum amount and age female" do
       setup do
         @calculator = SmartAnswer::Calculators::StatePensionTopupCalculator.new
-        @calculator.retirement_age('female')
       end
 
       should "Show rate for 63" do
-        assert_equal [{:amount=>9340.0, :age=>63}], @calculator.lump_sum_and_age(Date.parse('1953-04-06'), 10)
+        assert_equal [{:amount=>9340.0, :age=>63}], @calculator.lump_sum_and_age(Date.parse('1953-04-06'), 10, 'female')
       end
     end
   end


### PR DESCRIPTION
The fact that the state pension calculator was keeping retirement
age as part of its state was causing erroneous calculations for people around
male or female retirement age.
