### PR TITLE
Yes/No radio buttons side by side

### DIFF
--- a/app/views/smart_answers/_multiple_choice_question.html.erb
+++ b/app/views/smart_answers/_multiple_choice_question.html.erb
@@ -1,4 +1,6 @@
-<ul class="options">
+<% yes_no = question.options.map(&:label).sort == ['No','Yes'] %>
+<% style = yes_no ? 'options inline' : 'options' %>
+<ul class="<%= style %>">
   <% question.options.each.with_index do |option, i| %>
     <li>
       <% if number %>


### PR DESCRIPTION
Adds the `inline` style to Yes and No radio buttons. The inline style results in Yes
and No buttons being placed side by side. This is consistent with the GOV.UK
elements guide, see: http://govuk-elements.herokuapp.com/#form-radio-buttons

Here is a hackpad page where this issue is being discussed:
https://designpatterns.hackpad.com/Smart-answers-9q7BEVu6tOZ