### PR TITLE
Use component alpha label rather than slimmer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem 'extlib', '0.9.16'
 if ENV['SLIMMER_DEV']
   gem 'slimmer', :path => '../slimmer'
 else
-  gem 'slimmer', '4.1.0'
+  gem 'slimmer', '6.0.0'
 end
 
 if ENV['GOVSPEAK_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,12 +208,12 @@ GEM
     simplecov-html (0.5.3)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    slimmer (4.1.0)
+    slimmer (6.0.0)
+      activesupport
       json
-      lrucache (~> 0.1.3)
       nokogiri (~> 1.5.0)
       null_logger
-      plek (>= 0.1.8)
+      plek (>= 1.1.0)
       rack (>= 1.3.5)
       rest-client
     slop (3.4.5)
@@ -287,7 +287,7 @@ DEPENDENCIES
   shoulda (~> 2.11.3)
   simplecov (~> 0.6.4)
   simplecov-rcov (~> 0.2.3)
-  slimmer (= 4.1.0)
+  slimmer (= 6.0.0)
   smartdown (= 0.12.1)
   therubyracer (~> 0.12.1)
   tilt (= 1.4.1)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ require "slimmer/headers"
 
 class ApplicationController < ActionController::Base
   include Slimmer::Headers
+  include Slimmer::SharedTemplates
   before_filter :set_analytics_headers
 
   rescue_from GdsApi::TimedOutException, with: :error_503

--- a/app/controllers/smart_answers_controller.rb
+++ b/app/controllers/smart_answers_controller.rb
@@ -2,7 +2,6 @@ class SmartAnswersController < ApplicationController
   before_filter :reject_invalid_utf8
   before_filter :find_smart_answer
   before_filter :redirect_response_to_canonical_url, only: %w{show}
-  before_filter :set_alpha_header, only: %w{visualise}
   before_filter :set_header_footer_only, only: %w{visualise}
 
   rescue_from SmartAnswer::FlowRegistry::NotFound, with: :error_404
@@ -104,10 +103,6 @@ private
 
   def reject_invalid_utf8
     error_404 unless params[:responses].nil? or params[:responses].valid_encoding?
-  end
-
-  def set_alpha_header
-    set_slimmer_headers(alpha_label: 'before:#content header')
   end
 
   def set_header_footer_only

--- a/app/views/smart_answers/visualise.html.erb
+++ b/app/views/smart_answers/visualise.html.erb
@@ -19,6 +19,7 @@
 
 <main id="content" role="main" class="visualisation-">
   <div class="container">
+    <%= render partial: 'govuk_component/alpha_label' %>
     <header class="page-header group">
       <div>
         <h1>


### PR DESCRIPTION
Use the new style component for the alpha label rather than the old
slimmer version. This will make it more obvious as to where the label is
coming from.

This needs this pull request to be merged and deployed first:
https://github.com/alphagov/static/pull/527