### PR TITLE
Use separate test load paths for smartanswer/smartdown registries. 

### DIFF
--- a/lib/smart_answer/flow_registry.rb
+++ b/lib/smart_answer/flow_registry.rb
@@ -12,7 +12,7 @@ module SmartAnswer
     end
 
     def initialize(options = {})
-      @load_path = Pathname.new(options[:load_path] || FLOW_DIR)
+      @load_path = Pathname.new(options[:smart_answer_load_path] || FLOW_DIR)
       @show_drafts = options.fetch(:show_drafts, false)
       @show_transitions = options.fetch(:show_transitions, false)
       preload_flows! if Rails.env.production? or options[:preload_flows]

--- a/lib/smartdown_adapter/registry.rb
+++ b/lib/smartdown_adapter/registry.rb
@@ -13,7 +13,7 @@ module SmartdownAdapter
     end
 
     def initialize(options = {})
-      @load_path = Pathname.new(options[:load_path] || Rails.root.join('lib', 'smartdown_flows'))
+      @load_path = Pathname.new(options[:smartdown_load_path] || Rails.root.join('lib', 'smartdown_flows'))
       @show_drafts = options.fetch(:show_drafts, false)
       @show_transitions = options.fetch(:show_transitions, false)
       preload_flows! if options.fetch(:preload_flows, Rails.env.production?)

--- a/test/helpers/test_fixtures_helper.rb
+++ b/test/helpers/test_fixtures_helper.rb
@@ -2,7 +2,7 @@ module TestFixturesHelper
   def use_test_smartdown_flow_fixtures
     suppress_warnings do
       SmartdownAdapter::Registry.const_set(:FLOW_REGISTRY_OPTIONS, {}) unless SmartdownAdapter::Registry::FLOW_REGISTRY_OPTIONS
-      SmartdownAdapter::Registry::FLOW_REGISTRY_OPTIONS[:load_path] = Rails.root.join('test/fixtures/smartdown_flows')
+      SmartdownAdapter::Registry::FLOW_REGISTRY_OPTIONS[:smartdown_load_path] = Rails.root.join('test/fixtures/smartdown_flows')
       SmartdownAdapter::Registry.reset_instance
     end
     SmartdownAdapter::PluginFactory.stubs(:plugin_path).returns(Rails.root.join('test/fixtures/smartdown_plugins'))
@@ -11,7 +11,7 @@ module TestFixturesHelper
   def stop_using_test_smartdown_flow_fixtures
     suppress_warnings do
       SmartdownAdapter::Registry.const_set(:FLOW_REGISTRY_OPTIONS, {}) unless SmartdownAdapter::Registry::FLOW_REGISTRY_OPTIONS
-      SmartdownAdapter::Registry::FLOW_REGISTRY_OPTIONS.delete(:load_path)
+      SmartdownAdapter::Registry::FLOW_REGISTRY_OPTIONS.delete(:smartdown_load_path)
       SmartdownAdapter::Registry.reset_instance
     end
   end

--- a/test/integration/engine/engine_test_helper.rb
+++ b/test/integration/engine/engine_test_helper.rb
@@ -6,14 +6,14 @@ class EngineIntegrationTest < ActionDispatch::IntegrationTest
 
   setup do
     fixture_flows_path = Rails.root.join(*%w{test fixtures smart_answer_flows})
-    FLOW_REGISTRY_OPTIONS[:load_path] = fixture_flows_path
+    FLOW_REGISTRY_OPTIONS[:smart_answer_load_path] = fixture_flows_path
     SmartAnswer::FlowRegistry.reset_instance
 
     stub_content_api_default_artefact
   end
 
   teardown do
-    FLOW_REGISTRY_OPTIONS.delete(:load_path)
+    FLOW_REGISTRY_OPTIONS.delete(:smart_answer_load_path)
     SmartAnswer::FlowRegistry.reset_instance
   end
 end


### PR DESCRIPTION
We need use separate load paths for smartanswer / smartdown registries. This is because the production code is trying to evaluate if a flow belongs to the legacy flow building DSL or smartdown. Our test suite fixtures are not located in the same way as production expects. Currently we use the same options / load path constant and this means that the suite is trying to load files that do not exist. 
