### PR TITLE
Marriage Abroad - Update Cyprus outcome

### DIFF
--- a/lib/smart_answer_flows/locales/en/marriage-abroad-v2.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad-v2.yml
@@ -37,6 +37,10 @@ en-GB:
           ##What documents you’ll need
 
           You’ll need proof that you’ve been resident in the area covered by the embassy or consulate for at least 7 days, like an employer’s letter or a bank statement.
+        documents_needed_7_days_residency_hc: |
+          ##What documents you’ll need
+
+          You’ll need proof that you’ve been resident in the area covered by the high commission for at least 7 days, like an employer’s letter or a bank statement.
         documents_needed_21_days_residency: |
           ##What documents you’ll need
 
@@ -1583,6 +1587,8 @@ en-GB:
 # CP in countries with consular CP (exc australia) phrases
         consular_cp_ceremony: |
           You may be able to register a civil partnership at the British embassy or consulate in %{country_name_lowercase_prefix}.
+        consular_cp_ceremony_hc: |
+          You may be able to register a civil partnership at the High Commission in %{country_name_lowercase_prefix}.
         consular_cp_ceremony_vietnam_partner_local: |
           %However, you can’t enter into a civil partnership with a Vietnamese national.%
         consular_cp_local_partner_croatia_bulgaria: |
@@ -1614,6 +1620,19 @@ en-GB:
           - a declaration that you and your partner will need to swear, stating that you’re legally entitled to enter into a civil partnership
 
           Once you’ve submitted these and paid the registration fee (see below), the embassy or consulate will display your notice publicly for 14 days.
+
+          As long as nobody has registered an objection after this time, the registration officer can then register your partnership any time until 3 months after the date you gave notice.
+
+          You’ll need to provide two witnesses and pay a fee to register your civil partnership. You’ll need to pay an additional fee for your civil partnership certificate (see below).
+        consular_cp_all_what_you_need_to_do_hc: |
+          ###What you need to do
+
+          Once you’ve made your appointment, the high commission will give you:
+
+          - a notice of registration
+          - a declaration that you and your partner will need to swear, stating that you’re legally entitled to enter into a civil partnership
+
+          Once you’ve submitted these and paid the registration fee (see below), the high commission will display your notice publicly for 14 days.
 
           As long as nobody has registered an objection after this time, the registration officer can then register your partnership any time until 3 months after the date you gave notice.
 

--- a/lib/smart_answer_flows/marriage-abroad-v2.rb
+++ b/lib/smart_answer_flows/marriage-abroad-v2.rb
@@ -1322,7 +1322,15 @@ end
 outcome :outcome_cp_consular do
   precalculate :consular_cp_outcome do
     phrases = PhraseList.new
-    phrases << :consular_cp_ceremony
+    # cyprus is a country with a high commission. This is why some of its phraselists end with 'hc', we need to refer to High Commission instead Embassy or Consulate.
+    # The logic behind it could be made prettier by creating a group of High Commission Countries or by querying the API and checking whether the country has a High Commission, a consulate, an embassy or something else.
+    # I am not going to do any of that because Marriage Abroad will (Should) be rebuilt soon, is better to keep the logic as much explicit as possible.
+
+    if ceremony_country == 'cyprus'
+      phrases << :consular_cp_ceremony_hc
+    else
+      phrases << :consular_cp_ceremony
+    end
     if ceremony_country == 'vietnam'
       phrases << :consular_cp_ceremony_vietnam_partner_local if partner_nationality == 'partner_local'
       phrases << :consular_cp_vietnam
@@ -1335,7 +1343,9 @@ outcome :outcome_cp_consular do
     end
     phrases << :embassies_data
     unless ceremony_country == 'japan'
-      if data_query.ss_21_days_residency_required_countries?(ceremony_country)
+      if ceremony_country == 'cyprus'
+        phrases << :documents_needed_7_days_residency_hc
+      elsif data_query.ss_21_days_residency_required_countries?(ceremony_country)
         phrases << :documents_needed_21_days_residency
       else
         phrases << :documents_needed_7_days_residency
@@ -1343,7 +1353,11 @@ outcome :outcome_cp_consular do
     end
     phrases << :consular_cp_all_documents
     phrases << :consular_cp_partner_not_british if partner_nationality != 'partner_british'
-    phrases << :consular_cp_all_what_you_need_to_do
+    if ceremony_country == 'cyprus'
+      phrases << :consular_cp_all_what_you_need_to_do_hc
+    else
+      phrases << :consular_cp_all_what_you_need_to_do
+    end
     phrases << :consular_cp_naturalisation unless partner_nationality == 'partner_british'
     if %w(vietnam thailand south-korea).include?(ceremony_country)
       phrases << :fee_table_affidavit_55

--- a/test/integration/smart_answer_flows/marriage_abroad_v2_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_v2_test.rb
@@ -261,6 +261,20 @@ class MarriageAbroadV2Test < ActiveSupport::TestCase
       assert_phrase_list :commonwealth_os_outcome, [:local_resident_os_ceremony_not_zimbabwe, :commonwealth_os_all_cni, :commonwealth_os_other_countries_cyprus, :commonwealth_os_naturalisation]
     end
   end
+  context "resident in england, ceremony in cyprus, partner other" do
+    setup do
+      worldwide_api_has_organisations_for_location('cyprus', read_fixture_file('worldwide/cyprus_organisations.json'))
+      add_response 'cyprus'
+      add_response 'uk'
+      add_response 'uk_england'
+      add_response 'partner_other'
+      add_response 'same_sex'
+    end
+    should "go to consular cp outcome" do
+      assert_current_node :outcome_cp_consular
+      assert_phrase_list :consular_cp_outcome, [:consular_cp_ceremony_hc, :consular_cp_all_contact, :embassies_data, :documents_needed_7_days_residency_hc, :consular_cp_all_documents, :consular_cp_partner_not_british, :consular_cp_all_what_you_need_to_do_hc, :consular_cp_naturalisation, :consular_cp_all_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
   # testing for british overseas territories
   context "uk resident ceremony in british indian ocean territory" do
     setup do


### PR DESCRIPTION
Cyprus has a High Commission office and not Embassy or Consulate. Content updated.
ticket: https://www.pivotaltracker.com/story/show/87797826
