### PR TITLE
Highlight radio and checkbox selection buttons

### DIFF
--- a/app/assets/javascripts/smart-answers.js
+++ b/app/assets/javascripts/smart-answers.js
@@ -115,6 +115,8 @@ $(document).ready(function() {
     if ($(".outcome").length !== 0) {
       $.event.trigger('smartanswerOutcome');
     }
+    var $blockLabels = $("input[type='radio'], input[type='checkbox']");
+    GOVUK.selectionButtons($blockLabels);
   }
 
   function initializeHistory(data) {


### PR DESCRIPTION
Use the `GOVUK.selectionButtons()` function to add visual highlighting to
radio and checkboxes on forms. Logic is added to `updateContent()` function
to ensure highlighting works after content updates.

This change makes smart-answer selection buttons behave according to
recommendations in the GOV.UK elements guide. For example:
http://govuk-elements.herokuapp.com/#form-checkboxes

Here is a hackpad page where this issue is being discussed:
https://designpatterns.hackpad.com/Smart-answers-9q7BEVu6tOZ