### PR TITLE
Fix state pension calculator leap year bug

### DIFF
--- a/lib/smart_answer/calculators/state_pension_amount_calculator_v2.rb
+++ b/lib/smart_answer/calculators/state_pension_amount_calculator_v2.rb
@@ -91,7 +91,7 @@ module SmartAnswer::Calculators
 
     def state_pension_age
       if birthday_on_feb_29?
-        friendly_time_diff(dob + 1.day, state_pension_date)
+        friendly_time_diff(dob, state_pension_date - 1.day)
       else
         friendly_time_diff(dob, state_pension_date)
       end

--- a/lib/smart_answer/calculators/state_pension_amount_calculator_v2.rb
+++ b/lib/smart_answer/calculators/state_pension_amount_calculator_v2.rb
@@ -90,7 +90,15 @@ module SmartAnswer::Calculators
     end
 
     def state_pension_age
-      friendly_time_diff(dob, state_pension_date)
+      if birthday_on_feb_29?
+        friendly_time_diff(dob + 1.day, state_pension_date)
+      else
+        friendly_time_diff(dob, state_pension_date)
+      end
+    end
+
+    def birthday_on_feb_29?
+      dob.month == 2 and dob.day == 29
     end
 
     def before_state_pension_date?

--- a/test/integration/smart_answer_flows/calculate_state_pension_v2_test.rb
+++ b/test/integration/smart_answer_flows/calculate_state_pension_v2_test.rb
@@ -237,7 +237,7 @@ class CalculateStatePensionV2Test < ActiveSupport::TestCase
         add_response :female
         add_response Date.parse('29 February 1952')
         assert_current_node :age_result
-        assert_state_variable :state_pension_age, '61 years, 10 months, 8 days'
+        assert_state_variable :state_pension_age, '61 years, 10 months, 7 days'
       end
     end
   end # age calculation
@@ -1344,7 +1344,7 @@ class CalculateStatePensionV2Test < ActiveSupport::TestCase
         add_response 0 # years of NI
         add_response 0 # Years of unemployment
         add_response :no # claimed benefit
-        add_response 0 # years worked between 16 and 19 
+        add_response 0 # years worked between 16 and 19
         add_response :yes # lived or worked abroad
       end
       should "go to outcome and show correct phrases" do

--- a/test/unit/calculators/state_pension_amount_calculator_v2_test.rb
+++ b/test/unit/calculators/state_pension_amount_calculator_v2_test.rb
@@ -599,7 +599,7 @@ module SmartAnswer::Calculators
         should "67 years; dob: 1968-02-29; pension date: 2034-03-01 " do
           @calculator = SmartAnswer::Calculators::StatePensionAmountCalculatorV2.new(
               gender: "male", dob: "1968-02-29", qualifying_years: nil)
-          assert_equal "67 years, 1 day", @calculator.state_pension_age
+          assert_equal "67 years", @calculator.state_pension_age
           assert_equal Date.parse("2035-03-01"), @calculator.state_pension_date
         end
 
@@ -789,6 +789,20 @@ module SmartAnswer::Calculators
 
       should "be 67 years" do
         assert_equal "67 years", @calculator.state_pension_age
+      end
+    end
+
+    context "#birthday_on_feb_29??" do
+      should "be true for a date that is a the 29th of feb" do
+        @calculator = SmartAnswer::Calculators::StatePensionAmountCalculatorV2.new(
+          gender: "male", dob: "29 February 1976", qualifying_years: "20")
+        assert_equal true, @calculator.birthday_on_feb_29?
+      end
+
+      should "be false for a date that is not the 29th of feb" do
+        @calculator = SmartAnswer::Calculators::StatePensionAmountCalculatorV2.new(
+          gender: "male", dob: "7 June 1960", qualifying_years: "20")
+        assert_equal false, @calculator.birthday_on_feb_29?
       end
     end
   end


### PR DESCRIPTION
The Calculator correctly shows that these people reach SPA on 1 March if their Spa falls on their birthday in a year that isn’t a leap year. However, the calculation of what their SP age is shows that it is XX years and 1 day. This is potentially unhelpful as the calculator would also show that people born a day before them and a day after them would have a State Pension age of XX years, thereby creating a situation where people born on 29 February may feel they are being penalised compared to people born on 1 March.