### PR TITLE
Refactor lost or stolen passport

### DIFF
--- a/lib/smart_answer_flows/locales/en/report-a-lost-or-stolen-passport-v2.yml
+++ b/lib/smart_answer_flows/locales/en/report-a-lost-or-stolen-passport-v2.yml
@@ -1,0 +1,85 @@
+en-GB:
+  flow:
+    report-a-lost-or-stolen-passport-v2:
+      meta:
+        description: What you need to do if your passport has been lost or stolen and you need to travel urgently - emergency travel document and replacement passport.
+      title: Cancel a lost or stolen passport
+      body: |
+        You must cancel a lost or stolen passport as soon as possible.
+
+        This will reduce the risk of anyone else using your passport or your identity.
+
+        You can report a lost or stolen passport for someone else if they can't do it themselves.
+
+      phrases:
+        child_forms: |
+          To report your lost passport you can do any of:
+
+          - [download a copy of form LS01](/government/publications/report-a-lost-or-stolen-passport-form-ls01) and post the completed form to Her Majesty's Passport Office - the address is on the form
+          - get a copy of form LS01 from a Post Office that offers the [Check and Send service](/how-the-post-office-check-and-send-service-works)
+          - [ask for a callback](https://passportofficeforms.service.gov.uk/_/request-call-back.ofml) from Her Majesty's Passport Office
+
+          ^Your signature will be compared to the signature on the original passport application form. If the original application was made by someone else, you’ll also need to send a signed letter from that person confirming that the passport has been lost or stolen. This is to help prevent child abduction.^
+
+        adult_forms: |
+          To report your lost passport you can do any of:
+
+          - [download a copy of form LS01](/government/publications/report-a-lost-or-stolen-passport-form-ls01) and post the completed form to Her Majesty's Passport Office - the address is on the form
+          - get a copy of form LS01 from a Post Office that offers the [Check and Send service](/how-the-post-office-check-and-send-service-works)
+          - use the new [online service](https://www.loststolenpassport.service.gov.uk/report) - this service is [in beta](/help/beta)
+
+          ^You’ll need a daytime telephone number and either an email address or UK mobile number to use the online service.^
+
+      options:
+        adult: Adult
+        child: Child
+        in_the_uk: "In the UK"
+        abroad: "Abroad"
+
+      adult_or_child_passport?:
+        title: Is it an adult or a child passport?
+
+      which_country?:
+        title: In which country?
+
+      ## A1
+      complete_LS01_form:
+        body: |
+          You must report your lost or stolen passport to Her Majesty's Passport Office.
+
+          %{additional_content}
+          
+
+          ##Replacing your passport
+
+          You can apply for a replacement at the same time if you’re a British national and in the UK.
+
+          Follow the same process as [renewing a passport](/renew-adult-passport) but you must send a completed form LS01 with your application (if you haven’t already reported it as lost)
+          
+          ^Use the [online enquiry form](https://eforms.homeoffice.gov.uk/outreach/Passport_Enquiries.ofml) to contact Her Majesty’s Passport Office for general advice.
+
+          % You can’t use the [1-day Premium service](/get-a-passport-urgently) if you’re replacing a lost passport. %
+
+          ##If you find your passport
+
+          If you find your passport, don’t sign the form. Instead, return the form in the envelope provided with a signed note confirming that you have found your passport and don’t want to cancel it.
+
+      # A2
+      contact_the_embassy:
+        title: You must report your lost or stolen passport
+        body: |
+          [Download form LS01 - 'Lost or stolen passport notification'](/government/publications/report-a-lost-or-stolen-passport-form-ls01)
+
+          Fill in form LS01 and post, fax or take it to your nearest British embassy, high commission or consulate. Check if you need to make an appointment first if you’re taking it in.
+
+          You can use the [online enquiry form](https://eforms.homeoffice.gov.uk/outreach/Passport_Enquiries.ofml) to contact Her Majesty’s Passport Office for general advice.
+
+          +[data_partial:overseas_passports_embassies:overseas_passports_embassies]
+
+          ##Get a replacement passport
+
+          If you don’t need to travel urgently, you can [apply for a replacement passport from the country you’re in.](/apply-renew-passport-abroad)
+
+          ##Emergency travel documents
+
+          If you need to travel urgently, you may be able to get an [emergency travel document](/emergency-travel-document) from the Embassy, High Commission or Consulate. You will have to pay a fee.

--- a/lib/smart_answer_flows/locales/en/report-a-lost-or-stolen-passport-v2.yml
+++ b/lib/smart_answer_flows/locales/en/report-a-lost-or-stolen-passport-v2.yml
@@ -11,33 +11,9 @@ en-GB:
 
         You can report a lost or stolen passport for someone else if they can't do it themselves.
 
-      phrases:
-        child_forms: |
-          To report your lost passport you can do any of:
-
-          - [download a copy of form LS01](/government/publications/report-a-lost-or-stolen-passport-form-ls01) and post the completed form to Her Majesty's Passport Office - the address is on the form
-          - get a copy of form LS01 from a Post Office that offers the [Check and Send service](/how-the-post-office-check-and-send-service-works)
-          - [ask for a callback](https://passportofficeforms.service.gov.uk/_/request-call-back.ofml) from Her Majesty's Passport Office
-
-          ^Your signature will be compared to the signature on the original passport application form. If the original application was made by someone else, you’ll also need to send a signed letter from that person confirming that the passport has been lost or stolen. This is to help prevent child abduction.^
-
-        adult_forms: |
-          To report your lost passport you can do any of:
-
-          - [download a copy of form LS01](/government/publications/report-a-lost-or-stolen-passport-form-ls01) and post the completed form to Her Majesty's Passport Office - the address is on the form
-          - get a copy of form LS01 from a Post Office that offers the [Check and Send service](/how-the-post-office-check-and-send-service-works)
-          - use the new [online service](https://www.loststolenpassport.service.gov.uk/report) - this service is [in beta](/help/beta)
-
-          ^You’ll need a daytime telephone number and either an email address or UK mobile number to use the online service.^
-
       options:
-        adult: Adult
-        child: Child
         in_the_uk: "In the UK"
         abroad: "Abroad"
-
-      adult_or_child_passport?:
-        title: Is it an adult or a child passport?
 
       which_country?:
         title: In which country?
@@ -47,15 +23,27 @@ en-GB:
         body: |
           You must report your lost or stolen passport to Her Majesty's Passport Office.
 
-          %{additional_content}
+          To report your lost passport you can do any of:
+
+          - [download a copy of form LS01](/government/publications/report-a-lost-or-stolen-passport-form-ls01) and post the completed form to Her Majesty's Passport Office - the address is on the form
+          - get a copy of form LS01 from a Post Office that offers the [Check and Send service](/how-the-post-office-check-and-send-service-works)
+          - use the new [online service](https://www.loststolenpassport.service.gov.uk/report) - this service is [in beta](/help/beta)
+
+         
+          ^You’ll need a daytime telephone number and either an email address or UK mobile number to use the online service.^
+
+
+          %The person reporting a child’s passport lost or stolen must be the same person who signed the child’s original passport application. This is to prevent child abduction.%
+
           
+          You can use the [online enquiry form](https://eforms.homeoffice.gov.uk/outreach/Passport_Enquiries.ofml) to contact Her Majesty’s Passport Office for general advice.
 
           ##Replacing your passport
 
           You can apply for a replacement at the same time if you’re a British national and in the UK.
 
           Follow the same process as [renewing a passport](/renew-adult-passport) but you must send a completed form LS01 with your application (if you haven’t already reported it as lost)
-          
+
           ^Use the [online enquiry form](https://eforms.homeoffice.gov.uk/outreach/Passport_Enquiries.ofml) to contact Her Majesty’s Passport Office for general advice.
 
           % You can’t use the [1-day Premium service](/get-a-passport-urgently) if you’re replacing a lost passport. %
@@ -75,6 +63,8 @@ en-GB:
           You can use the [online enquiry form](https://eforms.homeoffice.gov.uk/outreach/Passport_Enquiries.ofml) to contact Her Majesty’s Passport Office for general advice.
 
           +[data_partial:overseas_passports_embassies:overseas_passports_embassies]
+
+          %The person reporting a child’s passport lost or stolen must be the same person who signed the child’s original passport application. This is to prevent child abduction.%
 
           ##Get a replacement passport
 

--- a/lib/smart_answer_flows/report-a-lost-or-stolen-passport-v2.rb
+++ b/lib/smart_answer_flows/report-a-lost-or-stolen-passport-v2.rb
@@ -4,21 +4,10 @@ satisfies_need "100221"
 exclude_countries = %w(holy-see british-antarctic-territory)
 
 multiple_choice :where_was_the_passport_lost_or_stolen? do
-  option in_the_uk: :adult_or_child_passport?
-  option abroad: :adult_or_child_passport?
+  option in_the_uk: :complete_LS01_form
+  option abroad: :which_country?
 
   save_input_as :location
-end
-
-multiple_choice :adult_or_child_passport? do
-  option :adult
-  option :child
-
-  save_input_as :age
-
-  calculate :additional_content do
-    age == 'child' ? PhraseList.new(:child_forms) : PhraseList.new(:adult_forms)
-  end
 
   next_node do
     case location

--- a/lib/smart_answer_flows/report-a-lost-or-stolen-passport-v2.rb
+++ b/lib/smart_answer_flows/report-a-lost-or-stolen-passport-v2.rb
@@ -1,0 +1,47 @@
+status :draft
+satisfies_need "100221"
+
+exclude_countries = %w(holy-see british-antarctic-territory)
+
+multiple_choice :where_was_the_passport_lost_or_stolen? do
+  option in_the_uk: :adult_or_child_passport?
+  option abroad: :adult_or_child_passport?
+
+  save_input_as :location
+end
+
+multiple_choice :adult_or_child_passport? do
+  option :adult
+  option :child
+
+  save_input_as :age
+
+  calculate :additional_content do
+    age == 'child' ? PhraseList.new(:child_forms) : PhraseList.new(:adult_forms)
+  end
+
+  next_node do
+    case location
+    when 'in_the_uk' then :complete_LS01_form
+    when 'abroad' then :which_country?
+    end
+  end
+end
+
+country_select :which_country?, exclude_countries: exclude_countries do
+  save_input_as :country
+
+  calculate :overseas_passports_embassies do
+    location = WorldLocation.find(country)
+    raise InvalidResponse unless location
+    if location.fco_organisation
+      location.fco_organisation.offices_with_service 'Lost or Stolen Passports'
+    else
+      []
+    end
+  end
+  next_node :contact_the_embassy
+end
+
+outcome :contact_the_embassy
+outcome :complete_LS01_form

--- a/test/integration/smart_answer_flows/report_a_lost_or_stolen_passport_v2_test.rb
+++ b/test/integration/smart_answer_flows/report_a_lost_or_stolen_passport_v2_test.rb
@@ -1,0 +1,97 @@
+require_relative "../../test_helper"
+require_relative "flow_test_helper"
+require 'gds_api/test_helpers/worldwide'
+
+class ReportALostOrStolenPassportV2Test < ActiveSupport::TestCase
+  include FlowTestHelper
+  include GdsApi::TestHelpers::Worldwide
+
+  setup do
+    @location_slugs = %w(azerbaijan)
+    worldwide_api_has_locations(@location_slugs)
+    json = read_fixture_file('worldwide/azerbaijan_organisations.json')
+    worldwide_api_has_organisations_for_location('azerbaijan', json)
+    setup_for_testing_flow "report-a-lost-or-stolen-passport-v2"
+  end
+
+  should "ask where the passport was lost or stolen" do
+    assert_current_node :where_was_the_passport_lost_or_stolen?
+  end
+
+  context "in the UK " do
+      setup do
+        add_response :in_the_uk
+      end
+
+    should "ask whether the passport is for a child or an adult" do
+      assert_current_node :adult_or_child_passport?
+    end
+
+    context "for an Adult" do
+        setup do
+          add_response :adult
+        end
+
+        should "tell you to fill out the LS01 form" do
+          assert_current_node :complete_LS01_form
+          assert_phrase_list :additional_content, [:adult_forms]
+        end
+      end
+      context "child" do
+        setup do
+          add_response :child
+        end
+        should "tell you to fill out the LS01 form" do
+          assert_current_node :complete_LS01_form
+          assert_phrase_list :additional_content, [:child_forms]
+        end
+      end
+    end
+    context "abroad" do
+    setup do
+      add_response :abroad
+    end
+
+      should "ask whether the passport is for a child or an adult" do
+        assert_current_node :adult_or_child_passport?
+      end
+
+      context "for an Adult" do
+      setup do
+        add_response :adult
+      end
+        should "ask in which country has been lost/stolen" do
+          assert_current_node :which_country?
+        end
+        context "in Azerbaijan" do
+        setup do
+          add_response "azerbaijan"
+        end
+
+        should "tell you to report it to the embassy" do
+          assert_current_node :contact_the_embassy
+          assert_phrase_list :additional_content, [:adult_forms]
+          assert_match /British Embassy Baku/, outcome_body
+        end
+      end
+    end
+    context "for a Child" do
+      setup do
+        add_response :child
+      end
+    should "ask which country you lost your passport in" do
+        assert_current_node :which_country?
+      end
+      context "in Azerbaijan" do
+        setup do
+          add_response "azerbaijan"
+        end
+
+        should "tell you to report it to the embassy" do
+          assert_current_node :contact_the_embassy
+          assert_phrase_list :additional_content, [:child_forms]
+        end
+      end
+    end
+  end
+end

--- a/test/integration/smart_answer_flows/report_a_lost_or_stolen_passport_v2_test.rb
+++ b/test/integration/smart_answer_flows/report_a_lost_or_stolen_passport_v2_test.rb
@@ -19,78 +19,32 @@ class ReportALostOrStolenPassportV2Test < ActiveSupport::TestCase
   end
 
   context "in the UK " do
-      setup do
-        add_response :in_the_uk
-      end
-
-    should "ask whether the passport is for a child or an adult" do
-      assert_current_node :adult_or_child_passport?
+    setup do
+      add_response :in_the_uk
     end
 
-    context "for an Adult" do
-        setup do
-          add_response :adult
-        end
-
-        should "tell you to fill out the LS01 form" do
-          assert_current_node :complete_LS01_form
-          assert_phrase_list :additional_content, [:adult_forms]
-        end
-      end
-      context "child" do
-        setup do
-          add_response :child
-        end
-        should "tell you to fill out the LS01 form" do
-          assert_current_node :complete_LS01_form
-          assert_phrase_list :additional_content, [:child_forms]
-        end
-      end
+    should "tell you to fill out the LS01 form" do
+      assert_current_node :complete_LS01_form
     end
-    context "abroad" do
+  end
+
+  context "abroad" do
     setup do
       add_response :abroad
     end
 
-      should "ask whether the passport is for a child or an adult" do
-        assert_current_node :adult_or_child_passport?
-      end
-
-      context "for an Adult" do
-      setup do
-        add_response :adult
-      end
-        should "ask in which country has been lost/stolen" do
-          assert_current_node :which_country?
-        end
-        context "in Azerbaijan" do
-        setup do
-          add_response "azerbaijan"
-        end
-
-        should "tell you to report it to the embassy" do
-          assert_current_node :contact_the_embassy
-          assert_phrase_list :additional_content, [:adult_forms]
-          assert_match /British Embassy Baku/, outcome_body
-        end
-      end
+    should "ask in which country has been lost/stolen" do
+      assert_current_node :which_country?
     end
-    context "for a Child" do
-      setup do
-        add_response :child
-      end
-    should "ask which country you lost your passport in" do
-        assert_current_node :which_country?
-      end
-      context "in Azerbaijan" do
-        setup do
-          add_response "azerbaijan"
-        end
 
-        should "tell you to report it to the embassy" do
-          assert_current_node :contact_the_embassy
-          assert_phrase_list :additional_content, [:child_forms]
-        end
+    context "in Azerbaijan" do
+      setup do
+        add_response "azerbaijan"
+      end
+
+      should "tell you to report it to the embassy" do
+        assert_current_node :contact_the_embassy
+        assert_match /British Embassy Baku/, outcome_body
       end
     end
   end


### PR DESCRIPTION
My first effort at updating smart_answer_flows is to refactor the smart answer for reporting a lost or stolen passport by removing the logic, content and node associated with determining adult or child status.

Please review and merge if suitable or comment here on what I need to modify.