### PR TITLE
Remove usage of `Date.today` inside the constant

### DIFF
--- a/lib/smart_answer/calculators/redundancy_calculator.rb
+++ b/lib/smart_answer/calculators/redundancy_calculator.rb
@@ -7,7 +7,7 @@ module SmartAnswer::Calculators
     AMOUNTS = [
       OpenStruct.new(start_date: Date.new(2012, 01, 01), end_date: Date.new(2013, 01, 31), max: "12,900", rate: 430),
       OpenStruct.new(start_date: Date.new(2013, 02, 01), end_date: Date.new(2014, 04, 05), max: "13,500", rate: 450),
-      OpenStruct.new(start_date: Date.new(2014, 04, 06), end_date: Date.new(Date.today.year, 12, 31), max: "13,920", rate: 464)
+      OpenStruct.new(start_date: Date.new(2014, 04, 06), end_date: Date.new(2015, 12, 31), max: "13,920", rate: 464)
     ]
 
     attr_reader :pay, :number_of_weeks_entitlement

--- a/lib/smart_answer/calculators/redundancy_calculator.rb
+++ b/lib/smart_answer/calculators/redundancy_calculator.rb
@@ -7,7 +7,7 @@ module SmartAnswer::Calculators
     AMOUNTS = [
       OpenStruct.new(start_date: Date.new(2012, 01, 01), end_date: Date.new(2013, 01, 31), max: "12,900", rate: 430),
       OpenStruct.new(start_date: Date.new(2013, 02, 01), end_date: Date.new(2014, 04, 05), max: "13,500", rate: 450),
-      OpenStruct.new(start_date: Date.new(2014, 04, 06), end_date: Date.new(2015, 12, 31), max: "13,920", rate: 464)
+      OpenStruct.new(start_date: Date.new(2014, 04, 06), end_date: Date.new(2030, 12, 31), max: "13,920", rate: 464)
     ]
 
     attr_reader :pay, :number_of_weeks_entitlement


### PR DESCRIPTION
This usage of `Date.today` caused a bug in production earlier. When the application was started the year was 2014, and the end date that was stored in the constant (and was never updated) was "2014-12-31".

As I've put in the commit message, I don't necessarily expect this to be merged. But I'm opening this pull request because the change is probably a net improvement and is a way to make sure the problem isn't forgotten.