### PR TITLE
Add a healthcheck endpoint

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 SmartAnswers::Application.routes.draw do
+  match 'healthcheck', to: proc { [200, {}, ['']] }
+
   constraints id: /[a-z0-9-]+/i do
     match '/:id/visualise(.:format)', to: 'smart_answers#visualise', as: :visualise
 

--- a/test/integration/healthcheck_test.rb
+++ b/test/integration/healthcheck_test.rb
@@ -1,0 +1,9 @@
+# encoding: UTF-8
+require_relative "../integration_test_helper"
+
+class HealthcheckTest < ActionDispatch::IntegrationTest
+  should "returns health check status" do
+    get "/healthcheck"
+    assert_response :success
+  end
+end


### PR DESCRIPTION
Currently healthcheck is done for this app by pointing at
a real bit of content, which if renamed or removed will
cause the healthcheck to fail.

Adding a specific healthcheck endpoint removes that
dependence on real content and is less likely to break.

See: https://github.gds/gds/puppet/pull/2568