### PR TITLE
Copy and Logic change in a V2 for marriage abroad

### DIFF
--- a/lib/smart_answer/calculators/marriage_abroad_data_query_v2.rb
+++ b/lib/smart_answer/calculators/marriage_abroad_data_query_v2.rb
@@ -1,0 +1,154 @@
+module SmartAnswer::Calculators
+  class MarriageAbroadDataQueryV2
+
+
+    COMMONWEALTH_COUNTRIES = %w(antigua-and-barbuda australia bahamas bangladesh barbados belize botswana brunei cameroon canada cyprus dominica fiji gambia ghana grenada guyana india jamaica kenya kiribati lesotho malawi malaysia maldives malta mauritius mozambique namibia nauru new-zealand nigeria pakistan papua-new-guinea samoa seychelles sierra-leone singapore solomon-islands south-africa sri-lanka st-kitts-and-nevis st-lucia st-vincent-and-the-grenadines  swaziland tanzania tonga trinidad-and-tobago tuvalu uganda vanuatu zambia)
+
+    REQUIRES_7_DAY_NOTICE_CEREMONY_COUNTRIES = (COMMONWEALTH_COUNTRIES - %w(brunei gambia)) + %w(ireland rwanda st-lucia)
+    REQUIRED_7_DAY_NOTICE_RESIDENCY_COUNTRIES = %w(albania algeria, angola armenia austria azerbaijan bahrain bolivia bosnia-and-herzegovina bulgeria croatia cuba ecuador estonia georgia greece hong-kong iceland iran italy japan kazakhstan libya lithuania luxembourg macedonia mexico moldova montenegro nicaragua norway poland russia serbia spain sweden tajikistan tunisia tuekmenistan, ukraine uzbekistan venezuela)
+
+    BRITISH_OVERSEAS_TERRITORIES = %w(anguilla bermuda british-antarctic-territory british-indian-ocean-territory british-virgin-islands cayman-islands falkland-islands gibraltar montserrat pitcairn-island st-helena-ascension-and-tristan-da-cunha south-georgia-and-south-sandwich-islands turks-and-caicos-islands)
+
+    FRENCH_OVERSEAS_TERRITORIES = %w(french-guiana french-polynesia guadeloupe martinique mayotte new-caledonia reunion st-pierre-and-miquelon wallis-and-futuna)
+
+    DUTCH_CARIBBEAN_ISLANDS = %w(aruba bonaire-st-eustatius-saba curacao st-maarten)
+
+    NON_COMMONWEALTH_COUNTRIES = %w(afghanistan albania algeria american-samoa andorra angola anguilla argentina armenia aruba austria azerbaijan bahrain belarus belgium benin bermuda bhutan bolivia bonaire-st-eustatius-saba bosnia-and-herzegovina brazil british-indian-ocean-territory british-virgin-islands bulgaria burkina-faso burma burundi cambodia cape-verde cayman-islands central-african-republic chad chile china colombia comoros congo democratic-republic-of-congo costa-rica cote-d-ivoire croatia cuba curacao czech-republic denmark djibouti dominican-republic ecuador egypt el-salvador equatorial-guinea eritrea estonia ethiopia falkland-islands fiji finland france french-guiana french-polynesia gabon georgia germany gibraltar greece guadeloupe guatemala guinea guinea-bissau haiti honduras hong-kong hungary iceland indonesia iran iraq ireland israel italy japan jordan kazakhstan south-korea kosovo kuwait kyrgyzstan laos latvia lebanon liberia libya liechtenstein lithuania luxembourg macao macedonia madagascar mali marshall-islands martinique mauritania mayotte mexico micronesia moldova monaco mongolia montenegro montserrat morocco nepal netherlands new-caledonia nicaragua niger north-korea norway oman palau panama paraguay peru philippines pitcairn-island poland portugal qatar reunion romania russia rwanda san-marino sao-tome-and-principe saudi-arabia senegal serbia slovakia slovenia somalia south-georgia-and-south-sandwich-islands south-sudan spain st-helena-ascension-and-tristan-da-cunha st-maarten st-pierre-and-miquelon sudan suriname sweden switzerland syria taiwan tajikistan thailand timor-leste togo tunisia turkmenistan turks-and-caicos-islands ukraine united-arab-emirates usa uruguay uzbekistan venezuela wallis-and-futuna western-sahara vietnam yemen zimbabwe)
+
+    OS_CONSULAR_CNI_COUNTRIES = %w(albania algeria angola armenia austria azerbaijan bahrain belarus belgium bolivia bosnia-and-herzegovina brazil bulgaria chile croatia cuba denmark dominican-republic el-salvador estonia ethiopia georgia germany greece guatemala honduras hungary iceland indonesia italy japan jordan kazakhstan kuwait kyrgyzstan latvia libya lithuania luxembourg macedonia moldova montenegro netherlands nepal norway oman panama poland romania russia serbia slovenia spain sudan sweden tajikistan tunisia turkmenistan ukraine uzbekistan venezuela)
+
+    OS_NO_CONSULAR_CNI_COUNTRIES = %w(argentina burundi czech-republic democratic-republic-of-congo mexico senegal slovakia taiwan usa uruguay)
+
+    OS_NO_MARRIAGE_CONSULAR_SERVICES = %w(afghanistan american-samoa andorra aruba benin bhutan bonaire-st-eustatius-saba burkina-faso burundi cape-verde central-african-republic chad comoros congo costa-rica cote-d-ivoire curacao djibouti equatorial-guinea eritrea gabon guinea guinea-bissau haiti hong-kong iraq israel kosovo laos liberia liechtenstein macao madagascar mali marshall-islands mauritania micronesia monaco nicaragua niger palau paraguay rwanda san-marino sao-tome-and-principe south-sudan st-maarten suriname timor-leste togo western-sahara)
+
+    OS_OTHER_COUNTRIES = %w(burma north-korea iran somalia syria yemen saudi-arabia)
+
+    OS_NOTICE_OF_MARRIAGE_7_DAY_WAIT_CEREMONY_COUNTRY = %w(albania algeria angola armenia austria azerbaijan bahrain bolivia bosnia-and-herzegovina bulgaria croatia cuba ecuador estonia georgia greece hong-kong iceland iran italy japan kazakhstan kuwait kyrgyzstan libya lithuania luxembourg macedonia mexico moldova montenegro nicaragua norway poland russia serbia spain sweden tajikistan tunisia turkmenistan ukraine uzbekistan venezuela)
+
+    OS_AFFIRMATION_COUNTRIES = %w(cambodia colombia china ecuador egypt lebanon finland mongolia morocco peru philippines portugal qatar south-korea thailand turkey united-arab-emirates vietnam)
+
+    CP_EQUIVALENT_COUNTRIES = %w(austria belgium brazil colombia czech-republic denmark ecuador finland germany hungary iceland luxembourg netherlands norway portugal slovenia sweden)
+
+    CP_CNI_NOT_REQUIRED_COUNTRIES = %w(argentina mexico uruguay usa andorra bonaire-st-eustatius-saba liechtenstein burundi )
+
+    CP_CONSULAR_COUNTRIES = %w(bulgaria cambodia costa-rica croatia cyprus guatemala japan latvia moldova panama peru philippines venezuela vietnam)
+
+    COUNTRIES_WITHOUT_CONSULAR_FACILITIES = %w(aruba slovakia curacao bonaire-st-eustatius-saba st-maarten taiwan czech-republic argentina cote-d-ivoire burundi)
+
+    SS_MARRIAGE_COUNTRIES = %w(australia azerbaijan bolivia chile china colombia dominican-republic estonia germany kosovo latvia mongolia montenegro nicaragua russia san-marino hungary serbia)
+
+    NO_SS_MARRIAGE_COUNTRIES = %w(san-marino)
+
+    SS_MARRIAGE_COUNTRIES_WHEN_COUPLE_BRITISH = %w(lithuania)
+
+    SS_MARRIAGE_AND_PARTNERSHIP_COUNTRIES = %w(cambodia costa-rica peru philippines vietnam japan)
+
+    SS_CLICKBOOK_COUNTRIES = %w(bolivia chile china colombia costa-rica hungary mongolia montenegro peru philippines russia san-marino serbia vietnam)
+
+    SS_ALT_FEES_TABLE_COUNTRY = %w(australia bolivia china estonia san-marino serbia)
+
+    SS_ALT_FEES_TABLE_OR_OUTCOME_GROUP_A = %w(hungary mongolia montenegro nicaragua russia)
+
+    SS_ALT_FEES_TABLE_OR_OUTCOME_GROUP_B = %w(azerbaijan chile dominican-republic kosovo latvia)
+
+    SS_21_DAYS_RESIDENCY_REQUIRED_COUNTRIES = %(australia azerbaijan bolivia cambodia chile china colombia costa-rica dominican-republic estonia germany hungary japan kosovo latvia lithuania mongolia montenegro nicaragua peru philippines russia san-marino serbia vietnam)
+
+    def ss_21_days_residency_required_countries?(country_slug)
+      SS_21_DAYS_RESIDENCY_REQUIRED_COUNTRIES.include?(country_slug)
+    end
+
+    def ss_clickbook_countries?(country_slug)
+      SS_CLICKBOOK_COUNTRIES.include?(country_slug)
+    end
+
+    def ss_marriage_countries?(country_slug)
+      SS_MARRIAGE_COUNTRIES.include?(country_slug)
+    end
+
+    def ss_marriage_countries_when_couple_british?(country_slug)
+      SS_MARRIAGE_COUNTRIES_WHEN_COUPLE_BRITISH.include?(country_slug)
+    end
+
+    def ss_marriage_and_partnership?(country_slug)
+      SS_MARRIAGE_AND_PARTNERSHIP_COUNTRIES.include?(country_slug)
+    end
+
+    def ss_alt_fees_table_country?(country_slug, partner_nationality)
+      SS_ALT_FEES_TABLE_COUNTRY.include?(country_slug) ||
+        (SS_ALT_FEES_TABLE_OR_OUTCOME_GROUP_A.include?(country_slug) && partner_nationality == "partner_british") ||
+        (SS_ALT_FEES_TABLE_OR_OUTCOME_GROUP_B.include?(country_slug) && partner_nationality != "partner_local") &&
+        (%w(cambodia vietnam).exclude?(country_slug))
+    end
+
+    def ss_marriage_not_possible?(country_slug, partner_nationality)
+      (SS_ALT_FEES_TABLE_OR_OUTCOME_GROUP_A.include?(country_slug) && partner_nationality != "partner_british") ||
+      ((SS_ALT_FEES_TABLE_OR_OUTCOME_GROUP_B.include?(country_slug) || %w(cambodia vietnam).include?(country_slug)) && partner_nationality == "partner_local") ||
+      NO_SS_MARRIAGE_COUNTRIES.include?(country_slug)
+    end
+
+    def commonwealth_country?(country_slug)
+      COMMONWEALTH_COUNTRIES.include?(country_slug)
+    end
+
+    def british_overseas_territories?(country_slug)
+      BRITISH_OVERSEAS_TERRITORIES.include?(country_slug)
+    end
+
+    def non_commonwealth_country?(country_slug)
+      NON_COMMONWEALTH_COUNTRIES.include?(country_slug)
+    end
+
+    def os_notice_of_marriage_7_day_wait_ceremony_country?(country_slug)
+      OS_NOTICE_OF_MARRIAGE_7_DAY_WAIT_CEREMONY_COUNTRY.include?(country_slug)
+    end
+
+    def french_overseas_territories?(country_slug)
+      FRENCH_OVERSEAS_TERRITORIES.include?(country_slug)
+    end
+
+    def dutch_caribbean_islands?(country_slug)
+      DUTCH_CARIBBEAN_ISLANDS.include?(country_slug)
+    end
+
+    def os_consular_cni_countries?(country_slug)
+      OS_CONSULAR_CNI_COUNTRIES.include?(country_slug)
+    end
+
+    def os_no_consular_cni_countries?(country_slug)
+      OS_NO_CONSULAR_CNI_COUNTRIES.include?(country_slug)
+    end
+
+    def os_no_marriage_related_consular_services?(country_slug)
+      OS_NO_MARRIAGE_CONSULAR_SERVICES.include?(country_slug)
+    end
+
+    def os_other_countries?(country_slug)
+      OS_OTHER_COUNTRIES.include?(country_slug)
+    end
+
+    def cp_equivalent_countries?(country_slug)
+      CP_EQUIVALENT_COUNTRIES.include?(country_slug)
+    end
+
+    def cp_cni_not_required_countries?(country_slug)
+      CP_CNI_NOT_REQUIRED_COUNTRIES.include?(country_slug)
+    end
+
+    def cp_consular_countries?(country_slug)
+      CP_CONSULAR_COUNTRIES.include?(country_slug)
+    end
+
+    def os_affirmation_countries?(country_slug)
+      OS_AFFIRMATION_COUNTRIES.include?(country_slug)
+    end
+
+    def countries_without_consular_facilities?(country_slug)
+      COUNTRIES_WITHOUT_CONSULAR_FACILITIES.include?(country_slug)
+    end
+
+    def requires_7_day_notice?(ceremony_country_slug, residency_country_slug)
+      REQUIRES_7_DAY_NOTICE_CEREMONY_COUNTRIES.include?(ceremony_country_slug) &&
+        REQUIRED_7_DAY_NOTICE_RESIDENCY_COUNTRIES.include?(residency_country_slug)
+    end
+  end
+end

--- a/lib/smart_answer/calculators/registrations_data_query_v2.rb
+++ b/lib/smart_answer/calculators/registrations_data_query_v2.rb
@@ -1,0 +1,135 @@
+module SmartAnswer::Calculators
+  class RegistrationsDataQueryV2
+
+    COMMONWEALTH_COUNTRIES = %w(anguilla australia bermuda british-indian-ocean-territory british-virgin-islands cayman-islands canada falkland-islands gibraltar ireland montserrat new-zealand pitcairn south-africa south-georgia-and-south-sandwich-islands st-helena-ascension-and-tristan-da-cunha turks-and-caicos-islands)
+
+    COUNTRIES_WITH_HIGH_COMMISSIONS = %w(antigua-and-barbuda bangladesh barbados belize botswana brunei cameroon cyprus dominica fiji gambia ghana grenada guyana india jamaica kenya malawi malaysia maldives malta mauritius mozambique namibia nigeria pakistan papua-new-guinea seychelles sierra-leone singapore solomon-islands sri-lanka tanzania trinidad-and-tobago uganda)
+
+    COUNTRIES_WITH_CONSULATES = %w(china colombia israel russia turkey)
+
+    COUNTRIES_WITH_CONSULATE_GENERALS = %(brazil hong-kong turkey)
+
+    CASH_ONLY_COUNTRIES = %w(armenia bosnia-and-herzegovina botswana brunei cambodia iceland kazakhstan laos latvia libya slovenia tunisia uganda)
+
+    PAY_BY_BANK_DRAFT_COUNTRIES = %w(taiwan)
+
+    CHEQUE_ONLY_COUNTRIES = %w(taiwan)
+
+    EASTERN_CARIBBEAN_COUNTRIES = %w(antigua-and-barbuda barbados dominica st-kitts-and-nevis st-vincent-and-the-grenadines)
+
+    NO_POSTAL_COUNTRIES = %w(barbados costa-rica malaysia papua-new-guinea sweden tanzania thailand)
+
+    POST_ONLY_COUNTRIES = %w(czech-republic hungary new-caledonia philippines poland slovakia)
+
+    COUNTRIES_WITH_TRADE_CULTURAL_OFFICES = %w(taiwan)
+
+    MODIFIED_CARD_ONLY_COUNTRIES = %w(czech-republic slovakia hungary poland)
+
+    CASH_AND_CARD_COUNTRIES = %w(estonia)
+
+    FOOTNOTE_EXCLUSIONS = %w(afghanistan cambodia central-african-republic chad comoros dominican-republic east-timor eritrea haiti kosovo laos lesotho liberia madagascar montenegro north-korea paraguay samoa slovenia somalia swaziland taiwan tajikistan western-sahara)
+
+    ORU_TRANSITIONED_COUNTRIES = %w(albania american-samoa andorra angola antigua-and-barbuda argentina armenia aruba austria bahamas bahrain barbados belarus belgium belize benin bolivia bonaire-st-eustatius-saba bosnia-and-herzegovina botswana brazil brunei bulgaria burkina-faso burma burundi cambodia cameroon cape-verde central-african-republic chad chile china comoros congo congo-(democratic-republic) costa-rica cote-d-ivoire croatia cuba curacao cyprus czech-republic denmark djibouti dominica dominican-republic ecuador egypt el-salvador equatorial-guinea eritrea estonia ethiopia fiji finland france french-guiana french-polynesia gabon gambia georgia ghana germany greece grenada guadeloupe guatemala guinea guinea-bissau guyana haiti honduras hong-kong hungary iceland indonesia iran israel italy jamaica japan jordan kazakhstan kiribati kosovo kuwait kyrgyzstan laos latvia lesotho liberia liechtenstein lithuania luxembourg macao macedonia madagascar malawi malaysia maldives mali malta marshall-islands martinique mauritania mauritius mayotte mexico micronesia moldova monaco mongolia montenegro morocco mozambique namibia nauru netherlands nicaragua niger north-korea norway oman palau panama papua-new-guinea paraguay peru poland portugal qatar reunion romania rwanda samoa san-marino sao-tome-and-principe saudi-arabia senegal serbia seychelles singapore slovakia slovenia solomon-islands south-korea spain st-kitts-and-nevis st-lucia st-maarten st-pierre-and-miquelon st-vincent-and-the-grenadines suriname swaziland sweden switzerland syria taiwan tajikistan tanzania thailand the-occupied-palestinian-territories timor-leste togo tonga trinidad-and-tobago tunisia turkey turkmenistan tuvalu ukraine united-arab-emirates usa uruguay uzbekistan vanuatu venezuela vietnam wallis-and-futuna western-sahara yemen zambia zimbabwe)
+
+    ORU_TRANSITION_EXCEPTIONS = %w(north-korea)
+
+    ORU_DOCUMENTS_VARIANT_COUNTRIES = %w(andorra belgium denmark finland france israel italy japan monaco morocco netherlands poland portugal south-korea spain sweden taiwan the-occupied-palestinian-territories turkey united-arab-emirates usa)
+
+    ORU_DOCUMENTS_VARIANT_COUNTRIES_DEATH = %w(papua-new-guinea poland)
+
+    ORU_COURIER_VARIANTS = %w(cambodia cameroon north-korea papua-new-guinea)
+
+    attr_reader :data
+
+    def initialize
+      @data = self.class.registration_data
+    end
+
+    def commonwealth_country?(country_slug)
+      COMMONWEALTH_COUNTRIES.include?(country_slug)
+    end
+
+    def responded_with_commonwealth_country?
+      SmartAnswer::Predicate::RespondedWith.new(COMMONWEALTH_COUNTRIES, "commonwealth country")
+    end
+
+    def born_in_oru_transitioned_country?
+      SmartAnswer::Predicate::VariableMatches.new(:country_of_birth, ORU_TRANSITIONED_COUNTRIES, "ORU transitioned country")
+    end
+
+    def died_in_oru_transitioned_country?
+      SmartAnswer::Predicate::VariableMatches.new(:country_of_death, ORU_TRANSITIONED_COUNTRIES, "ORU transitioned country of death")
+    end
+
+    def clickbook(country_slug)
+      data['clickbook'][country_slug]
+    end
+
+    def has_high_commission?(country_slug)
+      COUNTRIES_WITH_HIGH_COMMISSIONS.include?(country_slug)
+    end
+
+    def has_consulate?(country_slug)
+      COUNTRIES_WITH_CONSULATES.include?(country_slug)
+    end
+
+    def has_consulate_general?(country_slug)
+      COUNTRIES_WITH_CONSULATE_GENERALS.include?(country_slug)
+    end
+
+    def has_trade_and_cultural_office?(country_slug)
+      COUNTRIES_WITH_TRADE_CULTURAL_OFFICES.include?(country_slug)
+    end
+
+    def post_only_countries?(country_slug)
+      POST_ONLY_COUNTRIES.include?(country_slug)
+    end
+
+    def eastern_caribbean_countries?(country_slug)
+      EASTERN_CARIBBEAN_COUNTRIES.include?(country_slug)
+    end
+
+    def cash_only?(country_slug)
+      CASH_ONLY_COUNTRIES.include?(country_slug)
+    end
+
+    def pay_by_bank_draft?(country_slug)
+      PAY_BY_BANK_DRAFT_COUNTRIES.include?(country_slug)
+    end
+
+    def cheque_only?(country_slug)
+      CHEQUE_ONLY_COUNTRIES.include?(country_slug)
+    end
+    def cash_and_card_only?(country_slug)
+      CASH_AND_CARD_COUNTRIES.include?(country_slug)
+    end
+
+    def caribbean_alt_embassies?(country_slug)
+      CARIBBEAN_ALT_EMBASSIES.include?(country_slug)
+    end
+
+    def modified_card_only_countries?(country_slug)
+      MODIFIED_CARD_ONLY_COUNTRIES.include?(country_slug)
+    end
+
+    def postal_form(country_slug)
+      data['postal_form'][country_slug]
+    end
+
+    def postal_return_form(country_slug)
+      data['postal_return'][country_slug]
+    end
+
+    def register_death_by_post?(country_slug)
+      postal_form(country_slug) or NO_POSTAL_COUNTRIES.include?(country_slug)
+    end
+
+    def registration_country_slug(country_slug)
+      data['registration_country'][country_slug] || country_slug
+    end
+
+    def self.registration_data
+      @embassy_data ||= YAML.load_file(Rails.root.join("lib", "data", "registrations.yml"))
+    end
+  end
+end

--- a/lib/smart_answer_flows/locales/en/marriage-abroad-v2.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad-v2.yml
@@ -206,6 +206,11 @@ en-GB:
           [Download 'Affidavit for Marriage' (PDF, 446KB)](/government/uploads/system/uploads/attachment_data/file/293781/Affidavit_of_Marital_Status.pdf)
           $D
 
+        download_affidavit_brazil: |
+          $D
+          [Download 'Affidavit for Marriage' (PDF, 60KB)](/government/uploads/system/uploads/attachment_data/file/286008/Declaration_Marriage.pdf)
+          $D
+
         contact_for_affidavit: |
           Contact the local British embassy or consulate in %{country_name_lowercase_prefix} to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
         appointment_for_affidavit: |

--- a/lib/smart_answer_flows/locales/en/marriage-abroad-v2.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad-v2.yml
@@ -1,0 +1,2154 @@
+en-GB:
+  flow:
+    marriage-abroad-v2:
+      title: Getting married abroad
+      meta:
+        description: Requirements, paperwork and processes for weddings and civil partnerships overseas - registration, restrictions, fees
+      body: |
+        Contact the local authorities in the country where you want to get married or enter into a civil partnership to find out what you need to do.
+
+        Your marriage or civil partnership should be recognised in the UK if you follow the correct process according to local law.
+
+        You might be asked to get certain documents from the UK government if you’re a [British national](http://www.ukba.homeoffice.gov.uk/britishcitizenship/aboutcitizenship/). Use this tool to find out:
+
+        - which documents you can get
+        - how to apply for them
+
+        There’s a separate guide if you want to [get married or enter into a civil partnership in the UK](/marriages-civil-partnerships).
+
+        %If you’re living abroad and you want to get married in a different country, you'll need to go to that country to post notice of your marriage. [Read the guidance on posting notice in a third country](/if-you-live-abroad-and-wish-to-marry-in-a-third-country).%
+
+        *[GRO]:General Register Office
+
+      phrases:
+        ceremony_type_marriage: Marriage
+        ceremony_type_civil_partnership: Civil partnership
+# same sex marriage phrases
+        title_ss_marriage: Same-sex marriage
+        title_ss_marriage_and_partnership: Same-sex marriage and civil partnership
+        title_civil_partnership: Civil Partnership
+        able_to_ss_marriage: |
+          You may be able to get married at the British embassy or consulate in %{country_name_lowercase_prefix}.
+        able_to_ss_marriage_and_partnership: |
+          You may be able to register a civil partnership or get married at the British embassy or consulate in %{country_name_lowercase_prefix}.
+        able_to_ss_marriage_and_partnership_hc: |
+          You may be able to register a civil partnership or get married at the High Commission of %{country_name_lowercase_prefix}.
+        documents_needed_7_days_residency: |
+          ##What documents you’ll need
+
+          You’ll need proof that you’ve been resident in the area covered by the embassy or consulate for at least 7 days, like an employer’s letter or a bank statement.
+        documents_needed_7_days_residency_hc: |
+          ##What documents you’ll need
+
+          You’ll need proof that you’ve been resident in the area covered by the high commission for at least 7 days, like an employer’s letter or a bank statement.
+        documents_needed_21_days_residency: |
+          ##What documents you’ll need
+
+          You need to have been living in your country of residence for 21 days. You and your partner will need to sign a declaration and provide proof of residence eg, an employer’s letter or a bank statement.
+        documents_needed_ss_british: |
+          You’ll both need your original passports. If either of you have been divorced, widowed or in a civil partnership before, you’ll also need either:
+
+          - a [decree absolute or final order](/copy-decree-absolute-final-order)
+          - the [death certificate](/order-copy-birth-death-marriage-certificate/)
+        documents_needed_ss_not_british_germany_same_sex: |
+          You’ll both need your original passports. If either of you have been divorced, widowed or in a civil partnership before, you’ll also need to provide:
+
+          - a [decree absolute or final order](/copy-decree-absolute-final-order)
+          - the [death certificate](/order-copy-birth-death-marriage-certificate/)
+        documents_needed_ss_not_british: |
+          You’ll both need your original passports. You’ll also need evidence that your partner is free to marry - a document from their government or their passport that says they are unmarried. If either of you have been divorced, widowed or in a civil partnership before, you’ll also need to provide:
+
+          - a [decree absolute or final order](/copy-decree-absolute-final-order)
+          - the [death certificate](/order-copy-birth-death-marriage-certificate/)
+        convert_cc_to_ss_marriage: |
+          ##Convert a civil partnership to a same-sex marriage
+
+          If you’ve already entered into a civil partnership you may be able to convert it to a same-sex marriage - read [‘Convert a civil partnership to a same-sex marriage abroad’](/convert-civil-partnership-abroad).
+# marriage & marriage and partnership phrases
+        what_to_do_ss_marriage: |
+          ##What you need to do
+
+          Once you’ve made your appointment, the embassy or consulate will give you:
+
+          - a notice of registration
+          - a declaration that you and your partner will need to swear, stating that you’re legally entitled to marry
+        what_to_do_ss_marriage_and_partnership: |
+          ##What you need to do
+
+          Once you’ve made your appointment, the embassy or consulate will give you:
+
+          -  a notice of registration
+          -  a declaration that you and your partner will need to swear, stating that you’re legally entitled to marry or enter into a civil partnership
+        what_to_do_ss_marriage_and_partnership_hc: |
+          ##What you need to do
+
+          Once you’ve made your appointment, the high commission will give you:
+
+          -  a notice of registration
+          -  a declaration that you and your partner will need to swear, stating that you’re legally entitled to marry or enter into a civil partnership
+        will_display_in_14_days: |
+          Once you’ve submitted these and paid the registration fee (read the fees table on this page), the embassy or consulate will display your notice publicly for 14 days.
+        will_display_in_14_days_hc: |
+          Once you’ve submitted these and paid the registration fee (read the fees table on this page), the high commission will display your notice publicly for 14 days.
+# marriage & marriage and partnership phrases
+        no_objection_in_14_days_ss_marriage: |
+          As long as nobody registers an objection during the 14 days, the registration officer can then register your marriage any time until 3 months after you gave notice.
+        no_objection_in_14_days_ss_marriage_and_partnership: |
+          As long as nobody registers an objection during the 14 days, the registration officer can then register your marriage or partnership any time until 3 months after you gave notice.
+        provide_two_witnesses_ss_marriage: |
+          You’ll need to provide two witnesses and pay a fee to register your marriage. You’ll need to pay an additional fee for your marriage certificate (read the fees table on this page).
+        provide_two_witnesses_ss_marriage_and_partnership: |
+          You’ll need to provide 2 witnesses and pay a fee to register your marriage or civil partnership. You’ll need to pay an additional fee for your marriage or civil partnership certificate (read the fees table on this page).
+        ss_marriage_footnote_21_days_residency: |
+          ^All same-sex marriages must take place under English and Welsh or Scottish law even if you live in or are from Northern Ireland. Tell the embassy or consulate which law you want to get married under at your appointment.^
+        ss_marriage_footnote_hc: |
+          ^All same-sex marriages must take place under English and Welsh or Scottish law even if you live in or are from Northern Ireland. Tell the high commission which law you want to get married under at your appointment.^
+        ss_marriage_footnote: |
+          ^All same-sex marriages must take place under English and Welsh law even if you live in or are from Scotland or Northern Ireland. Tell the embassy or consulate which law you want to get married under at your appointment.^
+# marriage & marriage and partnership phrases
+        fees_table_ss_marriage: |
+          ##Fees
+
+          Service | Fee
+          -|-
+          Posting a marriage notice | £65
+          Performing a marriage ceremony | £140
+          Issuing a marriage certificate | £65
+        fees_table_ss_marriage_and_partnership: |
+          ##Fees
+
+          Service | Fee
+          -|-
+          Receiving a notice of registration | £65
+          Registering a marriage or civil partnership | £140
+          Issuing a marriage or civil partnership certificate | £65
+# additional marriage & marriage and partnership phrases
+        fees_table_ss_marriage_alt: |
+          ##Fees
+
+          Service | Fee
+          -|-
+          Receiving a notice of registration  | £65
+          Registering a marriage | £140
+          Issuing a marriage certificate | £65
+        australia_ss_relationships: |
+          You can’t have a same-sex marriage in a British embassy or consulate if you’re already in one of these relationships:
+
+          * civil partnership (Australian Capital Territory)
+          * relationship registered under the Relationships Register Act 2010 (New South Wales)
+          * civil partnership (Queensland)
+          * significant relationship (Tasmania)
+          * registered domestic relationship (Victoria)
+# Reusable phrases
+# titles
+        marriage_title: Marriage in %{country_name_lowercase_prefix}
+        same_sex_marriage_title: Same-sex in %{country_name_lowercase_prefix}
+# embassies
+        contact_british_embassy_or_consulate_berlin: |
+          Contact the British Embassy in Berlin to make an appointment.
+        contact_embassy_or_consulate: |
+          Contact the embassy or consulate to make an appointment.
+        embassies_data: |
+          +[data_partial:overseas_passports_embassies:overseas_passports_embassies]
+        check_travel_advice: |
+          You should check the [travel advice for %{country_name_lowercase_prefix}](/foreign-travel-advice/%{ceremony_country}).
+# payment methods
+        pay_by_cash_or_credit_card_no_cheque: |
+          You can pay by cash or credit card, but not by personal cheque.
+        pay_in_local_currency: |
+          ^You can only pay by cash in %{country_name_lowercase_prefix}. This must be in the local currency.^
+        pay_in_local_currency_ceremony_country_name: |
+          ^You can only pay by cash in %{ceremony_country_name}. This must be in the local currency.^
+        pay_in_euros_or_visa_electron: |
+          You can pay by cash (euros only) or credit card (but not Visa Electron).
+        pay_in_cash_or_manager_cheque: |
+          You can pay in cash or with a bank manager's cheque made payable to 'British Embassy'.
+        pay_in_cash_visa_or_mastercard: |
+          ^You can pay by cash in the local currency in %{country_name_lowercase_prefix}. You can also pay by Visa or Mastercard - other types of credit cards and debit cards are not accepted.^
+#fees
+        list_of_consular_fees: |
+          You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for %{country_name_lowercase_prefix}](/government/publications/%{ceremony_country}-consular-fees).
+        list_of_consular_kazakhstan: |
+          You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Kazakhstan](/government/publications/kazakhstan-kyrgyzstan-consular-fees).
+        list_of_consular_fees_france: |
+          You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for %{country_name_lowercase_prefix}](/government/publications/france-consular-fees).
+# "what you need to do" phrases
+        what_you_need_to_do: |
+          ##What you need to do
+        what_you_need_to_do_affirmation: |
+          ##What you need to do
+
+          You may be asked to provide an ‘affirmation for marriage’ document to prove you’re allowed to marry.
+        what_you_need_to_do_affidavit: |
+          ##What you need to do
+
+          You may be asked to provide an ‘affidavit for marriage’ document to prove you’re allowed to marry.
+        make_an_appointment: |
+          Make an appointment at the local British embassy or consulate in %{country_name_lowercase_prefix} to make a declaration that you’re free to marry. You’ll need to bring your passport and pay a fee.
+
+        make_an_appointment_bring_passport_and_pay_55_colombia: |
+          Make an appointment at the local British embassy or consulate in Colombia to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee of £55.
+
+        make_an_appointment_bring_passport_and_pay_55_brazil: |
+          Make an appointment at the local British embassy or consulate in Brazil to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee of £55.
+
+        download_affidavit_forms_but_do_not_sign: |
+          You’ll need to complete an ‘Affidavit for marriage’ form that will be used for your affidavit. You can download and fill in (but not sign) the forms in advance.
+# affidavit phrases
+        complete_affidavit: |
+          You’ll need to complete an ‘Affidavit for marriage’ form that will be used for your affidavit. Take the completed form with you to your appointment.
+
+        complete_affidavit_with_download_link: |
+          You’ll need to complete an [‘Affidavit for marriage’ form](/government/publications/marriage-in-%{country_name_lowercase_prefix}) that will be used for your affidavit. Take the completed form with you to your appointment.
+
+        download_affidavit: |
+          $D
+          [Download 'Affidavit for Marriage' (PDF, 446KB)](/government/uploads/system/uploads/attachment_data/file/293781/Affidavit_of_Marital_Status.pdf)
+          $D
+
+        contact_for_affidavit: |
+          Contact the local British embassy or consulate in %{country_name_lowercase_prefix} to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
+        appointment_for_affidavit: |
+          Make an appointment at the local British embassy or consulate in %{country_name_lowercase_prefix} to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
+        appointment_for_affidavit_china_addition: |
+          Your partner will need to bring a Hukou book (family registration book).
+        appointment_for_affidavit_notary: |
+          Make an appointment with a UK [notary or commissioner of oaths](http://www.thenotariessociety.org.uk/find-a-notary) to swear an affidavit - a written statement that is used to formally declare that you’re free to marry.
+# partner affirmation phrases
+        legalisation_and_translation: |
+          ###Legalisation and translation
+        partner_affirmation_needed: |
+          ^Your partner will need to get an affirmation as well.^
+        partner_affidavit_needed: |
+          ^Your partner will need to get an affidavit as well.^
+        affirmation_os_translation_in_local_language_text: |
+          You might need to get your affirmation [translated](/government/organisations/foreign-commonwealth-office/series/list-of-lawyers) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
+        affidavit_os_translation_in_local_language_text: |
+          You might need to get your affidavit [translated](/government/organisations/foreign-commonwealth-office/series/list-of-lawyers) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
+
+# fee tables
+        fee_table_45_70_55: |
+          ##Fees
+
+          Service | Fee
+          -|-
+          Issuing any other consular letter or certificate in English | £45
+          Issuing any other consular letter or certificate in any other language | £70
+          Affidavit for marriage | £55
+
+        fee_table_croatia: |
+          ##Fees
+
+          Service | Fee
+          -|-
+          Receiving a notice of marriage | £65
+          Issuing a CNI, Nulla Osta or equivalent | £65
+          Issuing any other consular letter or certificate in English | £45
+          Issuing any other consular letter or certificate in any other language | £70
+          Administering an oath or making a declaration | £55
+          Issuing a certificate of custom and law | £65
+
+        fee_table_affidavit_55: |
+          ##Fees
+
+          Service | Fee
+          -|-
+          Affidavit for marriage | £55
+        fee_table_affidavit_65: |
+          ##Fees
+
+          Service | Fee
+          -|-
+          Affidavit for marriage | £65
+        fee_table_affirmation_55: |
+          ##Fees
+
+          Service | Fee
+          -|-
+          Affirmation for marriage | £55
+        fee_table_affirmation_65: |
+          ##Fees
+
+          Service | Fee
+          -|-
+          Affirmation for marriage | £65
+#other phrases
+        living_in_residence_country_3_days: |
+          You need to have been living in your country of residence for 3 days.
+        check_with_embassy_or_consulate: |
+          Check with your nearest British embassy or consulate to find out if they can do this for you.
+        check_with_embassy_consulate_or_notary_public: |
+          Check with a notary public or your nearest British embassy or consulate to find out if they can do this for you.
+        morocco_affidavit_length: |
+          ^An 'affirmation for marriage' document issued in Morocco is valid for 3 months.^
+        callout_partner_equivalent_document: |
+          ^Your partner will probably need to get an equivalent document from their national authorities.^
+        partner_equivalent_document: |
+          Your partner will probably need to get an equivalent document from their national authorities.
+        partner_declaration: |
+          ^Your partner will need to make a declaration as well.^
+        what_to_do_croatia: |
+          You may be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
+
+          The local registrar may also need a certificate of custom and law, which confirms the marriage is valid - the Embassy in Zagreb can provide this.
+        get_legal_advice: |
+          ^You should [get legal advice](/government/organisations/foreign-commonwealth-office/series/list-of-lawyers) before making any plans.^
+
+        contact_local_authorities: |
+          Contact the relevant local authorities to find out about local marriage laws, including what documents you’ll need.
+
+        partner_naturalisation_in_uk: |
+          ##Naturalisation of your partner if they move to the UK
+
+          Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they've lived in the UK for 3 years.
+
+        documents_for_divorced_or_widowed: |
+          If you’ve been divorced or widowed, you’ll need to provide:
+
+          - a [decree absolute or final order](/copy-decree-absolute-final-order) or [death certificate](/order-copy-birth-death-marriage-certificate/)
+          - evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [translated](/government/organisations/foreign-commonwealth-office/series/list-of-lawyers) if it’s not in English
+          - evidence if you’ve changed your name by deed poll
+        documents_for_divorced_or_widowed_ecuador: |
+          If you’ve been divorced or widowed, you’ll need to provide:
+
+          - a [decree absolute or final order](/copy-decree-absolute-final-order) or [death certificate](/order-copy-birth-death-marriage-certificate/)
+          - evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [translated](/government/organisations/foreign-commonwealth-office/series/list-of-lawyers) if it’s not in English
+
+          You’ll also need to provide evidence if you’ve changed your name by deed poll.
+        documents_for_divorced_or_widowed_cambodia: |
+          If you’ve been divorced or widowed, you’ll need to provide:
+
+          - a [decree absolute or final order](/copy-decree-absolute-final-order) or [death certificate](/order-copy-birth-death-marriage-certificate/)
+          - evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [translated](/government/organisations/foreign-commonwealth-office/series/list-of-lawyers) if it’s not in English
+        documents_for_divorced_or_widowed_china_colombia: |
+          If you’ve been divorced or widowed, you’ll need to provide:
+
+          - a [decree absolute or final order](/copy-decree-absolute-final-order) or [death certificate](/order-copy-birth-death-marriage-certificate/)
+          - evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [translated](/government/organisations/foreign-commonwealth-office/series/list-of-lawyers) if it’s not in English
+
+        contact_civil_register_office_portugal: |
+          Contact your nearest [Civil Register Office](http://www.irn.mj.pt/IRN/sections/irn/a_registral/servicos-externos-docs/contactos/contactos-dos-servicos-civil/) in Portugal to find out about local marriage laws, including what documents you’ll need.
+# "book online" china phrases
+        book_online_china_non_local_prelude:
+          Make an appointment at your local British embassy or consulate in China to swear an affirmation/affadavit (written statement of facts) that you're free to marry. You'll need to bring your passport and pay a fee.
+        book_online_china_local_prelude:
+          Make an appointment at the British embassy or consulate in China nearest to the address in your partner's Hukou (family registration) book, to swear an affirmation/affadavit (written statement of facts) that you're free to marry. You'll need to bring your passport, your partner's Hukou and pay a fee.
+        book_online_china_affirmation_affidavit: |
+          You’ll need to complete an [‘Affirmation for marriage’](/government/publications/affirmation-form-china) (non-religious) form or an [‘Affidavit for marriage’](/government/publications/affidavit-form-china) (religious) form in English.
+
+# Marriage if resident of Isle of Man or Channel Islands
+        iom_ci_os_all: |
+
+          Contact the relevant local authorities in %{country_name_lowercase_prefix} to find out about local laws, including what documents you’ll need.
+        iom_ci_os_spain: |
+          %There are certain legal restrictions if neither of you is resident in Spain. You should check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re planning to get married to find out if this is allowed.%
+        iom_ci_os_resident_of_iom: |
+          You may be asked for a certificate of no impediment (CNI) or similar document. Check with the authorities in the [Isle of Man](http://www.gov.im/registries/general/civilregistry/) to find out what they can provide, then contact the authorities in %{country_name_lowercase_prefix} to confirm if this is acceptable.
+
+          The local British embassy or consulate may be able to advise if you have any problems getting the documents you need from the Manx authorities.
+        iom_ci_os_resident_of_ci: |
+          You may be asked for a certificate of no impediment (CNI) or similar document. Check with the authorities in [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us) to find out what they can provide, then contact the authorities in %{country_name_lowercase_prefix} to confirm if this is acceptable.
+
+          The local British embassy or consulate may be able to advise if you have any problems getting the documents you need from the authorities in Jersey or Guernsey.
+        iom_ci_os_ceremony_italy: |
+          $C
+          **British Embassy in Rome - marriages**
+          <rome.marriages@fco.gov.uk>
+          $C
+
+# Marriage in Ireland outcome phrases
+        outcome_ireland_opposite_sex: |
+          The General Register Office of Ireland's website explains what you need to do if you want to [get married in Ireland](http://www.groireland.ie/getting_married.htm).
+        outcome_ireland_same_sex: |
+          The General Register Office of Ireland's website explains what you need to do if you want to [enter into a civil partnership in Ireland](http://www.groireland.ie/civil_partnership.htm).
+
+# Marriage & CP in Switzerland phrases
+
+        what_you_need_to_do_switzerland_resident_uk: |
+
+          You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you're allowed to enter into a %{ceremony_type_lowercase} or equivalent in Switzerland.
+
+          Contact the local British embassy or consulate where you’re planning the ceremony to find out what you need to do.
+
+        switzerland_os_variant: |
+          Contact the Civil Register Office where you’re getting married to find out about local laws, including what documents you’ll need.
+        switzerland_ss_variant: |
+          Same-sex relationships in Switzerland that are recognised as civil partnerships under British law are known as 'eingetragene Partnerschaft', 'partenariat enregistré', 'unione domestica registrata' or 'partenadi registrà' ('registered partnership').
+
+          Contact the Civil Register Office where you’re entering into a civil partnership to find out about local laws, including what documents you’ll need.
+        switzerland_not_resident: |
+          [Your closest Swiss embassy](http://www.eda.admin.ch/eda/en/home/reps.html) may be able to give you advice, or put you in touch with the relevant local authorities if you don’t know who to contact.
+
+          ^You should [get legal advice](/government/publications/switzerland-list-of-lawyers) and check the [travel advice for Switzerland](/foreign-travel-advice/switzerland) before making any plans.^
+
+          ##What you need to do
+        switzerland_os_not_resident: |
+          You may be asked to provide a civil status declaration to prove you’re allowed to marry.
+        switzerland_ss_not_resident: |
+          You may be asked to provide a civil status declaration to prove you’re allowed to enter into a civil partnership.
+        switzerland_not_resident_two: |
+          If you need a civil status declaration, you can get one from the British Embassy in Berne in the language of the canton where the ceremony is taking place.
+
+          ##Getting your civil status declaration
+
+          You’ll need to provide supporting documents, including:
+
+          - your passport
+          - your [full birth certificate](/order-copy-birth-death-marriage-certificate) or [naturalisation certificate](/get-replacement-citizenship-certificate)
+          - proof of residence, such as a residence certificate - check with the consulate to find out what you need
+
+          If you've been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
+
+          - a [decree absolute or final order](/copy-decree-absolute-final-order)
+          - a civil partnership dissolution or annulment certificate
+          - your former spouse or civil partner’s [death certificate](/order-copy-birth-death-marriage-certificate/)
+
+          You’ll also need to provide evidence of nationality or residence if the divorce or dissolution took place outside the UK. You’ll need to get it [translated](/government/organisations/foreign-commonwealth-office/series/list-of-lawyers) if it’s not in English.
+
+          %The name on all documents you provide must appear exactly as they do on your passport - if not, the authorities may refuse to allow the ceremony to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage or civil partnership certificate, or deed poll).%
+
+          You should check if your civil status declaration needs to be legalised (certified as genuine) by the local authorities in Switzerland.
+
+# Marriage in commonwealth countries phrases
+        uk_resident_os_ceremony_not_zimbabwe: |
+          Contact the [High Commission of %{country_name_lowercase_prefix}](/government/publications/foreign-embassies-in-the-uk) to find out about local marriage laws, including what documents you’ll need.
+
+          ^You should [get legal advice](/government/organisations/foreign-commonwealth-office/series/list-of-lawyers) and check the [travel advice for %{country_name_lowercase_prefix}](/foreign-travel-advice/%{ceremony_country}) before making any plans.^
+        local_resident_os_ceremony_not_zimbabwe: |
+          Contact the relevant local authorities to find out about local marriage laws, including what documents you’ll need.
+
+          You should [get legal advice](/government/organisations/foreign-commonwealth-office/series/list-of-lawyers) before making any plans.
+        other_resident_os_ceremony_not_zimbabwe: |
+          Contact your nearest embassy, high commission or consulate of %{country_name_lowercase_prefix} before making any plans to find out about local marriage laws, including what documents you’ll need.
+
+          ^You should [get legal advice](/government/organisations/foreign-commonwealth-office/series/list-of-lawyers) and check the [travel advice for %{country_name_lowercase_prefix}](/foreign-travel-advice/%{ceremony_country}) before making any plans.^
+        uk_resident_os_ceremony_zimbabwe: |
+          Contact the [Zimbabwean Embassy in the UK](http://www.zimlondon.gov.zw/index.php/contact-us) to find out about local marriage laws, including what documents you’ll need.
+
+          ^You should [get legal advice](/government/organisations/foreign-commonwealth-office/series/list-of-lawyers) and check the [travel advice for %{country_name_lowercase_prefix}](/foreign-travel-advice/%{ceremony_country}) before making any plans.^
+        local_resident_os_ceremony_zimbabwe: |
+          Contact the relevant local authorities to find out about local marriage laws, including what documents you’ll need.
+
+          You should [get legal advice](/government/organisations/foreign-commonwealth-office/series/list-of-lawyers) before making any plans.
+        other_resident_os_ceremony_zimbabwe: |
+          Contact your nearest embassy or consulate of %{country_name_lowercase_prefix} before making any plans to find out about local marriage laws, including what documents you’ll need.
+
+          ^You should [get legal advice](/government/organisations/foreign-commonwealth-office/series/list-of-lawyers) and check the [travel advice for %{country_name_lowercase_prefix}](/foreign-travel-advice/%{ceremony_country}) before making any plans.^
+        commonwealth_os_all_cni: |
+          The UK doesn’t issue certificates of no impediment (CNI) for marriages in Commonwealth countries. You’ll need to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
+        commonwealth_os_all_cni_zimbabwe: |
+          The UK doesn’t issue certificates of no impediment (CNI) for marriages in Zimbabwe. You’ll need to explain this if you’re asked to provide a CNI or a similar document to prove you're allowed to marry.
+        commonwealth_os_other_countries_south_africa: |
+          %You’ll probably be asked for a CNI if you want to marry a South African citizen in South Africa. You’ll need to ask if there are any other documents the authorities will accept instead.%
+        commonwealth_os_other_countries_india: |
+          The British High Commission in India can provide you with a letter explaining this position for a charge - see [consular fees for India](/government/publications/india-consular-fees).
+          +[data_partial:overseas_passports_embassies:overseas_passports_embassies]
+        commonwealth_os_other_countries_malaysia: |
+          The British High Commission in Malaysia can provide you with a letter explaining this position for a charge - see [consular fees for Malaysia](/government/publications/malaysia-consular-fees).
+          +[data_partial:overseas_passports_embassies:overseas_passports_embassies]
+          You’ll need to provide the following documents:
+
+          - a statutory declaration made at the local High Court or at the office of a notary public in the UK or Malaysia
+          - your original passport and your partner’s passport
+          - a divorce certificate (if you have been previously married)
+
+          ^You must get married through an Islamic ceremony in Malaysia if you or your partner is a Muslim. Otherwise, you’ll need to have a civil marriage.^
+        commonwealth_os_other_countries_singapore: |
+          However, you can swear an affidavit (written statement of facts) that you’re free to marry in front of a local [notary public or commissioner of oaths](http://www.conp.sg/co-np-directory-listing).
+        commonwealth_os_other_countries_brunei: |
+          ^You must get married through an Islamic ceremony in Brunei if you or your partner is a Muslim. Otherwise, you’ll need to have a civil marriage.^
+        commonwealth_os_other_countries_cyprus: |
+          ###Other requirements for Cyprus
+
+          You must provide evidence that you’re allowed to marry if you’re resident in Cyprus but you’ve been there for less than 3 years. However, the [General Register Office](http://www.gro.gov.uk/gro/content/) (GRO) in the UK can only provide letters covering a specified 3-year period, not including the most recent 18 months.
+
+          You should [contact the municipality](http://www.ucm.org.cy/Account_List.aspx) in the area of Cyprus where you’d like to marry to check if they’ll accept this.
+        commonwealth_os_naturalisation: |
+          ##Naturalisation of your partner if they move to the UK
+
+          Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they've lived in the UK for 3 years.
+# Marriage in British overseas territories phrases
+        bot_os_ceremony_biot: |
+          Access to the British Indian Ocean Territory is restricted, and it’s unlikely that marriage would be allowed there.
+
+          Contact the British Indian Ocean Territory Administration for further details.
+          +[data_partial:overseas_passports_embassies:overseas_passports_embassies]
+        bot_os_ceremony_bvi: |
+          The British Virgin Islands is a British overseas territory.
+
+          Contact the [Civil Registry](http://www.bvi.gov.vg/department/civil-registry-and-passport-office) to find out about getting married there, including what documents you’ll need.
+
+          You should [get legal advice](/government/organisations/foreign-commonwealth-office/series/list-of-lawyers) before making any plans.
+        bot_os_ceremony_non_biot: |
+          %{country_name_uppercase_prefix} is a British overseas territory.
+
+          Contact the %{ceremony_country_name} Government to find out about getting married there, including what documents you’ll need.
+          +[data_partial:overseas_passports_embassies:overseas_passports_embassies]
+          You should [get legal advice](/government/organisations/foreign-commonwealth-office/series/list-of-lawyers) before making any plans.
+        bot_os_not_local_resident: |
+          You should also check the [travel advice for %{country_name_lowercase_prefix}](/foreign-travel-advice/%{ceremony_country}).
+        bot_os_naturalisation: |
+          ##Naturalisation of your partner if they move to the UK
+
+          Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they've lived in the UK for 3 years.
+# Marriage in a country with consular CNI phrases
+        ecuador_os_consular_cni: |
+          %Marriage between an Ecuadorian citizen and a foreign national is only allowed if you’ve been resident in Ecuador for at least 75 consecutive days - unless you already have a registered child with an Ecuadorian citizen.%
+        uk_resident_os_consular_cni: |
+          Contact the [Embassy of %{country_name_lowercase_prefix}](/government/publications/foreign-embassies-in-the-uk) before making any plans to find out about local marriage laws, including what documents you’ll need.
+
+          You should also check the [travel advice for %{country_name_lowercase_prefix}](/foreign-travel-advice/%{ceremony_country}).
+        local_resident_os_consular_cni: |
+          Contact the relevant local authorities in %{country_name_lowercase_prefix} to find out about local marriage laws, including what documents you’ll need.
+        uk_resident_os_consular_cni_dutch_caribbean_islands: |
+          %{country_name_uppercase_prefix} is one of the Dutch Caribbean islands.
+
+          Contact the [Dutch Embassy in the UK](http://www.netherlands-embassy.org.uk/about/index.php?i=121) before making any plans to find out about local marriage laws, including what documents you’ll need.
+
+          You should also check the [travel advice for %{country_name_lowercase_prefix}](/foreign-travel-advice/%{ceremony_country}).
+        other_resident_os_consular_cni: |
+          Contact your nearest embassy or consulate of %{country_name_lowercase_prefix} to find out about local marriage laws, including what documents you’ll need.
+
+          You should also check the [travel advice for %{country_name_lowercase_prefix}](/foreign-travel-advice/%{ceremony_country}) before making any plans.
+        gulf_states_os_consular_cni: |
+          ^There are no civil marriages in %{country_name_lowercase_prefix}, but you can get married through a religious ceremony at a church or Sharia court.^
+        gulf_states_os_consular_cni_local_resident_partner_not_irish: |
+          You may be able to get married at the British Embassy if you're both resident in %{country_name_lowercase_prefix} and can prove that there are no other suitable facilities.
+
+          Contact the British Embassy in %{country_name_lowercase_prefix} for more information.
+        spain_os_consular_cni_opposite_sex: |
+          Civil weddings in Spain take place at a town hall, register office or district court. You need to register with the local civil authorities afterwards to get an official marriage certificate if you have a religious wedding.
+        spain_os_consular_cni_same_sex: |
+          The process for same-sex marriages in Spain is the same as for opposite-sex civil marriages. Your marriage will be recognised as a civil partnership under British law.
+        spain_os_consular_civil_registry: |
+          Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married.
+        spain_os_consular_cni_not_local_resident: |
+          %There are certain legal restrictions if neither of you is resident in Spain. If you both live outside Spain, you should check with the civil registry where you’re planning to getting married to find out if this is allowed.%
+        italy_os_consular_cni_ceremony_italy: |
+          Contact the local comune (town hall) before making any plans to find out about local marriage laws, including what documents you’ll need.
+        italy_os_consular_cni_ceremony_not_italy_or_spain: |
+          ^You should [get legal advice](/government/organisations/foreign-commonwealth-office/series/list-of-lawyers) before making any plans.^
+        consular_cni_all_what_you_need_to_do: |
+          ##What you need to do
+        consular_cni_os_ceremony_not_spain_or_italy: |
+          You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you're allowed to marry.
+        spain_os_consular_cni_two: |
+          You may be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you're allowed to marry.
+
+          ^You may also need to get a marital status certificate if you’re living with your partner and want to get a ‘[pareja de hecho](/notarial-and-documentary-services-guide-for-spain#marital-status-certificate-for-pareja-de-hecho)’ (cohabitation registration).^
+        italy_os_consular_cni_uk_resident: |
+          You’ll need to get a certificate of no impediment (CNI) from the authorities in the UK to prove you’re allowed to marry.
+        italy_os_consular_cni_uk_resident_two: |
+          ^Your partner will need to follow the same process to get their own CNI.^
+        italy_os_consular_cni_uk_resident_three: |
+          You’ll be asked to provide a ‘Nulla Osta’ by the authorities in Italy. This is a certificate that proves you’re allowed to marry.
+        consular_cni_os_denmark: |
+          ^You don’t need a CNI if you’re getting married in the main town hall in Copenhagen.^
+        consular_cni_os_german_resident: |
+          You don’t need a certificate of no impediment (CNI) to prove you’re allowed to marry if you’re a British national resident in Germany. However, you’ll need to apply for an exemption (‘Befreiung von der Beibringung des Ehefähigkeitszeugnisses’).
+        consular_cni_os_not_germany_or_uk_resident: |
+          You don’t need a certificate of no impediment (CNI) to prove you’re allowed to marry if you’re a British national resident outside of the UK. However, you’ll need to apply for an exemption (‘Befreiung von der Beibringung des Ehefähigkeitszeugnisses’).
+        consular_cni_os_ceremony_germany_not_uk_resident: |
+          The local registry office (‘Standesamt’) where you’re getting married should tell you what to do.
+
+          If the Standesamt does ask you for a CNI (‘Ehefähigkeitszeugnis’), refer them to the relevant part of the [German Civil Code](http://www.gesetze-im-internet.de/bgb/__1309.html) (‘Bürgerliches Gesetzbuch’). This is published on the Stuttgart Higher Regional Court (‘Oberlandesgericht’) website, but it applies to the whole of Germany.
+
+          Check with the Higher Regional Court where you're getting married if they don't accept this.
+        uk_resident_partner_not_irish_os_consular_cni_three: |
+          You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf) or [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm).
+
+          ^A CNI issued in England, Wales or Northern Ireland is valid for 6 months. A CNI issued in Scotland is valid for 3 months.^
+
+        cni_at_local_register_office: |
+          You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf) or [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm).
+
+          ^A CNI issued in England, Wales or Northern Ireland is valid for 6 months. A CNI issued in Scotland is valid for 3 months.^
+
+        cni_posted_if_no_objection_14_days: |
+          You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf) or [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm).
+
+          ^A CNI issued in England, Wales or Northern Ireland is valid for 6 months. A CNI issued in Scotland is valid for 3 months.^
+
+          They’ll post your notice, and as long as nobody has registered an objection after 14 days, they’ll issue your CNI.
+
+        cni_at_local_register_office_notary_public: |
+          You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf) or [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm).
+
+          ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire, but you should check with the local authorities in the country where you intend to marry to find out how long a CNI is valid under local law.^
+
+        cni_posted_if_no_objection_14_days_notary_public: |
+          You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf) or [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm).
+
+          ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire, but you should check with the local authorities in the country where you intend to marry to find out how long a CNI is valid under local law.^
+
+          They’ll post your notice, and as long as nobody has registered an objection after 14 days, they’ll issue your CNI.
+        cni_posted_if_no_objection_7_days: |
+          You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf) or [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm).
+
+          ^A CNI issued in England, Wales or Northern Ireland is valid for 6 months. A CNI issued in Scotland is valid for 3 months.^
+
+          They’ll post your notice, and as long as nobody has registered an objection after 7 days, they’ll issue your CNI.
+        scotland_ni_resident_partner_irish_os_consular_cni_three: |
+          You can normally get a CNI by giving a notice of marriage at local registrar if you live in [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf) or [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm).
+
+          ^A CNI issued in Northern Ireland is valid for 6 months. A CNI issued in Scotland is valid for 3 months.^
+
+        consular_cni_os_scotland_or_ni_partner_irish_or_partner_not_irish_three: |
+          ###Getting a statutory declaration
+
+          While you’re waiting for your CNI, you and your partner will need to make a statutory declaration before a [solicitor or public notary](http://www.lawsociety.org.uk/find-a-solicitor/). The Italian authorities will need this in addition to your CNI. There’s a standard template in English and Italian that you can download and use.
+
+
+          $D
+          [Download ‘Bilingual statutory declaration for marriage in Italy’ (PDF, 90KB)](/government/uploads/system/uploads/attachment_data/file/153753/bilingual-statutory-declaration.pdf)
+          $D
+
+          ###Legalisation and translation
+
+          You’ll need to get your statutory declaration and CNI '[legalised](/get-document-legalised)' (certified as genuine) by the Foreign & Commonwealth Office (FCO).
+
+          You’ll also need to get your CNI [translated](/government/publications/italy-list-of-lawyers) and sworn before the Italian courts or an Italian Justice of the Peace.
+        consular_cni_os_england_or_wales_partner_irish_three: |
+          You need to get a Nulla Osta by applying to the Foreign & Commonwealth Office (FCO) in London if your partner is Irish and you live in England or Wales.
+
+          Your partner should contact the Irish authorities to get their Nulla Osta.
+
+          ###Applying for a Nulla Osta from the FCO
+
+          s1. [Download ‘Nulla Osta application form’ (DOT, 61KB)](/government/uploads/system/uploads/attachment_data/file/136828/nulla-osta-form.doc).
+          s2. Place a public announcement of your marriage in your local newspaper for at least 1 week, as described on the form.
+          s3. Swear an affidavit (written statement of facts) in front of a [solicitor](http://www.lawsociety.org.uk/find-a-solicitor/) - there’s an example on the form.
+          s4. Make sure you’ve got all of the supporting documents you need - there’s a checklist on the form.
+          s5. You’ll also need to include a pre-paid, self-addressed special delivery envelope, or a £10 postage fee, so the FCO can return your documents.
+          s6. Send your completed form to the FCO with your supporting documents and payment. [You can pay by credit card online](/pay-foreign-marriage-certificates), or send a postal order or bank draft for £65 (or £75 if you’re paying the postage) made payable to ‘FCO’. Personal cheques aren’t accepted. The address is on the form.
+          s7. FCO will forward your Nulla Osta application to the British Embassy in Rome. They'll aim to issue the Nulla Osta within 20 days, and contact you to arrange payment (see fees below).
+          s8. They’ll then send it to the town hall (‘comune’) in Italy where you’re getting married - or another address (such as your wedding planner) if you ask them to. It’s normally valid for 6 months, but you should check this with the comune.
+        consular_cni_os_england_or_wales_resident_not_italy: |
+          You need to get a CNI from the Foreign & Commonwealth Office (FCO) in London if your partner is Irish and you live in England or Wales.
+
+          Your partner should contact the Irish authorities to obtain their CNI.
+
+          ###Applying for a CNI from the FCO
+
+          s1. [Download ‘Certificate of no impediment application form’ (DOT, 60KB)](/government/uploads/system/uploads/attachment_data/file/136828/nulla-osta-form.doc).
+          s2. Place a public announcement of your marriage in your local newspaper for at least 1 week, as described on the form.
+          s3. Swear an affidavit (written statement of facts) in front of a [solicitor](http://www.lawsociety.org.uk/find-a-solicitor/) - there’s an example on the form.
+          s4. Make sure you’ve got all of the supporting documents you need - there’s a checklist on the form.
+          s5. You’ll also need to include a pre-paid, self-addressed special delivery envelope, or a £10 postage fee, so the FCO can return your documents.
+          s6. Send your completed form to the FCO with your supporting documents and payment. [You can pay by credit card online](/pay-foreign-marriage-certificates), or send a postal order or bank draft for £65 (or £75 if you’re paying the postage) made payable to ‘FCO’. Personal cheques aren’t accepted. The address is on the form.
+          s7. The FCO will forward your application to the local British embassy or consulate where you’re getting married, usually within 20 days - they’ll let you know when it’s ready to collect.
+          s8. The embassy or consulate will charge you an additional fee when you pick it up. It’s normally valid for 3 months, but you should check this with the local authorities.
+        consular_cni_os_uk_resident_montenegro: |
+          ###Getting a Montenegrin version of your CNI
+
+          You might need to exchange your UK-issued CNI for one that’s valid in Montenegro at the British Embassy in Podgorica.
+
+          Contact the embassy to make an appointment. You’ll need to pay the fee for issuing a CNI or equivalent - see below. Check with the local authorities to make sure they’ll accept your UK-issued CNI, and whether it needs to be:
+        consular_cni_os_uk_legalisation_check_with_authorities: |
+          ###Legalisation and translation
+
+          You should check with the local authorities in %{country_name_lowercase_prefix} to see if your CNI needs to be:
+
+        germany_legalisation_and_translation: |
+          ###Translation
+
+          Check with the local authorities if you need to get your UK-issued CNI translated.
+
+          [Find a translator abroad](/government/organisations/foreign-commonwealth-office/series/list-of-lawyers), or in the UK through the [Institute of Linguists](http://www.iol.org.uk/linguist/translator1.asp?r=PCTXYL10046)
+
+          You should also check with the local authorities if you need to provide [legalised](/get-document-legalised) and translated copies of any other documents.
+
+        tunisia_legalisation_and_translation: |
+          You’ll need to exchange your UK-issued CNI for one that’s valid in Tunisia at the nearest British embassy to where you’re getting married.
+        consular_cni_os_uk_resident_legalisation: |
+          ###Legalisation and translation
+
+          You might need to exchange your UK-issued CNI for one that’s valid in %{country_name_lowercase_prefix} at the nearest embassy or consulate to where you’re getting married.
+
+          You should also check if it needs to be:
+        consular_cni_os_uk_resident_not_italy_or_portugal: |
+          - ‘[legalised](/get-document-legalised)’ (certified as genuine)
+          - translated - [find a translator abroad](/government/organisations/foreign-commonwealth-office/series/list-of-lawyers), or in the UK through the [Institute of Linguists](http://www.iol.org.uk/linguist/translator1.asp?r=PCTXYL10046)
+
+          You should also check with the local authorities to find out if you need to provide legalised and translated copies of any other documents.
+        consular_cni_os_uk_resident_philippines: |
+          ###Getting a Philippine version of your CNI
+
+          Once you have your UK-issued CNI, the British Embassy in Manila can issue a Philippine version that will be recognised by the local authorities. You can arrange this by booking an appointment online at least 2 weeks before your visit.
+
+        consular_cni_os_local_resident_table: |
+
+          ###Applying for a CNI from the %{embassy_or_consulate_residency_country}
+
+          You’ll need to have been resident in Croatia for at least 3 days. You can then book an appointment at the embassy to give notice of your marriage. There’s a fee for this service (read the table on this page).
+        kazakhstan_os_local_resident: |
+          If you need a CNI, you’ll first need to give notice of your intended marriage (banns) at the British Embassy Office in Almaty.
+
+          ###Applying for a CNI from the consulate
+
+          You’ll normally need to have been resident in Kazakhstan for at least 3 days. You can then book an appointment at the consulate to give notice of your marriage. There’s a fee for this service (see below).
+        russia_os_local_resident: |
+          If you need a CNI, you’ll first need to give notice of your intended marriage at your nearest British %{embassy_or_consulate_residency_country}.
+
+          ###Applying for a CNI from the consulate
+
+          You’ll need to have been resident in the Russian Federation for at least 3 days. You can then book an appointment at the consulate in the district you’re resident in, to give notice of your marriage.
+
+          Email <RussiaConsular@fco.gov.uk> to find out where your local consulate is.
+
+          +[data_partial:overseas_passports_embassies:overseas_passports_embassies]
+
+        consular_cni_os_local_resident_italy: |
+          To get a Nulla Osta, you’ll first need to give notice of your intended marriage at the British Embassy in Rome.
+
+          ###Applying for a Nulla Osta from the embassy
+
+          You’ll need to have been resident in Italy for at least 3 days. You can then book an appointment at the British Embassy in Rome.
+
+        consular_cni_os_foreign_resident_ceremony_not_germany_italy: |
+          If you need a CNI, you’ll have to give notice of your intended marriage in the country where you live.
+        consular_cni_os_foreign_resident_ceremony_country_italy: |
+          You’ll have to give notice of your intended marriage in the country where you live.
+        consular_cni_os_foreign_resident_ceremony_country_not_germany: |
+          Check with your nearest British embassy or consulate to find out if they can do this for you.
+
+          +[data_partial:overseas_passports_embassies:overseas_passports_embassies]
+
+          ^Not all consulates are able to do this, but they may still be able to give you advice on other ways you can get a CNI.^
+
+          ###Giving notice of marriage
+
+          You need to have been living in your country of residence for 21 days.
+
+        consular_cni_os_foreign_resident_3_days: |
+          Check with your nearest British embassy or consulate to find out if they can do this for you.
+
+          +[data_partial:overseas_passports_embassies:overseas_passports_embassies]
+
+          ^Not all consulates are able to do this, but they may still be able to give you advice on other ways you can get a CNI.^
+
+          ###Giving notice of marriage
+
+          You need to have been living in your country of residence for 3 days.
+        consular_cni_os_foreign_resident_3_days_macedonia: |
+          Contact a notary public or the British Embassy in Macedonia to get advice:
+
+          $C
+          British Embassy Macedonia
+          Telephone: + 389 (2) 3299 299
+          <consular.skopje@fco.gov.uk>
+          $C
+
+          %You can't book an appointment to get advice at the embassy in person.%
+
+        consular_cni_os_foreign_resident_ceremony_notary_public: |
+          Check with a notary public or your nearest British embassy or consulate to find out if they can do this for you.
+
+          +[data_partial:overseas_passports_embassies:overseas_passports_embassies]
+
+          ###Giving notice of marriage
+
+          You need to have been living in your country of residence for 21 days.
+
+        consular_cni_os_foreign_resident_3_days_notary_public: |
+          Check with a notary public or your nearest British embassy or consulate to find out if they can do this for you.
+
+          +[data_partial:overseas_passports_embassies:overseas_passports_embassies]
+
+          ###Giving notice of marriage
+
+          You need to have been living in your country of residence for 3 days.
+        consular_cni_os_foreign_resident_3_days_macedonia: |
+          Contact a notary public or British Embassy in Macedonia to get advice:
+
+          $C
+          British Embassy Macedonia
+          Telephone: + 389 (2) 3299 299
+          <consular.skopje@fco.gov.uk>
+          $C
+
+          %You can't book an appointment to get advice at the embassy in person.%
+        consular_cni_os_foreign_resident_3_days_macedonia_giving_notice: |
+          ###Giving notice of marriage
+
+          You need to have been living in your country of residence for 3 days.
+        consular_cni_os_commonwealth_resident: |
+          If you need a certificate to prove you’re allowed to marry, you’ll have to give notice of your intended marriage in the country where you live.
+
+          Check with your nearest British high commission to find out if they can help you with this.
+
+          +[data_partial:overseas_passports_embassies:overseas_passports_embassies]
+
+          ^Not all high commissions are able to do this - if they can’t, they may be able to give you advice on other ways you can get a certificate.^
+        os_notice_of_marriage: |
+          ###Giving notice of marriage
+
+          You’ll need to place a public announcement of your marriage in a local newspaper where you live for 1 week. If possible (and appropriate), this should be in English and the local language. It’s easier to do this in a weekly newspaper, as otherwise the announcement needs to appear for 7 consecutive days.
+
+          You can use the example below as a template.
+
+
+          $E
+          I,………………………………...………………………(full name) single/widow(er)/divorcee,
+
+          of ……………………………………………………………………………….…..(full address),
+
+          intend to marry…………………...……… (full name of fiancee) single/widow(er)/divorcee,
+
+          of …………………………………………………………….……………………..(full address),
+
+          at …………….………(name and address of place where marriage has to be solemnised)
+
+          on…………….….…..(date of proposed marriage).
+
+          Any person knowing of any lawful impediment to the marriage should without delay notify:
+
+          (High Commission address)
+          $E
+        os_notice_of_marriage_7_day_wait: |
+          You need to wait 7 days after placing the announcement to allow for any objections to be registered. You’ll then need to swear an oath or affidavit (written statement of facts) in front of a local solicitor or public notary stating that you’re free to marry.
+        os_notice_of_marriage_21_day_wait: |
+          You need to wait 21 days after placing the announcement to allow for any objections to be registered. You’ll then need to swear an oath or affidavit (written statement of facts) in front of a local solicitor or public notary stating that you’re free to marry.
+        consular_cni_os_commonwealth_resident_british_partner: |
+          ^You’ll both need to place separate announcements and swear separate oaths if you’re both British nationals.^
+        consular_cni_os_commonwealth_resident_two: |
+          Once you’ve done this, you should then send or take the following documents and the relevant fee (see below) to the high commission:
+        consular_cni_os_ireland_resident: |
+          You need to give notice of your intended marriage in the country where you live. In Ireland, you can do this through the British Embassy in Dublin.
+          +[data_partial:overseas_passports_embassies:overseas_passports_embassies]
+          ###Giving notice of marriage
+
+          You’ll need to place a public announcement of your marriage in a local newspaper where you live for 1 week. It’s easier to do this in a weekly newspaper, as otherwise the announcement needs to appear for 7 consecutive days.
+
+          You can use the example below as a template.
+
+
+          $E
+          I,………………………………...………………………(full name) single/widow(er)/divorcee,
+
+          of ……………………………………………………………………………….…..(full address),
+
+          intend to marry…………………...……… (full name of fiancee) single/widow(er)/divorcee,
+
+          of …………………………………………………………….……………………..(full address),
+
+          at …………….………(name and address of place where marriage has to be solemnised)
+
+          on…………….….…..(date of proposed marriage).
+
+          Any person knowing of any lawful impediment to the marriage should without delay notify:
+
+          British Embassy in Ireland, 29 Merrion Road, Ballsbridge, Dublin 4
+          $E
+
+          You need to wait 21 days after placing the announcement to allow for any objections to be registered. You’ll then need to swear an oath or affidavit (written statement of facts) in front of a local solicitor or public notary stating that you’re free to marry.
+        consular_cni_os_ireland_resident_british_partner: |
+          ^You’ll both need to place separate announcements and swear separate oaths if you’re both British nationals.^
+        consular_cni_os_ireland_resident_two: |
+          Once you’ve done this, you should then send or take the following documents and the relevant fee (see below) to the British Embassy in Dublin:
+        consular_cni_os_commonwealth_or_ireland_resident_british_partner: |
+          - your original passport (or a photocopy certified by a local solicitor if you’re sending documents in the post)
+          - [full birth certificate](/order-copy-birth-death-marriage-certificate/) or [naturalisation certificate](/get-replacement-citizenship-certificate)
+          - the whole page of the newspaper your announcement appears on, including the date it was issued
+          - equivalent documents for your partner
+        consular_cni_os_commonwealth_or_ireland_resident_non_british_partner: |
+          - your original passport (or a photocopy certified by a local solicitor if you’re sending documents in the post)
+          - [full birth certificate](/order-copy-birth-death-marriage-certificate/) or [naturalisation certificate](/get-replacement-citizenship-certificate)
+          - the whole page of the newspaper your announcement appears on, including the date it was issued
+          - a photocopy of your partner’s passport
+
+        italy_consular_cni_os_commonwealth_or_ireland_resident_british_partner: |
+          - your original passport (or a photocopy certified by a local solicitor if you’re sending documents in the post)
+          - your [full birth certificate](/order-copy-birth-death-marriage-certificate/) or [naturalisation certificate](/get-replacement-citizenship-certificate) which states both of your parents' names
+          - the whole page of the newspaper your announcement appears on, including the date it was issued
+          - equivalent documents for your partner
+        italy_consular_cni_os_commonwealth_or_ireland_resident_non_british_partner: |
+          - your original passport (or a photocopy certified by a local solicitor if you’re sending documents in the post)
+          - your [full birth certificate](/order-copy-birth-death-marriage-certificate/) or [naturalisation certificate](/get-replacement-citizenship-certificate) which states both of your parents' names
+          - the whole page of the newspaper your announcement appears on, including the date it was issued
+          - a photocopy of your partner’s passport
+
+        consular_cni_variant_local_resident_not_germany_or_spain_or_foreign_resident: |
+          You’ll need to provide supporting documents, including:
+
+          - your passport
+          - your [full birth certificate](/order-copy-birth-death-marriage-certificate/) or [naturalisation certificate](/get-replacement-citizenship-certificate)
+          - proof of residence, such as a residence certificate - check with the %{embassy_or_consulate_residency_country} to find out what you need
+          - equivalent documents for your partner
+
+        consular_cni_variant_local_resident_or_foreign_resident_notary_public: |
+          You’ll need to provide supporting documents, including:
+
+          - your passport
+          - your [full birth certificate](/order-copy-birth-death-marriage-certificate/) or [naturalisation certificate](/get-replacement-citizenship-certificate)
+          - proof of residence, such as a residence certificate - check with the %{embassy_or_consulate_residency_country} or notary public to find out what you need
+          - equivalent documents for your partner
+
+        consular_cni_variant_local_resident_italy: |
+          You’ll need to provide supporting documents, including:
+
+          - your passport
+          - your [full birth certificate](/order-copy-birth-death-marriage-certificate/) or [naturalisation certificate](/get-replacement-citizenship-certificate) which states both of your parents' names
+          - proof of residence, such as a residence certificate - check with the %{embassy_or_consulate_residency_country} or notary public to find out what you need
+          - equivalent documents for your partner
+
+        cambodia_consular_cni_os_partner_local: |
+          You'll need to pay a fee and bring the following to your appointment:
+
+            - your passport
+            - your [birth certificate](/order-copy-birth-death-marriage-certificate/) or [naturalisation certificate](/get-replacement-citizenship-certificate)
+            - proof of residence, eg a residence certificate - check with the embassy or consulate for advice
+
+        japan_consular_cni_os_local_resident: |
+          +[data_partial:overseas_passports_embassies:overseas_passports_embassies]
+
+          ##Giving notice of marriage
+
+          You’ll need to provide supporting documents, including:
+
+          - your passport, showing that you’ve been in Japan for at least 3 days (if you’ve been outside of Japan for a short period and recently returned, a residence visa is normally acceptable)
+          - your [full birth certificate](/order-copy-birth-death-marriage-certificate) or [naturalisation certificate](/get-replacement-citizenship-certificate)
+          - evidence of parental consent if you’re below the age you can legally get married without consent in the country you’re from (eg 18 in England and Wales)
+          - equivalent documents for your partner
+        japan_consular_cni_os_local_resident_partner_local: |
+          Your partner can provide a recently certified copy of the family register (‘koseki-tohon’) as evidence that they’re free to marry.
+        italy_consular_cni_os_partner_local: |
+          You’ll need to provide supporting documents, including:
+
+          - your passport
+          - your [full birth certificate](/order-copy-birth-death-marriage-certificate/) or [naturalisation certificate](/get-replacement-citizenship-certificate)
+          - a copy of your partner’s ID card and Certificato di Stato Libero from the comune
+          - a copy of your partner’s Nulla Osta, if possible
+        italy_consular_cni_os_partner_other_or_irish: |
+          You’ll need to provide supporting documents, including:
+
+          - your passport
+          - your [full birth certificate](/order-copy-birth-death-marriage-certificate/) or [naturalisation certificate](/get-replacement-citizenship-certificate)
+          - a copy of your partner’s passport and, if possible, a copy of their Certificate of No Impediment (CNI) or similar document to prove they're allowed to marry
+        italy_consular_cni_os_partner_british: |
+          You and your partner will need to provide your passports and [full birth certificate](/order-copy-birth-death-marriage-certificate/) or [naturalisation certificate](/get-replacement-citizenship-certificate).
+        consular_cni_variant_local_resident_spain: |
+          The documents you need are:
+
+          - your passport
+          - your partner’s passport or national identity document
+          - a ‘certificado de empadronamiento’ (town hall registration certificate) or Spanish police residence certificate (green document with your NIE number address) issued at least 3 days ago
+
+          ^The Civil Registry will usually ask you for a certificado de empadronamiento issued in the last 3 months.^
+        consular_cni_os_not_uk_resident_ceremony_not_germany: |
+          If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
+
+          - a [decree absolute or final order](/copy-decree-absolute-final-order)
+          - a civil partnership dissolution or annulment certificate
+          - your (or your partner’s) former spouse or civil partner’s [death certificate](/order-copy-birth-death-marriage-certificate/)
+        consular_cni_os_other_resident_ceremony_not_germany_or_spain: |
+          ^You’ll also need to provide evidence of nationality or residence if the divorce or dissolution took place outside the UK. You’ll need to get it [translated](/government/organisations/foreign-commonwealth-office/series/list-of-lawyers) if it’s not in English.^
+
+        consular_cni_os_other_resident_ceremony_italy: |
+          You’ll also need to provide evidence of nationality or residence if the divorce or dissolution took place outside the UK. You’ll need to get it [translated](/government/organisations/foreign-commonwealth-office/series/list-of-lawyers) if it’s not in English.
+        spain_os_consular_cni_three: |
+          Send your completed CNI service request form and copies of the supporting documents to your [nearest British consulate](/notarial-and-documentary-services-guide-for-spain#where-to-send-your-request). You can send them as scanned attachments by email or by fax. You’ll need to bring the original documents to your appointment.
+
+          To request an appointment, fill in the CNI service request form and make sure you’ve got all of the necessary supporting documents.
+
+          $D
+          [Download 'CNI service request form' (DOC, 29KB)](/government/publications/certificate-of-no-impediment-service-request-form-spain)
+          $D
+
+          ###What happens next
+
+          The consulate will check your form and documents, and if everything’s in order they’ll send you details of how to book your appointment to give official notice of your marriage. They’ll then display your notice publicly for 7 days, and if nobody has raised an objection, they’ll issue your CNI. There’s an additional fee for this.
+
+        consular_cni_os_local_resident_not_germany_or_spain_or_foreign_resident_not_germany: |
+          The %{embassy_or_consulate_residency_country} will provide you with forms for your notice of marriage, and an oath or affidavit (written statement of facts) stating that you’re free to marry. You can download and fill in (but not sign) the forms in advance.
+
+
+          $D
+          [Download ‘Notice of marriage’ (PDF, 96KB)](/government/uploads/system/uploads/attachment_data/file/136829/nom2012.pdf)
+
+          [Download ‘Affidavit for marriage’ (PDF, 58KB)](/government/uploads/system/uploads/attachment_data/file/136830/affidavit2012.pdf)
+          $D
+
+        consular_cni_os_download_documents_notary_public: |
+          You’ll need to fill in forms for your notice of marriage, and an oath or affidavit (written statement of facts) stating that you’re free to marry.
+
+          You can download and fill in (but not sign) the forms in advance.
+
+
+          $D
+          [Download ‘Notice of marriage’ (PDF, 96KB)](/government/uploads/system/uploads/attachment_data/file/136829/nom2012.pdf)
+
+          [Download ‘Affidavit for marriage’ (PDF, 58KB)](/government/uploads/system/uploads/attachment_data/file/136830/affidavit2012.pdf)
+          $D
+
+        consular_cni_os_download_affidavit_notary_public: |
+          You’ll need to swear an oath or affidavit (written statement of facts) in front of a notary public stating that you're free to marry.
+
+          You can download and fill in (but not sign) the forms in advance.
+
+
+          $D
+          [Download ‘Notice of marriage’ (PDF, 96KB)](/government/uploads/system/uploads/attachment_data/file/136829/nom2012.pdf)
+
+          [Download ‘Affidavit for marriage’ (PDF, 58KB)](/government/uploads/system/uploads/attachment_data/file/136830/affidavit2012.pdf)
+          $D
+
+        wait_300_days_before_remarrying: |
+          ^If you're a woman you must wait 300 days after divorcing or the death of your husband before remarrying.^
+        display_notice_of_marriage_7_days: |
+          ###What happens next
+
+          The %{embassy_or_consulate_residency_country} will charge a fee for taking the oath, and then display your notice of marriage publicly for a further 7 days. They’ll then issue the CNI, as long as nobody has registered an objection. There’s an additional fee for this.
+
+        display_notice_of_marriage_21_days: |
+          ###What happens next
+
+          The %{embassy_or_consulate_residency_country} will charge a fee for taking the oath, and then display your notice of marriage publicly for a further 21 days. They’ll then issue the CNI, as long as nobody has registered an objection. There’s an additional fee for this.
+        consular_cni_os_foreign_resident_ceremony_not_italy: |
+          ###What happens next
+
+          The consulate will charge a fee for taking the oath, and then display your notice of marriage publicly for a further 21 days. They’ll then send all of your documentation to the nearest British embassy or consulate in %{country_name_lowercase_prefix} to where you’re getting married, who will issue your CNI (as long as nobody has registered an objection).
+
+          There’s an additional fee for this - the embassy or consulate will contact you to arrange payment.
+        consular_cni_os_foreign_resident_ceremony_7_days: |
+          ###What happens next
+
+          The consulate will charge a fee for taking the oath, and then display your notice of marriage publicly for a further 7 days. They’ll then send all of your documentation to the nearest British embassy or consulate in %{country_name_lowercase_prefix} to where you’re getting married, who will issue your CNI (as long as nobody has registered an objection).
+
+          There’s an additional fee for this - the embassy or consulate will contact you to arrange payment.
+
+        consular_cni_os_foreign_resident_ceremony_notary_public: |
+          ###What happens next
+
+          The embassy or notary public will charge a fee for taking the oath.
+
+          If you give notice at a notary public, you must post the signed forms and any supporting documents to your nearest British embassy or consulate afterwards.
+
+          ^The embassy or consulate may charge a fee to return your documents to you.^
+
+          The consulate will display your notice of marriage publicly for 7 days. They’ll then send all of your documentation to the nearest British embassy or consulate in %{country_name_lowercase_prefix} to where you’re getting married, who will issue your CNI (as long as nobody has registered an objection).
+
+          There’s an additional fee for this - the embassy or consulate will contact you to arrange payment.
+
+        consular_cni_os_commonwealth_resident_ceremony_italy: |
+          ###What happens next
+
+          The high commission will send a letter confirming that you’re free to marry to the local embassy or consulate where you’re planning the ceremony. They’ll need to include copies of your documents, so you should make sure they’re aware of this.
+
+          The embassy or consulate in %{ceremony_country_name} will then issue your CNI. They’ll contact you to arrange collection or delivery, and payment - see below for fees.
+        consular_cni_os_commonwealth_resident_ceremony_not_italy: |
+          ###What happens next
+
+          The high commission will send a letter confirming that you’re free to marry to the local embassy or consulate where you’re planning the ceremony. They’ll need to include copies of your documents, so you should make sure they’re aware of this.
+
+          The embassy or consulate in %{ceremony_country_name} will then issue your CNI. They’ll contact you to arrange collection or delivery, and payment - see below for fees.
+        consular_cni_os_ireland_resident_ceremony_not_italy: |
+          ###What happens next
+
+          The British Embassy will send a letter confirming that you’re free to marry to the local embassy or consulate where you’re planning the ceremony. They’ll need to include copies of your documents, so you should make sure they’re aware of this.
+
+          The embassy or consulate in %{ceremony_country_name} will then issue your CNI. They’ll contact you to arrange collection or delivery, and payment - see below for fees.
+        consular_cni_os_commonwealth_resident_ceremony_italy: |
+          ###What happens next
+
+          The high commission will send a letter confirming that you’re free to marry to the British Embassy in Rome. They’ll need to include copies of your documents, so you should make sure they’re aware of this.
+        consular_cni_os_ireland_resident_ceremony_italy: |
+          ###What happens next
+
+          The British Embassy will send a letter confirming that you’re free to marry to the British Embassy in Rome. They’ll need to include copies of your documents, so you should make sure they’re aware of this.
+        italy_os_consular_cni_four: |
+          You’ll then have to email the embassy with completed [credit card authorisation](/government/publications/credit-card-authorisation-form), [couple information](/government/publications/couple-information-form) and [request for consular services](/government/publications/request-for-consular-services) forms to arrange payment so they can issue your Nulla Osta.
+
+          $C
+          **British Embassy in Rome - marriages**
+          <rome.marriages@fco.gov.uk>
+          $C
+
+          They’ll contact you to arrange collection or delivery, and will normally aim to to issue the Nulla Osta within 20 days.
+
+        notary_public_will_charge_a_fee: |
+          The notary public will charge a fee for taking the oath, and then give you your notice of marriage. You should take this notice to the local authorities where you're getting married.
+
+        partner_will_need_a_cni: |
+          ^Your partner will need to get their own CNI.^
+        consular_cni_os_local_resident_ceremony_not_italy_not_germany_partner_british: |
+          ^Your partner will need to follow the same process and pay the fees to get their own CNI.^
+        consular_cni_os_other_resident_partner_british_ceremony_italy: |
+          ^Your partner will need to follow the same process to get their own Nulla Osta.^
+        consular_cni_os_all_names_but_germany: |
+          %The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
+        consular_cni_os_other_resident_ceremony_not_italy: |
+          You should check if your CNI needs to be legalised (certified as genuine) by the local authorities in %{country_name_lowercase_prefix}.
+        consular_cni_os_ceremony_belgium: |
+          ###Other requirements for Belgium
+
+          There are several other documents you might need to get from the British Embassy if requested by the town hall, including:
+
+          - certificate of custom law (‘certificat de coutume’ / ‘attest van gewoonterecht’)
+          - certificate of nationality (‘certificat de nationalité’ ‘certificaat van nationaliteit’) - this can be a certified copy of your passport
+          - certificate of celibacy (‘certificat de celibat’ / ‘certificaat van celibaat’) - there’s no UK equivalent, but you can make a statutory declaration at the British embassy instead
+
+          Check with the town hall to find out if you need any of these documents. You’ll need to make an appointment at the embassy to get them. Bring any supporting documents they ask for, and pay a fee (see below).
+        consular_cni_os_ceremony_spain: |
+          ###Getting a marital status certificate
+
+          In some parts of Spain you may need to to get a ‘marital status certificate’ (‘certificado de estado civil’) instead of, or as well as, a CNI ('certificado de no impedimento').
+
+          Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married. If you need one, ask a [solicitor](/government/publications/spain-list-of-lawyers) (‘abogado’) to draw up a declaration for you printed on their headed paper.
+
+          ^If it’s on blank, non-headed paper, they’ll need to give you a separate letter including their contact details, confirming that they’ve drawn up the declaration.^
+
+          You’ll then need to make an appointment at the consulate to make the declaration and sign the document in front of a consular officer - so don’t sign it beforehand.
+
+          Download instructions in English and Spanish on what the declaration needs to include.
+
+          $D
+          [Download ‘Marital status declaration instructions in English’ (PDF, 363KB)](/government/uploads/system/uploads/attachment_data/file/136832/marital-status-declaration-instruction-en.pdf)
+          [Download ‘Declaración de estado civil instrucciones en Español’ (PDF, 236KB)](/government/uploads/system/uploads/attachment_data/file/136833/marital-status-declaration-instruction-sp.pdf)
+          $D
+
+          You’ll also need a completed marital status certificate application form, as well as the supporting documents and the fee (see below).
+
+          $D
+          [Download 'Marital status certificate appointment request form' (DOC, 53KB)](/government/uploads/system/uploads/attachment_data/file/182249/Appointment_request_form_marital_status_marriage.doc)
+          $D
+        consular_cni_os_ceremony_spain_partner_british: |
+          Your partner will also need to get a marital status certificate from the consulate and pay the fees if the civil registry have told you that they need one.
+        consular_cni_os_ceremony_spain_two: |
+          ###Other requirements for Spain
+
+          The civil registrar may also ask for confirmation of your addresses for the past 2 years (‘confirmación de domicilio para casarse en España’).
+
+          You'll need to show one of the following:
+
+          - a letter confirming your address, eg electoral roll
+          - a bank or building society statement, credit card statement
+          - a mortgage statement
+          - a council tax letter
+          - utility bills
+          - recent proof of entitlement to local or state benefits, eg tax credits, pension, education or other benefits
+
+
+
+        consular_cni_os_naturalisation: |
+          ##Naturalisation of your partner if they move to the UK
+
+          Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they've lived in the UK for 3 years.
+
+        consular_cni_os_fees_not_italy_not_uk: |
+          ##Fees
+
+          Service | Fee
+          -|-
+          Receiving a notice of marriage | £65
+          Issuing a CNI, Nulla Osta or equivalent | £65
+          Issuing any other consular letter or certificate in English | £45
+          Issuing any other consular letter or certificate in any other language | £70
+          Administering an oath or making a declaration | £55
+
+        consular_cni_os_fees_foreign_commonwealth_roi_resident: |
+          You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for %{residency_country_name_lowercase_prefix}](/government/publications/%{residency_country}-consular-fees) and [consular fees for %{country_name_lowercase_prefix}](/government/publications/%{ceremony_country}-consular-fees).
+        consular_cni_os_fees_foreign_commonwealth_roi_resident_kazakhstan: |
+          You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for %{residency_country_name_lowercase_prefix}](/government/publications/%{residency_country}-consular-fees) and [consular fees for %{country_name_lowercase_prefix}](/government/publications/kazakhstan-kyrgyzstan-consular-fees).
+
+        consular_cni_os_fees_russia: |
+          You can pay by cash or credit card in Moscow, but not by personal cheque.
+
+          You can pay by credit card only in St Petersburg and Ekaterinburg.
+# France and French Overseas Territories phrases
+        fot_os_all: |
+          %{country_name_uppercase_prefix} is an overseas department or territory of France. The rules and requirements for getting married there are similar to France.
+# Affirmation to marry phrases
+        affirmation_os_uk_resident: |
+          Contact the [Embassy of %{country_name_lowercase_prefix}](/government/publications/foreign-embassies-in-the-uk) before making any plans to find out about local marriage laws, including what documents you’ll need.
+
+          You should also check the [travel advice for %{country_name_lowercase_prefix}](/foreign-travel-advice/%{ceremony_country}).
+        affirmation_os_uk_resident_ceremony_in_morocco: |
+          Contact the [Embassy of %{country_name_lowercase_prefix}](/government/publications/foreign-embassies-in-the-uk) before making any plans to find out about local marriage laws, including what documents you’ll need.
+
+          You also need to contact the Marriage Officer (Laadoul) in the city where you are going to get married.
+
+          ^You should [get legal advice](/government/organisations/foreign-commonwealth-office/series/list-of-lawyers) before making any plans and check the [travel advice for %{country_name_lowercase_prefix}](/foreign-travel-advice/%{ceremony_country}).^
+        affirmation_os_local_resident: |
+          Contact the relevant local authorities in %{country_name_lowercase_prefix} to find out about local marriage laws, including what documents you’ll need.
+        affirmation_os_other_resident: |
+          Contact your nearest embassy or consulate of %{country_name_lowercase_prefix} to find out about local marriage laws, including what documents you’ll need.
+
+          You should also check the [travel advice for %{country_name_lowercase_prefix}](/foreign-travel-advice/%{ceremony_country}).
+        affirmation_os_other_resident_ceremony_in_morocco: |
+          Contact your nearest embassy or consulate of %{country_name_lowercase_prefix} to find out about local marriage laws, including what documents you’ll need.
+
+          You also need to contact the Marriage Officer (Laadoul) in the city where you are going to get married.
+
+          ^You should [get legal advice](/government/organisations/foreign-commonwealth-office/series/list-of-lawyers) before making any plans and check the [travel advice for %{country_name_lowercase_prefix}](/foreign-travel-advice/%{ceremony_country})^
+        affirmation_os_legalised_in_turkey: |
+          You’ll need to get your affidavit ‘legalised’ (certified as genuine) by the local authorities, this is usually done on the same day - the embassy or consulate should be able to give you advice.
+        affirmation_os_uk_resident_two: |
+          ^You should [get legal advice](http://www.lawsociety.org.uk/find-a-solicitor/) before making any plans.^
+        affirmation_os_all_what_you_need_to_do: |
+          ^You should [get legal advice](/government/organisations/foreign-commonwealth-office/series/list-of-lawyers) before making any plans.^
+        affirmation_os_uae: |
+          ^There are no civil marriages in the United Arab Emirates, but you can get married through a religious ceremony at a church or Sharia court.^
+
+          You may be able to get married at the British Embassy if you're both resident in the United Arab Emirates and can prove that there are no other suitable facilities.
+
+          Contact the British Embassy in the United Arab Emirates for more information.
+
+        affirmation_os_partner: |
+          ^Your partner will need to get an affirmation as well.^
+
+        affirmation_os_partner_british: |
+          ^Your partner will probably need to get an affirmation as well.^
+
+        affirmation_affidavit_os_partner: |
+          ^Your partner will probably need to get an affirmation or affidavit as well.^
+
+        partner_equivalent_document_warning: |
+          ^Your partner will probably need to get an equivalent document from their national authorities.^
+
+        affirmation_os_partner_not_british: |
+          ##Naturalisation of your partner if they move to the UK
+
+          Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they've lived in the UK for 3 years.
+        affirmation_os_partner_not_british_turkey: |
+          ^Your partner will probably need to get an equivalent document from their national authorities.^
+
+          Once the document is legalised you’ll need to have it checked at the marriage office nearest to where your marriage will take place.
+        affirmation_os_naturalisation: |
+          ##Naturalisation of your partner if they move to the UK
+
+          Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they've lived in the UK for 3 years.
+
+        affirmation_os_legalised: |
+          You’ll need to get your affidavit ‘[legalised](https://www.gov.uk/get-document-legalised)’ (certified as genuine) before you travel to Turkey.
+
+        affirmation_os_download_affidavit_philippines: |
+          The embassy will provide you with an oath or affidavit (written statement of facts) stating that you’re free to marry. You can print and fill in (but not sign) the [affidavit/affirmation for marriage form](/government/publications/marriage-in-the-philippines) in advance.
+
+        docs_decree_and_death_certificate: |
+          If you’ve been divorced or widowed, you’ll also need:
+
+          - a [decree absolute or final order](/copy-decree-absolute-final-order) or the [death certificate](/order-copy-birth-death-marriage-certificate/)
+        divorced_or_widowed_evidences: |
+          - evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [translated](/government/organisations/foreign-commonwealth-office/series/list-of-lawyers) if it’s not in English.
+        change_of_name_evidence: |
+          You’ll also need to provide evidence if you’ve changed your name by deed poll.
+
+        affirmation_os_all_fees_45_70: |
+          ##Fees
+
+          Service | Fee
+          -|-
+          Affirmation for freedom to marry in English | £45
+          Affirmation for freedom to marry in any other language | £70
+
+        fee_table_45_55: |
+          ##Fees
+
+          Service | Fee
+          -|-
+          Marriage declaration | £45
+          Making an oath | £55
+
+        fee_table_55_70: |
+          ##Fees
+
+          Service | Fee
+          -|-
+          Affirmation for freedom to marry in English | £55
+          Affirmation for freedom to marry in any other language | £70
+
+# No CNI or consular services phrases
+        no_cni_os_dutch_caribbean_islands: |
+          %{country_name_uppercase_prefix} is one of the Dutch Caribbean islands.
+        no_cni_os_dutch_caribbean_islands_uk_resident: |
+          Contact the [Dutch Embassy in the UK](http://www.netherlands-embassy.org.uk/about/index.php?i=121) before making any plans to find out about local marriage laws, including what documents you’ll need.
+
+          You should also check the [travel advice for %{country_name_lowercase_prefix}](/foreign-travel-advice/%{ceremony_country}).
+        no_cni_os_dutch_caribbean_islands_local_resident: |
+          Contact the relevant local authorities in %{country_name_lowercase_prefix} to find out about local marriage laws, including what documents you’ll need.
+        no_cni_os_dutch_caribbean_other_resident: |
+          Contact the local authorities before making any plans to find out about local marriage laws, including what documents you’ll need.
+
+          You should also check the [travel advice for %{country_name_lowercase_prefix}](/foreign-travel-advice/%{ceremony_country}).
+        no_cni_os_not_dutch_caribbean_islands_uk_resident: |
+          Contact your [nearest embassy or consulate](/government/publications/foreign-embassies-in-the-uk) representing %{country_name_lowercase_prefix} before making any plans to find out about local marriage laws, including what documents you’ll need.
+
+          You should also check the [travel advice for %{country_name_lowercase_prefix}](/foreign-travel-advice/%{ceremony_country}).
+        no_cni_os_not_dutch_caribbean_islands_local_resident: |
+          Contact the relevant local authorities in %{country_name_lowercase_prefix} to find out about local marriage laws, including what documents you’ll need.
+        no_cni_os_not_dutch_caribbean_other_resident: |
+          Contact your nearest embassy or consulate representing %{country_name_lowercase_prefix} to find out about local marriage laws, including what documents you’ll need.
+
+          You should also check the [travel advice for %{country_name_lowercase_prefix}](/foreign-travel-advice/%{ceremony_country}).
+
+        cni_os_consular_facilities_unavailable: |
+          There aren’t any British consular facilities to register a marriage or get legal documents to prove you’re eligible to marry in %{country_name_lowercase_prefix}.
+
+        no_cni_os_naturalisation: |
+          ##Naturalisation of your partner if they move to the UK
+
+          Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they've lived in the UK for 3 years.
+
+# Other countries outcome phrases
+        other_countries_os_burma: |
+          The British Embassy in Rangoon doesn’t register marriages of British citizens in Burma. Contact the embassy if you need further advice.
+          +[data_partial:overseas_passports_embassies:overseas_passports_embassies]
+        other_countries_os_burma_partner_local: |
+          %Marriage between a Burmese citizen and a foreign national is not allowed under local law.%
+        other_countries_os_north_korea: |
+          It’s very unlikely that foreign nationals would be allowed to marry in North Korea. Contact the British Embassy in Pyongyang if you need further advice.
+          +[data_partial:overseas_passports_embassies:overseas_passports_embassies]
+        other_countries_os_north_korea_partner_local: |
+          %Marriage between a citizen of North Korea and a foreign national is not allowed under local law.%
+        other_countries_os_iran_somalia_syria: |
+          There are currently no British consular services available in %{country_name_lowercase_prefix}. See below if you need further advice.
+          +[data_partial:overseas_passports_embassies:overseas_passports_embassies]
+        other_countries_os_yemen: |
+          There are only limited British consular services available in %{country_name_lowercase_prefix}. See below if you need further advice.
+          +[data_partial:overseas_passports_embassies:overseas_passports_embassies]
+        other_countries_os_ceremony_saudia_arabia_not_local_resident: |
+          ^One of you must be a Muslim to get married under local laws in Saudi Arabia. You can only get married at the British Embassy if you’re resident in the country.^
+
+          Contact the [Embassy of Saudi Arabia](http://www.saudiembassy.org.uk/) to find out about local marriage laws.
+
+          The British Embassy in Saudi Arabia may also be able to give you advice.
+          +[data_partial:overseas_passports_embassies:overseas_passports_embassies]
+        other_countries_os_saudi_arabia_local_resident_partner_irish: |
+          ^One of you must be a Muslim to get married under local laws in Saudi Arabia. You can’t get married at the British Embassy in Saudi Arabia if one of you is an Irish national, as the Irish authorities do not recognise consular marriages.^
+
+          Contact the [Embassy of Saudi Arabia](http://www.saudiembassy.org.uk/) to find out about local marriage laws.
+
+          The British Embassy in Saudi Arabia may also be able to give you advice.
+          +[data_partial:overseas_passports_embassies:overseas_passports_embassies]
+        other_countries_os_saudi_arabia_local_resident_partner_not_irish: |
+          One of you must be a Muslim to get married under local laws in Saudi Arabia. Contact the [Embassy of Saudi Arabia](http://www.saudiembassy.org.uk/) to find out about local marriage laws.
+
+          ##Getting married at the British Embassy
+
+          You can apply to get married at the British Embassy in Riyadh if you’re resident in Saudi Arabia and neither of you is a Muslim. Contact them to make an appointment.
+          +[data_partial:overseas_passports_embassies:overseas_passports_embassies]
+          You’ll need to provide:
+
+          - proof that you’ve been resident in the area covered by the embassy for at least 21 days, eg, an employer’s letter or a bank statement (you’ll also need to sign a declaration to confirm this)
+          - your original passport and [full birth certificate](/order-copy-birth-death-marriage-certificate) or [naturalisation certificate](/get-replacement-citizenship-certificate)
+          - proof that you’re both over the age of 16, not within prohibited degrees of relationship to each other, and there’s no other impediment to your proposed marriage
+          - equivalent document for your partner
+
+          If either of you have been divorced, widowed or in a civil partnership before, you’ll also need:
+
+          - a [decree absolute or final order](/copy-decree-absolute-final-order), or
+          - the [death certificate](/order-copy-birth-death-marriage-certificate/)
+
+          ###What happens next
+
+          Once you’ve submitted these and paid the registration fee (see below), the embassy or consulate will post your marriage notice publicly for 14 days.
+
+          As long as nobody has registered an objection after this time, the consular officer can then perform the marriage ceremony any time until 3 months after the date you gave notice.
+
+          You’ll need to pay additional fees for the marriage ceremony and to get your marriage certificate (see below).
+        other_countries_os_saudi_arabia_local_resident_partner_not_irish_or_british: |
+          ##Naturalisation of your partner if they move to the UK
+
+          Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they've lived in the UK for 3 years.
+        other_countries_os_saudi_arabia_local_resident_partner_not_irish_two: |
+          ##Fees
+
+          Service | Fee
+          -|-
+          Posting a marriage notice | £65
+          Performing a marriage ceremony| £140
+          Issuing a marriage certificate | £65
+
+          You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for %{ceremony_country_name}](/government/publications/%{ceremony_country}-consular-fees).
+
+          You can pay by cash or credit card, but not by personal cheque.
+
+# CP in countries with CP or equivalent phrases
+        cp_or_equivalent_cp_austria: |
+          Same-sex relationships in Austria that are recognised as civil partnerships under British law are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’.
+        cp_or_equivalent_cp_belgium: |
+          Same-sex relationships in Belgium that are recognised as civil partnerships under British law are known as:
+
+          - marriage
+          - 'cohabitation légale', 'wettelijke samenwoning', or 'gesetzliches zusammenwohnen' ('statutory cohabitation')
+        cp_or_equivalent_cp_brazil: |
+          Same-sex relationships in Brazil that are recognised as civil partnerships under British law are known as:
+
+          - marriage
+          - 'união estável', or 'stable union'.
+        cp_or_equivalent_cp_colombia: |
+          Same-sex relationships in Colombia that are recognised as civil partnerships under British law are known as ‘unión de hecho’, or ‘common-law relationship’.
+        cp_or_equivalent_cp_czech-republic: |
+          Same-sex relationships in the Czech Republic that are recognised as civil partnerships under British law are known as 'registrované partnerství', or ‘registered partnership’.
+        cp_or_equivalent_cp_denmark: |
+          Same-sex relationships in Denmark that are recognised as civil partnerships under British law are known as:
+
+          - marriage
+          - 'registreret partnerskab' ('registered partnership')
+          - ‘nalunaarsukkamik inooqatigiinneq’ (in Greenland)
+        cp_or_equivalent_cp_ecuador: |
+          Same-sex relationships in Ecuador that are recognised as civil partnerships under British law are known as ‘unión civil’, or ‘civil union’.
+        cp_or_equivalent_cp_finland: |
+          Same-sex relationships in Finland that are recognised as civil partnerships under British law are known as 'rekisteröity parisuhde', or 'registrerad partnerskap' ('registered partnership').
+        cp_or_equivalent_cp_germany: |
+          Same-sex relationships in Germany that are recognised as civil partnerships under British law are known as 'Lebenspartnerschaft', or 'life partnership'.
+        cp_or_equivalent_cp_hungary: |
+          Same-sex relationships in Hungary that are recognised as civil partnerships under British law are known as 'bejegyzett élettársi kapcsolat', or 'registered partnership'.
+        cp_or_equivalent_cp_iceland: |
+          Same-sex relationships in Iceland that are recognised as civil partnerships under British law are known as:
+
+          - marriage
+          - 'staðfesta samvist', or 'confirmed cohabitation'
+        cp_or_equivalent_cp_luxembourg: |
+          Same-sex relationships in Luxembourg that are recognised as civil partnerships under British law are known as 'partenariat enregistré', or 'eingetragene partnerschaft' ('registered partnership').
+        cp_or_equivalent_cp_netherlands: |
+          Same-sex relationships in the Netherlands that are recognised as civil partnerships under British law are known as:
+
+          - marriage
+          - 'geregistreerd partnerschap' ('registered partnership')
+        cp_or_equivalent_cp_norway: |
+          Same-sex relationships in Norway that are recognised as civil partnerships under British law are known as:
+
+          - marriage
+          - 'registrert partnerskap', or 'registered partnership'.
+        cp_or_equivalent_cp_portugal: |
+          Same-sex relationships in Portugal that are recognised as civil partnerships under British law are known as ‘marriage’.
+        cp_or_equivalent_cp_slovenia: |
+          Same-sex relationships in Slovenia that are recognised as civil partnerships under British law are known as 'istospolne partnerske skupnosti’, or ‘same-sex partnerships’.
+        cp_or_equivalent_cp_sweden: |
+          Same-sex relationships in Sweden that are recognised as civil partnerships under British law are known as:
+
+          - marriage
+          - 'registrerat partnerskap', or 'registered partnership'.
+        cp_or_equivalent_cp_switzerland: |
+          Same-sex relationships in Switzerland that are recognised as civil partnerships under British law are known as 'eingetragene Partnerschaft', 'partenariat enregistré', 'unione domestica registrata' or 'partenadi registrà' ('registered partnership').
+        cp_or_equivalent_cp_uk_resident: |
+          Contact the [Embassy of %{country_name_lowercase_prefix}](/government/publications/foreign-embassies-in-the-uk) before making any plans to find out about local laws, including what documents you’ll need.
+
+          You should also check the [travel advice for %{country_name_lowercase_prefix}](/foreign-travel-advice/%{ceremony_country}).
+        cp_or_equivalent_cp_uk_resident_czech_republic: |
+          Contact the [Embassy of %{country_name_lowercase_prefix}](/government/publications/foreign-embassies-in-the-uk) before making any plans to find out about local marriage laws, including what documents you’ll need.
+
+          You should also check the [travel advice for %{country_name_lowercase_prefix}](/foreign-travel-advice/%{ceremony_country}).
+        cp_or_equivalent_cp_local_resident: |
+          Contact the relevant local authorities in %{country_name_lowercase_prefix} to find out about local laws, including what documents you’ll need.
+        cp_or_equivalent_cp_other_resident: |
+          Contact your nearest embassy or consulate of %{country_name_lowercase_prefix} to find out about local laws, including what documents you’ll need.
+
+        cp_or_equivalent_cp_all_fees: |
+          ##Fees
+
+          Service | Fee
+          -|-
+          Issuing a CNI or equivalent | £65
+        cp_or_equivalent_cp_all_what_you_need_to_do: |
+          ##What you need to do
+
+          You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you're allowed to enter into a civil partnership or equivalent in %{country_name_lowercase_prefix}.
+
+          Contact the local British embassy or consulate where you’re planning the ceremony to find out what you need to do.
+          +[data_partial:overseas_passports_embassies:overseas_passports_embassies]
+
+        cp_or_equivalent_cp_naturalisation: |
+          ##Naturalisation of your partner if they move to the UK
+
+          Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
+
+        what_you_need_to_do_cni: |
+          ##What you need to do
+
+          You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you're allowed to enter into a civil partnership or equivalent in %{country_name_lowercase_prefix}.
+
+# PACS in France or French overseas territories with PACS law
+        fot_cp_all: |
+          %{country_name_lowercase_prefix} is an overseas department or territory of France. The rules and requirements for PACS there are similar to France.
+
+# CP in countries where no CNI is required phrases
+        no_cni_required_cp_argentina: |
+          Same-sex relationships in Argentina that are recognised as civil partnerships under British law are known as:
+
+          - marriage
+          - ‘unión civil’, or ‘civil union’
+        no_cni_required_cp_usa: |
+          You can get a same-sex relationship legally recognised in some states in the United States.
+        no_cni_required_cp_andorra: |
+          Same-sex relationships in Andorra that are recognised as civil partnerships under British law are known as 'unió estable de parella', or 'stable union of pairs'.
+        no_cni_required_cp_bonaire-st-eustatius-saba: |
+          Same-sex relationships in Bonaire, St Eustatius and Saba that are recognised as civil partnerships under British law are known as:
+
+          - marriage
+          - 'geregistreerd partnerschap', or 'registered partnership'
+        no_cni_required_cp_liechtenstein: |
+          Same-sex relationships in Liechtenstein that are recognised as civil partnerships under British law are known as ‘eingetragene Partnerschaft’, or 'registered partnership'.
+        no_cni_required_cp_mexico: |
+          Same-sex relationships in Mexico that are recognised as civil partnerships under British law are known as:
+
+          - ‘pacto civil de solidaridad’, or ‘civil solidarity pact’ (in Coahuila)
+          - ‘sociedad de convivencia’, or ‘domestic partnership’ (in Mexico City Federal District)
+          - marriage (in Mexico City Federal District)
+        no_cni_required_cp_uruguay: |
+          Same-sex relationships in Uruguay that are recognised as civil partnerships under British law are known as ‘unión concubinaria’, or ‘civil union’.
+        no_cni_required_all_legal_advice: |
+          ^You should [get legal advice](/government/organisations/foreign-commonwealth-office/series/list-of-lawyers) before making any plans.^
+        no_cni_required_cp_ceremony_us: |
+          Same-sex relationships in US states that are recognised as civil partnerships under British law are known as:
+
+          - ‘domestic partnership’ or ‘marriage’ (California)
+          - ‘the relationship between designated beneficiaries’ (Colorado)
+          - ‘civil union’ or ‘marriage’ (Connecticut)
+          - ‘civil union’ (Delaware)
+          - ‘marriage’ (District of Colombia)
+          - ‘civil union’ or ‘reciprocal beneficiary relationship’ (Hawaii)
+          - ‘civil union’ (Illinois)
+          - ‘marriage’ (Iowa)
+          - ‘domestic partnership’ (Maine)
+          - ‘marriage’ (Massachusetts)
+          - ‘domestic partnership’ (Nevada)
+          - ‘marriage’ (New Hampshire)
+          - ‘civil union’ or ‘domestic partnership’ (New Jersey)
+          - ‘marriage’ (New York)
+          - ‘domestic partnership’ (Oregon)
+          - ‘civil union’ (Rhode Island)
+          - ‘civil union’ or ‘marriage’ (Vermont)
+          - ‘state registered domestic partnership’ (Washington)
+          - ‘domestic partnership’ (Wisconsin)
+        no_cni_required_all_what_you_need_to_do: |
+          ##What you need to do
+        no_cni_required_cp_dutch_islands: |
+          %{country_name_lowercase_prefix} is one of the Dutch Caribbean islands.
+        no_cni_required_cp_dutch_islands_uk_resident: |
+          Contact the [Dutch Embassy in the UK](http://www.netherlands-embassy.org.uk/about/index.php?i=121) before making any plans to find out about local laws, including what documents you’ll need.
+
+          You should also check the [travel advice for %{country_name_lowercase_prefix}](/foreign-travel-advice/%{ceremony_country}).
+        no_cni_required_cp_dutch_islands_local_resident: |
+          Contact the relevant local authorities in %{country_name_lowercase_prefix} to find out about local laws, including what documents you’ll need.
+        no_cni_required_cp_dutch_islands_other_resident: |
+          Contact your nearest Dutch embassy or consulate before making any plans to find out about local laws, including what documents you’ll need.
+
+          You should also check the [travel advice for %{country_name_lowercase_prefix}](/foreign-travel-advice/%{ceremony_country}).
+        no_cni_required_cp_not_dutch_islands_uk_resident: |
+          Contact your [nearest embassy or consulate](/government/publications/foreign-embassies-in-the-uk) representing %{country_name_lowercase_prefix} before making any plans to find out about local laws, including what documents you’ll need.
+
+          You should also check the [travel advice for %{country_name_lowercase_prefix}](/foreign-travel-advice/%{ceremony_country}).
+        no_cni_required_cp_not_dutch_islands_local_resident: |
+          Contact the relevant local authorities in %{country_name_lowercase_prefix} to find out about local laws, including what documents you’ll need.
+        no_cni_required_cp_not_dutch_islands_other_resident: |
+          Contact your nearest embassy or consulate representing %{country_name_lowercase_prefix} to find out about local laws, including what documents you’ll need.
+
+          You should also check the [travel advice for %{country_name_lowercase_prefix}](/foreign-travel-advice/%{ceremony_country}).
+        no_cni_required_cp_all_consular_facilities: |
+          There aren’t any British consular facilities to register a same-sex relationship, or get legal documents to prove you’re eligible enter into a same-sex relationship, in %{country_name_lowercase_prefix}.
+        no_cni_required_cp_naturalisation: |
+          ##Naturalisation of your partner if they move to the UK
+
+          Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
+
+# CP in commonwealth countries phrases
+
+        commonwealth_countries_cp_canada: |
+          Same-sex relationships in Canada that are recognised as civil partnerships under British law are known as:
+
+          - marriage
+          - 'union de fait', or 'common-law relationship' (in Manitoba)
+          - 'domestic partnership' (in Nova Scotia)
+          - 'union civile', or 'civil union' (in Quebec)
+        commonwealth_countries_cp_new_zealand: |
+          You may be able to get married or enter into a ‘civil union’ at the British embassy or consulate in New Zealand. Civil unions are recognised as civil partnerships under British law.
+        commonwealth_countries_cp_south_africa: |
+          Same-sex relationships in South Africa that are recognised as civil partnerships under British law are known as:
+
+          - marriage
+          - civil partnership
+        commonwealth_countries_cp_uk_resident_two: |
+          Contact the [High Commission of %{country_name_lowercase_prefix}](/government/publications/foreign-embassies-in-the-uk) to find out about local laws, including what documents you’ll need.
+
+          ^You should [get legal advice](/government/organisations/foreign-commonwealth-office/series/list-of-lawyers) and check the [travel advice for %{country_name_lowercase_prefix}](/foreign-travel-advice/%{ceremony_country}) before making any plans.^
+        commonwealth_countries_cp_local_resident: |
+          Contact the relevant local authorities to find out about local laws, including what documents you’ll need.
+
+          You should also [get legal advice](/government/organisations/foreign-commonwealth-office/series/list-of-lawyers) before making any plans.
+        commonwealth_countries_cp_other_resident: |
+          Contact your nearest high commission, embassy or consulate of %{country_name_lowercase_prefix} before making any plans to find out about local laws, including what documents you’ll need.
+
+          ^You should [get legal advice](/government/organisations/foreign-commonwealth-office/series/list-of-lawyers) and check the [travel advice for %{country_name_lowercase_prefix}](/foreign-travel-advice/%{ceremony_country}) before making any plans.^
+
+        commonwealth_countries_cp_australia_partner_local: |
+          Your Australian partner will also need a Single Status Certificate issued by state or territory authorities.
+        commonwealth_countries_cp_australia_partner_other: |
+          Your partner will also need either:
+
+          - a ‘certificate of no impediment’ (CNI) or similar document to prove they’re allowed to enter into a civil partnership from their national authorities
+          - a Single Status Certificate issued by state or territory authorities, if they’ve been resident in Australia for at least 21 days
+        commonwealth_countries_cp_naturalisation: |
+          ##Naturalisation of your partner if they move to the UK
+
+          Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they've lived in the UK for 3 years.
+# CP in countries with consular CP (exc australia) phrases
+        consular_cp_ceremony: |
+          You may be able to register a civil partnership at the British embassy or consulate in %{country_name_lowercase_prefix}.
+        consular_cp_ceremony_hc: |
+          You may be able to register a civil partnership at the High Commission in %{country_name_lowercase_prefix}.
+        consular_cp_ceremony_vietnam_partner_local: |
+          %However, you can’t enter into a civil partnership with a Vietnamese national.%
+        consular_cp_local_partner_croatia_bulgaria: |
+          %However, they can’t register a civil partnership between a British national and a national of %{country_name_lowercase_prefix}.%
+        consular_cp_vietnam: |
+          +[data_partial:overseas_passports_embassies:overseas_passports_embassies]
+        consular_cp_all_contact: |
+          Contact them to make an appointment:
+        consular_cp_no_clickbook_so_embassy_details: |
+          +[data_partial:overseas_passports_embassies:overseas_passports_embassies]
+        consular_cp_all_documents: |
+          You’ll both need your original passports. If either of you have been divorced, widowed or in a civil partnership before, you’ll also need:
+
+          - a [decree absolute or final order](/copy-decree-absolute-final-order), or
+          - the [death certificate](/order-copy-birth-death-marriage-certificate/)
+        consular_cp_partner_not_british: |
+          Your partner will also need either:
+
+          - a ‘certificate of no impediment’ (CNI) or similar document to prove they’re allowed to enter into a civil partnership from their national authorities
+          - an official letter from the local authorities in the country where they’re resident confirming that they’re single
+
+          ^Any foreign documents may need to be '[legalised](/get-document-legalised)' (certified as genuine) in the country they were issued (or that country’s embassy in %{country_name_lowercase_prefix}), and [translated into English](/government/organisations/foreign-commonwealth-office/series/list-of-lawyers).^
+        consular_cp_all_what_you_need_to_do: |
+          ###What you need to do
+
+          Once you’ve made your appointment, the embassy or consulate will give you:
+
+          - a notice of registration
+          - a declaration that you and your partner will need to swear, stating that you’re legally entitled to enter into a civil partnership
+
+          Once you’ve submitted these and paid the registration fee (see below), the embassy or consulate will display your notice publicly for 14 days.
+
+          As long as nobody has registered an objection after this time, the registration officer can then register your partnership any time until 3 months after the date you gave notice.
+
+          You’ll need to provide two witnesses and pay a fee to register your civil partnership. You’ll need to pay an additional fee for your civil partnership certificate (see below).
+        consular_cp_all_what_you_need_to_do_hc: |
+          ###What you need to do
+
+          Once you’ve made your appointment, the high commission will give you:
+
+          - a notice of registration
+          - a declaration that you and your partner will need to swear, stating that you’re legally entitled to enter into a civil partnership
+
+          Once you’ve submitted these and paid the registration fee (see below), the high commission will display your notice publicly for 14 days.
+
+          As long as nobody has registered an objection after this time, the registration officer can then register your partnership any time until 3 months after the date you gave notice.
+
+          You’ll need to provide two witnesses and pay a fee to register your civil partnership. You’ll need to pay an additional fee for your civil partnership certificate (see below).
+        consular_cp_naturalisation: |
+          ##Naturalisation of your partner if they move to the UK
+
+          Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they've lived in the UK for 3 years.
+
+        consular_cp_all_fees: |
+          ##Fees
+
+          Service | Fee
+          -|-
+          Receiving a notice of registration | £65
+          Registering a civil partnership | £140
+          Issuing a civil partnership certificate | £65
+
+          You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for %{ceremony_country_name}](/government/publications/%{ceremony_country}-consular-fees).
+
+        kosovo_uk_resident: |
+          Contact the [Embassy of the Republic of Kosovo in London](/government/publications/foreign-embassies-in-the-uk) to find out about local marriage laws, including what documents you’ll need.
+
+          You should also check the [travel advice for %{country_name_lowercase_prefix}](/foreign-travel-advice/%{ceremony_country}).
+
+          You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.
+
+          ##What you need to do
+
+          You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
+
+          You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf) or [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm).
+
+          ^A CNI issued in England, Wales or Northern Ireland is valid for 6 months. A CNI issued in Scotland is valid for 3 months.^
+
+          ###Legalisation and translation
+
+          You might need to exchange your UK-issued CNI for one that’s valid in %{country_name_lowercase_prefix} at the nearest embassy or consulate to where you’re getting married.
+
+          You should also check if it needs to be:
+
+          - ‘[legalised](/get-document-legalised)’ (certified as genuine)
+          - translated - [find a translator abroad](/government/organisations/foreign-commonwealth-office/series/list-of-lawyers), or in the UK through the [Institute of Linguists](http://www.iol.org.uk/linguist/translator1.asp?r=PCTXYL10046)
+
+          You should also check with the local authorities to find out if you need to provide legalised and translated copies of any other documents.
+
+          ^Your partner will need to follow the same process and pay the fees to get their own CNI.^
+
+          %The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
+
+          ##Fees
+
+          Service | Fee
+          -|-
+          Receiving a notice of marriage | £65
+          Issuing a CNI, Nulla Osta or equivalent | £65
+          Issuing any other consular letter or certificate in English | £45
+          Issuing any other consular letter or certificate in any other language | £70
+          Administering an oath or making a declaration | £55
+
+          You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for %{country_name_lowercase_prefix}](/government/publications/%{ceremony_country}-consular-fees).
+
+          You can pay by cash or credit card, but not by personal cheque.
+
+
+        kosovo_not_uk_resident: |
+          Contact the relevant local authorities in Kosovo to find out about local marriage laws, including what documents you’ll need.
+
+          You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.
+
+          ##What you need to do
+
+          You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
+
+          If you need a CNI, you’ll have to give notice of your intended marriage in the country where you live.
+
+          Check with your nearest British embassy or consulate to find out if they can do this for you.
+
+          +[data_partial:overseas_passports_embassies:overseas_passports_embassies]
+
+          You need to have been living in your country of residence for 3 days.
+
+          You’ll need to provide supporting documents, including:
+
+
+          - your passport
+          - your [full birth certificate](/order-copy-birth-death-marriage-certificate) or [naturalisation certificate](/get-replacement-citizenship-certificate)
+          - proof of residence, such as a residence certificate - check with the embassy to find out what you need
+          - equivalent documents for your partner
+
+          If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
+
+          - a [decree absolute or final order](/copy-decree-absolute-final-order)
+          - a civil partnership dissolution or annulment certificate
+          - your (or your partner’s) former spouse or civil partner’s [death certificate](/order-copy-birth-death-marriage-certificate/)
+
+          You’ll also need to provide evidence of nationality or residence if the divorce or dissolution took place outside the UK. You’ll need to get it [translated](/government/organisations/foreign-commonwealth-office/series/list-of-lawyers) if it’s not in English.
+
+          The embassy will provide you with forms for your notice of marriage, and an oath or affidavit (written statement of facts) stating that you’re free to marry. You can download and fill in (but not sign) the forms in advance.
+
+
+          $D
+          [Download ‘Notice of marriage’ (PDF, 96KB)](/government/uploads/system/uploads/attachment_data/file/136829/nom2012.pdf)
+
+          [Download ‘Affidavit for marriage’ (PDF, 58KB)](/government/uploads/system/uploads/attachment_data/file/136830/affidavit2012.pdf)
+          $D
+
+          ##What happens next
+
+          The embassy will charge a fee for taking the oath, and then display your notice of marriage publicly for a further 7 days. They’ll then issue the CNI, as long as nobody has registered an objection. There’s an additional fee for this.
+
+          %The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
+
+          You should check if your CNI needs to be legalised (certified as genuine) by the local authorities in Kosovo.
+
+          ##Naturalisation of your partner if they move to the UK
+
+          Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they've lived in the UK for 3 years.
+
+          ##Fees
+
+          Service | Fee
+          -|-
+          Receiving a notice of marriage | £65
+          Issuing a CNI, Nulla Osta or equivalent | £65
+          Issuing any other consular letter or certificate in English | £45
+          Issuing any other consular letter or certificate in any other language | £70
+          Administering an oath or making a declaration | £55
+
+          You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for %{country_name_lowercase_prefix}](/government/publications/%{ceremony_country}-consular-fees).
+
+          You can pay by cash or credit card, but not by personal cheque.
+
+        monaco_marriage: |
+
+          Contact the relevant local authorities to find out about local marriage laws, including what documents you'll need.
+
+          There isn't a British Embassy in Monaco. Contact the [British Embassy in Paris](/government/world/organisations/british-embassy-paris) for help with getting married in Monaco.
+
+          If you’re not in Monaco, [your closest Monegasque embassy](http://en.gouv.mc/Policy-Practice/Monaco-Worldwide/Diplomacy-and-International-Presence/bilateral-relations/All-the-countries) may be able to give you advice, or give you the contact details of the relevant local authorities.
+
+          ^You should get legal advice before making any plans.^
+
+          ##What you need to do
+
+          You may be asked to provide a certificate of custom law (‘certificat de coutume’) if you’re getting married in Monaco. You can get one of these from the [British Embassy in Paris](/government/world/organisations/british-embassy-paris).
+
+          You should check with the relevant local authorities in the town where you’re getting married to find out if you need one. Either you or your partner will need to have been resident there for 40 days before the ceremony.
+
+          Some local authorities only issue a certificate of custom law less than 6 months before the date of marriage. You should check with them before you apply. If your certificate is refused because you applied too early, you will need to apply and pay again.
+
+          ^You’ll need to have a civil ceremony first if you’re getting married in a religious ceremony.^
+
+          ###Applying for a certificate of custom law from the British Embassy
+
+          s1. Download the [certificate of custom law application form](/government/publications/application-for-a-certificate-of-custom-law-for-marriage-france).
+          s2. Make sure you’ve got all of the supporting documents you need - there’s a checklist on the form.
+          s3. You’ll need to include a pre-paid self-addressed envelope and a registered letter slip (‘récépissé d’un envoi recommandé sans avis de réception’) with your name and address, or a €6.55 postage fee, if you want your documents to be returned.
+          s4. Send your completed form to the British Embassy with your supporting documents and the correct fee. You’ll have to pay in Euros, as instructed on the payment slip attached to the form. See fee 11 on [consular fees for France](/government/publications/france-consular-fees) for the current cost.
+          s5. The embassy will send your certificate and return your documents between 5 and 7 days after receiving your application.
+
+
+          ###The certificate of celibacy
+
+          The local authority might also ask you for a certificate of celibacy (‘certificat de célibat’) to prove you’re not married or in a civil partnership. There’s no equivalent to this document in British law, so you’ll need to download the official note which explains this and take it with you instead.
+
+          $D
+          [Download ‘Explanatory note in lieu of a certificate of celibacy’](/government/publications/france-explanatory-note-in-lieu-of-certificat-celibat)
+          $D
+
+          ##Naturalisation of your foreign partner if they move to the UK
+
+          If your partner isn’t British, they can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they've lived in the UK for 3 years.
+
+        monaco_pacs: |
+          Contact the relevant local authorities to find out about local PACS laws, including what documents you'll need.
+
+          There isn't a British Embassy in Monaco. Contact the [British Embassy in Paris](/government/world/organisations/british-embassy-paris) for help entering into a PACS in Monaco.
+
+          If you’re not in Monaco, [your closest Monegasque embassy](http://en.gouv.mc/Policy-Practice/Monaco-Worldwide/Diplomacy-and-International-Presence/bilateral-relations/All-the-countries) may be able to give you advice, or give you the contact details of the relevant local authorities.
+
+          You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.
+
+          ##What you need to do
+
+          You may be asked to provide a certificate of custom law (‘certificat de coutume’) if you’re entering into a PACS in Monaco. You can get one of these from the [British Embassy in Paris](/government/world/organisations/british-embassy-paris).
+
+          You should check with the relevant local authorities in the town where you’re entering into a PACS to find out if you need one.
+
+          Some local authorities only issue a certificate of custom law less than 6 months before the date of your PACS. You should check with them before you apply. If your certificate is refused because you applied too early, you will need to apply and pay again.
+
+
+          ###Applying for a certificate of custom law from the British Embassy
+
+          s1. Download the [certificate of custom law application form](/government/publications/application-form-for-certificate-of-custom-law-for-pacs-france)
+          s2. Make sure you’ve got all of the supporting documents you need - there’s a checklist on the form.
+          s3. You’ll need to include a pre-paid self-addressed envelope and a registered letter slip (‘récépissé d’un envoi recommandé sans avis de réception’) with your name and address, or a €6.55 postage fee, if you want your documents to be returned.
+          s4. Send your completed form to the British Embassy with your supporting documents and the correct fee. You’ll have to pay in Euros, as instructed on the payment slip attached to the form. See fee 11 on [consular fees for France](/government/publications/france-consular-fees) for the current cost.
+          s5. The embassy will send your certificate and return your documents between 5 and 7 days after receiving your application.
+
+
+          ###The certificate of celibacy
+
+          The local authority might also ask you for a certificate of celibacy (‘certificat de célibat’) to prove you’re not already married or in a PACS. There’s no equivalent to this document in British law, so you’ll need to download the official note which explains this and take it with you instead.
+
+          $D
+          [Download ‘Explanatory note in lieu of a certificate of celibacy’](/government/publications/france-explanatory-note-in-lieu-of-certificat-celibat)
+          $D
+
+          ##Naturalisation of your foreign partner if they move to the UK
+
+          If your partner isn’t British, they can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they've lived in the UK for 3 years.
+
+
+
+# Q1
+      country_of_ceremony?:
+        title: Where do you want to get married?
+
+# Q2
+      legal_residency?:
+        title: Do you live in the UK?
+        options:
+          uk: "Yes"
+          other: "No"
+# Q3a
+      residency_uk?:
+        title: Where do you live?
+        options:
+          uk_england: "England"
+          uk_wales: "Wales"
+          uk_scotland: "Scotland"
+          uk_ni: "Northern Ireland"
+          uk_iom: "Isle of Man"
+          uk_ci: "Channel Islands"
+# Q3b
+      residency_nonuk?:
+        title: Where do you live?
+# Q3c
+      marriage_or_pacs?:
+        title: Do you want to get married or enter into a PACS?
+        hint: PACS (‘pacte civil de solidarité’, or ‘civil solidarity pact’) is the French version of civil partnership, and can be entered into by same-sex or opposite-sex couples.
+        options:
+          marriage: "Marriage"
+          pacs: "PACS"
+# Q3d
+      swiss_resident?:
+        title: Do you live in Switzerland?
+        options:
+          "yes": "Yes"
+          "no": "No"
+# Q4
+      what_is_your_partners_nationality?:
+        title: What is your partner’s nationality?
+        options:
+          partner_british: "British"
+          partner_irish: "Irish"
+          partner_local: "%{country_name_partner_residence}"
+          partner_other: "National of another country"
+# Q5
+      partner_opposite_or_same_sex?:
+        title: Is your partner of the opposite sex, or the same sex?
+        options:
+          opposite_sex: "Opposite sex"
+          same_sex: "Same sex"
+
+# Outcomes
+# outcome Channel Isles and Isle of Man
+      outcome_os_iom_ci:
+        title:
+        body: |
+          %{iom_ci_os_outcome}
+# outcome Netherlands
+      outcome_netherlands:
+        title: |
+          %{ceremony_type} in Netherlands
+        body: |
+          %{netherlands_phraselist}
+
+# outcome Ireland
+      outcome_ireland:
+        title: |
+          %{ceremony_type} in Ireland
+        body: |
+          %{ireland_partner_sex_variant}
+# outcome Indonesia - Opposite sex
+      outcome_os_indonesia:
+        title: |
+          Marriage in Indonesia
+        body: |
+          %{indonesia_os_phraselist}
+# outcome Kosovo - Opposite sex
+      outcome_os_kosovo:
+        title: |
+          Marriage in Kosovo
+        body: |
+          %{kosovo_os_phraselist}
+# outcome Brazil not living in the UK
+      outcome_brazil_not_living_in_the_uk:
+        title: |
+          Marriage in Brazil
+        body: |
+          %{brazil_phraselist_not_in_the_uk}
+# outcome Monaco
+      outcome_monaco:
+        title: |
+          %{monaco_title}
+        body: |
+          %{monaco_phraselist}
+# outcome Colombia - Opposite sex
+      outcome_os_colombia:
+        title: |
+          Marriage in Colombia
+        body: |
+          %{colombia_os_phraselist}
+# outcome Switzerland
+      outcome_switzerland:
+        title: |
+          %{ceremony_type} in Switzerland
+        body: |
+          %{switzerland_marriage_outcome}
+
+          *[GRO]:General Register Office
+          *[FCO]:Foreign & Commonwealth Office
+# outcome Portugal
+      outcome_portugal:
+        title: %{portugal_title}
+        body: |
+          Contact your nearest [Civil Register Office](http://www.irn.mj.pt/IRN/sections/irn/a_registral/servicos-externos-docs/contactos/contactos-dos-servicos-civil/) in Portugal to find out about local marriage laws, including what documents you’ll need.
+
+          You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.
+
+      outcome_ss_marriage_malta:
+        title: Same-sex marriage and civil partnership in Malta
+        body: |
+          %{ss_body}
+
+# outcome Commonwealth, opposite sex
+      outcome_os_commonwealth:
+        title: |
+          Marriage in %{country_name_lowercase_prefix}
+        body: |
+          %{commonwealth_os_outcome}
+
+          *[CNI]:certificate of no impediment
+          *[GRO]:General Register Office
+# outcome British oversesas territory, opposite sex
+      outcome_os_bot:
+        title: Marriage in %{country_name_lowercase_prefix}
+        body: |
+          %{bot_outcome}
+# outcome Countries with consular CNI, opposite sex
+      outcome_os_consular_cni:
+        title: Marriage in %{country_name_lowercase_prefix}
+        body: |
+          %{consular_cni_os_start}
+          %{consular_cni_os_remainder}
+
+          *[CNI]:certificate of no impediment
+          *[GRO]:General Register Office
+          *[FCO]:Foreign &amp; Commonwealth Office
+#outcome France or french overseas territories
+      outcome_os_france_or_fot:
+        title: Marriage in %{country_name_lowercase_prefix}
+        body: |
+          %{france_or_fot_os_outcome}
+
+          Contact the local town hall (‘mairie’) where you’re getting married to find out about local laws, including what documents you’ll need.
+
+          If you’re not in France, [your closest French embassy](http://www.mfe.org/index.php/Annuaires/Ambassades-et-consulats-francais-a-l-etranger) may also be able to give you advice, or put you in touch with the relevant local authorities if you don’t know who to contact.
+
+          ^You should [get legal advice](/government/organisations/foreign-commonwealth-office/series/list-of-lawyers) before making any plans.^
+
+          ##What you need to do
+
+          You may be asked to provide a certificate of custom law (‘certificat de coutume’) if you’re getting married in %{country_name_lowercase_prefix}.
+
+          You should check with the mairie in the town where you’re getting married to find out if you need one. Either you or your partner will need to have been legally resident there for at least 40 days before the ceremony.
+
+          ^You’ll need to have a civil ceremony first if you’re getting married in a religious ceremony.^
+
+          If you need a certificate of custom law, you can get one from the [British Embassy in Paris](/government/world/organisations/british-embassy-paris).
+
+          Some mairies only issue a certificate of custom less than 6 months before the date of marriage. You should check with them before you apply. If your certificate is refused because you applied too early, you will need to apply and pay again.
+
+          ###Applying for a certificate of custom law from the British Embassy
+
+          s1. Download the [certificate of custom law application form](/government/publications/application-for-a-certificate-of-custom-law-for-marriage-france).
+          s2. Make sure you’ve got all of the supporting documents you need - there’s a checklist on the form.
+          s3. You’ll need to include a pre-paid self-addressed envelope and a registered letter slip (‘récépissé d’un envoi recommandé sans avis de réception’) with your name and address, or a €6.55 postage fee, if you want your documents to be returned.
+          s4. Send your completed form to the British Embassy with your supporting documents and the correct fee. You’ll have to pay in Euros, as instructed on the payment slip attached to the form. See fee 11 on [consular fees for France](/government/publications/france-consular-fees) for the current cost.
+          s5. The embassy will send your certificate and return your documents between 5 and 7 days after receiving your application.
+
+
+          ###The certificate of celibacy
+
+          The mairie might also ask you for a certificate of celibacy (‘certificat de célibat’) to prove you’re not married or in a civil partnership. There’s no equivalent to this document in British law, so you’ll need to download the official note which explains this and take it to the mairie instead.
+
+          $D
+          [Download ‘Explanatory note in lieu of a certificate of celibacy’](/government/publications/france-explanatory-note-in-lieu-of-certificat-celibat)
+          $D
+
+          ##Naturalisation of your foreign partner if they move to the UK
+
+          If your partner isn’t British, they can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they've lived in the UK for 3 years.
+
+#outcome country with affirmation for frredom to marry
+      outcome_os_affirmation:
+        title: Marriage in %{country_name_lowercase_prefix}
+        body: |
+          %{affirmation_os_outcome}
+
+          *[GRO]:General Register Office
+          *[FCO]:Foreign &amp; Commonwealth Office
+#outcome country with no CNI or consular services
+      outcome_os_no_cni:
+        title: Marriage in %{country_name_lowercase_prefix}
+        body: |
+          %{no_cni_os_outcome}
+
+          *[GRO]:General Register Office
+          *[FCO]:Foreign &amp; Commonwealth Office
+#outcome other countries
+      outcome_os_other_countries:
+        title: Marriage in %{country_name_lowercase_prefix}
+        body: |
+          %{other_countries_os_outcome}
+
+#outcome for CP in country with CP or equivalent
+      outcome_cp_cp_or_equivalent:
+        title: Civil partnership in %{country_name_lowercase_prefix}
+        body: |
+          %{cp_or_equivalent_cp_outcome}
+
+          *[GRO]:General Register Office
+          *[FCO]:Foreign &amp; Commonwealth Office
+#outcome for CP in France or fot with PACS law
+      outcome_cp_france_pacs:
+        title: PACS in %{country_name_lowercase_prefix}
+        body: |
+          %{france_pacs_law_cp_outcome}
+
+          Contact the 'tribunal d’instance' in the town where you’re entering into a PACS to find out about local laws, including what documents you’ll need.
+
+          If you’re not in France, [your closest French embassy](http://www.mfe.org/index.php/Annuaires/Ambassades-et-consulats-francais-a-l-etranger) may also be able to give you advice, or put you in touch with the relevant local authorities if you don’t know who to contact.
+
+          ^You should [get legal advice](/government/organisations/foreign-commonwealth-office/series/list-of-lawyers) before making any plans.^
+
+          ##What you need to do
+
+          You may be asked to provide a certificate of custom law (‘certificat de coutume’) if you’re entering into a PACS in %{country_name_lowercase_prefix}.
+
+          You should check with the tribunal d’instance to find out if you need one.
+
+          If you need a certificate of custom law, you can get one from the [British Embassy in Paris](/government/world/organisations/british-embassy-paris).
+
+          Some tribunals only issue a certificate of custom less than 6 months before the date of your PACS. You should check with them before you apply. If your certificate is refused because you applied too early, you will need to apply and pay again.
+
+          ###Applying for a certificate of custom law from the British Embassy
+
+          s1. Download the [certificate of custom law application form](/government/publications/application-form-for-certificate-of-custom-law-for-pacs-france)
+          s2. Make sure you’ve got all of the supporting documents you need - there’s a checklist on the form.
+          s3. You’ll need to include a pre-paid self-addressed envelope and a registered letter slip (‘récépissé d’un envoi recommandé sans avis de réception’) with your name and address, or a €6.55 postage fee, if you want your documents to be returned.
+          s4. Send your completed form to the British Embassy with your supporting documents and the correct fee. You’ll have to pay in Euros, as instructed on the payment slip attached to the form. See fee 11 on [consular fees for France](/government/publications/france-consular-fees) for the current cost.
+          s5. The embassy will send your certificate and return your documents between 5 and 7 days after receiving your application.
+
+
+          ###The certificate of celibacy
+
+          The tribunal might also ask you for a certificate of celibacy (‘certificat de célibat’) to prove you’re not already married or in a civil partnership. It’s not possible to provide this under UK law, so you’ll need to download the explanatory note and take this to the tribunal instead.
+
+
+          $D
+          [Download ‘Explanatory note in lieu of a certificate of celibacy’ (PDF, 326KB)](/government/publications/france-explanatory-note-in-lieu-of-certificat-celibat)
+          $D
+
+          ##Naturalisation of your foreign partner if they move to the UK
+
+          If your partner isn’t British, they can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they've lived in the UK for 3 years.
+
+          *[GRO]:General Register Office
+          *[FCO]:Foreign &amp; Commonwealth Office
+          *[PACS]:pacte civil de solidarité
+#outcome for CP in countries where no CNI or equivalent required
+      outcome_cp_no_cni:
+        title: Civil partnership in %{country_name_lowercase_prefix}
+        body: |
+          %{no_cni_required_cp_outcome}
+
+          *[GRO]:General Register Office
+          *[FCO]:Foreign &amp; Commonwealth Office
+#outcome for CP in commonwealth countries
+      outcome_cp_commonwealth_countries:
+        title: %{type_of_ceremony} in %{country_name_lowercase_prefix}
+        body: |
+          %{commonwealth_countries_cp_outcome}
+
+          *[GRO]:General Register Office
+          *[FCO]:Foreign &amp; Commonwealth Office
+#outcome for CP in countries with consular CNI (exc. australia)
+      outcome_cp_consular:
+        title: Civil partnership in %{country_name_lowercase_prefix}
+        body: |
+          %{consular_cp_outcome}
+
+          *[CNI]:certificate of no impediment
+#outcome for CP in all other countries
+      outcome_cp_all_other_countries:
+        title: Same-sex marriage and civil partnership in %{country_name_lowercase_prefix}
+        body: |
+          It’s not possible to get legal recognition for a same-sex relationship in %{country_name_lowercase_prefix}.
+      outcome_ss_marriage:
+        title: "%{ss_title} in %{country_name_lowercase_prefix}"
+        body: |
+          %{ss_ceremony_body}
+      outcome_ss_marriage_not_possible:
+        title: Same-sex marriage and civil partnership in %{country_name_lowercase_prefix}
+        body: |
+          It’s not possible to get legal recognition for your same-sex relationship in %{country_name_lowercase_prefix}.

--- a/lib/smart_answer_flows/marriage-abroad-v2.rb
+++ b/lib/smart_answer_flows/marriage-abroad-v2.rb
@@ -412,7 +412,7 @@ outcome :outcome_brazil_not_living_in_the_uk do
     if ceremony_country == residency_country
       phrases << :local_resident_os_ceremony_not_zimbabwe << :consular_cni_os_download_affidavit_notary_public << :notary_public_will_charge_a_fee << :consular_cni_os_all_names_but_germany << :consular_cni_os_naturalisation
     else
-      phrases << :local_resident_os_consular_cni << :check_travel_advice << :get_legal_advice << :what_you_need_to_do << :make_an_appointment_bring_passport_and_pay_55_brazil << :list_of_consular_fees << :pay_by_cash_or_credit_card_no_cheque << :embassies_data << :download_affidavit_forms_but_do_not_sign << :download_affidavit << :documents_for_divorced_or_widowed << :affirmation_os_partner_not_british_turkey
+      phrases << :local_resident_os_consular_cni << :check_travel_advice << :get_legal_advice << :what_you_need_to_do << :make_an_appointment_bring_passport_and_pay_55_brazil << :list_of_consular_fees << :pay_by_cash_or_credit_card_no_cheque << :embassies_data << :download_affidavit_forms_but_do_not_sign << :download_affidavit_brazil << :documents_for_divorced_or_widowed << :affirmation_os_partner_not_british_turkey
     end
     phrases
   end

--- a/lib/smart_answer_flows/marriage-abroad-v2.rb
+++ b/lib/smart_answer_flows/marriage-abroad-v2.rb
@@ -1,0 +1,1435 @@
+status :draft
+satisfies_need "101000"
+
+data_query = SmartAnswer::Calculators::MarriageAbroadDataQueryV2.new
+country_name_query = SmartAnswer::Calculators::CountryNameFormatter.new
+reg_data_query = SmartAnswer::Calculators::RegistrationsDataQueryV2.new
+exclude_countries = %w(holy-see british-antarctic-territory the-occupied-palestinian-territories)
+
+# Q1
+country_select :country_of_ceremony?, exclude_countries: exclude_countries do
+  save_input_as :ceremony_country
+
+  calculate :location do
+    loc = WorldLocation.find(ceremony_country)
+    raise InvalidResponse unless loc
+    loc
+  end
+  calculate :organisation do
+    location.fco_organisation
+  end
+  calculate :overseas_passports_embassies do
+    if organisation
+      organisation.offices_with_service 'Registrations of Marriage and Civil Partnerships'
+    else
+      []
+    end
+  end
+
+  calculate :marriage_and_partnership_phrases do
+    if data_query.ss_marriage_countries?(ceremony_country) | data_query.ss_marriage_countries_when_couple_british?(ceremony_country)
+      "ss_marriage"
+    elsif data_query.ss_marriage_and_partnership?(ceremony_country)
+      "ss_marriage_and_partnership"
+    end
+  end
+
+  calculate :ceremony_country_name do
+    location.name
+  end
+
+  calculate :country_name_lowercase_prefix do
+    if country_name_query.class::COUNTRIES_WITH_DEFINITIVE_ARTICLES.include?(ceremony_country)
+      country_name_query.definitive_article(ceremony_country)
+    elsif country_name_query.class::FRIENDLY_COUNTRY_NAME.has_key?(ceremony_country)
+      country_name_query.class::FRIENDLY_COUNTRY_NAME[ceremony_country]
+    else
+      ceremony_country_name
+    end
+  end
+
+  calculate :country_name_uppercase_prefix do
+    country_name_query.definitive_article(ceremony_country, true)
+  end
+
+  calculate :country_name_partner_residence do
+    if data_query.british_overseas_territories?(ceremony_country)
+      "British (overseas territories citizen)"
+    elsif data_query.french_overseas_territories?(ceremony_country)
+      "French"
+    elsif data_query.dutch_caribbean_islands?(ceremony_country)
+      "Dutch"
+    elsif %w(hong-kong macao).include?(ceremony_country)
+      "Chinese"
+    else
+      "National of #{country_name_lowercase_prefix}"
+    end
+  end
+
+  calculate :embassy_or_consulate_ceremony_country do
+    if reg_data_query.has_consulate?(ceremony_country) or reg_data_query.has_consulate_general?(ceremony_country)
+      "consulate"
+    else
+      "embassy"
+    end
+  end
+
+  next_node_if(:partner_opposite_or_same_sex?, responded_with('ireland'))
+  next_node_if(:marriage_or_pacs?, responded_with(%w(france monaco new-caledonia wallis-and-futuna)))
+  next_node_if(:outcome_os_france_or_fot, ->(response) { data_query.french_overseas_territories?(response)})
+  next_node(:legal_residency?)
+end
+
+# Q2
+multiple_choice :legal_residency? do
+  option :uk
+  option :other
+
+  save_input_as :resident_of
+
+  on_condition(responded_with('uk')) do
+    next_node_if(:partner_opposite_or_same_sex?, variable_matches(:ceremony_country, 'switzerland'))
+    next_node(:residency_uk?)
+  end
+  next_node(:residency_nonuk?)
+end
+
+# Q3a
+multiple_choice :residency_uk? do
+  option :uk_england
+  option :uk_wales
+  option :uk_scotland
+  option :uk_ni
+  option :uk_iom
+  option :uk_ci
+
+  save_input_as :residency_uk_region
+
+  on_condition(responded_with(%w{uk_iom uk_ci})) do
+    next_node_if(:what_is_your_partners_nationality?,
+      -> {
+        data_query.os_other_countries?(ceremony_country) ||
+        data_query.ss_marriage_countries?(ceremony_country) ||
+        data_query.ss_marriage_and_partnership?(ceremony_country) ||
+        %w(portugal czech-republic).include?(ceremony_country)
+      })
+    next_node_if(:outcome_os_iom_ci)
+  end
+  next_node(:what_is_your_partners_nationality?)
+end
+
+# Q3b
+country_select :residency_nonuk?, exclude_countries: exclude_countries do
+  save_input_as :residency_country
+  countries_that_show_their_embassies_data = %w(belarus bolivia brazil cambodia chile colombia costa-rica dominican-republic egypt el-salvador ethiopia finland germany honduras hungary indonesia mongolia montenegro peru south-korea latvia lebanon mongolia morocco nepal oman panama peru philippines portugal qatar russia saudi-arabia serbia slovakia thailand united-arab-emirates vietnam portugal)
+  calculate :location do
+    if countries_that_show_their_embassies_data.include?(ceremony_country) and resident_of == 'other'
+      loc = WorldLocation.find(ceremony_country)
+    else
+      loc = WorldLocation.find(residency_country)
+    end
+    raise InvalidResponse unless loc
+    loc
+  end
+  calculate :organisation do
+    location.fco_organisation
+  end
+  calculate :overseas_passports_embassies do
+    if organisation
+      organisation.offices_with_service 'Registrations of Marriage and Civil Partnerships'
+    else
+      []
+    end
+  end
+
+  calculate :residency_country_name do
+    location.name
+  end
+
+  calculate :residency_country_name_lowercase_prefix do
+    if country_name_query.class::COUNTRIES_WITH_DEFINITIVE_ARTICLES.include?(residency_country)
+      country_name_query.definitive_article(residency_country)
+    elsif country_name_query.class::FRIENDLY_COUNTRY_NAME.has_key?(residency_country)
+      country_name_query.class::FRIENDLY_COUNTRY_NAME[residency_country]
+    else
+      residency_country_name
+    end
+  end
+
+  calculate :embassy_or_consulate_residency_country do
+    if reg_data_query.has_consulate?(residency_country) or reg_data_query.has_consulate_general?(residency_country)
+      "consulate"
+    else
+      "embassy"
+    end
+  end
+
+  next_node_if(:partner_opposite_or_same_sex?, variable_matches(:ceremony_country, "switzerland"))
+  next_node(:what_is_your_partners_nationality?)
+end
+
+# Q3c
+multiple_choice :marriage_or_pacs? do
+  option :marriage
+  option :pacs
+  save_input_as :marriage_or_pacs
+
+  next_node_if(:outcome_monaco, variable_matches(:ceremony_country, "monaco"))
+  next_node_if(:outcome_os_france_or_fot, responded_with('marriage'))
+  next_node(:outcome_cp_france_pacs)
+end
+
+# Q4
+multiple_choice :what_is_your_partners_nationality? do
+  option :partner_british
+  option :partner_irish
+  option :partner_local
+  option :partner_other
+
+  save_input_as :partner_nationality
+  next_node :partner_opposite_or_same_sex?
+end
+
+# Q5
+multiple_choice :partner_opposite_or_same_sex? do
+  option :opposite_sex
+  option :same_sex
+
+  save_input_as :sex_of_your_partner
+
+  calculate :ceremony_type do
+    if responses.last == 'opposite_sex'
+      PhraseList.new(:ceremony_type_marriage)
+    else
+      PhraseList.new(:ceremony_type_civil_partnership)
+    end
+  end
+
+  calculate :ceremony_type_lowercase do
+    if responses.last == 'opposite_sex'
+      "marriage"
+    else
+      "civil partnership"
+    end
+  end
+
+
+  define_predicate(:ceremony_in_colombia_partner_not_local) {
+    (ceremony_country == "colombia") & (partner_nationality != "partner_local")
+  }
+  define_predicate(:ceremony_in_finland_uk_resident_partner_not_irish) {
+    (ceremony_country == "finland") & (resident_of == "uk") & %w(partner_british partner_other partner_local).include?(partner_nationality)
+  }
+  define_predicate(:ceremony_in_mexico_partner_british) {
+    (ceremony_country == "mexico") & (partner_nationality == "partner_british")
+  }
+
+  define_predicate(:ceremony_in_brazil_not_resident_in_the_uk) {
+    (ceremony_country == "brazil") & (resident_of == "other")
+  }
+
+  next_node_if(:outcome_brazil_not_living_in_the_uk, ceremony_in_brazil_not_resident_in_the_uk)
+  next_node_if(:outcome_netherlands, variable_matches(:ceremony_country, "netherlands"))
+  next_node_if(:outcome_portugal, variable_matches(:ceremony_country, "portugal"))
+  next_node_if(:outcome_ireland, variable_matches(:ceremony_country, "ireland"))
+  next_node_if(:outcome_switzerland, variable_matches(:ceremony_country, "switzerland"))
+  on_condition(responded_with('opposite_sex')) do
+    next_node_if(:outcome_os_colombia, variable_matches(:ceremony_country, "colombia"))
+    next_node_if(:outcome_os_kosovo, variable_matches(:ceremony_country, "kosovo"))
+    next_node_if(:outcome_os_indonesia, variable_matches(:ceremony_country, "indonesia"))
+    next_node_if(:outcome_os_consular_cni, -> {
+      data_query.os_consular_cni_countries?(ceremony_country) or (resident_of == 'uk' and data_query.os_no_marriage_related_consular_services?(ceremony_country))
+     })
+    next_node_if(:outcome_os_consular_cni, ceremony_in_colombia_partner_not_local)
+    next_node_if(:outcome_os_consular_cni, ceremony_in_finland_uk_resident_partner_not_irish)
+    next_node_if(:outcome_os_consular_cni, ceremony_in_mexico_partner_british)
+    next_node_if(:outcome_os_affirmation, -> { data_query.os_affirmation_countries?(ceremony_country) })
+    next_node_if(:outcome_os_commonwealth, -> { data_query.commonwealth_country?(ceremony_country) or ceremony_country == 'zimbabwe' })
+    next_node_if(:outcome_os_bot, -> { data_query.british_overseas_territories?(ceremony_country) })
+    next_node_if(:outcome_os_no_cni, -> {
+      data_query.os_no_consular_cni_countries?(ceremony_country) or (resident_of == 'other' and data_query.os_no_marriage_related_consular_services?(ceremony_country))
+    })
+    next_node_if(:outcome_os_other_countries, -> {
+      data_query.os_other_countries?(ceremony_country)
+    })
+  end
+
+  define_predicate(:ss_marriage_germany_partner_local?) {
+    (ceremony_country == "germany") & (partner_nationality == "partner_local") & (ceremony_type != 'opposite_sex')
+  }
+  define_predicate(:ss_marriage_countries?) {
+    data_query.ss_marriage_countries?(ceremony_country)
+  }
+  define_predicate(:ss_marriage_countries_when_couple_british?) {
+    data_query.ss_marriage_countries_when_couple_british?(ceremony_country) & %w(partner_british).include?(partner_nationality)
+  }
+  define_predicate(:ss_marriage_and_partnership?) {
+    data_query.ss_marriage_and_partnership?(ceremony_country)
+  }
+
+  define_predicate(:ss_marriage_not_possible?) {
+    data_query.ss_marriage_not_possible?(ceremony_country, partner_nationality)
+  }
+
+  define_predicate(:uk_resident_irish_partner_finland_ss_ceremony) {
+    (ceremony_country == 'finland') & (resident_of == 'uk') & (partner_nationality == 'partner_irish')
+  }
+
+  next_node_if(:outcome_ss_marriage_malta, -> {ceremony_country == "malta"})
+
+  next_node_if(:outcome_os_affirmation, uk_resident_irish_partner_finland_ss_ceremony)
+
+  next_node_if(:outcome_ss_marriage_not_possible, ss_marriage_not_possible?)
+
+  next_node_if(:outcome_cp_cp_or_equivalent, ss_marriage_germany_partner_local?)
+
+  next_node_if(:outcome_ss_marriage,
+    ss_marriage_countries? | ss_marriage_countries_when_couple_british? | ss_marriage_and_partnership?
+  )
+
+  next_node_if(:outcome_os_consular_cni, variable_matches(:ceremony_country, "spain"))
+
+  next_node_if(:outcome_cp_cp_or_equivalent, -> {
+    data_query.cp_equivalent_countries?(ceremony_country)
+  })
+  next_node_if(:outcome_cp_no_cni, -> {
+    data_query.cp_cni_not_required_countries?(ceremony_country)
+  })
+  next_node_if(:outcome_cp_commonwealth_countries, -> {
+    %w(canada new-zealand south-africa).include?(ceremony_country)
+  })
+  next_node_if(:outcome_cp_consular, -> {
+    data_query.cp_consular_countries?(ceremony_country)
+  })
+  next_node(:outcome_cp_all_other_countries)
+end
+
+outcome :outcome_os_iom_ci do
+  precalculate :iom_ci_os_outcome do
+    phrases = PhraseList.new
+    phrases << :iom_ci_os_all
+    phrases << :iom_ci_os_spain if ceremony_country == 'spain'
+    if residency_uk_region == 'uk_iom'
+      phrases << :iom_ci_os_resident_of_iom
+    else
+      phrases << :iom_ci_os_resident_of_ci
+    end
+    if ceremony_country == 'italy'
+      phrases << :iom_ci_os_ceremony_italy
+    else
+      phrases << :embassies_data
+    end
+    phrases
+  end
+end
+
+outcome :outcome_ireland do
+  precalculate :ireland_partner_sex_variant do
+    if sex_of_your_partner == 'opposite_sex'
+      PhraseList.new(:outcome_ireland_opposite_sex)
+    else
+      PhraseList.new(:outcome_ireland_same_sex)
+    end
+  end
+end
+
+outcome :outcome_switzerland do
+  precalculate :switzerland_marriage_outcome do
+    phrases = PhraseList.new
+    if sex_of_your_partner == 'opposite_sex'
+      phrases << :switzerland_os_variant
+    else
+      phrases << :switzerland_ss_variant
+    end
+
+    unless residency_country == 'switzerland'
+      if resident_of == 'uk'
+        phrases << :what_you_need_to_do_switzerland_resident_uk
+      end
+      phrases << :switzerland_not_resident
+      if sex_of_your_partner == 'opposite_sex'
+        phrases << :switzerland_os_not_resident
+      else
+        phrases << :switzerland_ss_not_resident
+      end
+      phrases << :switzerland_not_resident_two
+    end
+    phrases
+  end
+end
+
+outcome :outcome_netherlands do
+  precalculate :netherlands_phraselist do
+    PhraseList.new(
+      :contact_local_authorities,
+      :get_legal_advice,
+      :partner_naturalisation_in_uk
+    )
+  end
+end
+
+outcome :outcome_portugal do
+  precalculate :portugal_phraselist do
+    PhraseList.new(:contact_civil_register_office_portugal)
+  end
+  precalculate :portugal_title do
+    phrases = PhraseList.new
+    if sex_of_your_partner == 'opposite_sex'
+      phrases << :marriage_title
+    else
+      phrases << :same_sex_marriage_title
+    end
+  end
+end
+
+outcome :outcome_os_indonesia do
+  precalculate :indonesia_os_phraselist do
+    PhraseList.new(
+      :appointment_for_affidavit,
+      :complete_affidavit_with_download_link,
+      :embassies_data,
+      :documents_for_divorced_or_widowed,
+      :partner_affidavit_needed,
+      :fee_table_45_70_55
+    )
+  end
+end
+
+outcome :outcome_os_kosovo do
+  precalculate :kosovo_os_phraselist do
+    phrases = PhraseList.new
+    if resident_of == 'uk'
+      phrases << :kosovo_uk_resident
+    else
+      phrases << :kosovo_not_uk_resident
+    end
+  end
+end
+
+outcome :outcome_brazil_not_living_in_the_uk do
+  precalculate :brazil_phraselist_not_in_the_uk do
+    phrases = PhraseList.new
+    if ceremony_country == residency_country
+      phrases << :local_resident_os_ceremony_not_zimbabwe << :consular_cni_os_download_affidavit_notary_public << :notary_public_will_charge_a_fee << :consular_cni_os_all_names_but_germany << :consular_cni_os_naturalisation
+    else
+      phrases << :local_resident_os_consular_cni << :check_travel_advice << :get_legal_advice << :what_you_need_to_do << :make_an_appointment_bring_passport_and_pay_55_brazil << :list_of_consular_fees << :pay_by_cash_or_credit_card_no_cheque << :embassies_data << :download_affidavit_forms_but_do_not_sign << :download_affidavit << :documents_for_divorced_or_widowed << :affirmation_os_partner_not_british_turkey
+    end
+    phrases
+  end
+
+end
+
+outcome :outcome_os_colombia do
+  precalculate :colombia_os_phraselist do
+    PhraseList.new(
+      :uk_resident_os_consular_cni,
+      :affirmation_os_all_what_you_need_to_do,
+      :what_you_need_to_do_affirmation,
+      :make_an_appointment_bring_passport_and_pay_55_colombia,
+      :list_of_consular_fees,
+      :pay_by_cash_or_credit_card_no_cheque,
+      :embassies_data,
+      :legalisation_and_translation,
+      :affirmation_os_translation_in_local_language_text,
+      :documents_for_divorced_or_widowed_china_colombia,
+      :change_of_name_evidence,
+      :consular_cni_os_all_names_but_germany,
+      :consular_cni_os_naturalisation
+    )
+  end
+end
+
+outcome :outcome_monaco do
+
+  precalculate :monaco_title do
+    phrases = PhraseList.new
+    if marriage_or_pacs == 'marriage'
+      phrases << "Marriage in Monaco"
+    else
+      phrases << "PACS in Monaco"
+    end
+    phrases
+  end
+  precalculate :monaco_phraselist do
+    PhraseList.new(:"monaco_#{marriage_or_pacs}")
+  end
+end
+
+outcome :outcome_os_commonwealth do
+  precalculate :commonwealth_os_outcome do
+    phrases = PhraseList.new
+
+    if ceremony_country == 'zimbabwe'
+      if resident_of == 'uk'
+        phrases << :uk_resident_os_ceremony_zimbabwe
+      elsif residency_country == ceremony_country
+        phrases << :local_resident_os_ceremony_zimbabwe
+      else
+        phrases << :other_resident_os_ceremony_zimbabwe
+      end
+      phrases << :commonwealth_os_all_cni_zimbabwe
+    else
+      if resident_of == 'uk'
+        phrases << :uk_resident_os_ceremony_not_zimbabwe
+      elsif residency_country == ceremony_country
+        phrases << :local_resident_os_ceremony_not_zimbabwe
+      else
+        phrases << :other_resident_os_ceremony_not_zimbabwe
+      end
+      phrases << :commonwealth_os_all_cni
+    end
+
+    case ceremony_country
+    when 'south-africa'
+      phrases << :commonwealth_os_other_countries_south_africa  if  partner_nationality == 'partner_local'
+    when 'india'
+      phrases << :commonwealth_os_other_countries_india
+    when 'malaysia'
+      phrases << :commonwealth_os_other_countries_malaysia
+    when 'singapore'
+      phrases << :commonwealth_os_other_countries_singapore
+    when 'brunei'
+      phrases << :commonwealth_os_other_countries_brunei
+    when 'cyprus'
+      phrases << :commonwealth_os_other_countries_cyprus if residency_country == 'cyprus'
+    end
+    phrases << :commonwealth_os_naturalisation unless partner_nationality == 'partner_british'
+    if data_query.requires_7_day_notice?(ceremony_country,residency_country)
+      phrases << :display_notice_of_marriage_7_days
+    end
+    phrases
+  end
+end
+
+outcome :outcome_os_bot do
+  precalculate :bot_outcome do
+    phrases = PhraseList.new
+    if ceremony_country == 'british-indian-ocean-territory'
+      phrases << :bot_os_ceremony_biot
+    elsif ceremony_country == 'british-virgin-islands'
+      phrases << :bot_os_ceremony_bvi
+    else
+      phrases << :bot_os_ceremony_non_biot
+      phrases << :bot_os_not_local_resident if residency_country != ceremony_country
+      phrases << :bot_os_naturalisation unless partner_nationality == 'partner_british'
+    end
+    phrases
+  end
+end
+
+outcome :outcome_os_consular_cni do
+  precalculate :consular_cni_os_start do
+    phrases = PhraseList.new
+
+    cni_posted_after_7_days_countries = %w(albania algeria angola armenia austria azerbaijan bahrain bolivia bosnia-and-herzegovina bulgaria cambodia chile croatia cuba ecuador estonia georgia greece hong-kong iceland iran italy japan kazakhstan kuwait kyrgyzstan libya lithuania luxembourg macedonia mexico montenegro nicaragua norway poland russia spain sweden tajikistan tunisia turkmenistan ukraine uzbekistan venezuela)
+
+    cni_notary_public_countries = %w(albania algeria angola armenia austria azerbaijan bahrain bolivia bosnia-and-herzegovina bulgaria croatia cuba estonia georgia greece iceland kazakhstan kuwait kyrgyzstan libya lithuania luxembourg mexico moldova montenegro norway poland russia serbia sweden tajikistan tunisia turkmenistan ukraine uzbekistan venezuela)
+
+    cni_posted_after_14_days_countries = %w(oman jordan qatar saudi-arabia united-arab-emirates yemen)
+    not_italy_or_spain = %w(italy spain).exclude?(ceremony_country)
+    ceremony_not_germany_or_not_resident_other = (ceremony_country != 'germany' or resident_of != 'other')
+    ceremony_and_residency_in_croatia = (ceremony_country == 'croatia' and residency_country == 'croatia')
+
+    if (resident_of == 'uk') and (ceremony_country != 'italy') and not data_query.dutch_caribbean_islands?(ceremony_country)
+      phrases << :uk_resident_os_consular_cni
+    elsif residency_country == ceremony_country and ceremony_country != 'italy'
+      phrases << :local_resident_os_consular_cni
+    elsif resident_of == 'uk' and data_query.dutch_caribbean_islands?(ceremony_country)
+      phrases << :uk_resident_os_consular_cni_dutch_caribbean_islands
+    else
+      unless resident_of == 'uk' or ceremony_country == residency_country or ceremony_country == 'italy'
+        phrases << :other_resident_os_consular_cni
+      end
+    end
+    if %w(jordan oman qatar).include?(ceremony_country)
+      phrases << :gulf_states_os_consular_cni
+      if residency_country == ceremony_country and partner_nationality != 'partner_irish'
+        phrases << :gulf_states_os_consular_cni_local_resident_partner_not_irish
+      end
+    end
+    if ceremony_country == 'spain'
+      if sex_of_your_partner == 'opposite_sex'
+        phrases << :spain_os_consular_cni_opposite_sex
+      else
+        phrases << :spain_os_consular_cni_same_sex
+      end
+      phrases << :spain_os_consular_civil_registry
+      phrases << :spain_os_consular_cni_not_local_resident unless residency_country == 'spain'
+    elsif ceremony_country == 'italy'
+      phrases << :italy_os_consular_cni_ceremony_italy
+    else
+      phrases << :italy_os_consular_cni_ceremony_not_italy_or_spain
+    end
+    phrases << :consular_cni_all_what_you_need_to_do
+
+    if ceremony_and_residency_in_croatia
+      phrases << :what_to_do_croatia
+    elsif not_italy_or_spain && ceremony_not_germany_or_not_resident_other
+      phrases << :consular_cni_os_ceremony_not_spain_or_italy
+      if ceremony_country == 'macedonia' && !data_query.non_commonwealth_country?(residency_country)
+        phrases << :consular_cni_os_foreign_resident_ceremony_not_germany_italy
+      end
+    end
+
+    if ceremony_country == 'spain'
+      phrases << :spain_os_consular_cni_two
+    elsif ceremony_country == 'italy'
+      if resident_of == 'uk'
+        if (partner_nationality != partner_irish) or (%w(uk_scotland uk_ni).include?(residency_uk_region) and partner_nationality == 'partner_irish')
+          phrases << :italy_os_consular_cni_uk_resident
+        end
+      end
+      if resident_of == 'uk' and partner_nationality == 'partner_british'
+        phrases << :italy_os_consular_cni_uk_resident_two
+      end
+      if resident_of != 'uk' or (resident_of == 'uk' and partner_nationality == 'partner_irish' and %w(uk_scotland uk_ni).exclude?(residency_uk_region))
+        phrases << :italy_os_consular_cni_uk_resident_three
+      end
+    end
+
+    if ceremony_country == 'denmark'
+      phrases << :consular_cni_os_denmark
+    elsif ceremony_country == 'germany'
+      if residency_country == 'germany'
+        phrases << :consular_cni_os_german_resident
+      else
+        phrases << :consular_cni_os_not_germany_or_uk_resident if resident_of == 'other'
+      end
+      phrases << :consular_cni_os_ceremony_germany_not_uk_resident if resident_of == 'other'
+    end
+    if resident_of =='uk'
+      if cni_posted_after_14_days_countries.include?(ceremony_country)
+        if cni_notary_public_countries.include?(ceremony_country) or ceremony_country == 'italy'
+          phrases << :cni_posted_if_no_objection_14_days_notary_public
+        else
+          phrases << :cni_posted_if_no_objection_14_days
+        end
+      elsif cni_posted_after_7_days_countries.include?(ceremony_country) or partner_nationality != 'partner_irish'
+        if cni_notary_public_countries.include?(ceremony_country) or %w(italy japan macedonia spain).include?(ceremony_country)
+          phrases << :cni_at_local_register_office_notary_public
+        else
+          phrases << :cni_at_local_register_office
+        end
+      elsif partner_nationality == 'partner_irish'and %w(uk_scotland uk_ni).include?(residency_uk_region)
+        phrases << :scotland_ni_resident_partner_irish_os_consular_cni_three
+      end
+      if ceremony_country == 'italy'
+        if %w(uk_england uk_wales).include?(residency_uk_region)
+          if partner_nationality == 'partner_irish'
+            phrases << :consular_cni_os_england_or_wales_partner_irish_three
+          else
+            phrases << :consular_cni_os_scotland_or_ni_partner_irish_or_partner_not_irish_three
+          end
+        else
+          phrases << :consular_cni_os_scotland_or_ni_partner_irish_or_partner_not_irish_three
+        end
+      end
+    end
+    if ceremony_country != 'italy' and partner_nationality == 'partner_irish'
+      if %w(uk_england uk_wales).include?(residency_uk_region)
+        phrases << :consular_cni_os_england_or_wales_resident_not_italy
+      end
+    end
+
+    if resident_of == 'uk'
+      if ceremony_country == 'tunisia'
+        phrases << :tunisia_legalisation_and_translation
+      elsif ceremony_country == 'germany'
+        phrases << :germany_legalisation_and_translation
+      elsif %w(italy finland kazakhstan kyrgyzstan montenegro poland portugal).exclude?(ceremony_country)
+        phrases << :consular_cni_os_uk_resident_legalisation
+      elsif ceremony_country == 'montenegro'
+        phrases << :consular_cni_os_uk_resident_montenegro
+      elsif %w(finland kazakhstan kyrgyzstan poland).include?(ceremony_country)
+        phrases << :consular_cni_os_uk_legalisation_check_with_authorities
+      end
+      phrases << :consular_cni_os_uk_resident_not_italy_or_portugal if %w(germany italy portugal tunisia).exclude?(ceremony_country)
+    end
+
+    if ceremony_country == residency_country
+      unless ceremony_country == 'macedonia'
+        if ceremony_country == 'croatia'
+          phrases << :consular_cni_os_local_resident_table
+        elsif %w(germany italy kazakhstan russia).exclude?(ceremony_country)
+          phrases << :consular_cni_os_foreign_resident_ceremony_not_germany_italy
+          if cni_notary_public_countries.include?(ceremony_country) or %w(italy japan spain).include?(ceremony_country)
+            phrases << :check_with_embassy_consulate_or_notary_public
+          else
+            phrases  << :check_with_embassy_or_consulate
+          end
+        end
+      end
+      phrases << :"#{ceremony_country}_os_local_resident" if %w(kazakhstan russia).include?(ceremony_country)
+      unless %w(germany italy japan russia spain).include?(ceremony_country)
+        if ceremony_country == 'macedonia'
+          phrases << :consular_cni_os_foreign_resident_3_days_macedonia
+        else
+          phrases << :embassies_data
+        end
+      end
+      phrases << :consular_cni_os_local_resident_italy if ceremony_country == 'italy'
+    end
+
+    if data_query.non_commonwealth_country?(residency_country) and residency_country != 'ireland' and ceremony_country != residency_country
+      if %w(germany italy).exclude?(ceremony_country)
+        phrases << :consular_cni_os_foreign_resident_ceremony_not_germany_italy
+      elsif ceremony_country == 'italy'
+        phrases << :consular_cni_os_foreign_resident_ceremony_country_italy
+      end
+      if ceremony_country != 'germany'
+        if cni_posted_after_7_days_countries.include?(ceremony_country)
+          if ceremony_country == 'macedonia'
+            phrases << :consular_cni_os_foreign_resident_3_days_macedonia
+            phrases << :consular_cni_os_foreign_resident_3_days_macedonia_giving_notice
+          elsif cni_notary_public_countries.include?(ceremony_country) or %w(italy japan spain).include?(ceremony_country)
+            phrases << :consular_cni_os_foreign_resident_3_days_notary_public
+          else
+            phrases << :consular_cni_os_foreign_resident_3_days
+          end
+        elsif cni_notary_public_countries.include?(ceremony_country) or %w(italy japan spain).include?(ceremony_country)
+          phrases << :consular_cni_os_foreign_resident_ceremony_notary_public
+        else
+          phrases << :consular_cni_os_foreign_resident_ceremony_country_not_germany
+        end
+      end
+    end
+
+    if data_query.commonwealth_country?(residency_country) and residency_country != 'ireland' and ceremony_country != 'germany' and ceremony_country != residency_country
+      if ceremony_country == 'macedonia'
+        phrases << :consular_cni_os_foreign_resident_3_days_macedonia
+      else
+        phrases << :consular_cni_os_commonwealth_resident
+      end
+      phrases << :os_notice_of_marriage
+      if data_query.os_notice_of_marriage_7_day_wait_ceremony_country?(ceremony_country)
+        phrases << :os_notice_of_marriage_7_day_wait
+      else
+        phrases << :os_notice_of_marriage_21_day_wait
+      end
+    end
+
+    if data_query.commonwealth_country?(residency_country) and partner_nationality == 'partner_british' and ceremony_country != residency_country and ceremony_country != 'germany'
+      phrases << :consular_cni_os_commonwealth_resident_british_partner
+    end
+    if data_query.commonwealth_country?(residency_country) and ceremony_country != residency_country and ceremony_country != 'germany'
+      phrases << :consular_cni_os_commonwealth_resident_two
+    elsif residency_country == 'ireland' and ceremony_country != 'germany'
+      phrases << :consular_cni_os_ireland_resident
+    end
+    if residency_country == 'ireland' and partner_nationality == 'partner_british' and ceremony_country != 'germany'
+      phrases << :consular_cni_os_ireland_resident_british_partner
+    end
+    if residency_country == 'ireland' and ceremony_country != 'germany'
+      phrases << :consular_cni_os_ireland_resident_two
+    end
+    if data_query.commonwealth_country?(residency_country) or residency_country == 'ireland' and ceremony_country != residency_country and ceremony_country != 'germany'
+      if partner_nationality == 'partner_british'
+        if ceremony_country == 'italy'
+          phrases << :italy_consular_cni_os_commonwealth_or_ireland_resident_british_partner
+        else
+          phrases << :consular_cni_os_commonwealth_or_ireland_resident_british_partner
+        end
+      else
+        if ceremony_country == 'italy'
+          phrases << :italy_consular_cni_os_commonwealth_or_ireland_resident_non_british_partner
+        else
+          phrases << :consular_cni_os_commonwealth_or_ireland_resident_non_british_partner
+        end
+      end
+    end
+    if ceremony_country == residency_country and %w(croatia germany italy japan spain russia).exclude?(ceremony_country) and cni_posted_after_7_days_countries.include?(ceremony_country)
+      phrases << :living_in_residence_country_3_days
+    end
+
+    if ceremony_country == 'italy' and resident_of == 'other' and data_query.non_commonwealth_country?(residency_country)
+      phrases << :consular_cni_variant_local_resident_italy
+    elsif ceremony_country == residency_country and %w(germany japan spain).exclude?(ceremony_country) or (data_query.non_commonwealth_country?(residency_country) and residency_country != 'ireland' and ceremony_country != residency_country and ceremony_country != 'germany')
+      if cni_notary_public_countries.include?(ceremony_country) or %w(japan macedonia spain).include?(ceremony_country)
+        phrases << :consular_cni_variant_local_resident_or_foreign_resident_notary_public
+      else
+        phrases << :consular_cni_variant_local_resident_not_germany_or_spain_or_foreign_resident
+      end
+    end
+
+    if ceremony_country == residency_country
+      if ceremony_country == 'japan'
+        phrases << :japan_consular_cni_os_local_resident
+        phrases << :japan_consular_cni_os_local_resident_partner_local if partner_nationality == 'partner_local'
+      end
+      if ceremony_country == 'italy'
+        if partner_nationality == 'partner_local'
+          phrases << :italy_consular_cni_os_partner_local
+        elsif %w(partner_irish partner_other).include?(partner_nationality)
+          phrases << :italy_consular_cni_os_partner_other_or_irish
+        elsif partner_nationality == 'partner_british'
+          phrases << :italy_consular_cni_os_partner_british
+        end
+      elsif ceremony_country == 'spain'
+        phrases << :consular_cni_variant_local_resident_spain
+      end
+    end
+
+    if ceremony_country != 'germany' and resident_of == 'other'
+      phrases << :consular_cni_os_not_uk_resident_ceremony_not_germany
+    end
+    if resident_of == 'other'
+      if ceremony_country == 'italy' and resident_of == 'other'
+        phrases << :consular_cni_os_other_resident_ceremony_italy
+      elsif %(germany spain).exclude?(ceremony_country)
+        phrases << :consular_cni_os_other_resident_ceremony_not_germany_or_spain
+      end
+    end
+    if ceremony_country == residency_country and ceremony_country == 'spain'
+      phrases << :spain_os_consular_cni_three
+    end
+    if ceremony_country == 'italy' and resident_of == 'other'
+      phrases << :wait_300_days_before_remarrying
+    end
+    if ceremony_country == residency_country
+      if ceremony_country == 'japan'
+        phrases << :consular_cni_os_download_documents_notary_public
+      elsif %w(spain germany).exclude?(ceremony_country)
+        if cni_notary_public_countries.include?(ceremony_country)
+          phrases << :consular_cni_os_download_documents_notary_public
+        else
+          phrases << :consular_cni_os_local_resident_not_germany_or_spain_or_foreign_resident_not_germany
+        end
+      end
+    else
+      if cni_notary_public_countries.include?(ceremony_country) or %w(italy japan macedonia spain).include?(ceremony_country) and ceremony_country != 'tunisia'
+        phrases << :consular_cni_os_download_documents_notary_public
+      elsif data_query.non_commonwealth_country?(residency_country) and residency_country != 'ireland' and ceremony_country != 'germany'
+        phrases << :consular_cni_os_local_resident_not_germany_or_spain_or_foreign_resident_not_germany
+      end
+    end
+
+    if ceremony_country == residency_country
+      if ceremony_country == 'kazakhstan'
+        phrases << :display_notice_of_marriage_7_days
+      elsif cni_notary_public_countries.include?(ceremony_country) or ceremony_country == 'italy' or ceremony_country == 'japan'
+        phrases << :consular_cni_os_foreign_resident_ceremony_notary_public
+      elsif %w(germany spain).exclude?(residency_country)
+        phrases << :display_notice_of_marriage_7_days
+      end
+    elsif data_query.requires_7_day_notice?(ceremony_country, residency_country)
+      phrases << :display_notice_of_marriage_7_days
+    end
+    if data_query.non_commonwealth_country?(residency_country) and residency_country != 'ireland' and ceremony_country != residency_country
+      if cni_notary_public_countries.include?(ceremony_country) or %w(italy japan macedonia spain).include?(ceremony_country)
+        phrases << :consular_cni_os_foreign_resident_ceremony_notary_public
+      elsif cni_posted_after_7_days_countries.include?(ceremony_country)
+        phrases << :consular_cni_os_foreign_resident_ceremony_7_days
+      elsif %w(germany).exclude?(ceremony_country)
+        phrases << :consular_cni_os_foreign_resident_ceremony_not_italy
+      end
+    end
+    if %w(italy germany).exclude?(ceremony_country)
+      if data_query.commonwealth_country?(residency_country) and ceremony_country != residency_country
+        phrases << :consular_cni_os_commonwealth_resident_ceremony_not_italy
+      elsif residency_country == 'ireland'
+        phrases << :consular_cni_os_ireland_resident_ceremony_not_italy
+      end
+    end
+    phrases
+  end
+
+  precalculate :consular_cni_os_remainder do
+    phrases = PhraseList.new
+    if data_query.commonwealth_country?(residency_country) and ceremony_country == 'italy'
+      phrases << :consular_cni_os_commonwealth_resident_ceremony_italy
+    end
+    if residency_country == 'ireland' and ceremony_country == 'italy'
+      phrases << :consular_cni_os_ireland_resident_ceremony_italy
+    end
+    if data_query.commonwealth_country?(residency_country) or residency_country == 'ireland' and ceremony_country == 'italy'
+      phrases << :italy_os_consular_cni_four
+    end
+    if ceremony_country != 'italy' and resident_of == 'uk' and "partner_other" == partner_nationality and "finland" == ceremony_country
+        phrases << :callout_partner_equivalent_document
+    end
+    if partner_nationality == 'partner_british' and %w(italy germany finland).exclude?(ceremony_country)
+      phrases << :consular_cni_os_local_resident_ceremony_not_italy_not_germany_partner_british
+    end
+    if ceremony_country != residency_country and resident_of == 'other' and partner_nationality == 'partner_british' and ceremony_country == 'italy'
+      phrases << :consular_cni_os_other_resident_partner_british_ceremony_italy
+    end
+    if ceremony_country != 'germany'  or (ceremony_country == 'germany' and resident_of == 'uk')
+      phrases << :consular_cni_os_all_names_but_germany
+    end
+
+    if resident_of == 'other' and %w(italy spain germany).exclude?(ceremony_country)
+      phrases << :consular_cni_os_other_resident_ceremony_not_italy
+    end
+    if ceremony_country == 'belgium'
+      phrases << :consular_cni_os_ceremony_belgium
+      if ceremony_country != residency_country
+        phrases << :embassies_data
+      end
+    end
+    if ceremony_country == 'spain'
+      phrases << :consular_cni_os_ceremony_spain
+      if partner_nationality == 'partner_british'
+        phrases << :consular_cni_os_ceremony_spain_partner_british
+      end
+      phrases << :consular_cni_os_ceremony_spain_two
+    end
+    phrases << :consular_cni_os_naturalisation if partner_nationality != 'partner_british'
+    unless (ceremony_country == 'italy' and resident_of == 'uk')
+      if ceremony_country == 'croatia' and residency_country == 'croatia'
+        phrases << :fee_table_croatia
+      else
+        phrases << :consular_cni_os_fees_not_italy_not_uk
+      end
+      unless data_query.countries_without_consular_facilities?(ceremony_country)
+        if ceremony_country == residency_country or resident_of == 'uk'
+          if ceremony_country != 'cote-d-ivoire'
+            if ceremony_country == 'monaco'
+              phrases << :list_of_consular_fees_france
+            elsif ceremony_country == 'kazakhstan'
+              phrases << :list_of_consular_kazakhstan
+            else
+              phrases << :list_of_consular_fees
+            end
+          end
+        else
+          if ceremony_country == 'kazakhstan'
+            phrases << :consular_cni_os_fees_foreign_commonwealth_roi_resident_kazakhstan
+          else
+            phrases << :consular_cni_os_fees_foreign_commonwealth_roi_resident
+          end
+        end
+      end
+    end
+    unless data_query.countries_without_consular_facilities?(ceremony_country)
+      if %w(armenia bosnia-and-herzegovina cambodia iceland kazakhstan latvia slovenia tunisia tajikistan).include?(ceremony_country)
+        phrases << :pay_in_local_currency_ceremony_country_name
+      elsif ceremony_country == 'luxembourg'
+        phrases << :pay_in_cash_visa_or_mastercard
+      elsif ceremony_country == 'russia'
+        phrases << :consular_cni_os_fees_russia
+      elsif ceremony_country == 'finland'
+        phrases << :pay_in_euros_or_visa_electron
+      elsif !%w(cote-d-ivoire burundi).include? ceremony_country
+        phrases << :pay_by_cash_or_credit_card_no_cheque
+      end
+    end
+    phrases
+  end
+end
+
+outcome :outcome_os_france_or_fot do
+  precalculate :france_or_fot_os_outcome do
+    phrases = PhraseList.new
+    if data_query.french_overseas_territories?(ceremony_country)
+      phrases << :fot_os_all
+    end
+    phrases
+  end
+end
+
+outcome :outcome_os_affirmation do
+  precalculate :affirmation_os_outcome do
+    phrases = PhraseList.new
+    if ceremony_country == 'colombia'
+      phrases << :uk_resident_os_consular_cni << :get_legal_advice
+    else
+      if resident_of == 'uk'
+        if ceremony_country == 'morocco'
+          phrases << :affirmation_os_uk_resident_ceremony_in_morocco
+        else
+          phrases << :affirmation_os_uk_resident
+        end
+      elsif (ceremony_country == residency_country) or ceremony_country == 'qatar'
+        phrases << :affirmation_os_local_resident
+        if ceremony_country == 'qatar'
+          phrases << :gulf_states_os_consular_cni << :gulf_states_os_consular_cni_local_resident_partner_not_irish
+        end
+      elsif ceremony_country != residency_country and resident_of != 'uk'
+        if ceremony_country == 'morocco'
+          phrases << :affirmation_os_other_resident_ceremony_in_morocco
+        else
+          phrases << :affirmation_os_other_resident
+        end
+      end
+      phrases << :affirmation_os_all_what_you_need_to_do unless %w(cambodia ecuador morocco ).include? ceremony_country
+      phrases << :affirmation_os_uae if ceremony_country == 'united-arab-emirates'
+    end
+#What you need to do section
+    if %w(turkey egypt china).include?(ceremony_country)
+      phrases << :what_you_need_to_do
+    elsif ceremony_country == 'finland' and partner_nationality == 'partner_irish' and resident_of == 'uk'
+      phrases << :what_you_need_to_do_affidavit
+    else
+      phrases << :what_you_need_to_do_affirmation
+    end
+
+    if ceremony_country == 'turkey' and resident_of == 'uk'
+      phrases << :appointment_for_affidavit_notary
+    elsif ceremony_country == 'philippines'
+      phrases << :contact_for_affidavit << :make_appointment_online_philippines
+    elsif ceremony_country == 'egypt'
+      phrases << :make_an_appointment
+    elsif ceremony_country == 'china'
+      prelude = "book_online_china_#{partner_nationality != 'partner_local' ? 'non_' : ''}local_prelude".to_sym
+      phrases << prelude << :book_online_china_affirmation_affidavit
+    else
+      phrases << :appointment_for_affidavit
+    end
+
+    unless (ceremony_country == 'turkey' or residency_country == 'portugal')
+      phrases << :embassies_data
+      if ceremony_country == 'finland' and partner_nationality == 'partner_irish' and resident_of == 'uk'
+        phrases << :affidavit_os_translation_in_local_language_text
+      elsif ceremony_country == 'cambodia'
+        phrases << :cambodia_consular_cni_os_partner_local
+        phrases << :affirmation_os_translation_in_local_language_text
+      elsif ceremony_country != 'china' and ceremony_country != 'egypt'
+        phrases << :affirmation_os_translation_in_local_language_text
+      end
+    end
+    phrases << :affirmation_os_download_affidavit_philippines if ceremony_country == 'philippines'
+
+    if ceremony_country == 'turkey' and not resident_of == 'uk'
+      phrases << :embassies_data
+    end
+    if ceremony_country == 'turkey'
+      phrases << :complete_affidavit << :download_affidavit
+      if residency_country == 'turkey'
+        phrases << :affirmation_os_legalised_in_turkey
+      else
+        phrases << :affirmation_os_legalised
+      end
+      phrases << :documents_for_divorced_or_widowed
+    end
+
+    if ceremony_country == 'morocco'
+      phrases << :documents_for_divorced_or_widowed
+    elsif ceremony_country == 'ecuador'
+      phrases << :documents_for_divorced_or_widowed_ecuador
+    elsif ceremony_country == 'cambodia'
+      phrases << :documents_for_divorced_or_widowed_cambodia
+      phrases << :change_of_name_evidence
+    elsif %w(china colombia).include?(ceremony_country)
+      phrases << :documents_for_divorced_or_widowed_china_colombia
+    elsif ceremony_country != 'turkey'
+      phrases << :docs_decree_and_death_certificate
+    end
+
+    if not %w(cambodia china colombia ecuador egypt morocco turkey).include?(ceremony_country)
+      phrases << :divorced_or_widowed_evidences
+    end
+    if not %w(cambodia ecuador morocco turkey).include?(ceremony_country)
+      phrases << :change_of_name_evidence
+    end
+
+    if ceremony_country == 'egypt'
+      if partner_nationality == 'partner_british'
+        phrases << :partner_declaration
+      else
+        phrases << :callout_partner_equivalent_document
+      end
+    end
+    unless ceremony_country == 'egypt'
+      if ceremony_country == 'turkey'
+        if partner_nationality == 'partner_british'
+          phrases << :affirmation_os_partner
+        else
+          phrases << :affirmation_os_partner_not_british_turkey
+        end
+      elsif ceremony_country == 'morocco'
+        phrases << :morocco_affidavit_length
+        phrases << :partner_equivalent_document
+      else
+        if partner_nationality == 'partner_british'
+          phrases << :affirmation_os_partner_british
+        else
+          if ceremony_country == 'china' && partner_nationality != 'partner_local'
+            phrases << :affirmation_affidavit_os_partner
+          else
+            phrases << :partner_equivalent_document_warning
+            phrases << :consular_cni_os_all_names_but_germany if %w(ecuador colombia).include?(ceremony_country)
+            phrases << :affirmation_os_partner_not_british
+          end
+        end
+      end
+    end
+    phrases << :consular_cni_os_all_names_but_germany if ceremony_country == 'cambodia'
+
+#fee tables
+    if %w(south-korea thailand turkey vietnam).include?(ceremony_country)
+      phrases << :fee_table_affidavit_55
+    elsif %w(cambodia ecuador morocco).include? ceremony_country
+      phrases << :fee_table_affirmation_55
+    elsif ceremony_country == 'finland'
+      if partner_nationality == 'partner_irish' and resident_of == 'uk'
+        phrases << :fee_table_affidavit_65
+      else
+        phrases << :fee_table_affirmation_65
+      end
+    elsif ceremony_country == 'philippines'
+      phrases << :fee_table_55_70
+    elsif ceremony_country == 'qatar'
+      phrases << :fee_table_45_70_55
+    elsif ceremony_country == 'egypt'
+      phrases << :fee_table_45_55
+    else
+      phrases << :affirmation_os_all_fees_45_70
+    end
+    unless data_query.countries_without_consular_facilities?(ceremony_country)
+      if ceremony_country == 'monaco'
+        phrases << :list_of_consular_fees_france
+      else
+        phrases << :list_of_consular_fees
+      end
+      if ceremony_country == 'finland'
+        phrases << :pay_in_euros_or_visa_electron
+      elsif ceremony_country == 'philippines'
+        phrases << :pay_in_cash_or_manager_cheque
+      else
+        phrases << :pay_by_cash_or_credit_card_no_cheque
+      end
+    end
+    phrases
+  end
+end
+
+outcome :outcome_os_no_cni do
+  precalculate :no_cni_os_outcome do
+    phrases = PhraseList.new
+    if data_query.dutch_caribbean_islands?(ceremony_country)
+      phrases << :no_cni_os_dutch_caribbean_islands
+      if resident_of == 'uk'
+        phrases << :no_cni_os_dutch_caribbean_islands_uk_resident
+      elsif (ceremony_country == residency_country) or residency_country == 'netherlands'
+        phrases << :no_cni_os_dutch_caribbean_islands_local_resident
+      elsif ceremony_country != residency_country and resident_of != 'uk'
+        phrases << :no_cni_os_dutch_caribbean_other_resident
+      end
+    else
+      if resident_of == 'uk'
+        phrases << :no_cni_os_not_dutch_caribbean_islands_uk_resident
+      elsif ceremony_country == residency_country
+        phrases << :no_cni_os_not_dutch_caribbean_islands_local_resident
+      elsif ceremony_country != residency_country and resident_of != 'uk'
+        phrases << :no_cni_os_not_dutch_caribbean_other_resident
+      end
+    end
+    phrases << :get_legal_advice << :cni_os_consular_facilities_unavailable
+
+    if data_query.os_notice_of_marriage_7_day_wait_ceremony_country?(ceremony_country) && data_query.commonwealth_country?(residency_country)
+      phrases << :os_notice_of_marriage
+      phrases << :os_notice_of_marriage_7_day_wait
+    end
+
+    unless data_query.countries_without_consular_facilities?(ceremony_country)
+      if ceremony_country == 'monaco'
+        phrases << :list_of_consular_fees_france
+      else
+        phrases << :list_of_consular_fees
+      end
+      phrases << :pay_by_cash_or_credit_card_no_cheque
+    end
+    if partner_nationality != 'partner_british'
+      phrases << :no_cni_os_naturalisation
+    end
+    if data_query.requires_7_day_notice?(ceremony_country,residency_country)
+      phrases << :display_notice_of_marriage_7_days
+    end
+
+    phrases
+  end
+end
+
+outcome :outcome_os_other_countries do
+  precalculate :other_countries_os_outcome do
+    phrases = PhraseList.new
+    if ceremony_country == 'burma'
+      phrases << :other_countries_os_burma
+      if partner_nationality == 'partner_local'
+        phrases << :other_countries_os_burma_partner_local
+      end
+    elsif ceremony_country == 'north-korea'
+      phrases << :other_countries_os_north_korea
+      if partner_nationality == 'partner_local'
+        phrases << :other_countries_os_north_korea_partner_local
+      end
+    elsif %w(iran somalia syria).include?(ceremony_country)
+      phrases << :other_countries_os_iran_somalia_syria
+    elsif ceremony_country == 'yemen'
+      phrases << :other_countries_os_yemen
+    end
+    if ceremony_country == 'saudi-arabia'
+      if ceremony_country != residency_country
+        phrases << :other_countries_os_ceremony_saudia_arabia_not_local_resident
+      else
+        if partner_nationality == 'partner_irish'
+          phrases << :other_countries_os_saudi_arabia_local_resident_partner_irish
+        else
+          phrases << :other_countries_os_saudi_arabia_local_resident_partner_not_irish
+        end
+        if %w(partner_irish partner_british).exclude?(partner_nationality)
+          phrases << :other_countries_os_saudi_arabia_local_resident_partner_not_irish_or_british
+        end
+        if partner_nationality != 'partner_irish'
+          phrases << :other_countries_os_saudi_arabia_local_resident_partner_not_irish_two
+        end
+      end
+    end
+    phrases
+  end
+end
+
+#CP outcomes
+outcome :outcome_cp_cp_or_equivalent do
+  precalculate :cp_or_equivalent_cp_outcome do
+    phrases = PhraseList.new
+    if data_query.cp_equivalent_countries?(ceremony_country)
+      phrases << :"cp_or_equivalent_cp_#{ceremony_country}"
+    end
+
+    if ceremony_country == 'brazil' and sex_of_your_partner == 'same_sex' and resident_of == 'uk'
+      phrases << :check_travel_advice
+    elsif ceremony_country == 'czech-republic' and sex_of_your_partner == 'same_sex'
+      phrases << :cp_or_equivalent_cp_uk_resident_czech_republic
+    elsif resident_of == 'uk'
+      phrases << :cp_or_equivalent_cp_uk_resident
+    elsif ceremony_country == residency_country
+      phrases << :cp_or_equivalent_cp_local_resident
+    elsif ceremony_country != residency_country and resident_of == 'other'
+      phrases << :cp_or_equivalent_cp_other_resident
+    end
+    unless ceremony_country == 'czech-republic' and sex_of_your_partner == 'same_sex'
+      if ceremony_country == 'brazil' and sex_of_your_partner == 'same_sex' and resident_of == 'uk'
+        phrases << :what_you_need_to_do_cni << :uk_resident_partner_not_irish_os_consular_cni_three << :consular_cni_os_uk_resident_legalisation << :consular_cni_os_uk_resident_not_italy_or_portugal << :consular_cni_os_all_names_but_germany
+      else
+        phrases << :cp_or_equivalent_cp_all_what_you_need_to_do
+      end
+    end
+    if partner_nationality != 'partner_british'
+      phrases << :cp_or_equivalent_cp_naturalisation
+    end
+    unless ceremony_country == 'czech-republic' and sex_of_your_partner == 'same_sex'
+      phrases << :cp_or_equivalent_cp_all_fees
+    end
+
+    unless (ceremony_country == 'czech-republic' or data_query.countries_without_consular_facilities?(ceremony_country))
+      if ceremony_country == 'monaco'
+        phrases << :list_of_consular_fees_france
+      else
+        phrases << :list_of_consular_fees
+      end
+    end
+    if %w(iceland slovenia).include?(ceremony_country)
+      phrases << :pay_in_local_currency
+    elsif ceremony_country == 'luxembourg'
+      phrases << :pay_in_cash_visa_or_mastercard
+    elsif %w(czech-republic cote-d-ivoire).exclude?(ceremony_country)
+      phrases << :pay_by_cash_or_credit_card_no_cheque
+    end
+    phrases
+  end
+end
+outcome :outcome_cp_france_pacs do
+  precalculate :france_pacs_law_cp_outcome do
+    PhraseList.new(:fot_cp_all) if %w(new-caledonia wallis-and-futuna).include?(ceremony_country)
+  end
+end
+
+outcome :outcome_cp_no_cni do
+  precalculate :no_cni_required_cp_outcome do
+    phrases = PhraseList.new
+    phrases << :"no_cni_required_cp_#{ceremony_country}" if data_query.cp_cni_not_required_countries?(ceremony_country)
+    phrases << :no_cni_required_all_legal_advice
+    phrases << :no_cni_required_cp_ceremony_us if ceremony_country == 'usa'
+    phrases << :no_cni_required_all_what_you_need_to_do
+    if ceremony_country == 'bonaire-st-eustatius-saba'
+      phrases << :no_cni_required_cp_dutch_islands
+      if resident_of == 'uk'
+        phrases << :no_cni_required_cp_dutch_islands_uk_resident
+      elsif ceremony_country == residency_country
+        phrases << :no_cni_required_cp_dutch_islands_local_resident
+      elsif ceremony_country != residency_country and resident_of != 'uk'
+        phrases << :no_cni_required_cp_dutch_islands_other_resident
+      end
+    else
+      if resident_of == 'uk'
+        phrases << :no_cni_required_cp_not_dutch_islands_uk_resident
+      elsif ceremony_country == residency_country
+        phrases << :no_cni_required_cp_not_dutch_islands_local_resident
+      elsif ceremony_country != residency_country and resident_of != 'uk'
+        phrases << :no_cni_required_cp_not_dutch_islands_other_resident
+      end
+    end
+    phrases << :no_cni_required_cp_all_consular_facilities
+    phrases << :no_cni_required_cp_naturalisation if partner_nationality != 'partner_british'
+    phrases
+  end
+end
+
+outcome :outcome_cp_commonwealth_countries do
+
+  precalculate :type_of_ceremony do
+    phrases = PhraseList.new
+    if ceremony_country == 'new-zealand'
+      phrases << :title_ss_marriage_and_partnership
+    else
+      phrases << :title_civil_partnership
+    end
+  end
+
+  precalculate :commonwealth_countries_cp_outcome do
+    phrases = PhraseList.new
+    if ceremony_country == 'australia'
+      phrases << :commonwealth_countries_cp_australia
+    elsif ceremony_country == 'canada'
+      phrases << :commonwealth_countries_cp_canada
+    elsif ceremony_country == 'new-zealand'
+      phrases << :commonwealth_countries_cp_new_zealand
+    elsif ceremony_country == 'south-africa'
+      phrases << :commonwealth_countries_cp_south_africa
+    end
+    phrases << :commonwealth_countries_cp_australia_two if ceremony_country == 'australia'
+
+    if resident_of == 'uk'
+      phrases << :commonwealth_countries_cp_uk_resident_two
+    elsif ceremony_country == residency_country
+      phrases << :commonwealth_countries_cp_local_resident
+    elsif ceremony_country != residency_country and resident_of != 'uk'
+      phrases << :commonwealth_countries_cp_other_resident
+    end
+
+    if ceremony_country == 'australia'
+      phrases << :commonwealth_countries_cp_australia_three
+      phrases << :commonwealth_countries_cp_australia_four
+      if partner_nationality == 'partner_local'
+        phrases << :commonwealth_countries_cp_australia_partner_local
+      elsif partner_nationality == 'partner_other'
+        phrases << :commonwealth_countries_cp_australia_partner_other
+      end
+      phrases << :commonwealth_countries_cp_australia_five
+    end
+    phrases << :embassies_data unless ceremony_country == 'australia'
+
+    if ceremony_country == 'new-zealand'
+      phrases << :commonwealth_os_all_cni
+    end
+    phrases << :commonwealth_countries_cp_naturalisation if partner_nationality != 'partner_british'
+    phrases << :commonwealth_countries_cp_australia_six if ceremony_country == 'australia'
+    phrases
+  end
+end
+
+outcome :outcome_cp_consular do
+  precalculate :consular_cp_outcome do
+    phrases = PhraseList.new
+    # cyprus is a country with a high commission. This is why some of its phraselists end with 'hc', we need to refer to High Commission instead Embassy or Consulate.
+    # The logic behind it could be made prettier by creating a group of High Commission Countries or by querying the API and checking whether the country has a High Commission, a consulate, an embassy or something else.
+    # I am not going to do any of that because Marriage Abroad will (Should) be rebuilt soon, is better to keep the logic as much explicit as possible.
+
+    if ceremony_country == 'cyprus'
+      phrases << :consular_cp_ceremony_hc
+    else
+      phrases << :consular_cp_ceremony
+    end
+    if ceremony_country == 'vietnam'
+      phrases << :consular_cp_ceremony_vietnam_partner_local if partner_nationality == 'partner_local'
+      phrases << :consular_cp_vietnam
+    elsif %w(croatia bulgaria).include?(ceremony_country) and partner_nationality == 'partner_local'
+      phrases << :consular_cp_local_partner_croatia_bulgaria
+    elsif ceremony_country == 'japan'
+      phrases << :consular_cp_all_contact << :embassies_data << :documents_needed_21_days_residency << :documents_needed_ss_british
+    else
+      phrases << :consular_cp_all_contact
+    end
+    phrases << :embassies_data
+    unless ceremony_country == 'japan'
+      if ceremony_country == 'cyprus'
+        phrases << :documents_needed_7_days_residency_hc
+      elsif data_query.ss_21_days_residency_required_countries?(ceremony_country)
+        phrases << :documents_needed_21_days_residency
+      else
+        phrases << :documents_needed_7_days_residency
+      end
+    end
+    phrases << :consular_cp_all_documents
+    phrases << :consular_cp_partner_not_british if partner_nationality != 'partner_british'
+    if ceremony_country == 'cyprus'
+      phrases << :consular_cp_all_what_you_need_to_do_hc
+    else
+      phrases << :consular_cp_all_what_you_need_to_do
+    end
+    phrases << :consular_cp_naturalisation unless partner_nationality == 'partner_british'
+    if %w(vietnam thailand south-korea).include?(ceremony_country)
+      phrases << :fee_table_affidavit_55
+    else
+      phrases << :consular_cp_all_fees
+    end
+    if %w(cambodia latvia).include?(ceremony_country)
+      phrases << :pay_in_local_currency
+    else
+      phrases << :pay_by_cash_or_credit_card_no_cheque
+    end
+    phrases
+  end
+end
+
+outcome :outcome_cp_all_other_countries
+
+outcome :outcome_ss_marriage do
+  precalculate :ss_title do
+    PhraseList.new(:"title_#{marriage_and_partnership_phrases}")
+  end
+
+  precalculate :ss_fees_table do
+    if data_query.ss_alt_fees_table_country?(ceremony_country, partner_nationality)
+      :"#{marriage_and_partnership_phrases}_alt"
+    else
+      :"#{marriage_and_partnership_phrases}"
+    end
+  end
+
+  precalculate :ss_ceremony_body do
+    phrases = PhraseList.new
+    phrases << :"able_to_#{marriage_and_partnership_phrases}"
+
+    if ceremony_country == 'japan'
+      phrases << :consular_cp_all_contact << :embassies_data << :documents_needed_21_days_residency << :documents_needed_ss_british
+    elsif ceremony_country == 'germany'
+      phrases << :contact_british_embassy_or_consulate_berlin << :embassies_data
+    else
+      phrases << :contact_embassy_or_consulate << :embassies_data
+    end
+
+    unless ceremony_country == 'japan'
+      if data_query.ss_21_days_residency_required_countries?(ceremony_country)
+        phrases << :documents_needed_21_days_residency
+      else
+        phrases << :documents_needed_7_days_residency
+      end
+      if partner_nationality == 'partner_british'
+        phrases << :documents_needed_ss_british
+      elsif ceremony_country == 'germany'
+        phrases << :documents_needed_ss_not_british_germany_same_sex
+      else
+        phrases << :documents_needed_ss_not_british
+      end
+    end
+    phrases << :"what_to_do_#{marriage_and_partnership_phrases}" << :will_display_in_14_days << :"no_objection_in_14_days_#{marriage_and_partnership_phrases}" << :"provide_two_witnesses_#{marriage_and_partnership_phrases}"
+    phrases << :australia_ss_relationships if ceremony_country == 'australia'
+    if data_query.ss_21_days_residency_required_countries?(ceremony_country)
+      phrases << :ss_marriage_footnote_21_days_residency
+    else
+      phrases << :ss_marriage_footnote
+    end
+    phrases << :partner_naturalisation_in_uk << :"fees_table_#{ss_fees_table}" << :list_of_consular_fees << :pay_by_cash_or_credit_card_no_cheque
+    phrases << :convert_cc_to_ss_marriage if %w{australia germany japan philippines russia serbia vietnam}.include?(ceremony_country)
+    phrases
+  end
+end
+
+outcome :outcome_ss_marriage_not_possible
+outcome :outcome_ss_marriage_malta do
+  precalculate :ss_body do
+    PhraseList.new(:able_to_ss_marriage_and_partnership_hc, :consular_cp_all_contact, :embassies_data, :documents_needed_21_days_residency, :documents_needed_ss_british, :what_to_do_ss_marriage_and_partnership_hc, :will_display_in_14_days_hc, :no_objection_in_14_days_ss_marriage_and_partnership, :provide_two_witnesses_ss_marriage_and_partnership, :ss_marriage_footnote_hc, :partner_naturalisation_in_uk, :fees_table_ss_marriage_and_partnership, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque, :convert_cc_to_ss_marriage)
+  end
+end

--- a/test/integration/smart_answer_flows/marriage_abroad_v2_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_v2_test.rb
@@ -8,7 +8,7 @@ class MarriageAbroadV2Test < ActiveSupport::TestCase
   include GdsApi::TestHelpers::Worldwide
 
   setup do
-    @location_slugs = %w(albania american-samoa anguilla argentina armenia aruba australia austria azerbaijan bahamas belarus belgium bonaire-st-eustatius-saba british-indian-ocean-territory burma burundi cambodia canada china cote-d-ivoire croatia colombia cyprus czech-republic denmark ecuador egypt estonia finland france germany indonesia iran ireland italy japan jordan kazakhstan latvia lebanon lithuania macedonia malta mayotte mexico monaco morocco netherlands nicaragua north-korea guatemala paraguay peru philippines poland portugal qatar russia rwanda san-marino saudi-arabia serbia slovakia south-africa st-maarten south-korea spain sweden switzerland thailand turkey turkmenistan united-arab-emirates usa vietnam wallis-and-futuna yemen zimbabwe)
+    @location_slugs = %w(albania american-samoa anguilla argentina armenia aruba australia austria azerbaijan bahamas belarus belgium bonaire-st-eustatius-saba brazil british-indian-ocean-territory burma burundi cambodia canada china cote-d-ivoire croatia colombia cyprus czech-republic denmark ecuador egypt estonia finland france germany indonesia iran ireland italy japan jordan kazakhstan latvia lebanon lithuania macedonia malta mayotte mexico monaco morocco netherlands nicaragua north-korea guatemala paraguay peru philippines poland portugal qatar russia rwanda san-marino saudi-arabia serbia slovakia south-africa st-maarten south-korea spain sweden switzerland thailand turkey turkmenistan united-arab-emirates usa vietnam wallis-and-futuna yemen zimbabwe)
     worldwide_api_has_locations(@location_slugs)
     setup_for_testing_flow 'marriage-abroad-v2'
   end
@@ -2426,6 +2426,21 @@ class MarriageAbroadV2Test < ActiveSupport::TestCase
     end
     should "do not allow marriage" do
       assert_current_node :outcome_os_commonwealth
+    end
+  end
+
+  context "opposite sex marriage to local partner in Brazil" do
+    setup do
+      worldwide_api_has_organisations_for_location('brazil', read_fixture_file('worldwide/brazil_organisations.json'))
+      add_response 'brazil'
+      add_response 'other'
+      add_response 'usa'
+      add_response 'partner_local'
+      add_response 'opposite_sex'
+    end
+    should "divert to the correct download link for the Affidavit for Marriage document" do
+      assert_current_node :outcome_brazil_not_living_in_the_uk
+      assert_phrase_list :brazil_phraselist_not_in_the_uk, [:local_resident_os_consular_cni,:check_travel_advice,:get_legal_advice,:what_you_need_to_do,:make_an_appointment_bring_passport_and_pay_55_brazil,:list_of_consular_fees,:pay_by_cash_or_credit_card_no_cheque,:embassies_data,:download_affidavit_forms_but_do_not_sign,:download_affidavit_brazil,:documents_for_divorced_or_widowed,:affirmation_os_partner_not_british_turkey]
     end
   end
 end

--- a/test/integration/smart_answer_flows/marriage_abroad_v2_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_v2_test.rb
@@ -1,0 +1,2431 @@
+# encoding: UTF-8
+require_relative '../../test_helper'
+require_relative 'flow_test_helper'
+require 'gds_api/test_helpers/worldwide'
+
+class MarriageAbroadV2Test < ActiveSupport::TestCase
+  include FlowTestHelper
+  include GdsApi::TestHelpers::Worldwide
+
+  setup do
+    @location_slugs = %w(albania american-samoa anguilla argentina armenia aruba australia austria azerbaijan bahamas belarus belgium bonaire-st-eustatius-saba british-indian-ocean-territory burma burundi cambodia canada china cote-d-ivoire croatia colombia cyprus czech-republic denmark ecuador egypt estonia finland france germany indonesia iran ireland italy japan jordan kazakhstan latvia lebanon lithuania macedonia malta mayotte mexico monaco morocco netherlands nicaragua north-korea guatemala paraguay peru philippines poland portugal qatar russia rwanda san-marino saudi-arabia serbia slovakia south-africa st-maarten south-korea spain sweden switzerland thailand turkey turkmenistan united-arab-emirates usa vietnam wallis-and-futuna yemen zimbabwe)
+    worldwide_api_has_locations(@location_slugs)
+    setup_for_testing_flow 'marriage-abroad-v2'
+  end
+
+  should "which country you want the ceremony to take place in" do
+    assert_current_node :country_of_ceremony?
+  end
+  context "ceremony in ireland" do
+    setup do
+      worldwide_api_has_organisations_for_location('ireland', read_fixture_file('worldwide/ireland_organisations.json'))
+      add_response 'ireland'
+    end
+    should "go to partner's sex question" do
+      assert_current_node :partner_opposite_or_same_sex?
+    end
+    context "partner is opposite sex" do
+      setup do
+        add_response 'opposite_sex'
+      end
+      should "give outcome ireland os" do
+        assert_current_node :outcome_ireland
+        assert_phrase_list :ireland_partner_sex_variant, [:outcome_ireland_opposite_sex]
+      end
+    end
+    context "partner is same sex" do
+      setup do
+        add_response 'same_sex'
+      end
+      should "give outcome ireland ss" do
+        assert_current_node :outcome_ireland
+        assert_phrase_list :ireland_partner_sex_variant, [:outcome_ireland_same_sex]
+        expected_location = WorldLocation.find('ireland')
+        assert_state_variable :location, expected_location
+      end
+    end
+  end
+
+  context "ceremony is outside ireland" do
+    setup do
+      worldwide_api_has_organisations_for_location('bahamas', read_fixture_file('worldwide/bahamas_organisations.json'))
+      add_response 'bahamas'
+    end
+    should "ask your country of residence" do
+      assert_current_node :legal_residency?
+      assert_state_variable :ceremony_country, 'bahamas'
+      assert_state_variable :ceremony_country_name, 'Bahamas'
+      assert_state_variable :country_name_lowercase_prefix, "the Bahamas"
+    end
+
+    context "resident in UK" do
+      setup do
+        add_response 'uk'
+      end
+      should "go to uk residency region question" do
+        assert_current_node :residency_uk?
+        assert_state_variable :ceremony_country, 'bahamas'
+        assert_state_variable :ceremony_country_name, 'Bahamas'
+        assert_state_variable :country_name_lowercase_prefix, "the Bahamas"
+        assert_state_variable :resident_of, 'uk'
+      end
+
+      context "resident in england" do
+        setup do
+          add_response 'uk_england'
+        end
+        should "go to partner nationality question" do
+          assert_current_node :what_is_your_partners_nationality?
+          assert_state_variable :ceremony_country, 'bahamas'
+          assert_state_variable :ceremony_country_name, 'Bahamas'
+          assert_state_variable :country_name_lowercase_prefix, "the Bahamas"
+          assert_state_variable :resident_of, 'uk'
+          assert_state_variable :residency_uk_region, 'uk_england'
+        end
+
+        context "partner is british" do
+          setup do
+            add_response 'partner_british'
+          end
+          should "ask what sex is your partner" do
+            assert_current_node :partner_opposite_or_same_sex?
+            assert_state_variable :partner_nationality, 'partner_british'
+          end
+          context "opposite sex partner" do
+            setup do
+              add_response 'opposite_sex'
+            end
+            should "give outcome opposite sex commonwealth" do
+              assert_current_node :outcome_os_commonwealth
+              assert_phrase_list :commonwealth_os_outcome, [:uk_resident_os_ceremony_not_zimbabwe, :commonwealth_os_all_cni]
+              expected_location = WorldLocation.find('bahamas')
+              assert_state_variable :location, expected_location
+            end
+          end
+          context "same sex partner" do
+            setup do
+              add_response 'same_sex'
+            end
+            should "give outcome same sex all other countries" do
+              assert_current_node :outcome_cp_all_other_countries
+            end
+          end
+        end
+      end
+    end
+    context "resident in non-UK country" do
+      setup do
+        add_response 'other'
+      end
+      should "go to non-uk residency country question" do
+        assert_current_node :residency_nonuk?
+        assert_state_variable :ceremony_country, 'bahamas'
+        assert_state_variable :ceremony_country_name, 'Bahamas'
+        assert_state_variable :resident_of, 'other'
+      end
+
+      context "resident in australia" do
+        setup do
+          worldwide_api_has_organisations_for_location('australia', read_fixture_file('worldwide/australia_organisations.json'))
+          add_response 'australia'
+        end
+        should "go to partner's nationality question" do
+          assert_current_node :what_is_your_partners_nationality?
+          assert_state_variable :ceremony_country, 'bahamas'
+          assert_state_variable :ceremony_country_name, 'Bahamas'
+          assert_state_variable :resident_of, 'other'
+          assert_state_variable :residency_country, 'australia'
+          assert_state_variable :residency_country_name, 'Australia'
+        end
+        context "partner is local" do
+          setup do
+            add_response 'partner_local'
+          end
+          should "ask what sex is your partner" do
+            assert_current_node :partner_opposite_or_same_sex?
+            assert_state_variable :partner_nationality, 'partner_local'
+          end
+          context "opposite sex partner" do
+            setup do
+              add_response 'opposite_sex'
+            end
+            should "give outcome opposite sex commonwealth" do
+              assert_current_node :outcome_os_commonwealth
+              assert_phrase_list :commonwealth_os_outcome, [:other_resident_os_ceremony_not_zimbabwe, :commonwealth_os_all_cni, :commonwealth_os_naturalisation]
+              expected_location = WorldLocation.find('australia')
+              assert_state_variable :location, expected_location
+            end
+          end
+          context "same sex partner" do
+            setup do
+              add_response 'same_sex'
+            end
+            should "give outcome all other countries" do
+              assert_current_node :outcome_cp_all_other_countries
+            end
+          end
+        end
+      end
+    end
+  end
+
+  # tests for specific countries
+  # testing for zimbabwe variants
+  context "local resident but ceremony not in zimbabwe" do
+    setup do
+      worldwide_api_has_organisations_for_location('australia', read_fixture_file('worldwide/australia_organisations.json'))
+      add_response 'australia'
+      add_response 'other'
+      add_response 'australia'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+    end
+    should "go to commonwealth os outcome" do
+      assert_current_node :outcome_os_commonwealth
+      assert_phrase_list :commonwealth_os_outcome, [:local_resident_os_ceremony_not_zimbabwe, :commonwealth_os_all_cni]
+      expected_location = WorldLocation.find('australia')
+      assert_state_variable :location, expected_location
+    end
+  end
+  context "uk resident but ceremony not in zimbabwe" do
+    setup do
+      worldwide_api_has_organisations_for_location('bahamas', read_fixture_file('worldwide/bahamas_organisations.json'))
+      add_response 'bahamas'
+      add_response 'uk'
+      add_response 'uk_england'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+    end
+    should "go to commonwealth os outcome" do
+      assert_current_node :outcome_os_commonwealth
+      assert_phrase_list :commonwealth_os_outcome, [:uk_resident_os_ceremony_not_zimbabwe, :commonwealth_os_all_cni]
+      expected_location = WorldLocation.find('bahamas')
+      assert_state_variable :location, expected_location
+    end
+  end
+  context "other resident but ceremony not in zimbabwe" do
+    setup do
+      worldwide_api_has_organisations_for_location('australia', read_fixture_file('worldwide/australia_organisations.json'))
+      worldwide_api_has_organisations_for_location('canada', read_fixture_file('worldwide/canada_organisations.json'))
+      add_response 'australia'
+      add_response 'other'
+      add_response 'canada'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+    end
+    should "go to commonwealth os outcome" do
+      assert_current_node :outcome_os_commonwealth
+      assert_phrase_list :commonwealth_os_outcome, [:other_resident_os_ceremony_not_zimbabwe, :commonwealth_os_all_cni]
+    end
+  end
+  context "uk resident ceremony in zimbabwe" do
+    setup do
+      worldwide_api_has_organisations_for_location('zimbabwe', read_fixture_file('worldwide/zimbabwe_organisations.json'))
+      add_response 'zimbabwe'
+      add_response 'uk'
+      add_response 'uk_wales'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+    end
+    should "go to commonwealth os outcome" do
+      assert_current_node :outcome_os_commonwealth
+      assert_phrase_list :commonwealth_os_outcome, [:uk_resident_os_ceremony_zimbabwe, :commonwealth_os_all_cni_zimbabwe]
+    end
+  end
+  # testing for other commonwealth countries
+  context "uk resident ceremony in south-africa" do
+    setup do
+      worldwide_api_has_organisations_for_location('south-africa', read_fixture_file('worldwide/south-africa_organisations.json'))
+      add_response 'south-africa'
+      add_response 'uk'
+      add_response 'uk_wales'
+      add_response 'partner_local'
+      add_response 'opposite_sex'
+    end
+    should "go to commonwealth os outcome" do
+      assert_current_node :outcome_os_commonwealth
+      assert_phrase_list :commonwealth_os_outcome, [:uk_resident_os_ceremony_not_zimbabwe, :commonwealth_os_all_cni, :commonwealth_os_other_countries_south_africa, :commonwealth_os_naturalisation]
+    end
+  end
+  context "resident in cyprus, ceremony in cyprus" do
+    setup do
+      worldwide_api_has_organisations_for_location('cyprus', read_fixture_file('worldwide/cyprus_organisations.json'))
+      add_response 'cyprus'
+      add_response 'other'
+      add_response 'cyprus'
+      add_response 'partner_irish'
+      add_response 'opposite_sex'
+    end
+    should "go to commonwealth os outcome" do
+      assert_current_node :outcome_os_commonwealth
+      assert_phrase_list :commonwealth_os_outcome, [:local_resident_os_ceremony_not_zimbabwe, :commonwealth_os_all_cni, :commonwealth_os_other_countries_cyprus, :commonwealth_os_naturalisation]
+    end
+  end
+  context "resident in england, ceremony in cyprus, partner other" do
+    setup do
+      worldwide_api_has_organisations_for_location('cyprus', read_fixture_file('worldwide/cyprus_organisations.json'))
+      add_response 'cyprus'
+      add_response 'uk'
+      add_response 'uk_england'
+      add_response 'partner_other'
+      add_response 'same_sex'
+    end
+    should "go to consular cp outcome" do
+      assert_current_node :outcome_cp_consular
+      assert_phrase_list :consular_cp_outcome, [:consular_cp_ceremony_hc, :consular_cp_all_contact, :embassies_data, :documents_needed_7_days_residency_hc, :consular_cp_all_documents, :consular_cp_partner_not_british, :consular_cp_all_what_you_need_to_do_hc, :consular_cp_naturalisation, :consular_cp_all_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  # testing for british overseas territories
+  context "uk resident ceremony in british indian ocean territory" do
+    setup do
+      worldwide_api_has_organisations_for_location('british-indian-ocean-territory', read_fixture_file('worldwide/british-indian-ocean-territory_organisations.json'))
+      add_response 'british-indian-ocean-territory'
+      add_response 'uk'
+      add_response 'uk_wales'
+      add_response 'partner_local'
+      add_response 'opposite_sex'
+    end
+    should "go to bot os outcome" do
+      assert_current_node :outcome_os_bot
+      assert_phrase_list :bot_outcome, [:bot_os_ceremony_biot]
+    end
+  end
+  context "resident in anguilla, ceremony in anguilla" do
+    setup do
+      worldwide_api_has_organisations_for_location('anguilla', read_fixture_file('worldwide/anguilla_organisations.json'))
+      add_response 'anguilla'
+      add_response 'other'
+      add_response 'anguilla'
+      add_response 'partner_irish'
+      add_response 'opposite_sex'
+    end
+    should "go to bos os outcome" do
+      assert_current_node :outcome_os_bot
+      assert_phrase_list :bot_outcome, [:bot_os_ceremony_non_biot, :bot_os_naturalisation]
+    end
+  end
+  # testing for consular cni countries
+  context "uk resident, ceremony in estonia, partner british" do
+    setup do
+      worldwide_api_has_organisations_for_location('estonia', read_fixture_file('worldwide/estonia_organisations.json'))
+      add_response 'estonia'
+      add_response 'uk'
+      add_response 'uk_wales'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:uk_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :cni_at_local_register_office, :consular_cni_os_uk_resident_legalisation, :consular_cni_os_uk_resident_not_italy_or_portugal]
+      assert_phrase_list :consular_cni_os_remainder, [:partner_will_need_a_cni, :consular_cni_os_local_resident_ceremony_not_italy_not_germany_partner_british, :consular_cni_os_all_names_but_germany, :consular_cni_os_fees_not_italy_not_uk, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  context "resident in estonia, ceremony in estonia" do
+    setup do
+      worldwide_api_has_organisations_for_location('estonia', read_fixture_file('worldwide/estonia_organisations.json'))
+      add_response 'estonia'
+      add_response 'other'
+      add_response 'estonia'
+      add_response 'partner_local'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:local_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :consular_cni_os_foreign_resident_ceremony_not_germany_italy, :check_with_embassy_consulate_or_notary_public, :embassies_data, :living_in_residence_country_3_days, :consular_cni_variant_local_resident_or_foreign_resident_notary_public, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :consular_cni_os_download_documents_notary_public, :consular_cni_os_foreign_resident_ceremony_notary_public]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :consular_cni_os_other_resident_ceremony_not_italy, :consular_cni_os_naturalisation, :consular_cni_os_fees_not_italy_not_uk, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  context "resident in canada, ceremony in estonia" do
+    setup do
+      worldwide_api_has_organisations_for_location('estonia', read_fixture_file('worldwide/estonia_organisations.json'))
+      worldwide_api_has_organisations_for_location('canada', read_fixture_file('worldwide/canada_organisations.json'))
+      add_response 'estonia'
+      add_response 'other'
+      add_response 'canada'
+      add_response 'partner_other'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:other_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :consular_cni_os_commonwealth_resident, :os_notice_of_marriage, :os_notice_of_marriage_7_day_wait, :consular_cni_os_commonwealth_resident_two, :consular_cni_os_commonwealth_or_ireland_resident_non_british_partner, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :consular_cni_os_download_documents_notary_public, :consular_cni_os_commonwealth_resident_ceremony_not_italy]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :consular_cni_os_other_resident_ceremony_not_italy, :consular_cni_os_naturalisation, :consular_cni_os_fees_not_italy_not_uk, :consular_cni_os_fees_foreign_commonwealth_roi_resident, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  context "local resident, ceremony in jordan, partner british" do
+    setup do
+      worldwide_api_has_organisations_for_location('jordan', read_fixture_file('worldwide/jordan_organisations.json'))
+      add_response 'jordan'
+      add_response 'other'
+      add_response 'jordan'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:local_resident_os_consular_cni, :gulf_states_os_consular_cni, :gulf_states_os_consular_cni_local_resident_partner_not_irish, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :consular_cni_os_foreign_resident_ceremony_not_germany_italy, :check_with_embassy_or_consulate, :embassies_data, :consular_cni_variant_local_resident_not_germany_or_spain_or_foreign_resident, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :consular_cni_os_local_resident_not_germany_or_spain_or_foreign_resident_not_germany, :display_notice_of_marriage_7_days]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_local_resident_ceremony_not_italy_not_germany_partner_british, :consular_cni_os_all_names_but_germany, :consular_cni_os_other_resident_ceremony_not_italy, :consular_cni_os_fees_not_italy_not_uk, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  # variants for italy
+  context "ceremony in italy, resident in england, partner british" do
+    setup do
+      worldwide_api_has_organisations_for_location('italy', read_fixture_file('worldwide/italy_organisations.json'))
+      add_response 'italy'
+      add_response 'uk'
+      add_response 'uk_england'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:italy_os_consular_cni_ceremony_italy, :consular_cni_all_what_you_need_to_do, :italy_os_consular_cni_uk_resident, :italy_os_consular_cni_uk_resident_two, :cni_at_local_register_office_notary_public, :consular_cni_os_scotland_or_ni_partner_irish_or_partner_not_irish_three, :consular_cni_os_download_documents_notary_public]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  context "ceremony in italy, resident in italy, partner local" do
+    setup do
+      worldwide_api_has_organisations_for_location('italy', read_fixture_file('worldwide/italy_organisations.json'))
+      add_response 'italy'
+      add_response 'other'
+      add_response 'italy'
+      add_response 'partner_local'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:italy_os_consular_cni_ceremony_italy, :consular_cni_all_what_you_need_to_do, :italy_os_consular_cni_uk_resident_three, :consular_cni_os_local_resident_italy, :consular_cni_variant_local_resident_italy, :italy_consular_cni_os_partner_local, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_italy, :wait_300_days_before_remarrying, :consular_cni_os_local_resident_not_germany_or_spain_or_foreign_resident_not_germany, :consular_cni_os_foreign_resident_ceremony_notary_public]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :consular_cni_os_naturalisation, :consular_cni_os_fees_not_italy_not_uk, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  context "ceremony in italy, resident in austria, partner other" do
+    setup do
+      worldwide_api_has_organisations_for_location('italy', read_fixture_file('worldwide/italy_organisations.json'))
+      worldwide_api_has_organisations_for_location('austria', read_fixture_file('worldwide/austria_organisations.json'))
+      add_response 'italy'
+      add_response 'other'
+      add_response 'austria'
+      add_response 'partner_other'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:italy_os_consular_cni_ceremony_italy, :consular_cni_all_what_you_need_to_do, :italy_os_consular_cni_uk_resident_three, :consular_cni_os_foreign_resident_ceremony_country_italy, :consular_cni_os_foreign_resident_3_days_notary_public, :consular_cni_variant_local_resident_italy, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_italy, :wait_300_days_before_remarrying, :consular_cni_os_download_documents_notary_public, :consular_cni_os_foreign_resident_ceremony_notary_public]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :consular_cni_os_naturalisation, :consular_cni_os_fees_not_italy_not_uk, :consular_cni_os_fees_foreign_commonwealth_roi_resident, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  #variants for denmark
+  context "ceremony in denmark, resident in canada, partner irish" do
+    setup do
+      worldwide_api_has_organisations_for_location('denmark', read_fixture_file('worldwide/denmark_organisations.json'))
+      worldwide_api_has_organisations_for_location('canada', read_fixture_file('worldwide/canada_organisations.json'))
+      add_response 'denmark'
+      add_response 'other'
+      add_response 'canada'
+      add_response 'partner_irish'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:other_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :consular_cni_os_denmark, :consular_cni_os_commonwealth_resident, :os_notice_of_marriage, :os_notice_of_marriage_21_day_wait, :consular_cni_os_commonwealth_resident_two, :consular_cni_os_commonwealth_or_ireland_resident_non_british_partner, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :consular_cni_os_commonwealth_resident_ceremony_not_italy]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :consular_cni_os_other_resident_ceremony_not_italy, :consular_cni_os_naturalisation, :consular_cni_os_fees_not_italy_not_uk, :consular_cni_os_fees_foreign_commonwealth_roi_resident, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  #variants for germany
+  context "ceremony in germany, resident in germany, partner irish" do
+    setup do
+      worldwide_api_has_organisations_for_location('germany', read_fixture_file('worldwide/germany_organisations.json'))
+      add_response 'germany'
+      add_response 'other'
+      add_response 'germany'
+      add_response 'partner_irish'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:local_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_german_resident, :consular_cni_os_ceremony_germany_not_uk_resident]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_naturalisation, :consular_cni_os_fees_not_italy_not_uk, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  context "ceremony in germany, partner german, same sex" do
+    setup do
+      worldwide_api_has_organisations_for_location('germany', read_fixture_file('worldwide/germany_organisations.json'))
+      add_response 'germany'
+      add_response 'other'
+      add_response 'germany'
+      add_response 'partner_local'
+      add_response 'same_sex'
+    end
+    should "go to cp or equivalent outcome" do
+      assert_current_node :outcome_cp_cp_or_equivalent
+      assert_phrase_list :cp_or_equivalent_cp_outcome, [:cp_or_equivalent_cp_germany, :cp_or_equivalent_cp_local_resident, :cp_or_equivalent_cp_all_what_you_need_to_do, :cp_or_equivalent_cp_naturalisation, :cp_or_equivalent_cp_all_fees, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  context "ceremony in germany, partner not german, same sex" do
+    setup do
+      worldwide_api_has_organisations_for_location('germany', read_fixture_file('worldwide/germany_organisations.json'))
+      add_response 'germany'
+      add_response 'other'
+      add_response 'germany'
+      add_response 'partner_other'
+      add_response 'same_sex'
+    end
+    should "go to ss marriage" do
+      assert_current_node :outcome_ss_marriage
+      assert_phrase_list :ss_ceremony_body, [:able_to_ss_marriage, :contact_british_embassy_or_consulate_berlin, :embassies_data, :documents_needed_21_days_residency, :documents_needed_ss_not_british_germany_same_sex, :what_to_do_ss_marriage, :will_display_in_14_days, :no_objection_in_14_days_ss_marriage, :provide_two_witnesses_ss_marriage, :ss_marriage_footnote_21_days_residency, :partner_naturalisation_in_uk, :fees_table_ss_marriage, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque, :convert_cc_to_ss_marriage]
+    end
+  end
+  #variants for uk residency (again)
+  context "ceremony in azerbaijan, resident in scotland, partner non-irish" do
+    setup do
+      worldwide_api_has_organisations_for_location('azerbaijan', read_fixture_file('worldwide/azerbaijan_organisations.json'))
+      add_response 'azerbaijan'
+      add_response 'uk'
+      add_response 'uk_scotland'
+      add_response 'partner_local'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:uk_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :cni_at_local_register_office_notary_public, :consular_cni_os_uk_resident_legalisation, :consular_cni_os_uk_resident_not_italy_or_portugal, :consular_cni_os_download_documents_notary_public]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :consular_cni_os_naturalisation, :consular_cni_os_fees_not_italy_not_uk, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  context "ceremony in azerbaijan, resident in northern ireland, partner irish" do
+    setup do
+      worldwide_api_has_organisations_for_location('azerbaijan', read_fixture_file('worldwide/azerbaijan_organisations.json'))
+      add_response 'azerbaijan'
+      add_response 'uk'
+      add_response 'uk_ni'
+      add_response 'partner_irish'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:uk_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :cni_at_local_register_office_notary_public, :consular_cni_os_uk_resident_legalisation, :consular_cni_os_uk_resident_not_italy_or_portugal, :consular_cni_os_download_documents_notary_public]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :consular_cni_os_naturalisation, :consular_cni_os_fees_not_italy_not_uk, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  #variant for england and wales, irish partner - ceremony not italy
+  context "ceremony in guatemala, resident in wales, partner irish" do
+    setup do
+      worldwide_api_has_organisations_for_location('guatemala', read_fixture_file('worldwide/guatemala_organisations.json'))
+      add_response 'guatemala'
+      add_response 'uk'
+      add_response 'uk_wales'
+      add_response 'partner_irish'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:uk_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :consular_cni_os_england_or_wales_resident_not_italy, :consular_cni_os_uk_resident_legalisation, :consular_cni_os_uk_resident_not_italy_or_portugal]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :consular_cni_os_naturalisation, :consular_cni_os_fees_not_italy_not_uk, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  #variant for uk resident, ceremony not in italy
+  context "ceremony in guatemala, resident in wales, partner other" do
+    setup do
+      worldwide_api_has_organisations_for_location('guatemala', read_fixture_file('worldwide/guatemala_organisations.json'))
+      add_response 'guatemala'
+      add_response 'uk'
+      add_response 'uk_wales'
+      add_response 'partner_other'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:uk_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :cni_at_local_register_office, :consular_cni_os_uk_resident_legalisation, :consular_cni_os_uk_resident_not_italy_or_portugal]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :consular_cni_os_naturalisation, :consular_cni_os_fees_not_italy_not_uk, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  #variant for local resident, ceremony not in italy or germany
+  context "ceremony in azerbaijan, resident in azerbaijan, partner other" do
+    setup do
+      worldwide_api_has_organisations_for_location('azerbaijan', read_fixture_file('worldwide/azerbaijan_organisations.json'))
+      add_response 'azerbaijan'
+      add_response 'other'
+      add_response 'azerbaijan'
+      add_response 'partner_other'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:local_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :consular_cni_os_foreign_resident_ceremony_not_germany_italy, :check_with_embassy_consulate_or_notary_public, :embassies_data, :living_in_residence_country_3_days, :consular_cni_variant_local_resident_or_foreign_resident_notary_public, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :consular_cni_os_download_documents_notary_public, :consular_cni_os_foreign_resident_ceremony_notary_public]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :consular_cni_os_other_resident_ceremony_not_italy, :consular_cni_os_naturalisation, :consular_cni_os_fees_not_italy_not_uk, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+
+  #variants for commonwealth or ireland resident
+  context "ceremony in denmark, resident in canada, partner british" do
+    setup do
+      worldwide_api_has_organisations_for_location('denmark', read_fixture_file('worldwide/denmark_organisations.json'))
+      worldwide_api_has_organisations_for_location('canada', read_fixture_file('worldwide/canada_organisations.json'))
+      add_response 'denmark'
+      add_response 'other'
+      add_response 'canada'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:other_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :consular_cni_os_denmark, :consular_cni_os_commonwealth_resident, :os_notice_of_marriage, :os_notice_of_marriage_21_day_wait, :consular_cni_os_commonwealth_resident_british_partner, :consular_cni_os_commonwealth_resident_two, :consular_cni_os_commonwealth_or_ireland_resident_british_partner, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :consular_cni_os_commonwealth_resident_ceremony_not_italy]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_local_resident_ceremony_not_italy_not_germany_partner_british, :consular_cni_os_all_names_but_germany, :consular_cni_os_other_resident_ceremony_not_italy, :consular_cni_os_fees_not_italy_not_uk, :consular_cni_os_fees_foreign_commonwealth_roi_resident, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  context "ceremony in denmark, resident in ireland, partner british" do
+    setup do
+      worldwide_api_has_organisations_for_location('denmark', read_fixture_file('worldwide/denmark_organisations.json'))
+      worldwide_api_has_organisations_for_location('ireland', read_fixture_file('worldwide/ireland_organisations.json'))
+      add_response 'denmark'
+      add_response 'other'
+      add_response 'ireland'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:other_resident_os_consular_cni, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ireland_resident]
+      assert_phrase_list :consular_cni_os_remainder, []
+    end
+  end
+  #variants for ireland residents
+  context "ceremony in denmark, resident in ireland, partner british" do
+    setup do
+      worldwide_api_has_organisations_for_location('denmark', read_fixture_file('worldwide/denmark_organisations.json'))
+      worldwide_api_has_organisations_for_location('ireland', read_fixture_file('worldwide/ireland_organisations.json'))
+      add_response 'denmark'
+      add_response 'other'
+      add_response 'ireland'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:other_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :consular_cni_os_denmark, :consular_cni_os_ireland_resident, :consular_cni_os_ireland_resident_british_partner, :consular_cni_os_ireland_resident_two, :consular_cni_os_commonwealth_or_ireland_resident_british_partner, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :consular_cni_os_ireland_resident_ceremony_not_italy]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_local_resident_ceremony_not_italy_not_germany_partner_british, :consular_cni_os_all_names_but_germany, :consular_cni_os_other_resident_ceremony_not_italy, :consular_cni_os_fees_not_italy_not_uk, :consular_cni_os_fees_foreign_commonwealth_roi_resident, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  context "ceremony in denmark, resident in ireland, partner other" do
+    setup do
+      worldwide_api_has_organisations_for_location('denmark', read_fixture_file('worldwide/denmark_organisations.json'))
+      worldwide_api_has_organisations_for_location('ireland', read_fixture_file('worldwide/ireland_organisations.json'))
+      add_response 'denmark'
+      add_response 'other'
+      add_response 'ireland'
+      add_response 'partner_other'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:other_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :consular_cni_os_denmark, :consular_cni_os_ireland_resident, :consular_cni_os_ireland_resident_two, :consular_cni_os_commonwealth_or_ireland_resident_non_british_partner, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :consular_cni_os_ireland_resident_ceremony_not_italy]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :consular_cni_os_other_resident_ceremony_not_italy, :consular_cni_os_naturalisation, :consular_cni_os_fees_not_italy_not_uk, :consular_cni_os_fees_foreign_commonwealth_roi_resident, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  #variants for commonwealth or ireland residents
+  context "ceremony in denmark, resident in australia, partner british" do
+    setup do
+      worldwide_api_has_organisations_for_location('denmark', read_fixture_file('worldwide/denmark_organisations.json'))
+      worldwide_api_has_organisations_for_location('australia', read_fixture_file('worldwide/australia_organisations.json'))
+      add_response 'denmark'
+      add_response 'other'
+      add_response 'australia'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:other_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :consular_cni_os_denmark, :consular_cni_os_commonwealth_resident, :os_notice_of_marriage, :os_notice_of_marriage_21_day_wait, :consular_cni_os_commonwealth_resident_british_partner, :consular_cni_os_commonwealth_resident_two, :consular_cni_os_commonwealth_or_ireland_resident_british_partner, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :consular_cni_os_commonwealth_resident_ceremony_not_italy]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_local_resident_ceremony_not_italy_not_germany_partner_british, :consular_cni_os_all_names_but_germany, :consular_cni_os_other_resident_ceremony_not_italy, :consular_cni_os_fees_not_italy_not_uk, :consular_cni_os_fees_foreign_commonwealth_roi_resident, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  context "ceremony in denmark, resident in australia, partner other" do
+    setup do
+      worldwide_api_has_organisations_for_location('denmark', read_fixture_file('worldwide/denmark_organisations.json'))
+      worldwide_api_has_organisations_for_location('australia', read_fixture_file('worldwide/australia_organisations.json'))
+      add_response 'denmark'
+      add_response 'other'
+      add_response 'australia'
+      add_response 'partner_other'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:other_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :consular_cni_os_denmark, :consular_cni_os_commonwealth_resident, :os_notice_of_marriage, :os_notice_of_marriage_21_day_wait, :consular_cni_os_commonwealth_resident_two, :consular_cni_os_commonwealth_or_ireland_resident_non_british_partner, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :consular_cni_os_commonwealth_resident_ceremony_not_italy]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :consular_cni_os_other_resident_ceremony_not_italy, :consular_cni_os_naturalisation, :consular_cni_os_fees_not_italy_not_uk, :consular_cni_os_fees_foreign_commonwealth_roi_resident, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  #variant for local residents (not germany or spain)
+  context "ceremony in denmark, resident in denmark, partner other" do
+    setup do
+      worldwide_api_has_organisations_for_location('denmark', read_fixture_file('worldwide/denmark_organisations.json'))
+      add_response 'denmark'
+      add_response 'other'
+      add_response 'denmark'
+      add_response 'partner_other'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:local_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :consular_cni_os_denmark, :consular_cni_os_foreign_resident_ceremony_not_germany_italy, :check_with_embassy_or_consulate, :embassies_data, :consular_cni_variant_local_resident_not_germany_or_spain_or_foreign_resident, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :consular_cni_os_local_resident_not_germany_or_spain_or_foreign_resident_not_germany, :display_notice_of_marriage_7_days]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :consular_cni_os_other_resident_ceremony_not_italy, :consular_cni_os_naturalisation, :consular_cni_os_fees_not_italy_not_uk, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  #variant for foreign resident
+  context "ceremony in azerbaijan, resident in denmark, partner other" do
+    setup do
+      worldwide_api_has_organisations_for_location('azerbaijan', read_fixture_file('worldwide/azerbaijan_organisations.json'))
+      worldwide_api_has_organisations_for_location('denmark', read_fixture_file('worldwide/denmark_organisations.json'))
+      add_response 'azerbaijan'
+      add_response 'other'
+      add_response 'denmark'
+      add_response 'partner_other'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:other_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :consular_cni_os_foreign_resident_ceremony_not_germany_italy, :consular_cni_os_foreign_resident_3_days_notary_public, :consular_cni_variant_local_resident_or_foreign_resident_notary_public, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :consular_cni_os_download_documents_notary_public, :consular_cni_os_foreign_resident_ceremony_notary_public]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :consular_cni_os_other_resident_ceremony_not_italy, :consular_cni_os_naturalisation, :consular_cni_os_fees_not_italy_not_uk, :consular_cni_os_fees_foreign_commonwealth_roi_resident, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  #testing for spain variants
+  context "ceremony in spain, resident in uk, partner british" do
+    setup do
+      worldwide_api_has_organisations_for_location('spain', read_fixture_file('worldwide/spain_organisations.json'))
+      add_response 'spain'
+      add_response 'uk'
+      add_response 'uk_england'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:uk_resident_os_consular_cni, :spain_os_consular_cni_opposite_sex, :spain_os_consular_civil_registry, :spain_os_consular_cni_not_local_resident, :consular_cni_all_what_you_need_to_do, :spain_os_consular_cni_two, :cni_at_local_register_office_notary_public, :consular_cni_os_uk_resident_legalisation, :consular_cni_os_uk_resident_not_italy_or_portugal, :consular_cni_os_download_documents_notary_public]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_local_resident_ceremony_not_italy_not_germany_partner_british, :consular_cni_os_all_names_but_germany, :consular_cni_os_ceremony_spain, :consular_cni_os_ceremony_spain_partner_british, :consular_cni_os_ceremony_spain_two, :consular_cni_os_fees_not_italy_not_uk, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  context "ceremony in spain, resident in spain, partner local" do
+    setup do
+      worldwide_api_has_organisations_for_location('spain', read_fixture_file('worldwide/spain_organisations.json'))
+      add_response 'spain'
+      add_response 'other'
+      add_response 'spain'
+      add_response 'partner_local'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:local_resident_os_consular_cni, :spain_os_consular_cni_opposite_sex, :spain_os_consular_civil_registry, :consular_cni_all_what_you_need_to_do, :spain_os_consular_cni_two, :consular_cni_os_foreign_resident_ceremony_not_germany_italy, :check_with_embassy_consulate_or_notary_public, :consular_cni_variant_local_resident_spain, :consular_cni_os_not_uk_resident_ceremony_not_germany, :spain_os_consular_cni_three]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :consular_cni_os_ceremony_spain, :consular_cni_os_ceremony_spain_two, :consular_cni_os_naturalisation, :consular_cni_os_fees_not_italy_not_uk, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  context "ceremony in spain, resident in poland, partner other" do
+    setup do
+      worldwide_api_has_organisations_for_location('spain', read_fixture_file('worldwide/spain_organisations.json'))
+      worldwide_api_has_organisations_for_location('poland', read_fixture_file('worldwide/poland_organisations.json'))
+      add_response 'spain'
+      add_response 'other'
+      add_response 'poland'
+      add_response 'partner_other'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:other_resident_os_consular_cni, :spain_os_consular_cni_opposite_sex, :spain_os_consular_civil_registry, :spain_os_consular_cni_not_local_resident, :consular_cni_all_what_you_need_to_do, :spain_os_consular_cni_two, :consular_cni_os_foreign_resident_ceremony_not_germany_italy, :consular_cni_os_foreign_resident_3_days_notary_public, :consular_cni_variant_local_resident_or_foreign_resident_notary_public, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_download_documents_notary_public, :consular_cni_os_foreign_resident_ceremony_notary_public]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :consular_cni_os_ceremony_spain, :consular_cni_os_ceremony_spain_two, :consular_cni_os_naturalisation, :consular_cni_os_fees_not_italy_not_uk, :consular_cni_os_fees_foreign_commonwealth_roi_resident, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+
+  #variant for local residents (not germany or spain) again
+  context "ceremony in poland, resident in poland, partner local" do
+    setup do
+      worldwide_api_has_organisations_for_location('poland', read_fixture_file('worldwide/poland_organisations.json'))
+      add_response 'poland'
+      add_response 'other'
+      add_response 'poland'
+      add_response 'partner_local'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:local_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :consular_cni_os_foreign_resident_ceremony_not_germany_italy, :check_with_embassy_consulate_or_notary_public, :embassies_data, :living_in_residence_country_3_days, :consular_cni_variant_local_resident_or_foreign_resident_notary_public, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :consular_cni_os_download_documents_notary_public, :consular_cni_os_foreign_resident_ceremony_notary_public]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :consular_cni_os_other_resident_ceremony_not_italy, :consular_cni_os_naturalisation, :consular_cni_os_fees_not_italy_not_uk, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  #variant for local resident (not germany or spain) or foreign residents
+  context "ceremony in azerbaijan, resident in denmark, partner local" do
+    setup do
+      worldwide_api_has_organisations_for_location('azerbaijan', read_fixture_file('worldwide/azerbaijan_organisations.json'))
+      worldwide_api_has_organisations_for_location('denmark', read_fixture_file('worldwide/denmark_organisations.json'))
+      add_response 'azerbaijan'
+      add_response 'other'
+      add_response 'denmark'
+      add_response 'partner_local'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:other_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :consular_cni_os_foreign_resident_ceremony_not_germany_italy, :consular_cni_os_foreign_resident_3_days_notary_public, :consular_cni_variant_local_resident_or_foreign_resident_notary_public, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :consular_cni_os_download_documents_notary_public, :consular_cni_os_foreign_resident_ceremony_notary_public]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :consular_cni_os_other_resident_ceremony_not_italy, :consular_cni_os_naturalisation, :consular_cni_os_fees_not_italy_not_uk, :consular_cni_os_fees_foreign_commonwealth_roi_resident, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  context "ceremony in azerbaijan, resident in azerbaijan, partner local" do
+    setup do
+      worldwide_api_has_organisations_for_location('azerbaijan', read_fixture_file('worldwide/azerbaijan_organisations.json'))
+      add_response 'azerbaijan'
+      add_response 'other'
+      add_response 'azerbaijan'
+      add_response 'partner_local'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:local_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :consular_cni_os_foreign_resident_ceremony_not_germany_italy, :check_with_embassy_consulate_or_notary_public, :embassies_data, :living_in_residence_country_3_days, :consular_cni_variant_local_resident_or_foreign_resident_notary_public, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :consular_cni_os_download_documents_notary_public, :consular_cni_os_foreign_resident_ceremony_notary_public]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :consular_cni_os_other_resident_ceremony_not_italy, :consular_cni_os_naturalisation, :consular_cni_os_fees_not_italy_not_uk, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  #variant for foreign resident, ceremony not in italy
+  context "ceremony in azerbaijan, resident in poland, partner local" do
+    setup do
+      worldwide_api_has_organisations_for_location('azerbaijan', read_fixture_file('worldwide/azerbaijan_organisations.json'))
+      worldwide_api_has_organisations_for_location('poland', read_fixture_file('worldwide/poland_organisations.json'))
+      add_response 'azerbaijan'
+      add_response 'other'
+      add_response 'poland'
+      add_response 'partner_local'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:other_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :consular_cni_os_foreign_resident_ceremony_not_germany_italy, :consular_cni_os_foreign_resident_3_days_notary_public, :consular_cni_variant_local_resident_or_foreign_resident_notary_public, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :consular_cni_os_download_documents_notary_public, :consular_cni_os_foreign_resident_ceremony_notary_public]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :consular_cni_os_other_resident_ceremony_not_italy, :consular_cni_os_naturalisation, :consular_cni_os_fees_not_italy_not_uk, :consular_cni_os_fees_foreign_commonwealth_roi_resident, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  #variant for commonwealth resident, ceremony not in italy
+  context "ceremony in azerbaijan, resident in canada, partner local" do
+    setup do
+      worldwide_api_has_organisations_for_location('azerbaijan', read_fixture_file('worldwide/azerbaijan_organisations.json'))
+      worldwide_api_has_organisations_for_location('canada', read_fixture_file('worldwide/canada_organisations.json'))
+      add_response 'azerbaijan'
+      add_response 'other'
+      add_response 'canada'
+      add_response 'partner_local'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:other_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :consular_cni_os_commonwealth_resident, :os_notice_of_marriage, :os_notice_of_marriage_7_day_wait, :consular_cni_os_commonwealth_resident_two, :consular_cni_os_commonwealth_or_ireland_resident_non_british_partner, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :consular_cni_os_download_documents_notary_public, :consular_cni_os_commonwealth_resident_ceremony_not_italy]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :consular_cni_os_other_resident_ceremony_not_italy, :consular_cni_os_naturalisation, :consular_cni_os_fees_not_italy_not_uk, :consular_cni_os_fees_foreign_commonwealth_roi_resident, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  context "ceremony in azerbaijan, resident in ireland, partner local" do
+    setup do
+      worldwide_api_has_organisations_for_location('azerbaijan', read_fixture_file('worldwide/azerbaijan_organisations.json'))
+      worldwide_api_has_organisations_for_location('ireland', read_fixture_file('worldwide/ireland_organisations.json'))
+      add_response 'azerbaijan'
+      add_response 'other'
+      add_response 'ireland'
+      add_response 'partner_local'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:other_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :consular_cni_os_ireland_resident, :consular_cni_os_ireland_resident_two, :consular_cni_os_commonwealth_or_ireland_resident_non_british_partner, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :consular_cni_os_download_documents_notary_public, :consular_cni_os_ireland_resident_ceremony_not_italy]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :consular_cni_os_other_resident_ceremony_not_italy, :consular_cni_os_naturalisation, :consular_cni_os_fees_not_italy_not_uk, :consular_cni_os_fees_foreign_commonwealth_roi_resident, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+
+  #tests using better code
+  #testing for ceremony in poland, british partner
+  context "ceremony in poland, resident in ireland, partner british" do
+    setup do
+      worldwide_api_has_organisations_for_location('poland', read_fixture_file('worldwide/poland_organisations.json'))
+      worldwide_api_has_organisations_for_location('ireland', read_fixture_file('worldwide/ireland_organisations.json'))
+      add_response 'poland'
+      add_response 'other'
+      add_response 'ireland'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:other_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :consular_cni_os_ireland_resident, :consular_cni_os_ireland_resident_british_partner, :consular_cni_os_ireland_resident_two, :consular_cni_os_commonwealth_or_ireland_resident_british_partner, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :consular_cni_os_download_documents_notary_public, :consular_cni_os_ireland_resident_ceremony_not_italy]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_local_resident_ceremony_not_italy_not_germany_partner_british, :consular_cni_os_all_names_but_germany, :consular_cni_os_other_resident_ceremony_not_italy, :consular_cni_os_fees_not_italy_not_uk, :consular_cni_os_fees_foreign_commonwealth_roi_resident, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  #testing for belgium variant
+  context "ceremony in belgium, resident in ireland, partner british" do
+    setup do
+      worldwide_api_has_organisations_for_location('belgium', read_fixture_file('worldwide/belgium_organisations.json'))
+      worldwide_api_has_organisations_for_location('ireland', read_fixture_file('worldwide/ireland_organisations.json'))
+      add_response 'belgium'
+      add_response 'other'
+      add_response 'ireland'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:other_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :consular_cni_os_ireland_resident, :consular_cni_os_ireland_resident_british_partner, :consular_cni_os_ireland_resident_two, :consular_cni_os_commonwealth_or_ireland_resident_british_partner, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :consular_cni_os_ireland_resident_ceremony_not_italy]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_local_resident_ceremony_not_italy_not_germany_partner_british, :consular_cni_os_all_names_but_germany, :consular_cni_os_other_resident_ceremony_not_italy, :consular_cni_os_ceremony_belgium, :embassies_data, :consular_cni_os_fees_not_italy_not_uk, :consular_cni_os_fees_foreign_commonwealth_roi_resident, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+
+  #testing for azerbaijan variant
+  context "ceremony in azerbaijan, resident in ireland, partner other" do
+    setup do
+      worldwide_api_has_organisations_for_location('azerbaijan', read_fixture_file('worldwide/azerbaijan_organisations.json'))
+      worldwide_api_has_organisations_for_location('ireland', read_fixture_file('worldwide/ireland_organisations.json'))
+      add_response 'azerbaijan'
+      add_response 'other'
+      add_response 'ireland'
+      add_response 'partner_other'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:other_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :consular_cni_os_ireland_resident, :consular_cni_os_ireland_resident_two, :consular_cni_os_commonwealth_or_ireland_resident_non_british_partner, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :consular_cni_os_download_documents_notary_public, :consular_cni_os_ireland_resident_ceremony_not_italy]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :consular_cni_os_other_resident_ceremony_not_italy, :consular_cni_os_naturalisation, :consular_cni_os_fees_not_italy_not_uk, :consular_cni_os_fees_foreign_commonwealth_roi_resident, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  #testing for uk resident variant
+  context "ceremony in azerbaijan, resident in scotland, partner other" do
+    setup do
+      worldwide_api_has_organisations_for_location('azerbaijan', read_fixture_file('worldwide/azerbaijan_organisations.json'))
+      add_response 'azerbaijan'
+      add_response 'uk'
+      add_response 'uk_scotland'
+      add_response 'partner_other'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:uk_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :cni_at_local_register_office_notary_public, :consular_cni_os_uk_resident_legalisation, :consular_cni_os_uk_resident_not_italy_or_portugal, :consular_cni_os_download_documents_notary_public]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :consular_cni_os_naturalisation, :consular_cni_os_fees_not_italy_not_uk, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  #testing for fee variant
+  context "ceremony in armenia, resident in scotland, partner other" do
+    setup do
+      worldwide_api_has_organisations_for_location('armenia', read_fixture_file('worldwide/armenia_organisations.json'))
+      add_response 'armenia'
+      add_response 'uk'
+      add_response 'uk_scotland'
+      add_response 'partner_other'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:uk_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :cni_at_local_register_office_notary_public, :consular_cni_os_uk_resident_legalisation, :consular_cni_os_uk_resident_not_italy_or_portugal, :consular_cni_os_download_documents_notary_public]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :consular_cni_os_naturalisation, :consular_cni_os_fees_not_italy_not_uk, :list_of_consular_fees, :pay_in_local_currency_ceremony_country_name]
+    end
+  end
+
+  #France or french overseas territories outcome
+  #testing for ceremony in french overseas territories
+  context "ceremony in fot" do
+    setup do
+      worldwide_api_has_organisations_for_location('mayotte', read_fixture_file('worldwide/mayotte_organisations.json'))
+      add_response 'mayotte'
+    end
+    should "go to marriage in france or fot outcome" do
+      assert_current_node :outcome_os_france_or_fot
+      assert_phrase_list :france_or_fot_os_outcome, [:fot_os_all]
+    end
+  end
+  #testing for ceremony in france
+  context "ceremony in france" do
+    setup do
+      worldwide_api_has_organisations_for_location('france', read_fixture_file('worldwide/france_organisations.json'))
+      add_response 'france'
+      add_response 'marriage'
+    end
+    should "go to france or fot marriage outcome" do
+      assert_current_node :outcome_os_france_or_fot
+    end
+  end
+
+  #tests for affirmation to marry outcomes
+  #testing for ceremony in thailand, uk resident, partner other
+  context "ceremony in thailand, resident in scotland, partner other" do
+    setup do
+      worldwide_api_has_organisations_for_location('thailand', read_fixture_file('worldwide/thailand_organisations.json'))
+      add_response 'thailand'
+      add_response 'uk'
+      add_response 'uk_scotland'
+      add_response 'partner_other'
+      add_response 'opposite_sex'
+    end
+    should "go to os affirmation outcome" do
+      assert_current_node :outcome_os_affirmation
+      assert_phrase_list :affirmation_os_outcome, [:affirmation_os_uk_resident, :affirmation_os_all_what_you_need_to_do, :what_you_need_to_do_affirmation, :appointment_for_affidavit, :embassies_data, :affirmation_os_translation_in_local_language_text, :docs_decree_and_death_certificate, :divorced_or_widowed_evidences, :change_of_name_evidence, :partner_equivalent_document_warning, :affirmation_os_partner_not_british, :fee_table_affidavit_55, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+
+  context "ceremony in colombia, partner colombian national, opposite sex" do
+    setup do
+      worldwide_api_has_organisations_for_location('colombia', read_fixture_file('worldwide/colombia_organisations.json'))
+      add_response 'colombia'
+      add_response 'uk'
+      add_response 'uk_scotland'
+      add_response 'partner_local'
+      add_response 'opposite_sex'
+    end
+    should "go to os affirmation outcome" do
+      assert_current_node :outcome_os_colombia
+      assert_phrase_list :colombia_os_phraselist, [:uk_resident_os_consular_cni, :affirmation_os_all_what_you_need_to_do, :what_you_need_to_do_affirmation, :make_an_appointment_bring_passport_and_pay_55_colombia, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque, :embassies_data, :legalisation_and_translation, :affirmation_os_translation_in_local_language_text, :documents_for_divorced_or_widowed_china_colombia, :change_of_name_evidence, :consular_cni_os_all_names_but_germany, :consular_cni_os_naturalisation]
+    end
+  end
+
+  #testing for ceremony in egypt, local resident, partner british
+  context "ceremony in egypt, resident in egypt, partner british" do
+    setup do
+      worldwide_api_has_organisations_for_location('egypt', read_fixture_file('worldwide/egypt_organisations.json'))
+      add_response 'egypt'
+      add_response 'other'
+      add_response 'egypt'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+    end
+    should "go to os affirmation outcome" do
+      assert_current_node :outcome_os_affirmation
+      assert_phrase_list :affirmation_os_outcome, [:affirmation_os_local_resident, :affirmation_os_all_what_you_need_to_do, :what_you_need_to_do, :make_an_appointment, :embassies_data, :docs_decree_and_death_certificate, :change_of_name_evidence, :partner_declaration, :fee_table_45_55, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  #testing for ceremony in lebanon, other resident, partner irish
+  context "ceremony in lebanon, resident in poland, partner irish" do
+    setup do
+      worldwide_api_has_organisations_for_location('lebanon', read_fixture_file('worldwide/lebanon_organisations.json'))
+      worldwide_api_has_organisations_for_location('poland', read_fixture_file('worldwide/poland_organisations.json'))
+      add_response 'lebanon'
+      add_response 'other'
+      add_response 'poland'
+      add_response 'partner_irish'
+      add_response 'opposite_sex'
+    end
+    should "go to os affirmation outcome" do
+      assert_current_node :outcome_os_affirmation
+      assert_phrase_list :affirmation_os_outcome, [:affirmation_os_other_resident, :affirmation_os_all_what_you_need_to_do, :what_you_need_to_do_affirmation, :appointment_for_affidavit, :embassies_data, :affirmation_os_translation_in_local_language_text, :docs_decree_and_death_certificate, :divorced_or_widowed_evidences, :change_of_name_evidence, :partner_equivalent_document_warning, :affirmation_os_partner_not_british, :affirmation_os_all_fees_45_70, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  #testing for ceremony in UAE, uk resident, partner other
+  context "ceremony in UAE, resident in UAE, partner local" do
+    setup do
+      worldwide_api_has_organisations_for_location('united-arab-emirates', read_fixture_file('worldwide/united-arab-emirates_organisations.json'))
+      add_response 'united-arab-emirates'
+      add_response 'other'
+      add_response 'united-arab-emirates'
+      add_response 'partner_local'
+      add_response 'opposite_sex'
+    end
+    should "go to os affirmation outcome" do
+      assert_current_node :outcome_os_affirmation
+    end
+  end
+  #testing for ceremony in Turkey, uk resident, partner british
+  context "ceremony in Turkey, resident in Scotland, partner local" do
+    setup do
+      worldwide_api_has_organisations_for_location('turkey', read_fixture_file('worldwide/turkey_organisations.json'))
+      add_response 'turkey'
+      add_response 'uk'
+      add_response 'uk_scotland'
+      add_response 'partner_local'
+      add_response 'opposite_sex'
+    end
+    should "go to os affirmation outcome" do
+      assert_current_node :outcome_os_affirmation
+      assert_phrase_list :affirmation_os_outcome, [:affirmation_os_uk_resident, :affirmation_os_all_what_you_need_to_do, :what_you_need_to_do, :appointment_for_affidavit_notary, :complete_affidavit, :download_affidavit, :affirmation_os_legalised, :documents_for_divorced_or_widowed, :affirmation_os_partner_not_british_turkey, :fee_table_affidavit_55, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  #testing for ceremony in Turkey, local resident, partner other
+  context "ceremony in Turkey, resident in Turkey, partner other" do
+    setup do
+      worldwide_api_has_organisations_for_location('turkey', read_fixture_file('worldwide/turkey_organisations.json'))
+      add_response 'turkey'
+      add_response 'other'
+      add_response 'turkey'
+      add_response 'partner_other'
+      add_response 'opposite_sex'
+    end
+    should "go to os affirmation outcome" do
+      assert_current_node :outcome_os_affirmation
+      assert_phrase_list :affirmation_os_outcome, [:affirmation_os_local_resident, :affirmation_os_all_what_you_need_to_do, :what_you_need_to_do, :appointment_for_affidavit, :embassies_data, :complete_affidavit, :download_affidavit, :affirmation_os_legalised_in_turkey, :documents_for_divorced_or_widowed, :affirmation_os_partner_not_british_turkey, :fee_table_affidavit_55, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  #testing for ceremony in Ecuador, resident anywhere, partner other
+  context "ceremony in Ecuador, resident in Ecuador, partner other" do
+    setup do
+      worldwide_api_has_organisations_for_location('ecuador', read_fixture_file('worldwide/ecuador_organisations.json'))
+      add_response 'ecuador'
+      add_response 'other'
+      add_response 'ecuador'
+      add_response 'partner_other'
+      add_response 'opposite_sex'
+    end
+    should "go to os affirmation outcome" do
+      assert_current_node :outcome_os_affirmation
+      assert_phrase_list :affirmation_os_outcome, [:affirmation_os_local_resident, :what_you_need_to_do_affirmation, :appointment_for_affidavit, :embassies_data,
+ :affirmation_os_translation_in_local_language_text, :documents_for_divorced_or_widowed_ecuador, :partner_equivalent_document_warning, :consular_cni_os_all_names_but_germany, :affirmation_os_partner_not_british, :fee_table_affirmation_55, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  #testing for ceremony in Cambodia, resident anywhere, partner other
+  context "ceremony in Cambodia, resident in Cambodia, partner other" do
+    setup do
+      worldwide_api_has_organisations_for_location('cambodia', read_fixture_file('worldwide/cambodia_organisations.json'))
+      add_response 'cambodia'
+      add_response 'other'
+      add_response 'cambodia'
+      add_response 'partner_other'
+      add_response 'opposite_sex'
+    end
+    should "go to os affirmation outcome" do
+      assert_current_node :outcome_os_affirmation
+      assert_phrase_list :affirmation_os_outcome, [:affirmation_os_local_resident, :what_you_need_to_do_affirmation, :appointment_for_affidavit, :embassies_data, :cambodia_consular_cni_os_partner_local, :affirmation_os_translation_in_local_language_text, :documents_for_divorced_or_widowed_cambodia, :change_of_name_evidence, :partner_equivalent_document_warning, :affirmation_os_partner_not_british, :consular_cni_os_all_names_but_germany, :fee_table_affirmation_55, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+
+  #tests for no cni or consular services
+  #testing for dutch caribbean islands
+  context "ceremony in aruba, resident in scotland, partner other" do
+    setup do
+      worldwide_api_has_organisations_for_location('aruba', read_fixture_file('worldwide/aruba_organisations.json'))
+      add_response 'aruba'
+      add_response 'uk'
+      add_response 'uk_scotland'
+      add_response 'partner_other'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:uk_resident_os_consular_cni_dutch_caribbean_islands, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :cni_at_local_register_office, :consular_cni_os_uk_resident_legalisation, :consular_cni_os_uk_resident_not_italy_or_portugal]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :consular_cni_os_naturalisation, :consular_cni_os_fees_not_italy_not_uk]
+    end
+  end
+  context "ceremony in aruba, resident in aruba, partner british" do
+    setup do
+      worldwide_api_has_organisations_for_location('aruba', read_fixture_file('worldwide/aruba_organisations.json'))
+      add_response 'aruba'
+      add_response 'other'
+      add_response 'aruba'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_no_cni
+      assert_phrase_list :no_cni_os_outcome, [:no_cni_os_dutch_caribbean_islands, :no_cni_os_dutch_caribbean_islands_local_resident, :get_legal_advice, :cni_os_consular_facilities_unavailable]
+    end
+  end
+  #testing for ceremony in aruba, other resident, partner irish
+  context "ceremony in aruba, resident in poland, partner irish" do
+    setup do
+      worldwide_api_has_organisations_for_location('aruba', read_fixture_file('worldwide/aruba_organisations.json'))
+      worldwide_api_has_organisations_for_location('poland', read_fixture_file('worldwide/poland_organisations.json'))
+      add_response 'aruba'
+      add_response 'other'
+      add_response 'poland'
+      add_response 'partner_irish'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_no_cni
+      assert_phrase_list :no_cni_os_outcome, [:no_cni_os_dutch_caribbean_islands, :no_cni_os_dutch_caribbean_other_resident, :get_legal_advice, :cni_os_consular_facilities_unavailable, :no_cni_os_naturalisation]
+    end
+  end
+  #testing for ceremony in cote-d-ivoire, uk resident, partner british
+  context "ceremony in cote-d-ivoire, uk resident, partner british" do
+    setup do
+      worldwide_api_has_organisations_for_location('cote-d-ivoire', read_fixture_file('worldwide/cote-d-ivoire_organisations.json'))
+      worldwide_api_has_organisations_for_location('poland', read_fixture_file('worldwide/cote-d-ivoire_organisations.json'))
+      add_response 'cote-d-ivoire'
+      add_response 'uk'
+      add_response 'uk_england'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:uk_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :cni_at_local_register_office, :consular_cni_os_uk_resident_legalisation, :consular_cni_os_uk_resident_not_italy_or_portugal]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_local_resident_ceremony_not_italy_not_germany_partner_british, :consular_cni_os_all_names_but_germany, :consular_cni_os_fees_not_italy_not_uk]
+      assert_state_variable :pay_by_cash_or_credit_card_no_cheque, nil
+    end
+  end
+  #testing for ceremony in cote-d-ivoire, other resident, partner british
+  context "ceremony in cote-d-ivoire, resident in poland, partner british" do
+    setup do
+      worldwide_api_has_organisations_for_location('cote-d-ivoire', read_fixture_file('worldwide/cote-d-ivoire_organisations.json'))
+      worldwide_api_has_organisations_for_location('poland', read_fixture_file('worldwide/poland_organisations.json'))
+      add_response 'cote-d-ivoire'
+      add_response 'other'
+      add_response 'poland'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+    end
+    should "go os no cni outcome" do
+      assert_current_node :outcome_os_no_cni
+      assert_phrase_list :no_cni_os_outcome, [:no_cni_os_not_dutch_caribbean_other_resident, :get_legal_advice, :cni_os_consular_facilities_unavailable]
+    end
+  end
+
+  #testing for ceremony in monaco
+  context "ceremony in monaco, maps to France, marriage" do
+    setup do
+      worldwide_api_has_organisations_for_location('monaco', read_fixture_file('worldwide/monaco_organisations.json'))
+      add_response 'monaco'
+      add_response 'marriage'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_monaco
+      assert_phrase_list :monaco_phraselist, [:monaco_marriage]
+    end
+  end
+  context "ceremony in monaco, maps to France, pacs" do
+    setup do
+      worldwide_api_has_organisations_for_location('monaco', read_fixture_file('worldwide/monaco_organisations.json'))
+      add_response 'monaco'
+      add_response 'pacs'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_monaco
+      assert_phrase_list :monaco_phraselist, [:monaco_pacs]
+    end
+  end
+
+  #testing for ceramony in macedonia
+  context "user doesn't live in uk, ceremony in macedonia, partner os (any nationality)" do
+    setup do
+      worldwide_api_has_organisations_for_location('macedonia', read_fixture_file('worldwide/macedonia_organisations.json'))
+      worldwide_api_has_organisations_for_location('poland', read_fixture_file('worldwide/poland_organisations.json'))
+      add_response 'macedonia'
+      add_response 'other'
+      add_response 'poland'
+      add_response 'partner_other'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :consular_cni_os_other_resident_ceremony_not_italy, :consular_cni_os_naturalisation, :consular_cni_os_fees_not_italy_not_uk, :consular_cni_os_fees_foreign_commonwealth_roi_resident, :pay_by_cash_or_credit_card_no_cheque]
+      assert_phrase_list :consular_cni_os_start, [:other_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :consular_cni_os_foreign_resident_ceremony_not_germany_italy, :consular_cni_os_foreign_resident_3_days_macedonia, :consular_cni_os_foreign_resident_3_days_macedonia_giving_notice, :consular_cni_variant_local_resident_or_foreign_resident_notary_public, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :consular_cni_os_download_documents_notary_public, :consular_cni_os_foreign_resident_ceremony_notary_public]
+    end
+  end
+
+  #testing for ceramony in macedonia
+  context "user lives in macedonia, ceremony in macedonia" do
+    setup do
+      worldwide_api_has_organisations_for_location('macedonia', read_fixture_file('worldwide/macedonia_organisations.json'))
+      add_response 'macedonia'
+      add_response 'other'
+      add_response 'macedonia'
+      add_response 'partner_other'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:local_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :consular_cni_os_foreign_resident_3_days_macedonia, :living_in_residence_country_3_days, :consular_cni_variant_local_resident_or_foreign_resident_notary_public, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :consular_cni_os_local_resident_not_germany_or_spain_or_foreign_resident_not_germany, :display_notice_of_marriage_7_days]
+    end
+  end
+
+  #testing for ceremony in usa
+  context "ceremony in usa, resident in poland, partner irish" do
+    setup do
+      worldwide_api_has_organisations_for_location('usa', read_fixture_file('worldwide/usa_organisations.json'))
+      worldwide_api_has_organisations_for_location('poland', read_fixture_file('worldwide/poland_organisations.json'))
+      add_response 'usa'
+      add_response 'other'
+      add_response 'poland'
+      add_response 'partner_irish'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_no_cni
+      assert_phrase_list :no_cni_os_outcome, [:no_cni_os_not_dutch_caribbean_other_resident, :get_legal_advice, :cni_os_consular_facilities_unavailable, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque, :no_cni_os_naturalisation]
+    end
+  end
+
+  #testing for ceremony in argentina
+  context "ceremony in argentina, resident in poland, partner irish" do
+    setup do
+      worldwide_api_has_organisations_for_location('argentina', read_fixture_file('worldwide/argentina_organisations.json'))
+      worldwide_api_has_organisations_for_location('poland', read_fixture_file('worldwide/poland_organisations.json'))
+      add_response 'argentina'
+      add_response 'other'
+      add_response 'poland'
+      add_response 'partner_irish'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_no_cni
+      assert_phrase_list :no_cni_os_outcome, [:no_cni_os_not_dutch_caribbean_other_resident, :get_legal_advice, :cni_os_consular_facilities_unavailable, :no_cni_os_naturalisation]
+    end
+  end
+  #testing for other countries
+  #testing for burma
+  context "ceremony in burma, resident in scotland, partner local" do
+    setup do
+      worldwide_api_has_organisations_for_location('burma', read_fixture_file('worldwide/burma_organisations.json'))
+      add_response 'burma'
+      add_response 'uk'
+      add_response 'uk_scotland'
+      add_response 'partner_local'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_other_countries
+      assert_phrase_list :other_countries_os_outcome, [:other_countries_os_burma, :other_countries_os_burma_partner_local]
+    end
+  end
+  context "ceremony in burundi, resident not in uk, partner anywhere" do
+    setup do
+      worldwide_api_has_organisations_for_location('burundi', read_fixture_file('worldwide/burundi_organisations.json'))
+      worldwide_api_has_organisations_for_location('poland', read_fixture_file('worldwide/poland_organisations.json'))
+      add_response 'burundi'
+      add_response 'other'
+      add_response 'poland'
+      add_response 'partner_other'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_no_cni
+      assert_phrase_list :no_cni_os_outcome, [:no_cni_os_not_dutch_caribbean_other_resident, :get_legal_advice, :cni_os_consular_facilities_unavailable, :no_cni_os_naturalisation]
+    end
+  end
+  #testing for north korea
+  context "ceremony in north korea, resident in scotland, partner local" do
+    setup do
+      worldwide_api_has_organisations_for_location('north-korea', read_fixture_file('worldwide/north-korea_organisations.json'))
+      add_response 'north-korea'
+      add_response 'uk'
+      add_response 'uk_scotland'
+      add_response 'partner_local'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_other_countries
+      assert_phrase_list :other_countries_os_outcome, [:other_countries_os_north_korea, :other_countries_os_north_korea_partner_local]
+    end
+  end
+  #testing for iran
+  context "ceremony in iran, resident in scotland, partner local" do
+    setup do
+      worldwide_api_has_organisations_for_location('iran', read_fixture_file('worldwide/iran_organisations.json'))
+      add_response 'iran'
+      add_response 'uk'
+      add_response 'uk_scotland'
+      add_response 'partner_local'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_other_countries
+      assert_phrase_list :other_countries_os_outcome, [:other_countries_os_iran_somalia_syria]
+    end
+  end
+  #testing for yemen
+  context "ceremony in yemen, resident in scotland, partner local" do
+    setup do
+      worldwide_api_has_organisations_for_location('yemen', read_fixture_file('worldwide/yemen_organisations.json'))
+      add_response 'yemen'
+      add_response 'uk'
+      add_response 'uk_scotland'
+      add_response 'partner_local'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_other_countries
+      assert_phrase_list :other_countries_os_outcome, [:other_countries_os_yemen]
+    end
+  end
+  #testing for saudi arabia, not local resident
+  context "ceremony in saudi arabia, resident in scotland, partner other" do
+    setup do
+      worldwide_api_has_organisations_for_location('saudi-arabia', read_fixture_file('worldwide/saudi-arabia_organisations.json'))
+      add_response 'saudi-arabia'
+      add_response 'uk'
+      add_response 'uk_scotland'
+      add_response 'partner_other'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_other_countries
+      assert_phrase_list :other_countries_os_outcome, [:other_countries_os_ceremony_saudia_arabia_not_local_resident]
+    end
+  end
+  #testing for saudi arabia, local resident, partner irish
+  context "ceremony in saudi arabia, resident in saudi arabia, partner irish" do
+    setup do
+      worldwide_api_has_organisations_for_location('saudi-arabia', read_fixture_file('worldwide/saudi-arabia_organisations.json'))
+      add_response 'saudi-arabia'
+      add_response 'other'
+      add_response 'saudi-arabia'
+      add_response 'partner_irish'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_other_countries
+      assert_phrase_list :other_countries_os_outcome, [:other_countries_os_saudi_arabia_local_resident_partner_irish]
+    end
+  end
+  #testing for saudi arabia, local resident, partner british
+  context "ceremony in saudi arabia, resident in saudi arabia, partner british" do
+    setup do
+      worldwide_api_has_organisations_for_location('saudi-arabia', read_fixture_file('worldwide/saudi-arabia_organisations.json'))
+      add_response 'saudi-arabia'
+      add_response 'other'
+      add_response 'saudi-arabia'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_other_countries
+      assert_phrase_list :other_countries_os_outcome, [:other_countries_os_saudi_arabia_local_resident_partner_not_irish, :other_countries_os_saudi_arabia_local_resident_partner_not_irish_two]
+    end
+  end
+  #testing for saudi arabia, local resident, partner other
+  context "ceremony in saudi arabia, resident in saudi arabia, partner other" do
+    setup do
+      worldwide_api_has_organisations_for_location('saudi-arabia', read_fixture_file('worldwide/saudi-arabia_organisations.json'))
+      add_response 'saudi-arabia'
+      add_response 'other'
+      add_response 'saudi-arabia'
+      add_response 'partner_other'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_other_countries
+      assert_phrase_list :other_countries_os_outcome, [:other_countries_os_saudi_arabia_local_resident_partner_not_irish, :other_countries_os_saudi_arabia_local_resident_partner_not_irish_or_british, :other_countries_os_saudi_arabia_local_resident_partner_not_irish_two]
+    end
+  end
+
+  #testing for ceremony in spain, england resident, british partner
+  context "ceremony in spain, resident in england, partner british" do
+    setup do
+      worldwide_api_has_organisations_for_location('spain', read_fixture_file('worldwide/spain_organisations.json'))
+      add_response 'spain'
+      add_response 'uk'
+      add_response 'uk_england'
+      add_response 'partner_british'
+      add_response 'same_sex'
+    end
+    should "go to cp or equivalent outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:uk_resident_os_consular_cni, :spain_os_consular_cni_same_sex, :spain_os_consular_civil_registry, :spain_os_consular_cni_not_local_resident, :consular_cni_all_what_you_need_to_do, :spain_os_consular_cni_two, :cni_at_local_register_office_notary_public, :consular_cni_os_uk_resident_legalisation, :consular_cni_os_uk_resident_not_italy_or_portugal, :consular_cni_os_download_documents_notary_public]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_local_resident_ceremony_not_italy_not_germany_partner_british, :consular_cni_os_all_names_but_germany, :consular_cni_os_ceremony_spain, :consular_cni_os_ceremony_spain_partner_british, :consular_cni_os_ceremony_spain_two, :consular_cni_os_fees_not_italy_not_uk, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+
+  #testing for CNI variant for russian-federation
+  context "ceremony in russia, resident in russia, partner british" do
+    setup do
+      worldwide_api_has_organisations_for_location('russia', read_fixture_file('worldwide/russia_organisations.json'))
+      add_response 'russia'
+      add_response 'other'
+      add_response 'russia'
+      add_response 'partner_local'
+      add_response 'opposite_sex'
+    end
+    should "go to russia CNI outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:local_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :russia_os_local_resident, :consular_cni_variant_local_resident_or_foreign_resident_notary_public, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :consular_cni_os_download_documents_notary_public, :consular_cni_os_foreign_resident_ceremony_notary_public]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :consular_cni_os_other_resident_ceremony_not_italy, :consular_cni_os_naturalisation, :consular_cni_os_fees_not_italy_not_uk, :list_of_consular_fees, :consular_cni_os_fees_russia]
+    end
+  end
+
+  #testing for civil partnership in countries with CP or equivalent
+  context "ceremony in denmark, resident in england, partner other" do
+    setup do
+      worldwide_api_has_organisations_for_location('denmark', read_fixture_file('worldwide/denmark_organisations.json'))
+      add_response 'denmark'
+      add_response 'uk'
+      add_response 'uk_england'
+      add_response 'partner_other'
+      add_response 'same_sex'
+    end
+    should "go to cp or equivalent outcome" do
+      assert_current_node :outcome_cp_cp_or_equivalent
+      assert_phrase_list :cp_or_equivalent_cp_outcome, [:"cp_or_equivalent_cp_denmark", :cp_or_equivalent_cp_uk_resident, :cp_or_equivalent_cp_all_what_you_need_to_do, :cp_or_equivalent_cp_naturalisation, :cp_or_equivalent_cp_all_fees, :list_of_consular_fees , :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  #testing for ceremony in czech republic, other resident, local partner
+  context "ceremony in czech republic, resident in poland, partner local" do
+    setup do
+      worldwide_api_has_organisations_for_location('czech-republic', read_fixture_file('worldwide/czech-republic_organisations.json'))
+      worldwide_api_has_organisations_for_location('poland', read_fixture_file('worldwide/poland_organisations.json'))
+      add_response 'czech-republic'
+      add_response 'other'
+      add_response 'poland'
+      add_response 'partner_local'
+      add_response 'same_sex'
+    end
+    should "go to cp or equivalent outcome" do
+      assert_current_node :outcome_cp_cp_or_equivalent
+      assert_state_variable :country_name_lowercase_prefix, 'the Czech Republic'
+      assert_phrase_list :cp_or_equivalent_cp_outcome, [:"cp_or_equivalent_cp_czech-republic", :cp_or_equivalent_cp_uk_resident_czech_republic, :cp_or_equivalent_cp_naturalisation]
+      assert_state_variable :pay_by_cash_or_credit_card_no_cheque, nil
+    end
+  end
+  #testing for ceremony in sweden, sweden resident, irish partner
+  context "ceremony in sweden, resident in sweden, partner irish" do
+    setup do
+      worldwide_api_has_organisations_for_location('sweden', read_fixture_file('worldwide/sweden_organisations.json'))
+      add_response 'sweden'
+      add_response 'other'
+      add_response 'sweden'
+      add_response 'partner_irish'
+      add_response 'same_sex'
+    end
+    should "go to cp or equivalent os outcome" do
+      assert_current_node :outcome_cp_cp_or_equivalent
+      assert_phrase_list :cp_or_equivalent_cp_outcome, [:cp_or_equivalent_cp_sweden, :cp_or_equivalent_cp_local_resident, :cp_or_equivalent_cp_all_what_you_need_to_do, :cp_or_equivalent_cp_naturalisation, :cp_or_equivalent_cp_all_fees, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  #testing for civil partnership in France, or french overseas territories with PACS law
+  #testing for ceremony in france, pacs
+  context "ceremony in france, " do
+    setup do
+      worldwide_api_has_organisations_for_location('france', read_fixture_file('worldwide/france_organisations.json'))
+      add_response 'france'
+      add_response 'pacs'
+    end
+    should "go to fran ce ot fot PACS outcome" do
+      assert_current_node :outcome_cp_france_pacs
+    end
+  end
+  #testing for ceremony in wallis and futuna, pacs
+  context "ceremony in wallis and futuna, pacs" do
+    setup do
+      worldwide_api_has_organisations_for_location('wallis-and-futuna', read_fixture_file('worldwide/wallis-and-futuna_organisations.json'))
+      add_response 'wallis-and-futuna'
+      add_response 'pacs'
+    end
+    should "go to france or fot pacs outcome" do
+      assert_current_node :outcome_cp_france_pacs
+      assert_phrase_list :france_pacs_law_cp_outcome, [:fot_cp_all]
+    end
+  end
+
+  #testing for CP in countries where cni not required
+  #testing for ceremony in united states, england resident, local partner
+  context "ceremony in US, resident in ni, partner local" do
+    setup do
+      worldwide_api_has_organisations_for_location('usa', read_fixture_file('worldwide/usa_organisations.json'))
+      add_response 'usa'
+      add_response 'uk'
+      add_response 'uk_ni'
+      add_response 'partner_local'
+      add_response 'same_sex'
+    end
+    should "go to cp no cni required outcome" do
+      assert_current_node :outcome_cp_no_cni
+      assert_state_variable :country_name_lowercase_prefix, 'the USA'
+      assert_phrase_list :no_cni_required_cp_outcome, [:"no_cni_required_cp_usa", :no_cni_required_all_legal_advice, :no_cni_required_cp_ceremony_us, :no_cni_required_all_what_you_need_to_do, :no_cni_required_cp_not_dutch_islands_uk_resident, :no_cni_required_cp_all_consular_facilities, :no_cni_required_cp_naturalisation]
+    end
+  end
+  #testing for ceremony in bonaire, england resident, other partner
+  context "ceremony in bonaire, resident in scotland, partner other" do
+    setup do
+      worldwide_api_has_organisations_for_location('bonaire-st-eustatius-saba', read_fixture_file('worldwide/bonaire-st-eustatius-saba_organisations.json'))
+      add_response 'bonaire-st-eustatius-saba'
+      add_response 'uk'
+      add_response 'uk_scotland'
+      add_response 'partner_other'
+      add_response 'same_sex'
+    end
+    should "go to cp no cni required outcome" do
+      assert_current_node :outcome_cp_no_cni
+      assert_phrase_list :no_cni_required_cp_outcome, [:"no_cni_required_cp_bonaire-st-eustatius-saba", :no_cni_required_all_legal_advice, :no_cni_required_all_what_you_need_to_do, :no_cni_required_cp_dutch_islands, :no_cni_required_cp_dutch_islands_uk_resident, :no_cni_required_cp_all_consular_facilities, :no_cni_required_cp_naturalisation]
+    end
+  end
+  #testing for ceremony in bonaire, bonaire resident, british partner
+  context "ceremony in bonaire, resident in bonaire, partner british" do
+    setup do
+      worldwide_api_has_organisations_for_location('bonaire-st-eustatius-saba', read_fixture_file('worldwide/bonaire-st-eustatius-saba_organisations.json'))
+      add_response 'bonaire-st-eustatius-saba'
+      add_response 'other'
+      add_response 'bonaire-st-eustatius-saba'
+      add_response 'partner_british'
+      add_response 'same_sex'
+    end
+    should "go to cp no cni required outcome" do
+      assert_current_node :outcome_cp_no_cni
+      assert_phrase_list :no_cni_required_cp_outcome, [:"no_cni_required_cp_bonaire-st-eustatius-saba", :no_cni_required_all_legal_advice, :no_cni_required_all_what_you_need_to_do, :no_cni_required_cp_dutch_islands, :no_cni_required_cp_dutch_islands_local_resident, :no_cni_required_cp_all_consular_facilities]
+    end
+  end
+  #testing for ceremony in bonaire, other resident, irish partner
+  context "ceremony in bonaire, resident in mexico, partner other" do
+    setup do
+      worldwide_api_has_organisations_for_location('bonaire-st-eustatius-saba', read_fixture_file('worldwide/bonaire-st-eustatius-saba_organisations.json'))
+      worldwide_api_has_organisations_for_location('mexico', read_fixture_file('worldwide/mexico_organisations.json'))
+      add_response 'bonaire-st-eustatius-saba'
+      add_response 'other'
+      add_response 'mexico'
+      add_response 'partner_irish'
+      add_response 'same_sex'
+    end
+    should "go to cp no cni required outcome" do
+      assert_current_node :outcome_cp_no_cni
+      assert_phrase_list :no_cni_required_cp_outcome, [:"no_cni_required_cp_bonaire-st-eustatius-saba", :no_cni_required_all_legal_advice, :no_cni_required_all_what_you_need_to_do, :no_cni_required_cp_dutch_islands, :no_cni_required_cp_dutch_islands_other_resident, :no_cni_required_cp_all_consular_facilities, :no_cni_required_cp_naturalisation]
+    end
+  end
+
+  #testing for CP in commonwealth countries outcomes
+  #testing for ceremony in canada, uk resident, other partner
+  context "ceremony in canada, uk resident, partner other" do
+    setup do
+      worldwide_api_has_organisations_for_location('canada', read_fixture_file('worldwide/canada_organisations.json'))
+      add_response 'canada'
+      add_response 'uk'
+      add_response 'uk_ni'
+      add_response 'partner_other'
+      add_response 'same_sex'
+    end
+    should "go to cp commonwealth countries outcome" do
+      assert_current_node :outcome_cp_commonwealth_countries
+      assert_phrase_list :commonwealth_countries_cp_outcome, [:commonwealth_countries_cp_canada, :commonwealth_countries_cp_uk_resident_two, :embassies_data, :commonwealth_countries_cp_naturalisation]
+    end
+  end
+
+  #testing for CP in countries with consular cni (not australia)
+  # testing for czech republic with non-local partner
+  context "ceremony in czech-republic, uk resident, partner other" do
+    setup do
+      worldwide_api_has_organisations_for_location('czech-republic', read_fixture_file('worldwide/czech-republic_organisations.json'))
+      add_response 'czech-republic'
+      add_response 'uk'
+      add_response 'uk_wales'
+      add_response 'partner_other'
+      add_response 'same_sex'
+    end
+    should "go to consular cni cp countries outcome" do
+      assert_current_node :outcome_cp_cp_or_equivalent
+      assert_phrase_list :cp_or_equivalent_cp_outcome, [:"cp_or_equivalent_cp_czech-republic", :cp_or_equivalent_cp_uk_resident_czech_republic, :cp_or_equivalent_cp_naturalisation]
+      assert_state_variable :pay_by_cash_or_credit_card_no_cheque, nil
+    end
+  end
+  # testing for vietnam with local partner
+  context "ceremony in vietnam, uk resident, partner local" do
+    setup do
+      worldwide_api_has_organisations_for_location('vietnam', read_fixture_file('worldwide/vietnam_organisations.json'))
+      add_response 'vietnam'
+      add_response 'uk'
+      add_response 'uk_england'
+      add_response 'partner_local'
+      add_response 'same_sex'
+    end
+    should "go to all other countries outcome" do
+      assert_current_node :outcome_ss_marriage_not_possible
+    end
+  end
+  context "ceremony in turkmenistan" do
+    setup do
+      worldwide_api_has_organisations_for_location('turkmenistan', read_fixture_file('worldwide/turkmenistan_organisations.json'))
+      add_response 'turkmenistan'
+      add_response 'uk'
+      add_response 'uk_england'
+      add_response 'partner_local'
+      add_response 'same_sex'
+    end
+    should "go to all other countries outcome" do
+      assert_current_node :outcome_cp_all_other_countries
+    end
+  end
+  # testing for latvia, other resident, british partner
+  context "ceremony in latvia, cyprus resident, partner british" do
+    setup do
+      worldwide_api_has_organisations_for_location('latvia', read_fixture_file('worldwide/latvia_organisations.json'))
+      worldwide_api_has_organisations_for_location('cyprus', read_fixture_file('worldwide/cyprus_organisations.json'))
+      add_response 'latvia'
+      add_response 'other'
+      add_response 'cyprus'
+      add_response 'partner_british'
+      add_response 'same_sex'
+    end
+    should "go to consular cni cp countries outcome" do
+      assert_current_node :outcome_ss_marriage
+      assert_phrase_list :ss_ceremony_body, [:able_to_ss_marriage, :contact_embassy_or_consulate, :embassies_data, :documents_needed_21_days_residency, :documents_needed_ss_british, :what_to_do_ss_marriage, :will_display_in_14_days, :no_objection_in_14_days_ss_marriage, :provide_two_witnesses_ss_marriage, :ss_marriage_footnote_21_days_residency, :partner_naturalisation_in_uk, :fees_table_ss_marriage_alt, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+
+  #testing for other countries outcome
+  # testing for serbia, other resident, british partner
+  context "ceremony in serbia, cyprus resident, partner british" do
+    setup do
+      worldwide_api_has_organisations_for_location('serbia', read_fixture_file('worldwide/serbia_organisations.json'))
+      worldwide_api_has_organisations_for_location('cyprus', read_fixture_file('worldwide/cyprus_organisations.json'))
+      add_response 'serbia'
+      add_response 'other'
+      add_response 'cyprus'
+      add_response 'partner_british'
+      add_response 'same_sex'
+    end
+    should "go to cp all other countries outcome" do
+      assert_current_node :outcome_ss_marriage
+    end
+  end
+
+  #testing for nicaragua
+  context "ceremony in nicaragua, resident in poland, partner irish" do
+    setup do
+      worldwide_api_has_organisations_for_location('nicaragua', read_fixture_file('worldwide/nicaragua_organisations.json'))
+      worldwide_api_has_organisations_for_location('poland', read_fixture_file('worldwide/poland_organisations.json'))
+      add_response 'nicaragua'
+      add_response 'other'
+      add_response 'poland'
+      add_response 'partner_irish'
+      add_response 'opposite_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_os_no_cni
+      assert_phrase_list :no_cni_os_outcome, [:no_cni_os_not_dutch_caribbean_other_resident, :get_legal_advice, :cni_os_consular_facilities_unavailable, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque, :no_cni_os_naturalisation]
+    end
+  end
+
+  #testing for Iom and Ci residents
+  context "ceremony in australia, resident in isle of man" do
+    setup do
+      worldwide_api_has_organisations_for_location('australia', read_fixture_file('worldwide/australia_organisations.json'))
+      add_response 'australia'
+      add_response 'uk'
+      add_response 'uk_iom'
+      add_response 'partner_local'
+      add_response "same_sex"
+    end
+    should "go to iom/ci os outcome" do
+      assert_current_node :outcome_ss_marriage
+      assert_phrase_list :ss_title, [:title_ss_marriage]
+      assert_phrase_list :ss_ceremony_body, [:able_to_ss_marriage, :contact_embassy_or_consulate, :embassies_data, :documents_needed_21_days_residency, :documents_needed_ss_not_british, :what_to_do_ss_marriage, :will_display_in_14_days, :no_objection_in_14_days_ss_marriage, :provide_two_witnesses_ss_marriage, :australia_ss_relationships, :ss_marriage_footnote_21_days_residency, :partner_naturalisation_in_uk, :fees_table_ss_marriage_alt, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque, :convert_cc_to_ss_marriage]
+    end
+  end
+  context "australia opposite sex outcome" do
+    should "bring you to australia os outcome" do
+      worldwide_api_has_organisations_for_location('australia', read_fixture_file('worldwide/australia_organisations.json'))
+      add_response 'australia'
+      add_response 'other'
+      add_response 'australia'
+      add_response 'partner_british'
+      add_response 'same_sex'
+      assert_current_node :outcome_ss_marriage
+      assert_phrase_list :ss_title, [:title_ss_marriage]
+      assert_phrase_list :ss_ceremony_body, [:able_to_ss_marriage, :contact_embassy_or_consulate, :embassies_data, :documents_needed_21_days_residency, :documents_needed_ss_british, :what_to_do_ss_marriage, :will_display_in_14_days, :no_objection_in_14_days_ss_marriage, :provide_two_witnesses_ss_marriage, :australia_ss_relationships, :ss_marriage_footnote_21_days_residency, :partner_naturalisation_in_uk, :fees_table_ss_marriage_alt, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque, :convert_cc_to_ss_marriage]
+    end
+  end
+  context "ceremony in italy, resident in channel islands" do
+    setup do
+      worldwide_api_has_organisations_for_location('italy', read_fixture_file('worldwide/italy_organisations.json'))
+      add_response 'italy'
+      add_response 'uk'
+      add_response 'uk_ci'
+    end
+    should "go to iom/ci os outcome" do
+      assert_current_node :outcome_os_iom_ci
+      assert_phrase_list :iom_ci_os_outcome, [:iom_ci_os_all, :iom_ci_os_resident_of_ci, :iom_ci_os_ceremony_italy]
+    end
+  end
+  #testing for china
+  context "ceremony in china, partner is not from china, opposite sex" do
+    should "render address from API" do
+      worldwide_api_has_organisations_for_location('china', read_fixture_file('worldwide/china_organisations.json'))
+      add_response 'china'
+      add_response 'uk'
+      add_response 'uk_england'
+      add_response 'partner_irish'
+      add_response 'opposite_sex'
+      assert_current_node :outcome_os_affirmation
+      assert_phrase_list :affirmation_os_outcome, [:affirmation_os_uk_resident, :affirmation_os_all_what_you_need_to_do, :what_you_need_to_do, :book_online_china_non_local_prelude, :book_online_china_affirmation_affidavit, :embassies_data, :documents_for_divorced_or_widowed_china_colombia, :change_of_name_evidence, :affirmation_affidavit_os_partner, :affirmation_os_all_fees_45_70, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  context "ceremony in china, partner is not from china, same sex" do
+    should "render address from API" do
+      worldwide_api_has_organisations_for_location('china', read_fixture_file('worldwide/china_organisations.json'))
+      add_response 'china'
+      add_response 'uk'
+      add_response 'uk_england'
+      add_response 'partner_irish'
+      add_response 'same_sex'
+      assert_current_node :outcome_ss_marriage
+      assert_phrase_list :ss_ceremony_body, [:able_to_ss_marriage, :contact_embassy_or_consulate, :embassies_data, :documents_needed_21_days_residency, :documents_needed_ss_not_british, :what_to_do_ss_marriage, :will_display_in_14_days, :no_objection_in_14_days_ss_marriage, :provide_two_witnesses_ss_marriage, :ss_marriage_footnote_21_days_residency, :partner_naturalisation_in_uk, :fees_table_ss_marriage_alt, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  context "ceremony in china, partner is national of china" do
+    should "render address from API" do
+      worldwide_api_has_organisations_for_location('china', read_fixture_file('worldwide/china_organisations.json'))
+      add_response 'china'
+      add_response 'other'
+      add_response 'china'
+      add_response 'partner_local'
+      add_response 'opposite_sex'
+      assert_current_node :outcome_os_affirmation
+      assert_phrase_list :affirmation_os_outcome, [:affirmation_os_local_resident, :affirmation_os_all_what_you_need_to_do, :what_you_need_to_do, :book_online_china_local_prelude, :book_online_china_affirmation_affidavit, :embassies_data, :documents_for_divorced_or_widowed_china_colombia, :change_of_name_evidence, :partner_equivalent_document_warning, :affirmation_os_partner_not_british, :affirmation_os_all_fees_45_70, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  #testing for japan
+  context "ceremony in japan, resident in japan" do
+    should "give os outcome with japan variants" do
+      worldwide_api_has_organisations_for_location('japan', read_fixture_file('worldwide/japan_organisations.json'))
+      add_response 'japan'
+      add_response 'other'
+      add_response 'japan'
+      add_response 'partner_local'
+      add_response 'opposite_sex'
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:local_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :consular_cni_os_foreign_resident_ceremony_not_germany_italy, :check_with_embassy_consulate_or_notary_public, :japan_consular_cni_os_local_resident, :japan_consular_cni_os_local_resident_partner_local, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :consular_cni_os_download_documents_notary_public, :consular_cni_os_foreign_resident_ceremony_notary_public]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :consular_cni_os_other_resident_ceremony_not_italy, :consular_cni_os_naturalisation, :consular_cni_os_fees_not_italy_not_uk, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  context "ceremony in japan, resident in japan" do
+    should "give ss outcome with japan variants" do
+      worldwide_api_has_organisations_for_location('japan', read_fixture_file('worldwide/japan_organisations.json'))
+      add_response 'japan'
+      add_response 'other'
+      add_response 'japan'
+      add_response 'partner_local'
+      add_response 'same_sex'
+      assert_current_node :outcome_ss_marriage
+      assert_phrase_list :ss_ceremony_body, [:able_to_ss_marriage_and_partnership, :consular_cp_all_contact, :embassies_data, :documents_needed_21_days_residency, :documents_needed_ss_british, :what_to_do_ss_marriage_and_partnership, :will_display_in_14_days, :no_objection_in_14_days_ss_marriage_and_partnership, :provide_two_witnesses_ss_marriage_and_partnership, :ss_marriage_footnote_21_days_residency, :partner_naturalisation_in_uk, :fees_table_ss_marriage_and_partnership, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque, :convert_cc_to_ss_marriage]
+    end
+  end
+
+  #testing for vietnam
+  context "testing that Vietnam is now affirmation to marry outcome" do
+    should "give the outcome" do
+      worldwide_api_has_organisations_for_location('vietnam', read_fixture_file('worldwide/vietnam_organisations.json'))
+      add_response 'vietnam'
+      add_response 'uk'
+      add_response 'uk_england'
+      add_response 'partner_local'
+      add_response 'opposite_sex'
+      assert_current_node :outcome_os_affirmation
+      assert_state_variable :ceremony_type_lowercase, 'marriage'
+      assert_phrase_list :affirmation_os_outcome, [:affirmation_os_uk_resident, :affirmation_os_all_what_you_need_to_do, :what_you_need_to_do_affirmation, :appointment_for_affidavit, :embassies_data, :affirmation_os_translation_in_local_language_text, :docs_decree_and_death_certificate, :divorced_or_widowed_evidences, :change_of_name_evidence, :partner_equivalent_document_warning, :affirmation_os_partner_not_british, :fee_table_affidavit_55, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+
+  #testing for switzerland variants
+  context "ceremony in switzerland, resident in switzerland, partner opposite sex" do
+    should "give swiss outcome with variants (gender variant)" do
+      worldwide_api_has_organisations_for_location('switzerland', read_fixture_file('worldwide/switzerland_organisations.json'))
+      add_response 'switzerland'
+      add_response 'uk'
+      add_response 'opposite_sex'
+      assert_current_node :outcome_switzerland
+      assert_state_variable :ceremony_type_lowercase, 'marriage'
+      assert_phrase_list :switzerland_marriage_outcome, [:switzerland_os_variant, :what_you_need_to_do_switzerland_resident_uk, :switzerland_not_resident, :switzerland_os_not_resident, :switzerland_not_resident_two]
+    end
+  end
+  context "ceremony in switzerland, resident in switzerland, partner same sex" do
+    should "give swiss outcome with variants" do
+      worldwide_api_has_organisations_for_location('switzerland', read_fixture_file('worldwide/switzerland_organisations.json'))
+      add_response 'switzerland'
+      add_response 'other'
+      add_response 'switzerland'
+      add_response 'same_sex'
+      assert_current_node :outcome_switzerland
+      assert_state_variable :ceremony_type_lowercase, 'civil partnership'
+      assert_phrase_list :switzerland_marriage_outcome, [:switzerland_ss_variant]
+    end
+  end
+  context "ceremony in switzerland, not resident in switzerland, partner opposite sex" do
+    should "give swiss outcome with variants" do
+      worldwide_api_has_organisations_for_location('switzerland', read_fixture_file('worldwide/switzerland_organisations.json'))
+      add_response 'switzerland'
+      add_response 'uk'
+      add_response 'same_sex'
+      assert_current_node :outcome_switzerland
+      assert_state_variable :ceremony_type_lowercase, 'civil partnership'
+      assert_phrase_list :switzerland_marriage_outcome, [:switzerland_ss_variant, :what_you_need_to_do_switzerland_resident_uk, :switzerland_not_resident, :switzerland_ss_not_resident, :switzerland_not_resident_two]
+    end
+  end
+  context "ceremony in switzerland, not resident in switzerland, partner same sex" do
+    should "give swiss outcome with variants" do
+      worldwide_api_has_organisations_for_location('switzerland', read_fixture_file('worldwide/switzerland_organisations.json'))
+      worldwide_api_has_organisations_for_location('poland', read_fixture_file('worldwide/poland_organisations.json'))
+      add_response 'switzerland'
+      add_response 'other'
+      add_response 'poland'
+      add_response 'opposite_sex'
+      assert_current_node :outcome_switzerland
+      assert_state_variable :ceremony_type_lowercase, 'marriage'
+      assert_phrase_list :switzerland_marriage_outcome, [:switzerland_os_variant, :switzerland_not_resident, :switzerland_os_not_resident, :switzerland_not_resident_two]
+    end
+  end
+  context "peru outcome mapped to lebanon" do
+    should "go to outcome cp all other countries" do
+      worldwide_api_has_organisations_for_location('peru', read_fixture_file('worldwide/peru_organisations.json'))
+      add_response 'peru'
+      add_response 'uk'
+      add_response 'uk_england'
+      add_response 'partner_british'
+      add_response 'same_sex'
+      assert_current_node :outcome_ss_marriage
+      assert_phrase_list :ss_ceremony_body, [:able_to_ss_marriage_and_partnership, :contact_embassy_or_consulate, :embassies_data, :documents_needed_21_days_residency, :documents_needed_ss_british, :what_to_do_ss_marriage_and_partnership, :will_display_in_14_days, :no_objection_in_14_days_ss_marriage_and_partnership, :provide_two_witnesses_ss_marriage_and_partnership, :ss_marriage_footnote_21_days_residency, :partner_naturalisation_in_uk, :fees_table_ss_marriage_and_partnership, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  context "peru outcome mapped to lebanon" do
+    should "go to outcome os affirmation" do
+      worldwide_api_has_organisations_for_location('peru', read_fixture_file('worldwide/peru_organisations.json'))
+      add_response 'peru'
+      add_response 'uk'
+      add_response 'uk_england'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+      assert_current_node :outcome_os_affirmation
+    end
+  end
+  context "portugal has his own outcome" do
+    should "go to portugal outcome" do
+      worldwide_api_has_organisations_for_location('portugal', read_fixture_file('worldwide/portugal_organisations.json'))
+      add_response 'portugal'
+      add_response 'uk'
+      add_response 'uk_england'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+      assert_current_node :outcome_portugal
+    end
+  end
+
+  context "ceremony in finland, resident in the UK, partner british" do
+    setup do
+      worldwide_api_has_organisations_for_location('finland', read_fixture_file('worldwide/finland_organisations.json'))
+      add_response 'finland'
+      add_response 'uk'
+      add_response 'uk_england'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+    end
+    should "go to cni outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :consular_cni_os_fees_not_italy_not_uk, :list_of_consular_fees, :pay_in_euros_or_visa_electron]
+      assert_phrase_list :consular_cni_os_start, [:uk_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :cni_at_local_register_office, :consular_cni_os_uk_legalisation_check_with_authorities, :consular_cni_os_uk_resident_not_italy_or_portugal]
+     end
+  end
+
+  context "ceremony in finland, resident in the UK, partner local" do
+    setup do
+      worldwide_api_has_organisations_for_location('finland', read_fixture_file('worldwide/finland_organisations.json'))
+      add_response 'finland'
+      add_response 'uk'
+      add_response 'uk_england'
+      add_response 'partner_local'
+      add_response 'opposite_sex'
+    end
+    should "go to cni outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :consular_cni_os_naturalisation, :consular_cni_os_fees_not_italy_not_uk, :list_of_consular_fees, :pay_in_euros_or_visa_electron]
+      assert_phrase_list :consular_cni_os_start, [:uk_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :cni_at_local_register_office, :consular_cni_os_uk_legalisation_check_with_authorities, :consular_cni_os_uk_resident_not_italy_or_portugal]
+     end
+  end
+
+  context "ceremony in finland, resident in Australia, partner other" do
+    setup do
+      worldwide_api_has_organisations_for_location('finland', read_fixture_file('worldwide/finland_organisations.json'))
+      worldwide_api_has_organisations_for_location('australia', read_fixture_file('worldwide/australia_organisations.json'))
+      add_response 'finland'
+      add_response 'other'
+      add_response 'australia'
+      add_response 'partner_other'
+      add_response 'opposite_sex'
+    end
+    should "go to affirmation outcome with specific fee table" do
+      assert_current_node :outcome_os_affirmation
+      assert_phrase_list :affirmation_os_outcome, [:affirmation_os_other_resident, :affirmation_os_all_what_you_need_to_do, :what_you_need_to_do_affirmation, :appointment_for_affidavit, :embassies_data, :affirmation_os_translation_in_local_language_text, :docs_decree_and_death_certificate, :divorced_or_widowed_evidences, :change_of_name_evidence, :partner_equivalent_document_warning, :affirmation_os_partner_not_british, :fee_table_affirmation_65, :list_of_consular_fees, :pay_in_euros_or_visa_electron]
+    end
+  end
+
+  context "ceremony in finland, resident in the UK, partner other" do
+    setup do
+      worldwide_api_has_organisations_for_location('finland', read_fixture_file('worldwide/finland_organisations.json'))
+      add_response 'finland'
+      add_response 'uk'
+      add_response 'uk_england'
+      add_response 'partner_other'
+      add_response 'opposite_sex'
+    end
+    should "go to outcome cni with specific fee table" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_remainder, [:callout_partner_equivalent_document, :consular_cni_os_all_names_but_germany, :consular_cni_os_naturalisation, :consular_cni_os_fees_not_italy_not_uk, :list_of_consular_fees, :pay_in_euros_or_visa_electron]
+      assert_phrase_list :consular_cni_os_start, [:uk_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :cni_at_local_register_office, :consular_cni_os_uk_legalisation_check_with_authorities, :consular_cni_os_uk_resident_not_italy_or_portugal]
+    end
+  end
+
+  context "ceremony in finland, resident in the UK, partner Irish OS" do
+    setup do
+      worldwide_api_has_organisations_for_location('finland', read_fixture_file('worldwide/finland_organisations.json'))
+      worldwide_api_has_organisations_for_location('australia', read_fixture_file('worldwide/australia_organisations.json'))
+      add_response 'finland'
+      add_response 'uk'
+      add_response 'uk_england'
+      add_response 'partner_irish'
+      add_response 'opposite_sex'
+    end
+    should "go to affirmation outcome with specific fee table" do
+      assert_current_node :outcome_os_affirmation
+      assert_phrase_list :affirmation_os_outcome, [:affirmation_os_uk_resident, :affirmation_os_all_what_you_need_to_do, :what_you_need_to_do_affidavit, :appointment_for_affidavit, :embassies_data, :affidavit_os_translation_in_local_language_text, :docs_decree_and_death_certificate, :divorced_or_widowed_evidences, :change_of_name_evidence, :partner_equivalent_document_warning, :affirmation_os_partner_not_british, :fee_table_affidavit_65, :list_of_consular_fees, :pay_in_euros_or_visa_electron]
+    end
+  end
+
+  context "ceremony in finland, resident in the UK, partner Irish SS" do
+    setup do
+      worldwide_api_has_organisations_for_location('finland', read_fixture_file('worldwide/finland_organisations.json'))
+      worldwide_api_has_organisations_for_location('australia', read_fixture_file('worldwide/australia_organisations.json'))
+      add_response 'finland'
+      add_response 'uk'
+      add_response 'uk_england'
+      add_response 'partner_irish'
+      add_response 'same_sex'
+    end
+    should "go to affirmation outcome with specific fee table" do
+      assert_current_node :outcome_os_affirmation
+      assert_phrase_list :affirmation_os_outcome, [:affirmation_os_uk_resident, :affirmation_os_all_what_you_need_to_do, :what_you_need_to_do_affidavit, :appointment_for_affidavit, :embassies_data, :affidavit_os_translation_in_local_language_text, :docs_decree_and_death_certificate, :divorced_or_widowed_evidences, :change_of_name_evidence, :partner_equivalent_document_warning, :affirmation_os_partner_not_british, :fee_table_affidavit_65, :list_of_consular_fees, :pay_in_euros_or_visa_electron]
+    end
+  end
+
+  context "south-korea new outcome" do
+    should "go to outcome os affirmation with new korea phraselist" do
+      worldwide_api_has_organisations_for_location('south-korea', read_fixture_file('worldwide/south-korea_organisations.json'))
+      add_response 'south-korea'
+      add_response 'uk'
+      add_response 'uk_england'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+      assert_current_node :outcome_os_affirmation
+      assert_phrase_list :affirmation_os_outcome, [:affirmation_os_uk_resident, :affirmation_os_all_what_you_need_to_do, :what_you_need_to_do_affirmation, :appointment_for_affidavit, :embassies_data, :affirmation_os_translation_in_local_language_text, :docs_decree_and_death_certificate, :divorced_or_widowed_evidences, :change_of_name_evidence, :affirmation_os_partner_british, :fee_table_affidavit_55, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+
+  #testing for ceremony in philippines, uk resident, partner other
+  context "ceremony in philippines, uk resident, partner other" do
+    setup do
+      worldwide_api_has_organisations_for_location('philippines', read_fixture_file('worldwide/philippines_organisations.json'))
+      add_response 'philippines'
+      add_response 'uk'
+      add_response 'uk_england'
+      add_response 'partner_local'
+      add_response 'opposite_sex'
+    end
+    should "go to os affirmation outcome" do
+      assert_phrase_list :affirmation_os_outcome, [:affirmation_os_uk_resident, :affirmation_os_all_what_you_need_to_do, :what_you_need_to_do_affirmation, :contact_for_affidavit, :make_appointment_online_philippines, :embassies_data, :affirmation_os_translation_in_local_language_text, :affirmation_os_download_affidavit_philippines, :docs_decree_and_death_certificate, :divorced_or_widowed_evidences, :change_of_name_evidence, :partner_equivalent_document_warning, :affirmation_os_partner_not_british, :fee_table_55_70, :list_of_consular_fees, :pay_in_cash_or_manager_cheque]
+    end
+  end
+
+  context "slovakia, no money phraselists" do
+    should "" do
+      worldwide_api_has_organisations_for_location('slovakia', read_fixture_file('worldwide/slovakia_organisations.json'))
+      add_response 'slovakia'
+      add_response 'uk'
+      add_response 'uk_england'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+      assert_current_node :outcome_os_no_cni
+      assert_phrase_list :no_cni_os_outcome, [:no_cni_os_not_dutch_caribbean_islands_uk_resident, :get_legal_advice, :cni_os_consular_facilities_unavailable]
+    end
+  end
+
+  context "netherlands outcome" do
+    should "bring you to netherlands outcome" do
+      worldwide_api_has_organisations_for_location('netherlands', read_fixture_file('worldwide/netherlands_organisations.json'))
+      add_response 'netherlands'
+      add_response 'uk'
+      add_response 'uk_england'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+      assert_current_node :outcome_netherlands
+      assert_phrase_list :netherlands_phraselist, [:contact_local_authorities, :get_legal_advice, :partner_naturalisation_in_uk]
+    end
+  end
+
+  context "indonesia opposite sex outcome" do
+    should "bring you to indonesia os outcome" do
+      worldwide_api_has_organisations_for_location('indonesia', read_fixture_file('worldwide/indonesia_organisations.json'))
+      add_response 'indonesia'
+      add_response 'uk'
+      add_response 'uk_england'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+      assert_current_node :outcome_os_indonesia
+      assert_phrase_list :indonesia_os_phraselist, [:appointment_for_affidavit, :complete_affidavit_with_download_link, :embassies_data, :documents_for_divorced_or_widowed, :partner_affidavit_needed, :fee_table_45_70_55]
+    end
+  end
+  context "aruba opposite sex outcome" do
+    should "bring you to aruba os outcome" do
+      worldwide_api_has_organisations_for_location('aruba', read_fixture_file('worldwide/aruba_organisations.json'))
+      add_response 'aruba'
+      add_response 'uk'
+      add_response 'uk_england'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_local_resident_ceremony_not_italy_not_germany_partner_british, :consular_cni_os_all_names_but_germany, :consular_cni_os_fees_not_italy_not_uk]
+    end
+  end
+  context "ceremony in azerbaijan, resident in northern ireland, partner irish" do
+    setup do
+      worldwide_api_has_organisations_for_location('azerbaijan', read_fixture_file('worldwide/azerbaijan_organisations.json'))
+      add_response 'azerbaijan'
+      add_response 'uk'
+      add_response 'uk_ni'
+      add_response 'partner_irish'
+      add_response 'same_sex'
+    end
+    should "go to outcome_ss_marriage" do
+      assert_current_node :outcome_ss_marriage
+    end
+  end
+  context "uk resident, ceremony in estonia, partner british" do
+    setup do
+      worldwide_api_has_organisations_for_location('estonia', read_fixture_file('worldwide/estonia_organisations.json'))
+      add_response 'estonia'
+      add_response 'uk'
+      add_response 'uk_wales'
+      add_response 'partner_british'
+      add_response 'same_sex'
+    end
+    should "go to consular cni os outcome" do
+      assert_current_node :outcome_ss_marriage
+      assert_phrase_list :ss_title, [:title_ss_marriage]
+      assert_phrase_list :ss_ceremony_body, [:able_to_ss_marriage, :contact_embassy_or_consulate, :embassies_data, :documents_needed_21_days_residency, :documents_needed_ss_british, :what_to_do_ss_marriage, :will_display_in_14_days, :no_objection_in_14_days_ss_marriage, :provide_two_witnesses_ss_marriage, :ss_marriage_footnote_21_days_residency, :partner_naturalisation_in_uk, :fees_table_ss_marriage_alt, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  context "ceremony in russia, lives in poland, same sex marriage, non british partner" do
+    setup do
+      worldwide_api_has_organisations_for_location('russia', read_fixture_file('worldwide/russia_organisations.json'))
+      worldwide_api_has_organisations_for_location('poland', read_fixture_file('worldwide/poland_organisations.json'))
+      add_response 'russia'
+      add_response 'other'
+      add_response 'poland'
+      add_response 'partner_other'
+      add_response 'same_sex'
+    end
+    should "go to outcome_ss_marriage_not_possible" do
+      assert_current_node :outcome_ss_marriage_not_possible
+    end
+  end
+  context "ceremony in cambodia, lives in poland, same sex marriage, non british partner" do
+    setup do
+      worldwide_api_has_organisations_for_location('cambodia', read_fixture_file('worldwide/cambodia_organisations.json'))
+      worldwide_api_has_organisations_for_location('poland', read_fixture_file('worldwide/poland_organisations.json'))
+      add_response 'cambodia'
+      add_response 'other'
+      add_response 'poland'
+      add_response 'partner_other'
+      add_response 'same_sex'
+    end
+    should "go to outcome_ss_marriage" do
+      assert_current_node :outcome_ss_marriage
+      assert_phrase_list :ss_ceremony_body, [:able_to_ss_marriage_and_partnership, :contact_embassy_or_consulate, :embassies_data, :documents_needed_21_days_residency, :documents_needed_ss_not_british, :what_to_do_ss_marriage_and_partnership, :will_display_in_14_days, :no_objection_in_14_days_ss_marriage_and_partnership, :provide_two_witnesses_ss_marriage_and_partnership, :ss_marriage_footnote_21_days_residency, :partner_naturalisation_in_uk, :fees_table_ss_marriage_and_partnership, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  context "Marrying anywhere in the world > British National not living in the UK > Resident in Portugal > Partner of any nationality > Opposite sex" do
+    setup do
+      worldwide_api_has_organisations_for_location('portugal', read_fixture_file('worldwide/portugal_organisations.json'))
+      worldwide_api_has_organisations_for_location('vietnam', read_fixture_file('worldwide/vietnam_organisations.json'))
+      add_response 'vietnam'
+      add_response 'other'
+      add_response 'portugal'
+      add_response 'partner_other'
+      add_response 'opposite_sex'
+    end
+    should "go to affirmation_os_outcome" do
+      assert_current_node :outcome_os_affirmation
+      assert_phrase_list :affirmation_os_outcome, [:affirmation_os_other_resident, :affirmation_os_all_what_you_need_to_do, :what_you_need_to_do_affirmation, :appointment_for_affidavit, :docs_decree_and_death_certificate, :divorced_or_widowed_evidences, :change_of_name_evidence, :partner_equivalent_document_warning, :affirmation_os_partner_not_british, :fee_table_affidavit_55, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  context "kazakhstan should show its correct embassy page" do
+    setup do
+      worldwide_api_has_organisations_for_location('kazakhstan', read_fixture_file('worldwide/kazakhstan_organisations.json'))
+      worldwide_api_has_organisations_for_location('american-samoa', read_fixture_file('worldwide/american-samoa_organisations.json'))
+      add_response 'kazakhstan'
+      add_response 'other'
+      add_response 'american-samoa'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+    end
+    should "go to affirmation_os_outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:other_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :consular_cni_os_foreign_resident_ceremony_not_germany_italy, :consular_cni_os_foreign_resident_3_days_notary_public, :consular_cni_variant_local_resident_or_foreign_resident_notary_public, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :consular_cni_os_download_documents_notary_public, :consular_cni_os_foreign_resident_ceremony_notary_public]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_local_resident_ceremony_not_italy_not_germany_partner_british, :consular_cni_os_all_names_but_germany, :consular_cni_os_other_resident_ceremony_not_italy, :consular_cni_os_fees_not_italy_not_uk, :consular_cni_os_fees_foreign_commonwealth_roi_resident_kazakhstan, :pay_in_local_currency_ceremony_country_name]
+    end
+  end
+  context "Marrying anywhere in the world > British National not living in the UK > Resident in Portugal > Partner of any nationality > Opposite sex" do
+    setup do
+      worldwide_api_has_organisations_for_location('portugal', read_fixture_file('worldwide/portugal_organisations.json'))
+      worldwide_api_has_organisations_for_location('vietnam', read_fixture_file('worldwide/vietnam_organisations.json'))
+      add_response 'portugal'
+      add_response 'other'
+      add_response 'vietnam'
+      add_response 'partner_other'
+      add_response 'opposite_sex'
+    end
+    should "go to portugal outcome" do
+      assert_current_node :outcome_portugal
+      assert_phrase_list :portugal_title, [:marriage_title]
+    end
+  end
+  context "Marrying anywhere in the world > British National not living in the UK > Resident in Portugal > Partner of any nationality > Opposite sex" do
+    setup do
+      worldwide_api_has_organisations_for_location('portugal', read_fixture_file('worldwide/portugal_organisations.json'))
+      add_response 'portugal'
+      add_response 'uk'
+      add_response 'uk_iom'
+      add_response 'partner_other'
+      add_response 'opposite_sex'
+    end
+    should "go to portugal outcome" do
+      assert_current_node :outcome_portugal
+      assert_phrase_list :portugal_title, [:marriage_title]
+    end
+  end
+  context "Residency Country and ceremony country = Croatia" do
+    setup do
+      worldwide_api_has_organisations_for_location('croatia', read_fixture_file('worldwide/croatia_organisations.json'))
+      add_response 'croatia'
+      add_response 'other'
+      add_response 'croatia'
+      add_response 'partner_other'
+      add_response 'opposite_sex'
+    end
+    should "go to outcome_os_consular_cni and show specific phraselist" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:local_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :what_to_do_croatia, :consular_cni_os_local_resident_table, :embassies_data, :consular_cni_variant_local_resident_or_foreign_resident_notary_public, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :consular_cni_os_download_documents_notary_public, :consular_cni_os_foreign_resident_ceremony_notary_public]
+    end
+  end
+  context "Marrying in Qatar > Resident in Qatar > Partner is British > Partner is opposite sex" do
+    setup do
+      worldwide_api_has_organisations_for_location('qatar', read_fixture_file('worldwide/croatia_organisations.json'))
+      add_response 'qatar'
+      add_response 'other'
+      add_response 'qatar'
+      add_response 'partner_other'
+      add_response 'opposite_sex'
+    end
+    should "go to outcome_os_consular_cni and show specific phraselist" do
+      assert_current_node :outcome_os_affirmation
+      assert_phrase_list :affirmation_os_outcome, [:affirmation_os_local_resident, :gulf_states_os_consular_cni, :gulf_states_os_consular_cni_local_resident_partner_not_irish, :affirmation_os_all_what_you_need_to_do, :what_you_need_to_do_affirmation, :appointment_for_affidavit, :embassies_data, :affirmation_os_translation_in_local_language_text, :docs_decree_and_death_certificate, :divorced_or_widowed_evidences, :change_of_name_evidence, :partner_equivalent_document_warning, :affirmation_os_partner_not_british, :fee_table_45_70_55, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  context "Marrying in Qatar > Resident of anywhere in the world > Partner is of any nationality in the world > Partner is opposite sex" do
+    setup do
+      worldwide_api_has_organisations_for_location('qatar', read_fixture_file('worldwide/qatar_organisations.json'))
+      worldwide_api_has_organisations_for_location('japan', read_fixture_file('worldwide/japan_organisations.json'))
+      add_response 'qatar'
+      add_response 'other'
+      add_response 'japan'
+      add_response 'partner_other'
+      add_response 'opposite_sex'
+    end
+    should "go to outcome_os_consular_cni and show specific phraselist" do
+      assert_current_node :outcome_os_affirmation
+      assert_phrase_list :affirmation_os_outcome, [:affirmation_os_local_resident, :gulf_states_os_consular_cni, :gulf_states_os_consular_cni_local_resident_partner_not_irish, :affirmation_os_all_what_you_need_to_do, :what_you_need_to_do_affirmation, :appointment_for_affidavit, :embassies_data, :affirmation_os_translation_in_local_language_text, :docs_decree_and_death_certificate, :divorced_or_widowed_evidences, :change_of_name_evidence, :partner_equivalent_document_warning, :affirmation_os_partner_not_british, :fee_table_45_70_55, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  context "ceremony in Lithuania, partner same sex, partner british" do
+    setup do
+      worldwide_api_has_organisations_for_location('lithuania', read_fixture_file('worldwide/lithuania_organisations.json'))
+      add_response 'lithuania'
+      add_response 'other'
+      add_response 'lithuania'
+      add_response 'partner_british'
+      add_response 'same_sex'
+    end
+    should "go to outcome_ss_marriage" do
+      assert_current_node :outcome_ss_marriage
+      assert_phrase_list :ss_ceremony_body, [:able_to_ss_marriage, :contact_embassy_or_consulate, :embassies_data, :documents_needed_21_days_residency, :documents_needed_ss_british, :what_to_do_ss_marriage, :will_display_in_14_days, :no_objection_in_14_days_ss_marriage, :provide_two_witnesses_ss_marriage, :ss_marriage_footnote_21_days_residency, :partner_naturalisation_in_uk, :fees_table_ss_marriage, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+  context "ceremony in Lithuania, partner same sex, partner not british" do
+    setup do
+      worldwide_api_has_organisations_for_location('lithuania', read_fixture_file('worldwide/lithuania_organisations.json'))
+      add_response 'lithuania'
+      add_response 'other'
+      add_response 'lithuania'
+      add_response 'partner_local'
+      add_response 'same_sex'
+    end
+    should "go to outcome 'no same sex marriage allowed' because partner is not british" do
+      assert_current_node :outcome_cp_all_other_countries
+    end
+  end
+  context "test Belarus' address box" do
+    setup do
+      worldwide_api_has_organisations_for_location('belarus', read_fixture_file('worldwide/belarus_organisations.json'))
+      worldwide_api_has_organisations_for_location('armenia', read_fixture_file('worldwide/armenia_organisations.json'))
+      add_response 'belarus'
+      add_response 'other'
+      add_response 'armenia'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+    end
+    should "go to outcome_ss_marriage and show correct address box" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:other_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :consular_cni_os_foreign_resident_ceremony_not_germany_italy, :consular_cni_os_foreign_resident_ceremony_country_not_germany, :consular_cni_variant_local_resident_not_germany_or_spain_or_foreign_resident, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :consular_cni_os_local_resident_not_germany_or_spain_or_foreign_resident_not_germany, :consular_cni_os_foreign_resident_ceremony_not_italy]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_local_resident_ceremony_not_italy_not_germany_partner_british, :consular_cni_os_all_names_but_germany, :consular_cni_os_other_resident_ceremony_not_italy, :consular_cni_os_fees_not_italy_not_uk, :consular_cni_os_fees_foreign_commonwealth_roi_resident, :pay_by_cash_or_credit_card_no_cheque]
+      assert_match /37, Karl Marx Street/, outcome_body
+    end
+  end
+
+  context "test morocco specific phraselists, living in the UK" do
+    setup do
+      worldwide_api_has_organisations_for_location('morocco', read_fixture_file('worldwide/morocco_organisations.json'))
+      add_response 'morocco'
+      add_response 'uk'
+      add_response 'uk_england'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+    end
+    should "go to os affirmation outcome" do
+      assert_current_node :outcome_os_affirmation
+      assert_phrase_list :affirmation_os_outcome, [:affirmation_os_uk_resident_ceremony_in_morocco, :what_you_need_to_do_affirmation, :appointment_for_affidavit, :embassies_data, :affirmation_os_translation_in_local_language_text, :documents_for_divorced_or_widowed, :morocco_affidavit_length, :partner_equivalent_document, :fee_table_affirmation_55, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+
+  context "test morocco specific phraselists, living in Armenia" do
+    setup do
+      worldwide_api_has_organisations_for_location('morocco', read_fixture_file('worldwide/morocco_organisations.json'))
+      worldwide_api_has_organisations_for_location('armenia', read_fixture_file('worldwide/armenia_organisations.json'))
+      add_response 'morocco'
+      add_response 'other'
+      add_response 'armenia'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+    end
+    should "go to os affirmation outcome" do
+      assert_current_node :outcome_os_affirmation
+      assert_phrase_list :affirmation_os_outcome, [:affirmation_os_other_resident_ceremony_in_morocco, :what_you_need_to_do_affirmation, :appointment_for_affidavit, :embassies_data, :affirmation_os_translation_in_local_language_text, :documents_for_divorced_or_widowed, :morocco_affidavit_length, :partner_equivalent_document, :fee_table_affirmation_55, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+
+  context "Marriage in Mexico, living in Germany, partner British, opposite sex" do
+    setup do
+      worldwide_api_has_organisations_for_location('mexico', read_fixture_file('worldwide/mexico_organisations.json'))
+      worldwide_api_has_organisations_for_location('germany', read_fixture_file('worldwide/germany_organisations.json'))
+      add_response 'mexico'
+      add_response 'other'
+      add_response 'germany'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+    end
+    should "show same outcome of Albania" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:other_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :consular_cni_os_foreign_resident_ceremony_not_germany_italy, :consular_cni_os_foreign_resident_3_days_notary_public, :consular_cni_variant_local_resident_or_foreign_resident_notary_public, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :consular_cni_os_download_documents_notary_public, :consular_cni_os_foreign_resident_ceremony_notary_public]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_local_resident_ceremony_not_italy_not_germany_partner_british, :consular_cni_os_all_names_but_germany, :consular_cni_os_other_resident_ceremony_not_italy, :consular_cni_os_fees_not_italy_not_uk, :consular_cni_os_fees_foreign_commonwealth_roi_resident, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+
+  context "Marriage in Albania, living in Germany, partner British, opposite sex" do
+    setup do
+      worldwide_api_has_organisations_for_location('albania', read_fixture_file('worldwide/albania_organisations.json'))
+      worldwide_api_has_organisations_for_location('germany', read_fixture_file('worldwide/germany_organisations.json'))
+      add_response 'albania'
+      add_response 'other'
+      add_response 'germany'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+    end
+    should "show Albania outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:other_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :consular_cni_os_foreign_resident_ceremony_not_germany_italy, :consular_cni_os_foreign_resident_3_days_notary_public, :consular_cni_variant_local_resident_or_foreign_resident_notary_public, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :consular_cni_os_download_documents_notary_public, :consular_cni_os_foreign_resident_ceremony_notary_public]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_local_resident_ceremony_not_italy_not_germany_partner_british, :consular_cni_os_all_names_but_germany, :consular_cni_os_other_resident_ceremony_not_italy, :consular_cni_os_fees_not_italy_not_uk, :consular_cni_os_fees_foreign_commonwealth_roi_resident, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+
+  context "Marriage in Mexico, living in the UK, partner British, opposite sex" do
+    setup do
+      worldwide_api_has_organisations_for_location('mexico', read_fixture_file('worldwide/mexico_organisations.json'))
+      add_response 'mexico'
+      add_response 'uk'
+      add_response 'uk_england'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+    end
+    should "show the same content of Albania" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:uk_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :cni_at_local_register_office_notary_public, :consular_cni_os_uk_resident_legalisation, :consular_cni_os_uk_resident_not_italy_or_portugal, :consular_cni_os_download_documents_notary_public]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_local_resident_ceremony_not_italy_not_germany_partner_british, :consular_cni_os_all_names_but_germany, :consular_cni_os_fees_not_italy_not_uk, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+
+  context "Marriage in Albania, living in the UK, partner British, opposite sex" do
+    setup do
+      worldwide_api_has_organisations_for_location('albania', read_fixture_file('worldwide/albania_organisations.json'))
+      add_response 'albania'
+      add_response 'uk'
+      add_response 'uk_england'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+    end
+    should "show Albania outcome" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:uk_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :cni_at_local_register_office_notary_public, :consular_cni_os_uk_resident_legalisation, :consular_cni_os_uk_resident_not_italy_or_portugal, :consular_cni_os_download_documents_notary_public]
+      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_local_resident_ceremony_not_italy_not_germany_partner_british, :consular_cni_os_all_names_but_germany, :consular_cni_os_fees_not_italy_not_uk, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+
+  #Marriage that requires a 7 day notice to be given
+  context "Marriage in Canada, living in Spain" do
+    setup do
+      worldwide_api_has_organisations_for_location('canada', read_fixture_file('worldwide/canada_organisations.json'))
+      worldwide_api_has_organisations_for_location('spain', read_fixture_file('worldwide/spain_organisations.json'))
+      add_response 'canada'
+      add_response 'other'
+      add_response 'spain'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+    end
+    should "show 7 day notice" do
+      assert_current_node :outcome_os_commonwealth
+      assert_phrase_list :commonwealth_os_outcome, [:other_resident_os_ceremony_not_zimbabwe, :commonwealth_os_all_cni, :display_notice_of_marriage_7_days]
+    end
+  end
+  context "Marriage in Rwanda, living in Spain" do
+    setup do
+      worldwide_api_has_organisations_for_location('rwanda', read_fixture_file('worldwide/rwanda_organisations.json'))
+      worldwide_api_has_organisations_for_location('spain', read_fixture_file('worldwide/spain_organisations.json'))
+      add_response 'rwanda'
+      add_response 'other'
+      add_response 'spain'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+    end
+    should "show 7 day notice" do
+      assert_current_node :outcome_os_no_cni
+      assert_phrase_list :no_cni_os_outcome, [:no_cni_os_not_dutch_caribbean_other_resident, :get_legal_advice, :cni_os_consular_facilities_unavailable, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque, :display_notice_of_marriage_7_days]
+    end
+  end
+
+  context "same sex marriage in San Marino is not allowed" do
+    setup do
+      worldwide_api_has_organisations_for_location('san-marino', read_fixture_file('worldwide/san-marino_organisations.json'))
+      add_response 'san-marino'
+      add_response 'uk'
+      add_response 'uk_england'
+      add_response 'partner_british'
+      add_response 'same_sex'
+    end
+    should "do not allow marriage" do
+      assert_current_node :outcome_ss_marriage_not_possible
+    end
+  end
+
+  context "same sex marriage in Malta" do
+    setup do
+      worldwide_api_has_organisations_for_location('malta', read_fixture_file('worldwide/malta_organisations.json'))
+      add_response 'malta'
+      add_response 'uk'
+      add_response 'uk_england'
+      add_response 'partner_british'
+      add_response 'same_sex'
+    end
+    should "do not allow marriage" do
+      assert_current_node :outcome_ss_marriage_malta
+      assert_phrase_list :ss_body, [:able_to_ss_marriage_and_partnership_hc, :consular_cp_all_contact, :embassies_data, :documents_needed_21_days_residency, :documents_needed_ss_british, :what_to_do_ss_marriage_and_partnership_hc, :will_display_in_14_days_hc, :no_objection_in_14_days_ss_marriage_and_partnership, :provide_two_witnesses_ss_marriage_and_partnership, :ss_marriage_footnote_hc, :partner_naturalisation_in_uk, :fees_table_ss_marriage_and_partnership, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque, :convert_cc_to_ss_marriage]
+    end
+  end
+
+  context "opposite sex marriage in Malta" do
+    setup do
+      worldwide_api_has_organisations_for_location('malta', read_fixture_file('worldwide/malta_organisations.json'))
+      add_response 'malta'
+      add_response 'uk'
+      add_response 'uk_england'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+    end
+    should "do not allow marriage" do
+      assert_current_node :outcome_os_commonwealth
+    end
+  end
+end

--- a/test/unit/calculators/registrations_data_query_v2_test.rb
+++ b/test/unit/calculators/registrations_data_query_v2_test.rb
@@ -1,0 +1,102 @@
+require_relative "../../test_helper"
+
+module SmartAnswer::Calculators
+  class RegistrationsDataQueryV2Test < ActiveSupport::TestCase
+
+    context RegistrationsDataQueryV2 do
+      setup do
+        @query = SmartAnswer::Calculators::RegistrationsDataQueryV2.new
+      end
+      context "registration_data method" do
+        should "read registrations data" do
+          assert_equal Hash, @query.data.class
+        end
+      end
+      context "commonwealth_country? method" do
+        should "indicate whether a country slug refers to a commonwealth country" do
+          assert @query.commonwealth_country?('australia')
+          refute @query.commonwealth_country?('spain')
+        end
+      end
+      context "clickbook method" do
+        should "return the url for a country with a single clickbook url" do
+          assert_equal "http://www.britishembassyinbsas.clickbook.net/", @query.clickbook('argentina')
+        end
+        should "return a hash of urls keyed by city for countries with multiple clickbooks" do
+          clickbook = @query.clickbook('china')
+          assert_equal Hash, clickbook.class
+          assert_equal "Beijing", clickbook.keys.first
+          assert_equal "https://www.clickbook.net/dev/bc.nsf/sub/BritConChongqing", clickbook["Chongqing"]
+        end
+      end
+      context "has_high_commission?" do
+        should "be true for countries with a high commission" do
+          assert @query.has_high_commission?('trinidad-and-tobago')
+          refute @query.has_high_commission?('australia')
+        end
+      end
+      context "has_consulate?" do
+        should "be true for countries with a consulate" do
+          assert @query.has_consulate?('russia')
+          refute @query.has_consulate?('uganda')
+        end
+      end
+      context "cash_only?" do
+        should "be true for countries that only accept cash" do
+          assert @query.cash_only?('iceland')
+          refute @query.cash_only?('spain')
+        end
+      end
+      context "register_death_by_post?" do
+        should "be true for countries that allow registration by post" do
+          assert @query.register_death_by_post?('barbados')
+          refute @query.register_death_by_post?('afghanistan')
+        end
+      end
+      context "postal_form" do
+        should "give the form url if it exists" do
+          assert_equal "/government/publications/passport-credit-debit-card-payment-authorisation-slip-austria", @query.postal_form('austria')
+          refute @query.postal_form('usa')
+        end
+      end
+      context "postal_return_form" do
+        should "give the form url if it exists" do
+          assert_equal "/government/publications/registered-post-return-delivery-form-italy", @query.postal_return_form('italy')
+          refute @query.postal_return_form('belgium')
+        end
+      end
+      context "registration_country_slug" do
+        should "map the country to a registration country if one exists" do
+          assert_equal "spain", @query.registration_country_slug('andorra')
+        end
+        should "give the original if no mapping exists" do
+          assert_equal "spain", @query.registration_country_slug('spain')
+        end
+      end
+
+      context "oru transition countries" do
+        should "be true for Wallis and Fortuna" do
+          assert SmartAnswer::Calculators::RegistrationsDataQueryV2::ORU_TRANSITIONED_COUNTRIES.include?('wallis-and-futuna')
+          refute SmartAnswer::Calculators::RegistrationsDataQueryV2::ORU_TRANSITIONED_COUNTRIES.include?('pakistan')
+        end
+
+        should "be true for Martinique" do
+          assert SmartAnswer::Calculators::RegistrationsDataQueryV2::ORU_TRANSITIONED_COUNTRIES.include?('martinique')
+          refute SmartAnswer::Calculators::RegistrationsDataQueryV2::ORU_TRANSITIONED_COUNTRIES.include?('ireland')
+        end
+      end
+
+      context "oru document variant countries" do
+        should "be true for Netherlands" do
+          assert SmartAnswer::Calculators::RegistrationsDataQueryV2::ORU_TRANSITIONED_COUNTRIES.include?('netherlands')
+        end
+
+        should "be true for Belgium" do
+          assert SmartAnswer::Calculators::RegistrationsDataQueryV2::ORU_TRANSITIONED_COUNTRIES.include?('belgium')
+          refute SmartAnswer::Calculators::RegistrationsDataQueryV2::ORU_TRANSITIONED_COUNTRIES.include?('india')
+        end
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Updates the download link to fetch the 'Affidavit for Marriage' document required by non-uk resident Brazilian nationals wishing to marry in another country.