### PR TITLE
MiniTest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,8 @@ group :test do
   gem 'simplecov-rcov', '~> 0.2.3', :require => false
   gem 'poltergeist', '1.5.1'
   gem 'timecop'
+  gem 'minitest', '4.7.5'
+  gem 'minitest-rails', '1.0.1'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,6 +115,13 @@ GEM
     metaclass (0.0.1)
     method_source (0.8.2)
     mime-types (1.25.1)
+    minitest (4.7.5)
+    minitest-rails (1.0.1)
+      minitest (~> 4.7)
+      minitest-test (~> 1.0)
+      railties (>= 3.0, < 4.1)
+    minitest-test (1.1.0)
+      minitest (~> 4.0)
     mocha (0.13.3)
       metaclass (~> 0.0.1)
     multi_json (1.8.4)
@@ -258,6 +265,8 @@ DEPENDENCIES
   json
   logstasher (= 0.4.8)
   lrucache (= 0.1.4)
+  minitest (= 4.7.5)
+  minitest-rails (= 1.0.1)
   mocha (= 0.13.3)
   nokogiri (= 1.5.11)
   parser

--- a/config/application.rb
+++ b/config/application.rb
@@ -3,7 +3,7 @@ require File.expand_path('../boot', __FILE__)
 # Don't include all of rails, we don't need activerecord
 require "action_controller/railtie"
 require "action_mailer/railtie"
-require "rails/test_unit/railtie"
+require "minitest/rails/railtie"
 require "sprockets/railtie"
 
 if defined?(Bundler)

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -12,7 +12,6 @@ export GOVUK_APP_DOMAIN=dev.gov.uk
 export GOVUK_ASSET_HOST=http://static.dev.gov.uk
 
 export DISPLAY=:99
-bundle exec rake stats
 RAILS_ENV=test bundle exec rake test
 
 bundle exec rake assets:precompile

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,7 +8,6 @@ SimpleCov.start 'rails'
 
 ENV["RAILS_ENV"] = "test"
 require File.expand_path('../../config/environment', __FILE__)
-require 'rails/test_help'
 
 require 'minitest/unit'
 require 'minitest/autorun'


### PR DESCRIPTION
### Why?

According to ruby-doc Test::Unit is no longer under active development 

```
If you are writing new test code, please use MiniTest instead of Test::Unit.
Test::Unit has been left in the standard library to support legacy test suites.
```

http://www.ruby-doc.org/stdlib-2.1.0/libdoc/test/unit/rdoc/Test/Unit.html
### Primary Motivation

Wanted to use https://github.com/kern/minitest-reporters and couldnt find a decent reporter library for Test::Unit example output https://ci-new.alphagov.co.uk/job/govuk_smartanswers_branches/1367/consoleText
