### PR TITLE
Smartdown money question type

### DIFF
--- a/lib/smartdown_adapter/money_question_presenter.rb
+++ b/lib/smartdown_adapter/money_question_presenter.rb
@@ -1,7 +1,7 @@
 module SmartdownAdapter
   class MoneyQuestionPresenter < SmartdownAdapter::QuestionPresenter
     def to_response(input)
-      { amount: input }
+      input
     end
 
     def has_suffix_label?

--- a/lib/smartdown_adapter/money_question_presenter.rb
+++ b/lib/smartdown_adapter/money_question_presenter.rb
@@ -1,0 +1,13 @@
+module SmartdownAdapter
+  class MoneyQuestionPresenter < SmartdownAdapter::QuestionPresenter
+    def to_response(input)
+      { amount: input }
+    end
+
+    def has_suffix_label?
+      false
+    end
+
+  end
+end
+

--- a/lib/smartdown_adapter/question_page_presenter.rb
+++ b/lib/smartdown_adapter/question_page_presenter.rb
@@ -21,6 +21,8 @@ module SmartdownAdapter
           SmartdownAdapter::TextQuestionPresenter.new(smartdown_question, smartdown_answer)
         when Smartdown::Api::PostcodeQuestion
           SmartdownAdapter::TextQuestionPresenter.new(smartdown_question, smartdown_answer)
+        when Smartdown::Api::MoneyQuestion
+          SmartdownAdapter::MoneyQuestionPresenter.new(smartdown_question, smartdown_answer)
         else
           SmartdownAdapter::QuestionPresenter.new(smartdown_question, smartdown_answer)
         end

--- a/lib/smartdown_adapter/question_presenter.rb
+++ b/lib/smartdown_adapter/question_presenter.rb
@@ -47,6 +47,8 @@ module SmartdownAdapter
         "text_question"
       when Smartdown::Api::PostcodeQuestion
         "postcode_question"
+      when Smartdown::Api::MoneyQuestion
+        "money_question"
       end
     end
 


### PR DESCRIPTION
* REQUIRES this [smartdown money question PR 131](https://github.com/alphagov/smartdown/pull/131) to have been merged on smartdown gem.
* Adds support for new smartdown money question type.
* Required for possible MOJ fee remission smartanswers - see smartdown issue [#128](https://github.com/alphagov/smartdown/issues/128)