### PR TITLE
Update smartdown, to get new line bug fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'tilt', '1.4.1'
 if ENV['SMARTDOWN_DEV']
   gem 'smartdown', :path => '../smartdown'
 else
-  gem 'smartdown', '0.12.1'
+  gem 'smartdown', '0.13.1'
 end
 
 if ENV['API_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -217,7 +217,7 @@ GEM
       rack (>= 1.3.5)
       rest-client
     slop (3.4.5)
-    smartdown (0.12.1)
+    smartdown (0.13.1)
       parslet (~> 1.6.2)
       uk_postcode (~> 1.0.1)
     sprockets (2.2.2)
@@ -288,7 +288,7 @@ DEPENDENCIES
   simplecov (~> 0.6.4)
   simplecov-rcov (~> 0.2.3)
   slimmer (= 6.0.0)
-  smartdown (= 0.12.1)
+  smartdown (= 0.13.1)
   therubyracer (~> 0.12.1)
   tilt (= 1.4.1)
   timecop


### PR DESCRIPTION
0.13.1 added a fix for additional new lines being inserted into
the resulting markdown/govspeak content, which for some markdown
constucts where new lines are semantically meaningful (like
tables) this broke the rendering of markdown

0.13.0 added support for a new `Money` question type, which shouldn't affect anything else in the running of SA.