### PR TITLE
Remove unnecessary analytics event tracking

### DIFF
--- a/app/assets/javascripts/smart-answers.js
+++ b/app/assets/javascripts/smart-answers.js
@@ -18,14 +18,8 @@ $(document).ready(function() {
       return false;
     });
 
-    $('.start-right').live('click', function() {
+    $('.start-right, .link-right a').live('click', function() {
       reloadQuestions($(this).attr('href'));
-      return false;
-    });
-
-    $('.link-right a').live('click', function() {
-      var href = $(this).attr('href');
-      reloadQuestions(href);
       return false;
     });
 

--- a/app/assets/javascripts/smart-answers.js
+++ b/app/assets/javascripts/smart-answers.js
@@ -3,18 +3,11 @@ function browserSupportsHtml5HistoryApi() {
 }
 
 $(document).ready(function() {
-  //_gaq.push(['_trackEvent', 'Citizen-Format-Smartanswer', 'Load']);
   if(browserSupportsHtml5HistoryApi()) {
     var formSelector = ".current form";
 
     initializeHistory();
 
-    var getCurrentPosition = function () {
-      var slugArray = document.URL.split('/');
-      return slugArray.splice(3, slugArray.length).join('/');
-    };
-
-    // events
     // get new questions on submit
     $(formSelector).live('submit', function(event) {
       $('input[type=submit]', this).attr('disabled', 'disabled');
@@ -25,17 +18,13 @@ $(document).ready(function() {
       return false;
     });
 
-    // Track when a user clicks on 'Start again' link
     $('.start-right').live('click', function() {
-      window._gaq && window._gaq.push(['_trackEvent', 'MS_smart_answer', getCurrentPosition(), 'Start again']);
       reloadQuestions($(this).attr('href'));
       return false;
     });
 
-    // Track when a user clicks on a 'Change Answer' link
     $('.link-right a').live('click', function() {
       var href = $(this).attr('href');
-      window._gaq && window._gaq.push(['_trackEvent', 'MS_smart_answer', href, 'Change Answer']);
       reloadQuestions(href);
       return false;
     });


### PR DESCRIPTION
Prior to moving to Google Universal Analytics, an audit was carried
out on which analytics events are still relevant, and the events removed
in this commit aren't being used anywhere.