### PR TITLE
Send virtual pageview through the GOV.UK Analytics API

### DIFF
--- a/app/assets/javascripts/smart-answers.js
+++ b/app/assets/javascripts/smart-answers.js
@@ -95,7 +95,7 @@ $(document).ready(function() {
   // manage the URL
   function addToHistory(data) {
     history.pushState(data, data['title'], data['url']);
-    window._gaq && window._gaq.push(['_trackPageview', data['url']]);
+    GOVUK && GOVUK.analytics && GOVUK.analytics.trackPageview && GOVUK.analytics.trackPageview(data['url']);
   }
 
   // add an indicator of loading


### PR DESCRIPTION
This change wraps the GA event in the newly introduced
analytics API. This will aid in the migration from GA Classic to
Universal Analytics, while remaining functionally equivalent
during the migration.

https://www.pivotaltracker.com/n/projects/1261204/stories/87738926