### PR TITLE
Remove all references to 'undo' links

### DIFF
--- a/app/assets/javascripts/smart-answers.js
+++ b/app/assets/javascripts/smart-answers.js
@@ -24,20 +24,6 @@ $(document).ready(function() {
         return false;
       });
 
-    // we want to start over with whatever gets provided if someone clicks to change the answer
-    $(".undo a").live('click', function() {
-      /*
-        This is short lived tracking - to help inform a design decision, should not be permanent
-
-        * Cat/Action/Label convention is taken from GOVUK.Analytics.Trackers in static
-        * Slug extraction is based on position logic in GOVUK.Analytics.Trackers.smart_answer
-      */
-      window._gaq && window._gaq.push(['_trackEvent', "MS_smart_answer", getCurrentSlug(), "Change Answer"]);
-
-      reloadQuestions($(this).attr("href"), "");
-      return false;
-    });
-
     // Track when a user clicks on 'Start again' link
     $('.start-right').live('click', function() {
       window._gaq && window._gaq.push(['_trackEvent', 'MS_smart_answer', getCurrentSlug(), 'Start again']);

--- a/app/assets/stylesheets/smart_answers.scss
+++ b/app/assets/stylesheets/smart_answers.scss
@@ -235,35 +235,9 @@ $is-ie: false !default;
     font-weight: normal;
   }
 
-  li.done .undo {
-    position: absolute;
-    top: (0.75em/0.9);
-    right: (1.5em/0.9);
-    margin: 0;
-    @include core-14;
-
-    @include ie-lte(8) {
-      margin: 0;
-    }
-
-    @include ie-lte(6) {
-      position: absolute;
-      right: 1em;
-    }
-
-    a {
-      color: $text-colour;
-      display: block;
-    }
-  }
-
   li.done .answer ul {
     margin: 0.5em 0 0 -2.1em;
     padding-left: 2.1em;
-  }
-
-  li.done:hover .undo a {
-    color: inherit;
   }
 
   .step.current {


### PR DESCRIPTION
The original commit that added tracking to these links appears to have gone in in April as a temporary measure to support some design reckons. 

This commit proposes to take out the link tracking and css references to 'undo', as we no longer seem to have the concept of an 'undo' link in the markup.

Original ref from `git log -p -S 'This is short lived tracking'`:

``` git
commit cfefadf12a3844bb03838b9b2d9cd98fe2239bb6
Author: David Singleton <david.singleton@digital.cabinet-office.gov.uk>
Date:   Mon Apr 28 13:38:39 2014 +0000
```

Will leave this with @dsingleton for review...
