### PR TITLE
Clean files from previous builds

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -7,6 +7,7 @@ set -e
 # is master.
 git merge --no-commit origin/master || git merge --abort
 
+git clean -fdx
 bundle install --path "/home/jenkins/bundles/${JOB_NAME}" --deployment --without=development
 export GOVUK_APP_DOMAIN=dev.gov.uk
 export GOVUK_ASSET_HOST=http://static.dev.gov.uk


### PR DESCRIPTION
This stops previous builds interfering with the current build.