### PR TITLE
Copy and Logic changes to overseas passports

### DIFF
--- a/lib/data/passport_data.yml
+++ b/lib/data/passport_data.yml
@@ -1845,7 +1845,7 @@ tonga:
   replacing: 8_weeks
 trinidad-and-tobago:
   type: ips_application_1
-  group: ips_documents_group_1
+  group: ips_documents_group_3
   app_form: hmpo_2_application_form
   online_application: true
   renewing_new: 8_weeks

--- a/lib/smart_answer/calculators/passport_and_embassy_data_query_v2.rb
+++ b/lib/smart_answer/calculators/passport_and_embassy_data_query_v2.rb
@@ -1,0 +1,88 @@
+module SmartAnswer::Calculators
+  class PassportAndEmbassyDataQueryV2
+    def ineligible_country?
+      SmartAnswer::Predicate::RespondedWith.new(%w{iran libya syria})
+    end
+
+    def apply_in_neighbouring_countries?
+      SmartAnswer::Predicate::RespondedWith.new(
+        %w(british-indian-ocean-territory north-korea south-georgia-and-south-sandwich-islands)
+      )
+    end
+
+    def ips_application?
+      SmartAnswer::Predicate::VariableMatches.new(:application_type,
+        %w{ips_application_1 ips_application_2 ips_application_3},
+        "IPS")
+    end
+
+    def fco_application?
+      SmartAnswer::Predicate::VariableMatches.new(:application_type, %w{pretoria_south_africa})
+    end
+
+    include ActionView::Helpers::NumberHelper
+
+    ALT_EMBASSIES = {
+      'benin' =>  'nigeria',
+      'guinea' => 'ghana'
+    }
+
+    RETAIN_PASSPORT_COUNTRIES = %w(angola brazil burundi cuba
+    egypt eritrea georgia iraq lebanon libya morocco rwanda sri-lanka sudan timor-leste tunisia uganda yemen zambia)
+
+    RETAIN_PASSPORT_COUNTRIES_HURRICANES = %w(anguilla antigua-and-barbuda bahamas bermuda bonaire-st-eustatius-saba british-virgin-islands cayman-islands curacao dominica dominican-republic french-guiana grenada guadeloupe guyana haiti martinique mexico montserrat st-maarten st-kitts-and-nevis st-lucia st-pierre-and-miquelon st-vincent-and-the-grenadines suriname trinidad-and-tobago turks-and-caicos-islands)
+
+    PASSPORT_COSTS = {
+      'Australian Dollars'  => [[282.21], [325.81], [205.81]],
+      'Euros'               => [[161, 186],   [195, 220],   [103, 128]],
+      'New Zealand Dollars' => [["317.80", 337.69], ["371.80", 391.69], ["222.80", 242.69]],
+      'SLL'                 => [[900000, 1135000], [1085000, 1320000], [575000, 810000]],
+      'South African Rand'  => [[2112, 2440], [2549, 2877], [1345, 1673]]
+    }
+
+    CASH_ONLY_COUNTRIES = %w(cuba sudan)
+
+    RENEWING_COUNTRIES = %w(belarus burma cuba lebanon libya russia sudan tajikistan tunisia turkmenistan uzbekistan zimbabwe)
+
+    attr_reader :passport_data
+
+    def initialize
+      @passport_data = self.class.passport_data
+    end
+
+    def find_passport_data(country_slug)
+      passport_data[country_slug]
+    end
+
+    def retain_passport?(country_slug)
+      RETAIN_PASSPORT_COUNTRIES.include?(country_slug)
+    end
+
+    def retain_passport_hurricanes?(country_slug)
+      RETAIN_PASSPORT_COUNTRIES_HURRICANES.include?(country_slug)
+    end
+
+    def cash_only_countries?(country_slug)
+      CASH_ONLY_COUNTRIES.include?(country_slug)
+    end
+
+    def renewing_countries?(country_slug)
+      RENEWING_COUNTRIES.include?(country_slug)
+    end
+
+    def passport_costs
+      {}.tap do |costs|
+        PASSPORT_COSTS.each do |k, v|
+          [:adult_32, :adult_48, :child].each_with_index do |t, i|
+            key = "#{k.downcase.gsub(' ', '_')}_#{t}"
+            costs[key] = v[i].map { |c| "#{number_with_delimiter(c)} #{k}"}.join(" | ")
+          end
+        end
+      end
+    end
+
+    def self.passport_data
+      @passport_data ||= YAML.load_file(Rails.root.join("lib", "data", "passport_data.yml"))
+    end
+  end
+end

--- a/lib/smart_answer_flows/locales/en/overseas-passports-v2.yml
+++ b/lib/smart_answer_flows/locales/en/overseas-passports-v2.yml
@@ -1,0 +1,1552 @@
+en-GB:
+  flow:
+    overseas-passports-v2:
+      title: Overseas British passport applications
+      meta:
+        description: Renew, replace or apply for an adult or child British passport if you’re living abroad or working overseas - forms, prices, how long it takes
+      body: |
+        Get the forms, prices and application details you need if you're a British national and you want to renew or apply for a British passport from overseas.
+
+        %If you can't wait for a new passport, you can get details on how to apply for a [12-month extension](/get-an-emergency-passport-extension-or-child-travel-document) to your British passport.%
+
+        ##Dual nationals
+
+        You must send a colour photocopy of your non-British passport (every page including blank pages) as part of your application.
+
+        You may be asked to show your non-British passport at a later date.
+
+      which_country_are_you_in?:
+        title: Which country or territory are you in?
+      which_opt?:
+        title: Where are you?
+        options:
+          gaza: "Gaza"
+          jerusalem-or-westbank: "Jerusalem and the West Bank"
+      renewing_replacing_applying?:
+        title: Are you renewing, replacing or applying for a first passport?
+        options:
+          renewing_new: "Renewing a red passport"
+          renewing_old: "Renewing an old black or blue passport"
+          applying: "Applying for a first passport"
+          replacing: "Replacing a lost or stolen passport"
+      child_or_adult_passport?:
+        title: Do you need an adult or child passport?
+        options:
+          adult: "Adult (aged 16 and over)"
+          child: "Child (aged 15 or under)"
+      country_of_birth?:
+        title: Which country were you born in?
+      which_best_describes_you_adult?:
+        title: Which of the following best describes you?
+      which_best_describes_you_child?:
+        title: Which of the following best describes you?
+      phrases:
+        birth_certificate_south-africa: |
+          ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
+        birth_certificate_spain: |
+          ^You must include your full birth certificate (‘certificación literal’) with your application - a photocopy won’t be accepted.^
+        passport_delivered_by_courier: |
+          Your passport will be delivered to you by courier.
+        you_may_have_to_attend_an_interview: |
+          You may have to attend an interview.
+
+        supporting_documents_south_africa_applying: |
+          ^[Supporting documents for adults born in the UK](/government/publications/british-passport-adult-supporting-documentation)^
+          ^[Supporting documents for adults born overseas](/government/publications/british-passport-adult-supporting-documentation-overseas)^
+          ^[Supporting documents for children born in the UK](/government/publications/british-passport-child-supporting-documentation)^
+          ^[Supporting documents for children born overseas](/government/publications/british-passport-child-supporting-documentation-overseas)^
+
+        passport_courier_costs_fco_europe:
+          You’ll have to pay a fee for your passport and a courier fee of 24 Euros. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+
+        adult_passport_costs_fco_europe: |
+          Passport type | Passport fee | Total to pay (including courier fee)
+          -|-|-
+          Adult standard 32-page passport | %{costs_euros_adult_32}
+          Adult jumbo 48-page passport | %{costs_euros_adult_48}
+
+        child_passport_costs_fco_europe: |
+          Passport type | Passport fee | Total to pay (including courier fee)
+          -|-|-
+          Child passport | %{costs_euros_child}
+
+        how_to_apply_retain_passport: |
+          Send a photocopy of the pages of your existing passport that show your personal details, photograph and residence permit or visa.
+
+          Keep your existing passport for security and ID purposes - don’t send it with your application.
+
+        how_to_apply_retain_passport_hurricane: |
+          Don’t send your passport - keep it in case you have to to evacuate in the event of a hurricane.
+
+          You’ll need to send a photocopy of your passport, and a letter to explain why you’ve not sent the original.
+
+          When you get your new passport, send your old one to the [nearest British embassy, high commission or governors office](/government/world/organisations).
+
+        adult_fco_forms: |
+          __Smart application form__
+
+          - [Smart application form](/government/publications/application-for-united-kingdom-passport-for-overseas-customers) (fill in on screen, print and sign)
+
+          __Blank application form__
+
+           If you can’t use the smart form above, print this [blank application form](/government/publications/application-for-united-kingdom-passport-for-applicants-aged-16-or-over), fill in on paper and sign
+
+          __Guidance notes__
+
+          - [Guidance notes for adult applications](/government/publications/application-for-united-kingdom-passport-for-applicants-16-and-over-notes)
+
+        child_fco_forms: |
+          __Smart application form__
+
+          - [Smart application form](/government/publications/application-for-united-kingdom-passport-for-overseas-customers) (fill in on screen, print and sign)
+
+          __Blank application form__
+
+           If you can’t use the smart form above, print this [blank application form](/government/publications/application-for-united-kingdom-passport-for-applicants-under-16), fill in on paper and sign
+
+          __Guidance notes__
+
+            - [Guidance notes for child applications](/government/publications/application-for-united-kingdom-passport-for-applicants-under-16-notes)
+
+        getting_your_passport_fco: |
+          Your passport and supporting documents will be delivered separately by courier.
+
+          When you get your passport, check your name, date of birth and other personal details are correct.
+
+          If they’re not, send the passport back to the address above with a covering letter and evidence of what needs to be corrected (eg if your name is spelled incorrectly, provide evidence of how your name should be spelled).
+
+          If the error was made by the passport processing office, you’ll get a replacement free of charge. If the error was yours, you’ll have to pay for a replacement passport.
+
+        send_application_fco_preamble: |
+          Send your application, photographs and supporting documents, ideally by courier.
+
+        helpline_yemen: |
+
+
+          $C
+            **Passport information - Yemen**
+
+            967 1308 114
+            8am to-3pm local time, Sunday to Thursday
+
+             +44 207 008 1500 at any other time
+
+          $C
+
+        helpline_intro: |
+          If you haven’t received your passport within the expected timescale, you can check your application’s progress by phone. You will be charged for the call.
+
+          Don’t use this service any earlier - information won’t be available but you will still be charged for the call.
+        helpline_exceptions: |
+          If you haven’t received your passport within the expected timescales, or need to change your travel plans urgently (eg a close relative has died), you can leave a message with the passport processing centre in Madrid.
+
+          They will only call you back if your passport has been delayed or you have a genuine emergency.
+
+          $C
+
+            **Passport processing centre, Madrid**
+
+            00 34 91 714 6314
+          $C
+        helpline_exception_yemen: |
+          If you haven’t received your passport within the expected timescale, you can check your application’s progress by phone. You’ll be charged for the call.
+
+          $C
+          **Passport information - Yemen**
+
+          +44 208 082 4729
+          Monday to Friday, 24 hours a day
+          $C
+        helpline_: ''
+        helpline_fco_webchat: |
+          ### Webchat service
+
+          A webchat service is available. It costs a flat rate of £4 - you must pay by credit card before you start. Once you’ve paid, you’ll be given a reference number to launch your webchat. You’ll receive an email transcript of your conversation when you finish.
+
+          [Use the webchat service](https://www.synthetix.info/fco/ "Use the webchat service to chat to an advisor")
+
+        hmpo_1_application_form: |
+          ^[Application form - applying for a British passport overseas](/government/publications/applying-for-a-passport-from-outside-the-uk-application-form)^
+
+        hmpo_2_application_form: |
+          ^[Application form - applying for a British passport overseas](/government/publications/overseas-passport-application-form)^
+
+        ips_documents_group_1: |
+          ^[Guidance notes - applying for a passport if you’re outside the UK](/government/publications/overseas-passports-guidance)^
+          ^[Supporting documents you must send with your application](/government/publications/overseas-passport-applications-supporting-documents-guidance)^
+
+        ips_documents_group_2: |
+          ^[Guidance notes - applying for a passport if you’re outside the UK](/government/publications/overseas-passports-guidance)^
+          ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-2)^
+
+        ips_documents_group_3: |
+          ^[Guidance notes - applying for a passport if you’re outside the UK](/government/publications/overseas-passports-guidance)^
+          ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
+
+        passport_costs_ips_cash: |
+          You must pay in cash using local currency - the prices above will be converted according to the exchange rate when you apply.
+
+        passport_costs_ips_euros: |
+          You must pay in cash in Euros, the prices above will be converted according to the exchange rate when you apply.
+
+        passport_cost_and_admin_fee: |
+          You must pay in cash. In addition to the passport fee you’ll need to pay any local administration fees which apply from the office where you make your application.
+
+        how_long_additional_time_online: |
+          Applications may take longer if:
+
+          - HM Passport Office need to ask you for more information or documents
+          - the photographs you send are rejected
+
+          Don’t book any travel until you have a valid passport. If you need to travel more urgently, apply for an [Emergency Travel Document](/emergency-travel-document).
+        passport_courier_costs_ips1: |
+          You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
+
+        adult_passport_costs_ips1: |
+          | Passport type | Passport fee | Total to pay (including courier fee) |
+          |---------------|--------------|--------------------------------------|
+          | Adult standard 32-page passport | £83.00 | £102.86 |
+          | Adult jumbo 48-page passport | £91.00 | £110.86 |
+
+        child_passport_costs_ips1: |
+          | Passport type | Passport fee | Total to pay (including courier fee) |
+          |---------------|--------------|--------------------------------------|
+          | Child passport | £53.00 | £72.86 |
+
+        passport_courier_costs_replacing_ips1: |
+          You’ll have to pay a fee for your passport and a courier fee of £9.70. The courier fee pays for your passport to be sent back to you securely.
+
+        adult_passport_costs_replacing_ips1: |
+          | Passport type | Passport fee | Total to pay (including courier fee) |
+          |---------------|--------------|--------------------------------------|
+          | Adult standard 32-page passport | £83.00 | £92.70 |
+          | Adult jumbo 48-page passport | £91.00 | £100.70 |
+
+        child_passport_costs_replacing_ips1: |
+          | Passport type | Passport fee | Total to pay (including courier fee) |
+          |---------------|--------------|--------------------------------------|
+          | Child passport | £53.00 | £62.70 |
+
+        passport_costs_ips1: |
+          Fill in a [‘Paying by credit card or debit card’ form](/government/publications/overseas-passport-creditdebit-card-payment-authorisation) for each passport you’re applying for and submit it with your application. Your credit or debit card will be charged in sterling.
+
+          You can use Mastercard, Visa, Electron, Diners Club and JCB.
+
+        how_to_apply_ips1: |
+          1. Download the application form.
+          2. Use the ‘Applying for a passport if you’re outside the UK’ guidance notes to help you fill in the application form.
+          3. Include 2 identical new photos of you (or your child, if it’s a child passport application). [Follow the rules about passport photos](/photos-for-passports) or your application may be delayed.
+          4. Check the guidance notes to find out which supporting documents you must send with your application. You must get documents that aren’t in English - including documents showing an address - fully translated by a professional translator.
+
+        send_application_ips1_pakistan: |
+          5. You should fill in the [Applying for a passport from Pakistan form](https://www.gov.uk/government/publications/applying-for-a-passport-from-pakistan) if you are submitting supporting documents from the UK.
+
+        how_to_apply_online: |
+          You must apply and pay for your passport online.
+
+        how_to_apply_online_prerequisites_applying: |
+          Before you start you need:
+
+          - the passport numbers of both parents and their dates and place of birth, and in some cases the same details of grandparents
+          - 2 identical new photos of you (or your child, if it’s a child passport application)
+          - any other current passports issued by other countries
+          - a MasterCard, Visa, Visa Electron, Visa Debit or Maestro (UK Domestic) card - Maestro (International) cards aren’t accepted
+
+        how_to_apply_online_prerequisites_renewing: |
+          Before you start you need:
+
+          - your current passport
+          - 2 identical new photos of you (or your child, if it’s a child passport application)
+          - any other current passports issued by other countries
+          - a MasterCard, Visa, Visa Electron, Visa Debit or Maestro (UK Domestic) card - Maestro (International) cards aren’t accepted
+
+        how_to_apply_online_prerequisites_replacing: |
+          Before you start you need:
+
+          - 2 identical new photos of you (or your child, if it’s a child passport application)
+          - any other current passports issued by other countries
+          - a MasterCard, Visa, Visa Electron, Visa Debit or Maestro (UK Domestic) card - Maestro (International) cards aren’t accepted
+
+        how_to_apply_online_guidance_doc_group_1: |
+          Read the [guidance notes](/government/publications/help-completing-the-online-passport-application-from-outside-the-uk) to help you fill in your online application. Check which [supporting documents](/government/publications/overseas-passport-applications-supporting-documents-guidance) you must send with your application. Any documents that aren’t in English (including documents showing an address) must be translated by a professional translator.
+
+        how_to_apply_online_guidance_doc_group_2: |
+          Read the [guidance notes](/government/publications/help-completing-the-online-passport-application-from-outside-the-uk) to help you fill in your online application. Check which [supporting documents](/government/publications/overseas-passport-supporting-documents-group-2) you must send with your application. Any documents that aren’t in English (including documents showing an address) must be translated by a professional translator.
+
+        how_to_apply_online_guidance_doc_group_3: |
+          Read the [guidance notes](/government/publications/help-completing-the-online-passport-application-from-outside-the-uk) to help you fill in your online application. Check which [supporting documents](/government/publications/overseas-passport-supporting-documents-group-3) you must send with your application. Any documents that aren’t in English (including documents showing an address) must be translated by a professional translator.
+
+        hong_kong_id_required: |
+          ^You must provide a colour photocopy of your Hong Kong Permanent Identity Card with your application if you’re applying for a British National (Overseas) passport.^
+
+        how_to_apply_online_guidance_doc_outro: |
+          You will need to print, sign and post your declaration form at the end.
+
+          [Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
+
+        send_application_ips1: |
+          ## Send your application
+
+          Her Majesty's Passport Office recommends you send your application using a secure delivery service or courier.
+
+
+          $A
+          Her Majesty's Passport Office
+          OVS-L
+          101 Old Hall Street
+          Liverpool
+          L3 9BP
+          United Kingdom
+          $A
+
+        send_application_belfast: |
+          ## Send your application
+
+          Her Majesty's Passport Office recommends you send your application using a secure delivery service or courier.
+
+
+          $A
+          Her Majesty's Passport Office
+          OVS-B
+          Ground Floor
+          Law Society House
+          90-106 Victoria Street
+          Belfast
+          BT1 3GN
+          United Kingdom
+          $A
+
+        send_application_durham: |
+          ## Send your application
+
+          Her Majesty's Passport Office recommends you send your application using a secure delivery service or courier.
+
+
+          $A
+          Her Majesty's Passport Office
+          OVS-D
+          Millburngate House
+          Millburngate
+          Durham
+          DH97 1PA
+          $A
+
+        getting_your_passport_ips1: |
+          Your passport and supporting documents will be delivered separately by courier.
+        getting_your_passport_contact_and_id: |
+          They will contact you - using the details on your application form - when your passport is ready to collect.
+
+          You must bring photo ID with you.
+        getting_your_passport_contact: |
+          They will contact you - using the details on your application form - when your passport is ready to collect.
+        getting_your_passport_with_id: |
+          You must bring photo ID with you.
+        getting_your_passport_id_renew_new: |
+          You must bring your existing passport as photo ID.
+        getting_your_passport_id_apply_renew_old_replace: |
+          You must bring photo ID with you.
+        getting_your_passport_angola: |
+          Your passport and supporting documents will be delivered to the British Embassy in Luanda, Angola - you must collect them in person.
+        getting_your_passport_benin: |
+          Your passport and supporting documents will be delivered to the British Deputy High Commission in Lagos, Nigeria - you must collect them in person.
+        getting_your_passport_cameroon: |
+          Your passport and supporting documents will be delivered to the British High Commission in Yaounde, Cameroon - you must collect them in person.
+        getting_your_passport_chad: |
+          Your passport and supporting documents will be delivered to the British High Commission in Yaounde, Cameroon - you must collect them in person.
+        getting_your_passport_congo: |
+          Your passport and supporting documents will be delivered to the Honorary Consul in Brazzaville, Congo - you must collect them in person.
+        getting_your_passport_djibouti: |
+          Your passport and supporting documents will be delivered to you by courier.
+        getting_your_passport_ethiopia: |
+          Your passport and supporting documents will be delivered to the British Embassy in Addis Ababa, Ethiopia - you must collect them in person.
+        getting_your_passport_eritrea: |
+          Your passport and supporting documents will be delivered to the British Embassy in Asmara, Eritrea - you must collect them in person.
+        getting_your_passport_gambia: |
+          Your passport and supporting documents will be delivered to the British High Commission in Banjul, Gambia - you must collect them in person.
+        getting_your_passport_ghana: |
+          Your passport and supporting documents will be delivered to the British High Commission in Accra, Ghana - you must collect them in person.
+        getting_your_passport_guinea: |
+          Your passport and supporting documents will be delivered to the British Embassy in Conakry, Guinea - you must collect them in person.
+        getting_your_passport_jamaica: |
+          Your passport and supporting documents will be delivered to the British High Commission in Kingston - you must collect them in person.
+        getting_your_passport_kenya: |
+          Your passport and supporting documents will be delivered to the British High Commission Nairobi, Kenya - you must collect them in person.
+        getting_your_passport_nigeria: |
+          Your passport and supporting documents will be delivered to the British Deputy High Commission in Lagos, Nigeria - you must collect them in person.
+        getting_your_passport_somalia: |
+          Your passport and supporting documents will be delivered to the British Embassy in Addis Ababa, Ethiopia - you must collect them in person.
+        getting_your_passport_south-sudan: |
+          Your passport and supporting documents will be delivered to the DHL Office in Juba, South Sudan - you must collect them in person.
+        getting_your_passport_st-helena-ascension-and-tristan-da-cunha: |
+          Your passport will be delivered to the office where you applied - you must collect it in person.
+        getting_your_passport_uk_visa_centre: |
+          Your passport will be delivered to the UK Visa Application Centre where you applied - you must collect it in person.
+        getting_your_passport_uk_visa_where_to_collect: |
+          They will contact you with details of where to collect your passport when it arrives, using the contact details you provided on your form.
+        getting_your_passport_zambia: |
+          Your passport and supporting documents will be delivered to the British High Commission in Lusaka, Zambia - you must collect them in person.
+        getting_your_passport_zimbabwe: |
+          Your passport and supporting documents will be delivered to the British Embassy in Harare - you must collect them in person.
+        getting_your_passport_burundi: |
+          Your passport and supporting documents will be delivered to the British Embassy Liaison Office in Bujumbura, Burundi - you must collect them in person.
+        getting_your_passport_burundi_renew_new: |
+          Your passport will be delivered to the British Embassy Liaison Office in Bujumbura, Burundi - you must collect it in person.
+
+          They will contact you - using the details on your application form - when your passport is ready to collect.
+
+          You must bring your existing passport as photo ID.
+        getting_your_passport_cambodia: |
+          Your passport and supporting documents will be delivered to the UK Visa Application Centre in Phnom Penh - you must collect them in person.
+        getting_your_passport_egypt: |
+          Your passport and supporting documents will be delivered to the UK Visa Application Centre in Cairo - you must collect them in person.
+        getting_your_passport_libya: |
+          Your passport and supporting documents will be delivered to the UK Visa Application Centre in Tripoli - you must collect them in person.
+        getting_your_passport_rwanda: |
+          Your passport and supporting documents will be delivered to the UK Visa Application Centre in Kigali – you must collect them in person.
+        getting_your_passport_sierra-leone: |
+          Your passport and supporting documents will be delivered to the UK Visa Application Centre in Freetown – you must collect them in person.
+        getting_your_passport_tunisia: |
+          Your passport and supporting documents will be delivered to the UK Visa Application Centre in Tunis - you must collect them in person.
+        getting_your_passport_uganda: |
+          Your passport and supporting documents will be delivered to the UK Visa Application Centre in Kampala, Uganda - you must collect them in person.
+        getting_your_passport_india: |
+          Your passport will be returned to you by post, or you can arrange for it to be delivered to the British High Commission in New Delhi for you to collect in person. You must specify that you want to collect it in section 8 of the application form.
+
+          They will contact you using the details on your application form when your passport is ready to collect.
+
+          You must bring photo ID with you.
+        getting_your_passport_iraq: |
+          Your passport and supporting documents will be delivered to the UK Visa Application Centre in Baghdad – you must collect them in person.
+        getting_your_passport_jordan: |
+          Your passport and supporting documents will be delivered to the British Embassy in Amman, Jordan - you must collect them in person. You must bring photo ID with you.
+          They will contact you when your passport arrives using the contact details on your form.
+        getting_your_passport_pitcairn-island: |
+          Your passport and supporting documents will be delivered to you via the Pitcairn Island Office in Auckland, New Zealand.
+        getting_your_passport_yemen: |
+          Your passport and supporting documents will be delivered to the British Embassy in Sana'a - you must collect them in person.
+        getting_your_passport_burma: |
+          Your passport will be delivered to the British Embassy in Rangoon - you must collect it in person.
+        getting_your_passport_nepal: |
+          Your passport will be delivered to the UK Visa Application Centre in Kathmandu - you must collect it in person.
+        contact_passport_adviceline: |
+          ##Contact the Passport Adviceline
+
+          $C
+          Telephone: +44 (0) 300 222 0000
+          Monday to Friday, 8am to 8pm (UK time)
+          Saturday, Sunday and public holidays, 9am to 5:30pm (UK time)
+          $C
+
+          [Find out about call charges](/call-charges)
+
+        how_long_4_weeks: |
+          Your application will take **at least** 4 weeks from when it’s received by Her Majesty's Passport Office in the UK.
+        how_long_5_weeks: |
+          Your application will take **at least** 5 weeks from when it’s received by Her Majesty's Passport Office in the UK.
+        how_long_6_weeks: |
+          Your application will take **at least** 6 weeks from when it’s received by Her Majesty's Passport Office in the UK.
+        how_long_8_weeks: |
+          Your application will take **at least** 8 weeks from when it’s received by Her Majesty's Passport Office in the UK.
+        how_long_10_weeks: |
+          Your application will take **at least** 10 weeks from when it’s received by Her Majesty's Passport Office in the UK.
+        how_long_12_weeks: |
+          Your application will take **at least** 12 weeks from when it’s received by Her Majesty's Passport Office in the UK.
+        how_long_14_weeks: |
+          Your application will take **at least** 14 weeks from when it’s received by Her Majesty's Passport Office in the UK.
+        how_long_16_weeks: |
+          Your application will take **at least** 16 weeks from when it’s received by Her Majesty's Passport Office in the UK.
+        how_long_18_weeks: |
+          Your application will take **at least** 18 weeks from when it’s received by Her Majesty's Passport Office in the UK.
+        how_long_5_months: |
+          Your application will take **at least** 5 months from when it’s received by Her Majesty's Passport Office in the UK. You may have to attend an interview for a first adult passport.
+        how_long_6_months: |
+          Your application will take **at least** 6 months from when it’s received by Her Majesty's Passport Office in the UK. You may have to attend an interview for a first adult passport.
+        how_long_8_months: |
+          Your application will take **at least** 8 months from when it’s received by Her Majesty's Passport Office in the UK. You may have to attend an interview for a first adult passport.
+        report_loss_or_theft: |
+          If you haven’t already reported the loss or theft, you must include [form LS01](/government/publications/lost-or-stolen-passport-notification--2) with your passport application.
+
+        how_long_additional_info_applying: |
+          You may have to attend an interview for a first adult passport.
+
+        how_long_additional_info_replacing: |
+          If you haven’t already reported the loss or theft, you must include [form LS01](/government/publications/lost-or-stolen-passport-notification--2) with your declaration form.
+
+        how_long_additional_info_renewing_old: |
+          You may have to attend an interview for a first adult passport.
+        how_long_additional_info_renewing_new: |
+          You may have to attend an interview for a first adult passport.
+
+        how_long_it_takes_ips1: |
+          Applications may take longer if:
+
+          - Her Majesty's Passport Office needs to ask you for more information or documents
+          - the photographs you send are rejected
+
+          Don’t book travel until you have a valid passport. If you need to travel more urgently, apply for an [Emergency Travel Document.](/emergency-travel-document)
+
+        how_long_it_takes_ips2: |
+          Applications may take longer if:
+
+          - Her Majesty's Passport Office needs to ask you for more information or documents
+          - the photographs you send are rejected
+
+          Don’t book travel until you have a valid passport. If you need to travel more urgently, you may be able to apply for an [Emergency Travel Document.](/emergency-travel-document)
+
+        how_long_it_takes_ips3: |
+          Applications may take longer if:
+
+          - Her Majesty's Passport Office needs to ask you for more information or documents
+          - the photographs you send are rejected
+
+          Don’t book travel until you have a valid passport. If you need to travel more urgently, you may be able to apply for an [Emergency Travel Document.](/emergency-travel-document)
+
+        passport_courier_costs_ips2: |
+          You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the British embassy, high commission or consulate where you applied for you to collect.
+
+        adult_passport_costs_ips2: |
+          | Passport type | Passport fee | Total to pay (including courier fee) |
+          |---------------|--------------|--------------------------------------|
+          | Adult standard 32-page passport | £83.00 | £107.72 |
+          | Adult jumbo 48-page passport | £91.00 | £115.72 |
+
+        child_passport_costs_ips2: |
+          | Passport type | Passport fee | Total to pay (including courier fee) |
+          |---------------|--------------|--------------------------------------|
+          | Child passport | £53.00 | £77.72 |
+
+        passport_costs_ips2: |
+          Fill in a [‘Paying by credit card or debit card’ form](/government/publications/overseas-passport-creditdebit-card-payment-authorisation) for each passport you’re applying for and submit it with your application. Your credit or debit card will be charged in sterling.
+
+          You can use Mastercard, Visa, Electron, Diners Club and JCB.
+
+        how_to_apply_ips2: |
+          1. Download the application form.
+          2. Use the ‘Applying for a passport if you’re outside the UK’ guidance notes to help you fill in the application form.
+          3. Include 2 identical new photos of you (or your child, if it’s a child passport application). [Follow the rules about passport photos](/photos-for-passports) or your application may be delayed.
+          4. Check which supporting documents you must include with your application. You must get documents that aren’t in English - including documents showing an address - fully translated by a professional translator.
+
+        renewing_new_renewing_old: |
+          You must also bring your current passport with you when you apply, and a full colour photocopy of the entire passport (every page including blank pages).
+
+          You can’t travel with it after you’ve applied for a new one - but you will be able to keep your existing passport for ID purposes.
+
+        send_application_embassy_address: |
+          +[data_partial:overseas_passports_embassies:overseas_passports_embassies]
+
+        send_application_ips2: |
+          ## Making your application
+          You must apply in person.
+
+          You must bring photo ID with you.
+
+          Bring original supporting documents and a photocopy of each one. The original documents will be returned to you.
+
+        getting_your_passport_ips2: |
+          Your passport will be delivered to the British embassy, high commission or consulate where you applied  - you must collect it in person.
+
+          They will contact you - using the details on your application form - when your passport is ready to collect. You must bring photo ID with you. If you’re renewing or replacing a passport, you must bring your existing passport as photo ID.
+
+        passport_costs_fee_only: |
+          You’ll have to pay a fee for your passport.
+
+        adult_passport_costs_only: |
+
+          | Passport type | Passport fee |
+          |---------------|--------------|
+          | Adult standard 32-page passport | £83.00 |
+          | Adult jumbo 48-page passport | £91.00 |
+
+        child_passport_costs_only: |
+
+          | Passport type | Passport fee |
+          |---------------|--------------|
+          | Child passport | £53.00 |
+
+        passport_courier_costs_ips3: |
+          You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British embassy, high commission or consulate where you applied for you to collect.
+
+        passport_courier_costs_ips2_uk_visa: |
+          You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+
+        passport_courier_costs_ips3_uk_visa: |
+          You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
+
+        passport_courier_costs_ips3_pitcairn-island: |
+          You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport and supporting documents to be sent back to you securely via the Pitcairn Islands Office in Auckland.
+
+        adult_passport_costs_ips3: |
+          | Passport type | Passport fee | Total to pay (including courier fee) |
+          |---------------|--------------|--------------------------------------|
+          | Adult standard 32-page passport | £83.00 | £106.01  |
+          | Adult jumbo 48-page passport | £91.00 | £114.01 |
+
+        child_passport_costs_ips3: |
+          | Passport type | Passport fee | Total to pay (including courier fee) |
+          |---------------|--------------|--------------------------------------|
+          | Child passport | £53.00 | £76.01 |
+
+        passport_costs_ips3: |
+          Fill in a [‘Paying by credit card or debit card’ form](/government/publications/overseas-passport-creditdebit-card-payment-authorisation) for each passport you’re applying for and submit it with your application. Your credit or debit card will be charged in sterling.
+
+          You can use Mastercard, Visa, Electron, Diners Club and JCB.
+
+        passport_costs_ips3_cash_or_card: |
+          Or you can fill in a [payment instruction form](/government/publications/overseas-passport-creditdebit-card-payment-authorisation) for each passport you’re applying for and submit it with your application. Your credit or debit card will be charged in sterling.
+
+          You can use Mastercard, Visa, Electron, Diners Club and JCB.
+
+        passport_costs_pay_at_appointment: |
+          You must pay at your scheduled appointment using a debit or credit card. American Express, Diner’s Club and Discovery cards aren’t accepted.
+
+        how_to_apply_ips3: |
+          1. Download the application form.
+          2. Use the ‘Applying for a passport if you’re outside the UK’ guidance notes to help you fill in the application form.
+          3. Include 2 identical new photos of you (or your child, if it’s a child passport application). [Follow the rules about passport photos](/photos-for-passports) or your application may be delayed.
+          4. Check which supporting documents you must submit with your application. You must get documents that aren’t in English - including documents showing an address - fully translated by a professional translator.
+
+        send_application_ips3: |
+          ## Making your application
+          You must apply in person. You must bring photo ID with you.
+
+          Bring original supporting documents and a photocopy of each one. The original documents will be returned to you.
+
+        send_application_ips3_must_post: |
+          Send original supporting documents and a photocopy of each one. If you’re renewing a passport, you must also send your current passport and a full colour photocopy of the entire passport (every page including blank pages).
+        send_application_ips3_must_post_colour_photo: |
+          Send original supporting documents and a colour photocopy of each one. If you’re renewing a passport, you must also send your current passport and a full colour photocopy of the entire passport (every page including blank pages).
+
+        send_application_uk_visa_renew_new: |
+          ## Making your application
+
+          You must apply in person. You must bring photo ID with you.
+
+          Bring original supporting documents and a photocopy of each one. The original documents will be returned to you.
+
+          You must also bring your current passport with you when you apply, and a full colour photocopy of the entire passport (every page including blank pages).
+
+          You can’t travel with it after you’ve applied for a new one - but you will be able to keep your existing passport for ID purposes.
+
+          You’ll need to book an appointment by email. Include your first name and last name and 3 alternative dates and times. You will receive an email confirming your appointment.
+
+        send_application_uk_visa_renew_new_colour: |
+          ## Making your application
+
+          You must apply in person. If you’re unable to, someone else can go on your behalf. You must bring photo ID with you.
+
+          Bring original supporting documents and a colour photocopy of each one. The original documents will be returned to you.
+
+          You must also bring your current passport with you when you apply, and a full colour photocopy of the entire passport (every page including blank pages).
+
+          You can’t travel with it after you’ve applied for a new one - but you will be able to keep your existing passport for ID purposes.
+
+          You’ll need to book an appointment by email. Include your first name and last name and 3 alternative dates and times. You will receive an email confirming your appointment.
+        send_application_uk_visa_renew_new_colour_western_sahara: |
+          ## Making your application
+
+          You must apply in person. If you’re unable to, someone else can go on your behalf.
+          You must bring photo ID with you.
+
+          Bring original supporting documents and a colour photocopy of each one. The original documents will be returned to you.
+
+          You must also bring your current passport with you when you apply, and a full colour photocopy of the entire passport (every page including blank pages).
+
+          You can’t travel with it after you’ve applied for a new one - but you will be able to keep your existing passport for ID purposes.
+
+          You’ll need to book an appointment by email. Include your first name and last name and 3 alternative dates and times. You will receive an email confirming your appointment.
+        send_application_uk_visa_renew_old_replace_colour_western_sahara: |
+          ## Making your application
+
+          You must apply in person. If you’re unable to, someone else can go on your behalf.
+          You must bring photo ID with you.
+
+          Bring original supporting documents and a colour photocopy of each one. The original documents will be returned to you.
+
+          You’ll need to book an appointment by email. Include your first name and last name and 3 alternative dates and times. You will receive an email confirming your appointment.
+
+        send_application_non_uk_visa_renew_new: |
+          ## Making your application
+
+          You must apply in person. You must bring photo ID with you.
+
+          Bring original supporting documents and a photocopy of each one. The original documents will be returned to you.
+
+          You must also bring your current passport with you when you apply, and a full colour photocopy of the entire passport (every page including blank pages).
+
+          You can’t travel with it after you’ve applied for a new one - but you will be able to keep your existing passport for ID purposes.
+
+        send_application_non_uk_visa_renew_new_colour: |
+          ## Making your application
+
+          You must apply in person. If you’re unable to, someone else can go on your behalf. You must bring photo ID with you.
+
+          Bring original supporting documents and a colour photocopy of each one. The original documents will be returned to you.
+
+          You must also bring your current passport with you when you apply, and a full colour photocopy of the entire passport (every page including blank pages).
+
+          You can’t travel with it after you’ve applied for a new one - but you will be able to keep your existing passport for ID purposes.
+
+        send_application_non_uk_visa_apply_renew_old_replace: |
+          ## Making your application
+
+          You must apply in person.
+          You must bring photo ID with you.
+
+          Bring original supporting documents and a photocopy of each one. The original documents will be returned to you.
+        send_application_non_uk_visa_apply_renew_old_replace_colour: |
+          ## Making your application
+
+          You must apply in person. If you’re unable to, someone else can go on your behalf.
+          You must bring photo ID with you.
+
+          Bring original supporting documents and a colour photocopy of each one. The original documents will be returned to you.
+
+        send_application_timor-leste: |
+          ## Making your application
+          You must submit your passport application through the New Zealand Embassy in Dili.
+
+          You must apply in person. If you’re unable to, someone else can go on your behalf. You must bring photo ID with you.
+
+          Bring original supporting documents and a colour photocopy of each one. The original documents will be returned to you.
+
+          You must also bring your current passport with you when you apply, and a full colour photocopy of the entire passport (every page including blank pages).
+
+          You can’t travel with it after you’ve applied for a new one - but you will be able to keep your existing passport for ID purposes.
+
+          You need to book an appointment - contact the embassy to arrange one.
+
+        send_application_uk_visa_apply_renew_old_replace: |
+          ## Making your application
+          You must apply in person. You must bring photo ID with you.
+
+          Bring original supporting documents and a photocopy of each one. The original documents will be returned to you.
+
+          You’ll need to book an appointment by email. Include your name and surname and 3 alternative dates and times. You will receive an email confirming your appointment.
+
+        send_application_uk_visa_apply_renew_old_replace_colour: |
+          ## Making your application
+          You must apply in person. If you’re unable to, someone else can go on your behalf.
+          You must bring photo ID with you.
+
+          Bring original supporting documents and a colour photocopy of each one. The original documents will be returned to you.
+
+          You’ll need to book an appointment by email. Include your first name and last name and 3 alternative dates and times. You will receive an email confirming your appointment.
+
+        send_application_address_algeria: |
+          $A
+          UK Visa Application Centre
+          Des Deux Bassins Oued Romane El Achour Alger (résidence sahraoui)
+          Algiers
+          Algeria
+          $A
+          $C
+          Email: <hmpoalgeria@teleperformance.com>
+          $C
+
+        send_application_address_azerbaijan: |
+          $A
+          UK Visa Application Centre
+          Demirchi Development
+          37 Khojali Avenue
+          Baku
+          AZ1025
+          Azerbaijan
+          $A
+          $C
+          Email: <hmpoazerbaijan@teleperformance.com>
+          $C
+        send_application_address_bangladesh: |
+          $A
+          UK Visa Application Centre
+          4th Floor, Delta Life Tower
+          Plot 37, Road 90
+          Gulshan North
+          Dhaka 11212
+          $A
+          $C
+          Email: <dhaka.hmpo@vfshelpline.com>
+          $C
+          $A
+          UK Visa Application Centre
+          7th Floor, Nirvana Inn
+          Mirza Jungle Road
+          Ramerdhigir par
+          Sylhet 3100
+          $A
+          $C
+          Email: <sylhet.hmpo@vfshelpline.com>
+          $C
+        send_application_address_belarus: |
+          $A
+          UK Visa Application Centre
+          BC Nemiga City
+          40 Nemiga street
+          Minsk 220004
+          Belarus
+          $A
+          $C
+          Email: <hmpobelarus@teleperformance.com>
+          $C
+        send_application_address_china: |
+          $A
+          UK Visa Application Centre
+          Beijing Inn
+          A901-919
+          A Zone
+          9th Floor
+          Building A
+          Second group
+          No 5 Dongshuijing Alley
+          Dongcheng District
+          Beijing 100010
+          $A
+          $C
+          Email: <beijing.HMPO@vfshelpline.com>
+          Opening hours: Monday to Friday 7:30am to 2:30pm (local time)
+          $C
+
+          $A
+          UK Visa Application Centre
+          33-B
+          HNA-Poly International Center
+          235 Minsheng Road
+          Yuzhong District
+          Chongqing
+          400010 P.R.China
+          $A
+          $C
+          Email: <chongqing.hmpo@vfshelpline.com>
+          Opening hours: Monday to Friday 8am to 3pm (local time)
+          $C
+
+          $A
+          UK Visa Application Centre
+          Room 215
+          Cheng Jian Mansion
+          No 189 Tiyu Rd. (West)
+          Tian He District
+          Guangzhou City 510620
+          $A
+          $C
+          Email: <guangzhou.hmpo@vfshelpline.com>
+          Opening hours: Monday to Friday 8am to 3pm (local time)
+          $C
+
+          $A
+          UK Visa Application Centre
+          3/F
+          Guangfa Bank Tower
+          555 Xujiahui Road
+          Huangpu District
+          Shanghai
+          $A
+          $C
+          Email: <shanghai.hmpo@vfshelpline.com>
+          Opening hours: Monday to Friday 8am to 3pm (local time)
+          $C
+
+        send_application_address_georgia: |
+          $A
+          UK Visa Application Centre
+          Besiki Business Center
+          4 Besiki Street
+          Tbilisi
+          Georgia
+          0108
+          $A
+          $C
+          Email: <hmpogeorgia@teleperformance.com>
+          $C
+
+        send_application_address_kyrgyzstan: |
+          $A
+          UK Visa Application Centre
+          Hyatt Regency Bishkek Hotel
+          191 Abdrahmanov Street
+          Bishkek 720011
+          Kyrgyzstan
+          $A
+          $C
+          Email: <hmpokyrgyzstan@teleperformance.com>
+          $C
+
+        send_application_address_india: |
+          $A
+          UK Visa Application Centre
+          Unit No. ( 1 & 2 ), First floor Bhikhubhai Chambers
+          Opposite Bharat Petroleum
+          Near Kochrab Ashram Ashram Road
+          Paldi, Ahmedabad 380009
+          $A
+          $C
+          Email: <ahmedabad.hmpo@vfshelpline.com>
+          $C
+
+          $A
+          UK Visa Application Centre
+          Unit No. 302 & 303, Second Floor, Level 3
+          Prestige Atrium No 1
+          Behind Palmgroove Military Canteen and opposite to Empire Hotel
+          Central Street, Shivaji Nagar
+          Bangalore 560001
+          $A
+          $C
+          Email: <bangalore.hmpo@vfshelpline.com>
+          $C
+
+          $A
+          UK Visa Application Centre
+          SCO 62 63, Sector 8 C
+          Near Hotel Icon and Times of India office
+          Madhya Marg
+          Chandigarh 160018
+          $A
+          $C
+          Email: <chandigarh.hmpo@vfshelpline.com>
+          $C
+
+          $A
+          UK Visa Application Centre
+          Fagun Towers
+          Second Floor
+          No 74 Ethiraj Salai
+          Egmore
+          Chennai 600 008
+          $A
+          $C
+          Email: <chennai.hmpo@vfshelpline.com>
+          $C
+
+          $A
+          UK Visa Application Centre
+          S&T Arcade,Kurisupally Road
+          Ravipuram
+          Cochin 682016
+          $A
+          $C
+          Email: <cochin.hmpo@vfshelpline.com>
+          $C
+
+          $A
+          UK Visa Application Centre
+          Sunil Chambers, 8-2-542/A Road No. 7
+          Near Meridian School
+          Above Ratnadeep Supermarket
+          Banjara Hills
+          Hyderabad 500 034
+          $A
+          $C
+          Email: <hyderabad.hmpo@vfshelpline.com>
+          $C
+
+          $A
+          UK Visa Application Centre
+          Lower Ground Floor
+          MIDAS Corporate Park
+          Plot No. 37, G.T. Road
+          opposite Jalandhar Bus Stand
+          Jalandhar 144001
+          $A
+          $C
+          Email: <jalandhar.hmpo@vfshelpline.com>
+          $C
+
+          $A
+          UK Visa Application Centre
+          Fifth floor, RENE Tower
+          Plot No. AA-I, 1842
+          Rajdanga Main Road
+          Kasba
+          Kolkata 700107
+          $A
+          $C
+          Email: <kolkata.hmpo@vfshelpline.com>
+          $C
+
+          $A
+          UK Visa Application Centre
+          Trade Centre, G Block, Ground Floor
+          Next to Regus office, Bandra Kurla Complex
+          Bandra (East)
+          Mumbai 400 051
+          $A
+          $C
+          Email: <mumbai.hmpo@vfshelpline.com>
+          $C
+
+          $A
+          UK Visa Application Centre
+          Upper Ground Floor, S-2 Level
+          International Trade Tower
+          Opposite Satyam Cinemas
+          Nehru Place
+          New Delhi 110019
+          $A
+          $C
+          Email: <newdelhi.hmpo@vfshelpline.com>
+          $C
+
+          $A
+          UK Visa Application Centre
+          Office No. 305, Gera 77
+          Next to Bishops Co-Ed School
+          Kalyani Nagar
+          Pune 411014
+          $A
+          $C
+          Email: <pune.hmpo@vfshelpline.com>
+          $C
+
+        send_application_address_indonesia: |
+          $A
+          UK Visa application Centre,
+          Kuningan City Mall,
+          2nd Floor No. L2-19,
+          Jl. Prof. Dr. Satrio Kav. 18 -
+          Setiabudi,
+          Kuningan
+          South of Jakarta
+          12940,
+          Indonesia
+          $A
+          $C
+          Email: <JakartaHMPO@vfshelpline.com>
+          $C
+
+          $A
+          3rd Floor
+          No. 7-9.3/A,
+          Benoa Square,
+          Jl. By pass I Gusti Ngurah Rai No. 21A,
+          Kedonganan,
+          Kuta,
+          Bali - 80361,
+          Indonesia
+          $A
+          $C
+          Email: <BaliHMPO@vfshelpline.com>
+          $C
+
+        send_application_address_gaza: |
+          $A
+          British Information and Services Office
+          1st Floor, Al-Riyad Tower
+          Jerusalem Street
+          Al-Rimal South
+          Gaza
+          $A
+          $C
+          Email: <dljerusalemconsularprotect@fco.gov.uk>
+          Telephone: +972 (8) 2641456
+          Fax: +972 (8) 2641457
+          $C
+
+        send_application_address_kazakhstan: |
+          $A
+          UK Visa Application Centre
+          Stolichniy centre
+          92/87, Ablai Khan str. corner
+          Kabanbai Batyr str.
+          Almalinskiy district
+          Almaty
+          Kazakhstan, 050000
+          $A
+          $C
+          Email: <hmpokazakhstan@teleperformance.com>
+          $C
+
+        send_application_address_laos: |
+          $A
+          UK Visa Application Centre
+          British Embassy
+          Rue J. Nehru
+          Saysettha District
+          Vientiane
+          Laos
+          $A
+          $C
+          Email: <LaosHMPO@vfshelpline.com>
+          $C
+
+        send_application_address_lebanon: |
+          $A
+          UK Visa Application Centre
+          Central Beirut District
+          Maarad Street
+          Building 201
+          Second Floor
+          Beirut, Lebanon
+          $A
+          $C
+          Email: <hmpolebanon@teleperformance.com>
+          $C
+
+        send_application_address_mauritania: |
+          $A
+          UK Visa Application Centre
+          12 Rue Al Koufa,
+          Av Moulay Youssef
+          Rabat
+          Morocco
+          $A
+          $C
+          Email: <hmpomorocco@teleperformance.com>
+          $C
+
+        send_application_address_morocco: |
+          $A
+          UK Visa Application Centre
+          12 Rue Al Koufa,
+          Av Moulay Youssef
+          Rabat
+          Morocco
+          $A
+          $C
+          Email: <hmpomorocco@teleperformance.com>
+          $C
+
+        send_application_address_nepal: |
+          $A
+          UK Visa Application Centre
+          4th floor, Four Square Building,
+          (Opposite Police Head Quarters),
+          Narayan Chaur, Naxal,
+          Kathmandu
+          Nepal
+          $A
+          $C
+          Email: <KathmanduHMPO@vfshelpline.com>
+          Opening hours: Monday to Friday 2pm to 4pm (local time)
+          $C
+
+        send_application_address_pakistan: |
+
+          $A
+          UK Visa Application Centre
+          14-B, Sadiq Plaza G-9 Markaz
+          Islamabad
+          $A
+          $C
+          Email:<islamabad.hmpo@gerrys.com.pk>
+          $C
+
+          $A
+          UK Visa Application Centre
+          43/1/D, Razi Road PECHS
+          Shaharah-e-Faisal
+          Karachi
+          $A
+          $C
+          Email: <karachi.hmpo@gerrys.com.pk>
+          $C
+
+          $A
+          UK Visa Application Centre
+          20, Ex American Centre Building
+          Opp. Ganga Ram Hospital
+          Queens Road
+          Lahore
+          $A
+          $C
+          Email: <lahore.hmpo@gerrys.com.pk>
+          $C
+
+          $A
+          UK Visa Application Centre
+          Nau Mahal Plaza, Near Foot Ball Square,
+          Defense Road
+          Mirpur
+          $A
+          $C
+          Email: <mirpur.hmpo@gerrys.com.pk>
+          $C
+
+        send_application_address_pitcairn-island: |
+          ## Making your application
+          Send your completed forms and supporting documents to the Pitcairn Islands Office.
+
+
+          $A
+          Pitcairn Islands Office
+          P.O. Box 105 696
+          Auckland
+          New Zealand
+          $A
+
+          $C
+          Email: <admin@pitcairn.gov.pn>
+          Telephone: +64 9 366 0186
+          Fax: +64 9 366 0187
+          $C
+
+        send_application_address_russia: |
+          $A
+          UK Visa Application Centre
+          70, Bolshakova st
+          Ekaterinburg
+          Russia
+          $A
+          $C
+          Email: <hmpoekaterinburg@teleperformance.com>
+          $C
+
+          $A
+          UK Visa Application Centre
+          Delta Plaza, 1
+          2nd Syromyatnichesky lane
+          Moscow
+          Russia
+          $A
+          $C
+          Email: <hmpomoscow@teleperformance.com>
+          $C
+
+          $A
+          UK Visa Application Centre
+          26, Liteyniy pr
+          St Petersburg
+          Russia
+          $A
+          $C
+          Email: <hmpostpetersburg@teleperformance.com>
+          $C
+
+        send_application_address_st_helena_ascension_and_tristan_da_cunha: |
+          $A
+          Administration Office
+          Ascension Island Government
+          Georgetown
+          Ascension Island
+          $A
+          $C
+          Opening hours: Monday to Friday, 8am to 12.30pm and 1.30pm to 4.30pm (local time)
+          $C
+
+          $A
+          Immigration Office
+          Ogborn House
+          Jamestown
+          St. Helena Island
+          STHL 1ZZ
+          $A
+          $C
+          Opening hours: Monday to Friday, 8am to 4pm (local time)
+          $C
+
+          $A
+          Head of the Administrator's Office
+          Administration Building
+          Tristan Da Cunha
+          South Atlantic
+          TDCU 1ZZ
+          $A
+          $C
+          Opening hours:
+          1 April to 30 September, Monday to Friday, 8.30am to 3.30pm (local time)
+          $C
+          $C
+          1 October to 31 March, Monday to Friday, 8am to 3pm (local time)
+          $C
+
+        send_application_address_thailand: |
+          $A
+          UK Visa Application Centre
+          The Trendy Office Building,
+          28th Floor,
+          Sukhumvit Soi13,
+          Klongtoey-Nua,
+          Wattana,
+          Bangkok
+          10110,
+          Thailand
+          $A
+          $C
+          Email: <BangkokHMPO@vfshelpline.com>
+          $C
+
+        send_application_address_timor-leste: |
+          $A
+          New Zealand Embassy, East Timor
+          Rua Geremias do Amaral
+          Motael
+          Dili
+          East Timor
+          $A
+          $C
+          Telephone: (+670) 331 0087
+          $C
+        send_application_address_ukraine: |
+          $A
+          UK Visa Application Centre
+          Antem Business Centre
+          4 Hlybochyts’ka Street
+          Kyiv
+          Ukraine
+          $A
+          $C
+          Email: <hmpoukraine@teleperformance.com>
+          $C
+        send_application_address_venezuela: |
+          $A
+          UK Visa Application Centre
+          Centro de Solicitud de Visas del Reino Unido
+          Avenida Francisco de Miranda
+          Edificio Mene Grande
+          Piso 6 Oficina 6-1
+          Los Palos Grandes
+          Caracas
+          $A
+          $C
+          Email: <VenezuelaHMPO@vfshelpline.com>
+          $C
+        send_application_address_western-sahara: |
+          $A
+          UK Visa Application Centre
+          12 Rue Al Koufa,
+          Av Moulay Youssef
+          Rabat
+          Morocco
+          $A
+          $C
+          Email: <hmpomorocco@teleperformance.com>
+          $C
+
+        getting_your_passport_ips3: |
+          Your passport will be delivered to the British embassy, high commission or consulate where you applied - you must collect it in person.
+
+          They will contact you - using the details on your application form - when your passport is ready to collect. You must bring photo ID with you. If you’re renewing or replacing a passport, you must bring your existing passport as photo ID.
+
+        title_output_biot: |
+          British Indian Ocean Territory
+
+        emergency_travel_help_kyrgyzstan: |
+          If you need help with emergency travel arrangements, contact the [British Embassy in Almaty, Kazakhstan](/government/world/organisations/british-embassy-astana/office/british-embassy-office-almaty).
+
+        emergency_travel_help_north-korea: |
+          If you need help with emergency travel arrangements in North Korea, contact the [British Embassy in Pyongyang](/government/world/organisations/british-embassy-pyonyang).
+
+
+        body_iran: |
+          You can’t apply for a British passport from Iran at this time.
+
+          You should apply in a neighbouring country of your choice.
+
+          If you need an emergency travel document to leave Iran, contact the Foreign and Commonwealth Office for further information.
+
+
+          $C
+            Foreign and Commonwealth Office
+
+            Email: consularenquiries.tehran@fco.gov.uk
+
+            Telephone: (+44) 207 008 1500
+          $C
+
+        body_libya: |
+          You can’t apply for a British passport from Libya at this time.
+
+          You should apply in a neighbouring country of your choice.
+
+          If you need more information read the [Foreign Commonwealth Office travel advice](/foreign-travel-advice/libya).
+
+        body_syria: |
+          You can’t apply for a British passport from Syria at this time.
+
+          You should apply in a neighbouring country of your choice.
+
+          If you need an emergency travel document to leave Syria, contact the Foreign and Commonwealth Office for further information.
+
+
+          $C
+            Foreign and Commonwealth Office
+
+            Email: consularenquiries.damascus@fco.gov.uk
+
+            Telephone: (+44) 207 008 1500
+          $C
+
+        send_application_pretoria_south_africa: |
+
+          $A
+          Postal address:
+
+          British Passport Section
+          British Consulate
+          PO Box 13611
+          Hatfield, Pretoria 0028
+          South Africa
+
+          Courier address:
+
+          British Passport Section
+          British Consulate
+          256 Glyn Street
+          Hatfield
+          Pretoria 0083
+          South Africa
+          $A
+        helpline_pretoria_south_africa: |
+
+          $C
+            __Passport Information Helpline__
+
+            +44 208 082 4743
+
+            Calls charged at £0.72 per minute plus VAT - you must pay by credit card when you call.
+
+            Textphone: +44 1750 725 368
+          $C
+
+      fco_result:
+        body: |
+          ## How long it takes
+          %{how_long_it_takes}
+
+          Your application may take longer if:
+
+          - you don’t send the right supporting documents or payment
+          - the photographs you send are rejected
+
+          Don’t book travel until you have a valid passport. If you need to travel more urgently, you may be able to apply for an [Emergency Travel Document.](/emergency-travel-document)
+
+          ## Cost
+          %{cost}
+
+          ## How to apply
+
+          1. Download the application form and guidance notes that help you fill it in.
+
+          2. Include 2 identical new photos of you (or your child, if it’s a child passport application). [Follow the rules about passport photos](/photos-for-passports "Passport photo requirements") or your application may be delayed.
+
+          3. Check the guidance notes to find out which supporting documents you must send with your application. You must get documents that aren’t in English fully translated by a professional translator.
+
+          %{how_to_apply_supplement}
+
+          %{hurricane_warning}
+
+          %{fco_forms}
+
+          %{supporting_documents}
+
+          ## Submit your application
+
+          %{send_your_application}
+
+          ## Getting your passport
+
+          %{getting_your_passport}
+
+
+          ## If your passport hasn't arrived
+
+          If you haven’t received your passport within the expected timescale, you can check your application’s progress by phone. You will be charged for the call.
+
+          Don’t use this service any earlier - information won’t be available but you will still be charged for the call.
+
+          %{helpline}
+
+      ips_application_result_online:
+        body: |
+          ## How long it takes
+
+          %{how_long_it_takes}
+
+          ## Cost
+
+          %{cost}
+
+          ## How to apply
+
+          %{how_to_apply}
+
+          ## Getting your passport
+
+          %{getting_your_passport}
+
+          %{contact_passport_adviceline}
+
+      ips_application_result:
+        body: |
+          ## How long it takes
+
+          %{how_long_it_takes}
+
+          ## Cost
+
+          %{cost}
+
+          ## How to apply
+
+          %{how_to_apply}
+
+          %{send_your_application}
+
+          ## Getting your passport
+
+          %{getting_your_passport}
+
+          %{contact_passport_adviceline}
+
+      result:
+        body: |
+          ## How long it takes
+
+          %{how_long_it_takes}
+
+          Don't book travel until you have a valid passport. If you need to travel urgently, you may be able to apply for an [Emergency Travel Document](/emergency-travel-document).
+
+          If your passport has been lost or stolen and you haven't reported it yet, include [form LS01](/government/publications/lost-or-stolen-passport-notification--2) with your application.
+
+          ## Cost
+
+          %{cost}
+
+          ## How to apply
+
+          1. Download the application form and guidance notes that help you fill it in.
+
+          2. Include 2 identical new photos of you (or your child, if it’s a child passport application). [Follow the rules about passport photos](/photos-for-passports) or your application may be delayed.
+
+          3. Check the supporting documents you must send with your application. Non-English supporting documents must be translated into English by a professional translator.
+          %{how_to_apply}
+
+
+            %{fco_forms}
+
+          %{supporting_documents}
+
+          ## Making your application
+
+          %{making_application}
+
+
+          +[data_partial:overseas_passports_embassies:overseas_passports_embassies]
+
+          %{making_application_additional}
+
+          ## Getting your passport
+
+          %{getting_your_passport}
+
+          ## If your passport hasn’t arrived
+
+          %{helpline}
+
+      cannot_apply:
+        body: |
+          %{body_text}
+
+      apply_in_neighbouring_country:
+        title: You can’t apply for a British passport from %{title_output}.
+        body: |
+          You should apply in a neighbouring country of your choice.
+
+          %{emergency_travel_help}
+
+          ###Passport Adviceline
+
+          $C
+          Telephone: +44 (0) 300 222 0000
+          Monday to Friday, 8am to 8pm (UK time)
+          Saturday, Sunday and public holidays, 9am to 5:30pm (UK time)
+          $C

--- a/lib/smart_answer_flows/locales/en/overseas-passports-v2.yml
+++ b/lib/smart_answer_flows/locales/en/overseas-passports-v2.yml
@@ -379,6 +379,18 @@ en-GB:
           Your passport and supporting documents will be delivered to the DHL Office in Juba, South Sudan - you must collect them in person.
         getting_your_passport_st-helena-ascension-and-tristan-da-cunha: |
           Your passport will be delivered to the office where you applied - you must collect it in person.
+        getting_your_passport_tajikistan: |
+          Your passport will be delivered to the British embassy in Dushanbe - you must collect it in person.
+
+          They'll contact you - using the details on your application form - when your passport is ready to collect. You must bring photo ID with you. If you're renewing or replacing a passport, you must bring your existing passport as photo ID.
+        getting_your_passport_turkmenistan: |
+          Your passport will be delivered to the British embassy in Ashgabat - you must collect it in person.
+
+          They'll contact you - using the details on your application form - when your passport is ready to collect. You must bring photo ID with you. If you're renewing or replacing a passport, you must bring your existing passport as photo ID.
+        getting_your_passport_uzbekistan: |
+          Your passport will be delivered to the British embassy in Tashkent - you must collect it in person.
+
+          They'll contact you - using the details on your application form - when your passport is ready to collect. You must bring photo ID with you. If you're renewing or replacing a passport, you must bring your existing passport as photo ID.
         getting_your_passport_uk_visa_centre: |
           Your passport will be delivered to the UK Visa Application Centre where you applied - you must collect it in person.
         getting_your_passport_uk_visa_where_to_collect: |
@@ -503,6 +515,21 @@ en-GB:
 
         passport_courier_costs_ips2: |
           You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the British embassy, high commission or consulate where you applied for you to collect.
+
+        passport_courier_costs_tajikistan: |
+          You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+            The courier fee pays for your passport to be sent securely to the British Embassy in Dushanbe for you to collect.
+
+        passport_courier_costs_turkmenistan: |
+          You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+          The courier fee pays for your passport to be sent securely to the British Embassy in Ashgabat for you to collect.
+
+        passport_courier_costs_uzbekistan: |
+          You’ll have to pay a fee for your passport and a courier fee of £24.72.
+
+          The courier fee pays for your passport to be sent securely to the British Embassy in Tashkent for you to collect.
 
         adult_passport_costs_ips2: |
           | Passport type | Passport fee | Total to pay (including courier fee) |

--- a/lib/smart_answer_flows/locales/en/overseas-passports-v2.yml
+++ b/lib/smart_answer_flows/locales/en/overseas-passports-v2.yml
@@ -56,7 +56,7 @@ en-GB:
           ^[Supporting documents for children born in the UK](/government/publications/british-passport-child-supporting-documentation)^
           ^[Supporting documents for children born overseas](/government/publications/british-passport-child-supporting-documentation-overseas)^
 
-        passport_courier_costs_fco_europe:
+        passport_courier_costs_fco_europe: |
           You’ll have to pay a fee for your passport and a courier fee of 24 Euros. The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
         adult_passport_costs_fco_europe: |
@@ -197,12 +197,12 @@ en-GB:
           You must pay in cash. In addition to the passport fee you’ll need to pay any local administration fees which apply from the office where you make your application.
 
         how_long_additional_time_online: |
-          Applications may take longer if:
+          Applications will take longer if:
 
           - HM Passport Office need to ask you for more information or documents
           - the photographs you send are rejected
 
-          Don’t book any travel until you have a valid passport. If you need to travel more urgently, apply for an [Emergency Travel Document](/emergency-travel-document).
+          Don’t book any travel until you have a valid passport. If you need to travel more urgently, you may be able to apply for an [Emergency Travel Document](/emergency-travel-document).
         passport_courier_costs_ips1: |
           You’ll have to pay a fee for your passport and a courier fee of £19.86. The courier fee pays for your passport and supporting documents to be sent back to you securely.
 
@@ -474,35 +474,35 @@ en-GB:
         how_long_18_weeks: |
           Your application will take **at least** 18 weeks from when it’s received by Her Majesty's Passport Office in the UK.
         how_long_5_months: |
-          Your application will take **at least** 5 months from when it’s received by Her Majesty's Passport Office in the UK. You may have to attend an interview for a first adult passport.
+          Your application will take **at least** 5 months from when it’s received by Her Majesty's Passport Office in the UK. You may have to attend an interview.
         how_long_6_months: |
-          Your application will take **at least** 6 months from when it’s received by Her Majesty's Passport Office in the UK. You may have to attend an interview for a first adult passport.
+          Your application will take **at least** 6 months from when it’s received by Her Majesty's Passport Office in the UK. You may have to attend an interview.
         how_long_8_months: |
-          Your application will take **at least** 8 months from when it’s received by Her Majesty's Passport Office in the UK. You may have to attend an interview for a first adult passport.
+          Your application will take **at least** 8 months from when it’s received by Her Majesty's Passport Office in the UK. You may have to attend an interview.
         report_loss_or_theft: |
           If you haven’t already reported the loss or theft, you must include [form LS01](/government/publications/lost-or-stolen-passport-notification--2) with your passport application.
 
         how_long_additional_info_applying: |
-          You may have to attend an interview for a first adult passport.
+          You may have to attend an interview.
 
         how_long_additional_info_replacing: |
           If you haven’t already reported the loss or theft, you must include [form LS01](/government/publications/lost-or-stolen-passport-notification--2) with your declaration form.
 
         how_long_additional_info_renewing_old: |
-          You may have to attend an interview for a first adult passport.
+          You may have to attend an interview.
         how_long_additional_info_renewing_new: |
-          You may have to attend an interview for a first adult passport.
+          You may have to attend an interview.
 
         how_long_it_takes_ips1: |
-          Applications may take longer if:
+          Applications will take longer if:
 
           - Her Majesty's Passport Office needs to ask you for more information or documents
           - the photographs you send are rejected
 
-          Don’t book travel until you have a valid passport. If you need to travel more urgently, apply for an [Emergency Travel Document.](/emergency-travel-document)
+          Don’t book travel until you have a valid passport. If you need to travel more urgently, you may be able to apply for an [Emergency Travel Document.](/emergency-travel-document)
 
         how_long_it_takes_ips2: |
-          Applications may take longer if:
+          Applications will take longer if:
 
           - Her Majesty's Passport Office needs to ask you for more information or documents
           - the photographs you send are rejected
@@ -510,7 +510,7 @@ en-GB:
           Don’t book travel until you have a valid passport. If you need to travel more urgently, you may be able to apply for an [Emergency Travel Document.](/emergency-travel-document)
 
         how_long_it_takes_ips3: |
-          Applications may take longer if:
+          Applications will take longer if:
 
           - Her Majesty's Passport Office needs to ask you for more information or documents
           - the photographs you send are rejected
@@ -717,6 +717,8 @@ en-GB:
 
           You can’t travel with it after you’ve applied for a new one - but you will be able to keep your existing passport for ID purposes.
 
+          You'll need to book an appointment by email. Include your first name and last name and 3 alternative dates and times. You'll get an email confirming your appointment.
+
         send_application_non_uk_visa_apply_renew_old_replace: |
           ## Making your application
 
@@ -731,6 +733,8 @@ en-GB:
           You must bring photo ID with you.
 
           Bring original supporting documents and a colour photocopy of each one. The original documents will be returned to you.
+
+          You'll need to book an appointment by email. Include your first name and last name and 3 alternative dates and times. You'll get an email confirming your appointment.
 
         send_application_timor-leste: |
           ## Making your application

--- a/lib/smart_answer_flows/locales/en/overseas-passports-v2.yml
+++ b/lib/smart_answer_flows/locales/en/overseas-passports-v2.yml
@@ -82,6 +82,10 @@ en-GB:
 
           When you get your new passport, send your old one to the [nearest British embassy, high commission or governors office](/government/world/organisations).
 
+        how_to_apply_incomplete_application_deadline: |
+
+          ^You'll be contacted if your application is incomplete. You must return all the missing information within 6 weeks or your application will be cancelled - you won't get a refund.^
+
         adult_fco_forms: |
           __Smart application form__
 
@@ -1486,6 +1490,8 @@ en-GB:
 
           %{how_to_apply}
 
+          %{incomplete_application_deadline}
+
           ## Getting your passport
 
           %{getting_your_passport}
@@ -1505,6 +1511,8 @@ en-GB:
           ## How to apply
 
           %{how_to_apply}
+
+          %{incomplete_application_deadline}
 
           %{send_your_application}
 
@@ -1537,6 +1545,7 @@ en-GB:
           3. Check the supporting documents you must send with your application. Non-English supporting documents must be translated into English by a professional translator.
           %{how_to_apply}
 
+          %{incomplete_application_deadline}
 
             %{fco_forms}
 

--- a/lib/smart_answer_flows/overseas-passports-v2.rb
+++ b/lib/smart_answer_flows/overseas-passports-v2.rb
@@ -207,6 +207,11 @@ outcome :ips_application_result do
       PhraseList.new(:"passport_courier_costs_replacing_ips#{ips_number}",
                     :"#{child_or_adult}_passport_costs_replacing_ips#{ips_number}",
                     :"passport_costs_ips#{ips_number}")
+
+    elsif %w(tajikistan turkmenistan uzbekistan).include?(current_location)
+      PhraseList.new(:"passport_courier_costs_#{current_location}",
+                    :"#{child_or_adult}_passport_costs_ips#{ips_number}",
+                    :"passport_costs_ips#{ips_number}")
     else
       phrases = PhraseList.new
       if uk_visa_application_centre_countries.include?(current_location)
@@ -332,6 +337,7 @@ outcome :ips_application_result do
     uk_visa_application_centre_variant_countries = %w(cambodia egypt iraq libya rwanda sierra-leone tunisia uganda yemen)
     collect_with_photo_id_countries = %w(cambodia egypt iraq libya rwanda sierra-leone tunisia uganda yemen)
     passport_delivered_by_courier_countries = %w(laos)
+    named_embassy_countries = %w(tajikistan turkmenistan uzbekistan)
 
     phrases = PhraseList.new
     if passport_delivered_by_courier_countries.include?(current_location)
@@ -354,6 +360,8 @@ outcome :ips_application_result do
       else
         phrases << :getting_your_passport_id_apply_renew_old_replace
       end
+    elsif named_embassy_countries.include?(current_location)
+        phrases << :"getting_your_passport_#{current_location}"
     elsif collect_in_person_countries.include?(current_location)
       phrases << :"getting_your_passport_#{current_location}" << :getting_your_passport_contact_and_id
     elsif collect_in_person_variant_countries.include?(current_location)

--- a/lib/smart_answer_flows/overseas-passports-v2.rb
+++ b/lib/smart_answer_flows/overseas-passports-v2.rb
@@ -1,0 +1,536 @@
+status :draft
+satisfies_need "100131"
+
+data_query = Calculators::PassportAndEmbassyDataQueryV2.new
+
+exclude_countries = %w(holy-see british-antarctic-territory)
+
+# Q1
+country_select :which_country_are_you_in?, exclude_countries: exclude_countries do
+  save_input_as :current_location
+
+  calculate :location do
+    loc = WorldLocation.find(current_location)
+    if Calculators::PassportAndEmbassyDataQueryV2::ALT_EMBASSIES.has_key?(current_location)
+      loc = WorldLocation.find(Calculators::PassportAndEmbassyDataQueryV2::ALT_EMBASSIES[current_location])
+    end
+    raise InvalidResponse unless loc
+    loc
+  end
+
+  next_node_if(:cannot_apply, data_query.ineligible_country?)
+  next_node_if(:which_opt?, responded_with('the-occupied-palestinian-territories'))
+  next_node_if(:apply_in_neighbouring_country, data_query.apply_in_neighbouring_countries?)
+  next_node(:renewing_replacing_applying?)
+end
+
+# Q1a
+multiple_choice :which_opt? do
+  option :gaza
+  option :"jerusalem-or-westbank"
+
+  save_input_as :current_location
+  next_node :renewing_replacing_applying?
+end
+
+# Q2
+multiple_choice :renewing_replacing_applying? do
+  option :renewing_new
+  option :renewing_old
+  option :applying
+  option :replacing
+
+  save_input_as :application_action
+
+  precalculate :organisation do
+    location.fco_organisation
+  end
+
+  calculate :overseas_passports_embassies do
+    if organisation
+      organisation.offices_with_service 'Overseas Passports Service'
+    else
+      []
+    end
+  end
+
+  calculate :general_action do
+    responses.last =~ /^renewing_/ ? 'renewing' : responses.last
+  end
+
+  calculate :passport_data do
+    data_query.find_passport_data(current_location)
+  end
+  calculate :application_type do
+    passport_data['type']
+  end
+  calculate :is_ips_application do
+    data_query.ips_application?.call(self, nil)
+  end
+  calculate :ips_number do
+    application_type.split("_")[2] if is_ips_application
+  end
+
+  calculate :application_form do
+    passport_data['app_form']
+  end
+
+  calculate :supporting_documents do
+    passport_data['group']
+  end
+
+  calculate :application_address do
+    passport_data['address']
+  end
+
+  calculate :ips_docs_number do
+    supporting_documents.split("_")[3] if is_ips_application
+  end
+
+  calculate :ips_result_type do
+    passport_data['online_application'] ? :ips_application_result_online : :ips_application_result
+  end
+
+  data_query.passport_costs.each do |k, v|
+    calculate "costs_#{k}".to_sym do
+      v
+    end
+  end
+
+  calculate :waiting_time do
+    passport_data[application_action]
+  end
+
+  next_node :child_or_adult_passport?
+end
+
+# Q3
+multiple_choice :child_or_adult_passport? do
+  option :adult
+  option :child
+
+  save_input_as :child_or_adult
+
+  calculate :fco_forms do
+    if %w(nigeria).include?(current_location)
+      PhraseList.new(:"#{responses.last}_fco_forms_nigeria")
+    else
+      PhraseList.new(:"#{responses.last}_fco_forms")
+    end
+  end
+
+  on_condition(data_query.ips_application?) do
+    next_node_if(:country_of_birth?, variable_matches(:application_action, %w(applying renewing_old)))
+    next_node_if(:ips_application_result_online, variable_matches(:ips_result_type, :ips_application_result_online))
+    next_node(:ips_application_result)
+  end
+  next_node_if(:fco_result, data_query.fco_application?)
+  next_node(:result)
+end
+
+# Q4
+country_select :country_of_birth?, include_uk: true, exclude_countries: exclude_countries do
+  save_input_as :birth_location
+
+  calculate :application_group do
+    data_query.find_passport_data(responses.last)['group']
+  end
+
+  calculate :supporting_documents do
+    responses.last == 'united-kingdom' ? supporting_documents : application_group
+  end
+
+  calculate :ips_docs_number do
+    supporting_documents.split("_")[3]
+  end
+
+  on_condition(data_query.ips_application?) do
+    next_node_if(:ips_application_result_online, variable_matches(:ips_result_type, :ips_application_result_online))
+    next_node(:ips_application_result)
+  end
+  next_node_if(:fco_result, data_query.fco_application?)
+  next_node(:result)
+end
+
+## Online IPS Application Result
+outcome :ips_application_result_online do
+  precalculate :how_long_it_takes do
+    PhraseList.new(:"how_long_#{waiting_time}",
+                   :"how_long_additional_info_#{application_action}",
+                   :how_long_additional_time_online)
+  end
+
+  precalculate :cost do
+    if application_action == 'replacing' and ips_number == '1' and ips_docs_number == '1'
+      PhraseList.new(:"passport_courier_costs_replacing_ips#{ips_number}",
+                     :"#{child_or_adult}_passport_costs_replacing_ips#{ips_number}")
+    else
+      PhraseList.new(:"passport_courier_costs_ips#{ips_number}",
+                     :"#{child_or_adult}_passport_costs_ips#{ips_number}")
+    end
+  end
+
+  precalculate :how_to_apply do
+    phrases = PhraseList.new(:how_to_apply_online,
+                   :"how_to_apply_online_prerequisites_#{general_action}",
+                   :"how_to_apply_online_guidance_doc_group_#{ips_docs_number}")
+    phrases << :"birth_certificate_#{birth_location}" if %w(south-africa spain).include?(birth_location)
+    phrases << :hong_kong_id_required if %w(hong-kong).include?(current_location)
+    phrases << :how_to_apply_online_guidance_doc_outro
+  end
+
+  precalculate :getting_your_passport do
+    PhraseList.new(:"getting_your_passport_ips#{ips_number}")
+  end
+  precalculate :contact_passport_adviceline do
+    PhraseList.new(:contact_passport_adviceline)
+  end
+end
+
+## IPS Application Result
+outcome :ips_application_result do
+  precalculate :how_long_it_takes do
+    phrases = PhraseList.new
+    phrases << :"how_long_#{waiting_time}"
+    phrases << :report_loss_or_theft if application_action == "replacing"
+    phrases << :"how_long_it_takes_ips#{ips_number}"
+    phrases
+  end
+
+  precalculate :cost do
+    uk_visa_application_centre_countries = %w(algeria azerbaijan bangladesh belarus china georgia india indonesia kazakhstan kyrgyzstan laos lebanon mauritania morocco nepal pakistan russia thailand ukraine venezuela western-sahara)
+    pay_at_appointment_countries = %(venezuela)
+
+    if %w(st-helena-ascension-and-tristan-da-cunha).include?(current_location)
+      PhraseList.new(:passport_costs_fee_only, :"#{child_or_adult}_passport_costs_only", :passport_cost_and_admin_fee)
+    elsif application_action == 'replacing' and ips_number == '1' and ips_docs_number == '1'
+      PhraseList.new(:"passport_courier_costs_replacing_ips#{ips_number}",
+                    :"#{child_or_adult}_passport_costs_replacing_ips#{ips_number}",
+                    :"passport_costs_ips#{ips_number}")
+    else
+      phrases = PhraseList.new
+      if uk_visa_application_centre_countries.include?(current_location)
+        phrases << :"passport_courier_costs_ips#{ips_number}_uk_visa"
+      elsif %w(pitcairn-island).include?(current_location)
+        phrases << :"passport_courier_costs_ips3_#{current_location}"
+      else
+        phrases << :"passport_courier_costs_ips#{ips_number}"
+      end
+      phrases << :"#{child_or_adult}_passport_costs_ips#{ips_number}"
+
+      if data_query.cash_only_countries?(current_location)
+        phrases << :passport_costs_ips_cash
+      elsif pay_at_appointment_countries.include?(current_location)
+        phrases << :passport_costs_pay_at_appointment
+      else
+        phrases << :"passport_costs_ips#{ips_number}"
+      end
+      phrases
+    end
+  end
+
+  precalculate :how_to_apply do
+    if passport_data['online_application']
+    else
+      phrases = PhraseList.new
+      phrases <<  :"how_to_apply_ips#{ips_number}"
+      if %w(pakistan).include?(current_location)
+        phrases << :send_application_ips1_pakistan
+      end
+      phrases << application_form.to_sym
+      phrases << supporting_documents.to_sym
+      if %w(south-africa spain).include?(birth_location)
+        phrases << :"birth_certificate_#{birth_location}"
+      end
+      phrases
+    end
+  end
+
+  precalculate :send_your_application do
+    uk_visa_application_centre_countries = %w(afghanistan algeria azerbaijan bangladesh belarus burundi china gaza georgia india indonesia kazakhstan kyrgyzstan laos lebanon mauritania morocco nepal pakistan russia thailand ukraine western-sahara venezuela)
+    uk_visa_application_with_colour_pictures = %w(azerbaijan algeria bangladesh belarus china georgia india indonesia kazakhstan kyrgyzstan laos lebanon mauritania morocco nepal pakistan thailand ukraine russia venezuela)
+    non_uk_visa_application_with_colour_pictures = %w(burma cuba sudan tajikistan turkmenistan uzbekistan)
+    phrases = PhraseList.new
+    if application_address
+      phrases << :"send_application_#{application_address}"
+    elsif uk_visa_application_centre_countries.include?(current_location)
+      if %w(renewing_new).include?(application_action)
+        if passport_data['application_office']
+          if %w(western-sahara).include?(current_location)
+            phrases << :send_application_uk_visa_renew_new_colour_western_sahara
+          elsif uk_visa_application_with_colour_pictures.include?(current_location)
+            phrases << :send_application_uk_visa_renew_new_colour
+          else
+            phrases << :send_application_uk_visa_renew_new
+          end
+          phrases << :"send_application_address_#{current_location}"
+        else
+          if %w(afghanistan burundi gaza).include?(current_location)
+            phrases << :send_application_non_uk_visa_renew_new_colour
+          else
+            phrases << :send_application_non_uk_visa_renew_new
+          end
+          phrases << :send_application_embassy_address
+        end
+      else
+        if passport_data['application_office']
+          if %w(western-sahara).include?(current_location)
+            phrases << :send_application_uk_visa_renew_old_replace_colour_western_sahara
+          elsif uk_visa_application_with_colour_pictures.include?(current_location)
+            phrases << :send_application_uk_visa_apply_renew_old_replace_colour
+          else
+            phrases << :send_application_uk_visa_apply_renew_old_replace
+          end
+          phrases << :"send_application_address_#{current_location}"
+        else
+          if %w(afghanistan burundi gaza).include?(current_location)
+            phrases << :send_application_non_uk_visa_apply_renew_old_replace_colour
+          else
+            phrases << :send_application_non_uk_visa_apply_renew_old_replace
+          end
+          phrases << :send_application_embassy_address
+        end
+      end
+    elsif %w(timor-leste).include?(current_location)
+      phrases << :"send_application_#{current_location}" << :"send_application_address_#{current_location}"
+    elsif general_action == 'renewing' and data_query.renewing_countries?(current_location)
+      if passport_data['application_office']
+        phrases << :"send_application_address_#{current_location}"
+      else
+        if non_uk_visa_application_with_colour_pictures.include?(current_location)
+          phrases << :send_application_non_uk_visa_renew_new_colour
+        else
+          phrases << :"send_application_ips#{ips_number}" << :renewing_new_renewing_old
+        end
+        phrases << :send_application_embassy_address
+      end
+    else
+      if passport_data['application_office']
+        phrases << :"send_application_address_#{current_location}"
+      else
+        if non_uk_visa_application_with_colour_pictures.include?(current_location)
+          phrases << :send_application_non_uk_visa_apply_renew_old_replace_colour
+        else
+          phrases << :"send_application_ips#{ips_number}"
+        end
+        if %w(st-helena-ascension-and-tristan-da-cunha).include?(current_location)
+          phrases << :renewing_new_renewing_old if %w(renewing_new).include?(application_action)
+          phrases << :send_application_address_st_helena_ascension_and_tristan_da_cunha
+        else
+          phrases << :send_application_embassy_address if ips_number.to_i > 1
+        end
+      end
+    end
+    phrases
+  end
+
+  precalculate :getting_your_passport do
+    collect_in_person_countries = %w(angola benin cameroon chad congo eritrea ethiopia gambia ghana guinea jamaica kenya nigeria somalia south-sudan zambia zimbabwe)
+    collect_in_person_variant_countries = %w(burundi india jordan pitcairn-island)
+    collect_in_person_renewing_new_variant_countries = %(burma nepal north-korea st-helena-ascension-and-tristan-da-cunha)
+    uk_visa_application_centre_countries = %w(algeria azerbaijan bangladesh belarus china georgia india indonesia kazakhstan kyrgyzstan lebanon mauritania morocco pakistan russia thailand ukraine venezuela western-sahara)
+    uk_visa_application_centre_variant_countries = %w(cambodia egypt iraq libya rwanda sierra-leone tunisia uganda yemen)
+    collect_with_photo_id_countries = %w(cambodia egypt iraq libya rwanda sierra-leone tunisia uganda yemen)
+    passport_delivered_by_courier_countries = %w(laos)
+
+    phrases = PhraseList.new
+    if passport_delivered_by_courier_countries.include?(current_location)
+      phrases << :passport_delivered_by_courier
+    elsif uk_visa_application_centre_countries.include?(current_location)
+      phrases << :getting_your_passport_uk_visa_centre
+      if %w(renewing_new).include?(application_action)
+        phrases << :getting_your_passport_contact << :getting_your_passport_id_renew_new
+      else
+        phrases << :getting_your_passport_contact_and_id
+      end
+    elsif uk_visa_application_centre_variant_countries.include?(current_location)
+      phrases << :"getting_your_passport_#{current_location}" << :getting_your_passport_uk_visa_where_to_collect
+      if %w(renewing_new).include?(application_action)
+        if collect_with_photo_id_countries.include?(current_location)
+          phrases << :getting_your_passport_with_id
+        else
+          phrases << :getting_your_passport_id_renew_new
+        end
+      else
+        phrases << :getting_your_passport_id_apply_renew_old_replace
+      end
+    elsif collect_in_person_countries.include?(current_location)
+      phrases << :"getting_your_passport_#{current_location}" << :getting_your_passport_contact_and_id
+    elsif collect_in_person_variant_countries.include?(current_location)
+      if %w(burundi).include?(current_location)
+        if %w(renewing_new).include?(application_action)
+          phrases << :"getting_your_passport_#{current_location}_renew_new"
+        else
+          phrases << :"getting_your_passport_#{current_location}" << :getting_your_passport_contact_and_id
+        end
+      else
+        phrases << :"getting_your_passport_#{current_location}"
+      end
+    elsif collect_in_person_renewing_new_variant_countries.include?(current_location)
+      phrases << :"getting_your_passport_#{current_location}" << :getting_your_passport_contact
+      if %w(renewing_new).include?(application_action)
+        phrases << :getting_your_passport_id_renew_new
+      else
+        phrases << :getting_your_passport_id_apply_renew_old_replace
+      end
+    else
+      phrases << :"getting_your_passport_ips#{ips_number}"
+    end
+  end
+  precalculate :contact_passport_adviceline do
+    PhraseList.new(:contact_passport_adviceline)
+  end
+end
+
+## FCO Result
+outcome :fco_result do
+  precalculate :how_long_it_takes do
+    phrases = PhraseList.new
+    phrases << :"how_long_#{waiting_time}"
+    phrases << :you_may_have_to_attend_an_interview if %w(renewing_old applying).include?(application_action)
+    phrases << :report_loss_or_theft if application_action == "replacing"
+    phrases
+  end
+
+  precalculate :cost do
+    cost_type = application_type
+    payment_methods = :"passport_costs_#{application_type}"
+
+    phrases = PhraseList.new(:"passport_courier_costs_#{cost_type}",
+                             :"#{child_or_adult}_passport_costs_#{cost_type}",
+                             payment_methods)
+
+    phrases
+  end
+
+  precalculate :how_to_apply_supplement do
+    if general_action == 'renewing' and data_query.retain_passport?(current_location)
+      PhraseList.new(:how_to_apply_retain_passport)
+    else
+      ''
+    end
+  end
+
+  precalculate :hurricane_warning do
+    if general_action == 'renewing' and data_query.retain_passport_hurricanes?(current_location)
+      PhraseList.new(:how_to_apply_retain_passport_hurricane)
+    else
+      ''
+    end
+  end
+
+  precalculate :supporting_documents do
+    if application_action == 'applying' and current_location == 'jordan'
+      PhraseList.new(:supporting_documents_jordan_applying)
+    elsif current_location == 'south-africa' and general_action == 'applying'
+      PhraseList.new(:supporting_documents_south_africa_applying)
+    else
+      ''
+    end
+  end
+
+  precalculate :send_your_application do
+    phrases = PhraseList.new
+    if %(south-africa).include?(current_location)
+      phrases << :"send_application_#{current_location}"
+    elsif current_location == 'indonesia'
+      if application_action == 'applying' or application_action == 'replacing'
+        phrases << :send_application_indonesia_applying
+      else
+        phrases << :send_application_fco_preamble << :"send_application_#{application_type}"
+      end
+    else
+      phrases << :send_application_fco_preamble
+      phrases << :"send_application_#{application_type}"
+    end
+    phrases
+  end
+  precalculate :getting_your_passport do
+    location = 'fco'
+    location = current_location if %(cambodia congo nepal).include?(current_location)
+    PhraseList.new(:"getting_your_passport_#{location}")
+  end
+  precalculate :helpline do
+    PhraseList.new(:"helpline_#{application_type}", :helpline_fco_webchat)
+  end
+end
+
+## Generic country outcome.
+outcome :result do
+  precalculate :how_long_it_takes do
+    PhraseList.new(:"how_long_#{application_type}")
+  end
+  precalculate :cost do
+    PhraseList.new(:"cost_#{application_type}")
+  end
+  precalculate :how_to_apply do
+    phrases = PhraseList.new(:"how_to_apply_#{application_type}")
+    if general_action == 'renewing' and data_query.retain_passport?(current_location)
+      phrases << :how_to_apply_retain_passport
+    elsif general_action == 'renewing' and data_query.retain_passport_exception?(current_location)
+      phrases << :how_to_apply_retain_passport_exception
+    end
+    phrases
+  end
+  precalculate :making_application_additional do
+    if current_location == 'yemen'
+      PhraseList.new(:making_application_additional_yemen)
+    else
+      ''
+    end
+  end
+  precalculate :supporting_documents do
+    phrase = ['supporting_documents', application_type]
+    phrase << general_action if %w(iraq yemen zambia).include?(application_type)
+    PhraseList.new(phrase.join('_').to_sym)
+  end
+  precalculate :making_application do
+    PhraseList.new(:"making_application_#{application_type}")
+  end
+  precalculate :getting_your_passport do
+    PhraseList.new(:"getting_your_passport_#{application_type}")
+  end
+  precalculate :helpline do
+    phrases = PhraseList.new
+    if %w(cuba libya morocco tunisia).include?(current_location)
+      phrases << :helpline_exceptions
+    elsif current_location == 'yemen'
+      phrases << :helpline_exception_yemen
+    else
+      phrases << :helpline_intro << :"helpline_#{passport_data['helpline']}"
+    end
+    phrases << :helpline_fco_webchat
+    phrases
+  end
+end
+
+## No-op outcome.
+outcome :cannot_apply do
+  precalculate :organisation do
+    location.fco_organisation
+  end
+
+  precalculate :overseas_passports_embassies do
+    if organisation
+      organisation.offices_with_service 'Overseas Passports Service'
+    else
+      []
+    end
+  end
+
+  precalculate :body_text do
+    PhraseList.new(:"body_#{current_location}")
+  end
+end
+
+outcome :apply_in_neighbouring_country do
+  precalculate :title_output do
+    location.name
+  end
+
+  precalculate :emergency_travel_help do
+    if %w(kyrgyzstan north-korea).include?(current_location)
+      PhraseList.new(:"emergency_travel_help_#{current_location}")
+    end
+  end
+end

--- a/lib/smart_answer_flows/overseas-passports-v2.rb
+++ b/lib/smart_answer_flows/overseas-passports-v2.rb
@@ -101,6 +101,17 @@ multiple_choice :renewing_replacing_applying? do
     passport_data[application_action]
   end
 
+  calculate :incomplete_application_deadline do
+    phrases = PhraseList.new
+    incomplete_deadline_countries = %w(afghanistan australia austria bahrain bangladesh barbados belgium brazil canada china denmark egypt ethiopia finland france germany ghana greece hong-kong india indonesia iraq ireland israel italy jamaica japan kenya lebanon malawi malaysia netherlands new-zealand nigeria norway pakistan philippines portugal qatar russia saudi-arabia sierra-leone singapore south-africa spain sri-lanka sudan sweden switzerland thailand trinidad-and-tobago turkey uganda united-arab-emirates usa venezuela vietnam zambia zimbabwe)
+    if incomplete_deadline_countries.include?(current_location)
+      phrases << :how_to_apply_incomplete_application_deadline
+    else
+      phrases << ''
+    end
+    phrases
+  end
+
   next_node :child_or_adult_passport?
 end
 

--- a/test/fixtures/worldwide/tajikistan_organisations.json
+++ b/test/fixtures/worldwide/tajikistan_organisations.json
@@ -1,0 +1,149 @@
+{
+  "results": [
+    {
+      "id": "https://www.gov.uk/api/worldwide-organisations/british-embassy-dushanbe",
+      "title": "British Embassy Dushanbe",
+      "format": "Worldwide Organisation",
+      "updated_at": "2014-02-27T06:37:13.000+00:00",
+      "web_url": "https://www.gov.uk/government/world/organisations/british-embassy-dushanbe",
+      "details": {
+        "slug": "british-embassy-dushanbe"
+      },
+      "offices": {
+        "main": {
+          "title": "British Embassy Dushanbe",
+          "format": "World Office",
+          "updated_at": "2013-08-01T10:39:00.000+01:00",
+          "web_url": "https://www.gov.uk/government/world/organisations/british-embassy-dushanbe/office/british-embassy-dushanbe",
+          "details": {
+            "email": "dushanbe.reception@fco.gov.uk ",
+            "description": "Office hours: By appointment only. Access our clickbook to fix an appointment.\r\nOpening hours: 9am to 5pm Monday to Friday (local time)",
+            "contact_form_url": "",
+            "access_and_opening_times": "",
+            "type": "Embassy"
+          },
+          "address": {
+            "adr": {
+              "fn": "",
+              "street-address": "65 Mirzo Tursunzoda Street",
+              "postal-code": "734002",
+              "locality": "Dushanbe",
+              "region": "Dushanbe",
+              "country-name": "Tajikistan"
+            },
+            "label": {
+              "value": "65 Mirzo Tursunzoda Street\nDushanbe\nDushanbe\n734002\nTajikistan"
+            }
+          },
+          "contact_numbers": [
+            {
+              "label": "Telephone",
+              "number": "+99 237 224 2221"
+            },
+            {
+              "label": "Fax",
+              "number": "+99 237 227 1726"
+            }
+          ],
+          "services": [
+            {
+              "title": "Emergency Travel Documents service",
+              "type": "Assistance Services"
+            },
+            {
+              "title": "Notarial services",
+              "type": "Documentary Services"
+            },
+            {
+              "title": "Overseas Passports Service",
+              "type": "Other Services"
+            }
+          ]
+        },
+        "other": []
+      },
+      "sponsors": [
+        {
+          "title": "Foreign & Commonwealth Office",
+          "web_url": "https://www.gov.uk/government/organisations/foreign-commonwealth-office",
+          "details": {
+            "acronym": "FCO"
+          }
+        }
+      ]
+    },
+    {
+      "id": "https://www.gov.uk/api/worldwide-organisations/dfid-tajikistan",
+      "title": "DFID Tajikistan",
+      "format": "Worldwide Organisation",
+      "updated_at": "2013-10-25T13:55:30.000+01:00",
+      "web_url": "https://www.gov.uk/government/world/organisations/dfid-tajikistan",
+      "details": {
+        "slug": "dfid-tajikistan"
+      },
+      "offices": {
+        "main": {
+          "title": " DFID Tajikistan",
+          "format": "World Office",
+          "updated_at": "2013-03-25T10:37:54.000+00:00",
+          "web_url": "https://www.gov.uk/government/world/organisations/dfid-tajikistan/office/dfid-tajikistan",
+          "details": {
+            "email": "DFIDTajikistan@dfid.gov.uk",
+            "description": "",
+            "contact_form_url": "",
+            "access_and_opening_times": "",
+            "type": "Other"
+          },
+          "address": {
+            "adr": {
+              "fn": "British Embassy ",
+              "street-address": "65 Mirzo Tursunzoda Street,",
+              "postal-code": "734002",
+              "locality": "Dushanbe",
+              "region": "",
+              "country-name": "Tajikistan"
+            },
+            "label": {
+              "value": "British Embassy \n65 Mirzo Tursunzoda Street,\nDushanbe\n734002\nTajikistan"
+            }
+          },
+          "contact_numbers": [
+            {
+              "label": "Tel:\t",
+              "number": "+992 372 510 038"
+            },
+            {
+              "label": "Fax:\t",
+              "number": "+992 372 271 726"
+            }
+          ],
+          "services": []
+        },
+        "other": []
+      },
+      "sponsors": [
+        {
+          "title": "Department for International Development",
+          "web_url": "https://www.gov.uk/government/organisations/department-for-international-development",
+          "details": {
+            "acronym": "DFID"
+          }
+        }
+      ]
+    }
+  ],
+  "current_page": 1,
+  "total": 2,
+  "pages": 1,
+  "page_size": 20,
+  "start_index": 1,
+  "_response_info": {
+    "status": "ok",
+    "links": [
+      {
+        "href": "https://www.gov.uk/api/world-locations/tajikistan/organisations?page=1",
+        "rel": "self"
+      }
+    ]
+  }
+}

--- a/test/integration/smart_answer_flows/overseas_passports_v2_test.rb
+++ b/test/integration/smart_answer_flows/overseas_passports_v2_test.rb
@@ -1,0 +1,1194 @@
+# encoding: UTF-8
+require_relative '../../test_helper'
+require_relative 'flow_test_helper'
+require 'gds_api/test_helpers/worldwide'
+
+class OverseasPassportsV2Test < ActiveSupport::TestCase
+  include FlowTestHelper
+  include GdsApi::TestHelpers::Worldwide
+
+  setup do
+    @location_slugs = %w(albania algeria afghanistan australia austria azerbaijan bahamas bangladesh benin british-indian-ocean-territory burma burundi cambodia cameroon china congo georgia greece haiti hong-kong india iran iraq ireland italy jamaica jordan kenya kyrgyzstan malta nepal nigeria pakistan pitcairn-island saudi-arabia syria south-africa spain sri-lanka st-helena-ascension-and-tristan-da-cunha tanzania timor-leste turkey ukraine united-kingdom united-arab-emirates usa uzbekistan yemen zimbabwe venezuela vietnam zambia)
+    worldwide_api_has_locations(@location_slugs)
+    setup_for_testing_flow 'overseas-passports-v2'
+  end
+
+  ## Q1
+  should "ask which country you are in" do
+    assert_current_node :which_country_are_you_in?
+  end
+
+  # Afghanistan (An example of bespoke application process).
+  context "answer Afghanistan" do
+    setup do
+      worldwide_api_has_organisations_for_location('afghanistan', read_fixture_file('worldwide/afghanistan_organisations.json'))
+      add_response 'afghanistan'
+    end
+    should "ask if you are renewing, replacing or applying for a passport" do
+      assert_current_node :renewing_replacing_applying?
+      assert_state_variable :current_location, 'afghanistan'
+    end
+    context "answer applying" do
+      setup do
+        add_response 'applying'
+      end
+      should "ask if the passport is for an adult or a child" do
+        assert_current_node :child_or_adult_passport?
+      end
+      context "answer adult" do
+        should "give the result and be done" do
+          add_response 'adult'
+          add_response 'afghanistan'
+          assert_state_variable :application_type, 'ips_application_3'
+          assert_current_node :ips_application_result
+          assert_phrase_list :how_long_it_takes, [:how_long_6_months, :how_long_it_takes_ips3]
+          assert_phrase_list :cost, [:passport_courier_costs_ips3, :adult_passport_costs_ips3, :passport_costs_ips3]
+          assert_phrase_list :send_your_application, [:send_application_non_uk_visa_apply_renew_old_replace_colour, :send_application_embassy_address]
+        end
+      end
+    end
+
+    context "answer renewing" do
+      setup do
+        add_response 'renewing_new'
+      end
+      should "ask if the passport is for an adult or a child" do
+        assert_current_node :child_or_adult_passport?
+      end
+      context "answer adult" do
+        should "give the result and be done" do
+          add_response 'adult'
+          assert_state_variable :application_type, 'ips_application_3'
+          assert_current_node :ips_application_result
+          assert_phrase_list :how_long_it_takes, [:how_long_6_weeks, :how_long_it_takes_ips3]
+          assert_phrase_list :cost, [:passport_courier_costs_ips3, :adult_passport_costs_ips3, :passport_costs_ips3]
+          assert_phrase_list :send_your_application, [:send_application_non_uk_visa_renew_new_colour, :send_application_embassy_address]
+        end
+      end
+    end
+
+    context "answer lost or stolen" do
+      setup do
+        add_response 'replacing'
+      end
+      should "ask if the passport is for an adult or a child" do
+        assert_current_node :child_or_adult_passport?
+      end
+      context "answer adult" do
+        should "give the result and be done" do
+          add_response 'adult'
+          assert_state_variable :application_type, 'ips_application_3'
+          assert_current_node :ips_application_result
+   assert_phrase_list :how_long_it_takes, [:how_long_14_weeks, :report_loss_or_theft, :how_long_it_takes_ips3]
+        end
+      end
+    end
+  end # Afghanistan
+
+  # Iraq (An example of ips 1 application with some conditional phrases).
+  context "answer Iraq" do
+    setup do
+      worldwide_api_has_organisations_for_location('iraq', read_fixture_file('worldwide/iraq_organisations.json'))
+      add_response 'iraq'
+    end
+    should "ask if you are renewing, replacing or applying for a passport" do
+      assert_current_node :renewing_replacing_applying?
+      assert_state_variable :current_location, 'iraq'
+    end
+    context "answer applying" do
+      setup do
+        add_response 'applying'
+      end
+      should "ask if the passport is for an adult or a child" do
+        assert_current_node :child_or_adult_passport?
+        assert_state_variable :application_type, 'ips_application_1'
+      end
+      context "answer adult" do
+        setup do
+          add_response 'adult'
+        end
+        should "ask the country of birth" do
+          assert_current_node :country_of_birth?
+        end
+        context "answer UK" do
+          setup do
+            add_response 'united-kingdom'
+          end
+          should "give the result and be done" do
+            assert_current_node :ips_application_result
+            assert_phrase_list :fco_forms, [:adult_fco_forms]
+            assert_phrase_list :how_long_it_takes, [:how_long_12_weeks, :how_long_it_takes_ips1]
+            assert_phrase_list :cost, [:passport_courier_costs_ips1, :adult_passport_costs_ips1, :passport_costs_ips1]
+            assert_phrase_list :how_to_apply, [:how_to_apply_ips1, :hmpo_1_application_form, :ips_documents_group_3]
+            assert_phrase_list :send_your_application, [:send_application_durham]
+            assert_phrase_list :getting_your_passport, [:getting_your_passport_iraq, :getting_your_passport_uk_visa_where_to_collect, :getting_your_passport_id_apply_renew_old_replace]
+            assert_phrase_list :contact_passport_adviceline, [:contact_passport_adviceline]
+            assert_match /Millburngate House/, outcome_body
+          end
+        end
+      end
+    end
+  end # Iraq
+
+  context "answer Benin, renewing old passport" do
+    setup do
+      worldwide_api_has_organisations_for_location('nigeria', read_fixture_file('worldwide/nigeria_organisations.json'))
+      add_response 'benin'
+      add_response 'renewing_old'
+      add_response 'adult'
+      add_response 'united-kingdom'
+    end
+    should "give the result with alternative embassy details" do
+      assert_current_node :ips_application_result
+      assert_phrase_list :fco_forms, [:adult_fco_forms]
+      assert_phrase_list :how_long_it_takes, [:how_long_12_weeks, :how_long_it_takes_ips1]
+      assert_phrase_list :cost, [:passport_courier_costs_ips1, :adult_passport_costs_ips1, :passport_costs_ips1]
+      assert_phrase_list :how_to_apply, [:how_to_apply_ips1, :hmpo_1_application_form, :ips_documents_group_3]
+      assert_phrase_list :send_your_application, [:send_application_durham]
+      assert_phrase_list :getting_your_passport, [:getting_your_passport_benin, :getting_your_passport_contact_and_id]
+      assert_phrase_list :contact_passport_adviceline, [:contact_passport_adviceline]
+    end
+  end
+
+  # Austria (An example of IPS application 1).
+  context "answer Austria" do
+    setup do
+      worldwide_api_has_organisations_for_location('austria', read_fixture_file('worldwide/austria_organisations.json'))
+      add_response 'austria'
+    end
+    should "ask if you are renewing, replacing or applying for a passport" do
+      assert_current_node :renewing_replacing_applying?
+      assert_state_variable :current_location, 'austria'
+    end
+    context "answer applying" do
+      setup do
+        add_response 'applying'
+      end
+      should "ask if the passport is for an adult or a child" do
+        assert_state_variable :application_type, 'ips_application_1'
+        assert_state_variable :ips_number, "1"
+        assert_current_node :child_or_adult_passport?
+      end
+      context "answer adult" do
+        setup do
+          add_response 'adult'
+        end
+        should "give the result and be done" do
+          assert_phrase_list :fco_forms, [:adult_fco_forms]
+          assert_current_node :country_of_birth?
+        end
+        context "answer Greece" do
+          setup do
+            add_response 'greece'
+          end
+
+          should "use the greek document group in the results" do
+            assert_state_variable :supporting_documents, 'ips_documents_group_2'
+          end
+
+          should "give the result" do
+            assert_current_node :ips_application_result_online
+            assert_phrase_list :fco_forms, [:adult_fco_forms]
+            assert_phrase_list :how_long_it_takes, [:how_long_8_weeks, :how_long_additional_info_applying, :how_long_additional_time_online]
+            assert_phrase_list :how_to_apply, [:how_to_apply_online, :how_to_apply_online_prerequisites_applying, :how_to_apply_online_guidance_doc_group_2, :how_to_apply_online_guidance_doc_outro]
+            assert_phrase_list :cost, [:passport_courier_costs_ips1, :adult_passport_costs_ips1]
+            assert_phrase_list :getting_your_passport, [:getting_your_passport_ips1]
+            assert_phrase_list :contact_passport_adviceline, [:contact_passport_adviceline]
+          end
+        end
+      end
+    end # Applying
+
+    context "answer renewing old blue or black passport" do
+      setup do
+        add_response 'renewing_old'
+        add_response 'adult'
+      end
+      should "ask which country you were born in" do
+        assert_current_node :country_of_birth?
+      end
+    end # Renewing old style passport
+    context "answer replacing" do
+      setup do
+        add_response 'replacing'
+      end
+      should "ask if the passport is for an adult or a child" do
+        assert_current_node :child_or_adult_passport?
+      end
+      context "answer adult" do
+        should "give the result and be done" do
+          add_response 'adult'
+          assert_state_variable :supporting_documents, 'ips_documents_group_1'
+          assert_current_node :ips_application_result_online
+          assert_phrase_list :fco_forms, [:adult_fco_forms]
+          assert_phrase_list :how_long_it_takes, [:how_long_8_weeks, :how_long_additional_info_replacing, :how_long_additional_time_online]
+          assert_phrase_list :how_to_apply, [:how_to_apply_online, :how_to_apply_online_prerequisites_replacing, :how_to_apply_online_guidance_doc_group_1, :how_to_apply_online_guidance_doc_outro]
+          assert_phrase_list :cost, [:passport_courier_costs_replacing_ips1, :adult_passport_costs_replacing_ips1]
+          assert_phrase_list :contact_passport_adviceline, [:contact_passport_adviceline]
+          assert_state_variable :embassy_address, nil
+        end
+      end
+    end # Replacing
+  end # Austria - IPS_application_1
+
+  context "answer Spain, an example of online application, doc group 1" do
+    setup do
+      worldwide_api_has_organisations_for_location('spain', read_fixture_file('worldwide/spain_organisations.json'))
+      add_response 'spain'
+    end
+    should "show how to apply online" do
+      add_response 'applying'
+      add_response 'adult'
+      add_response 'united-kingdom'
+      assert_current_node :ips_application_result_online
+      assert_phrase_list :how_long_it_takes, [:how_long_8_weeks, :how_long_additional_info_applying, :how_long_additional_time_online]
+      assert_phrase_list :cost, [:passport_courier_costs_ips1, :adult_passport_costs_ips1]
+      assert_phrase_list :how_to_apply, [:how_to_apply_online, :how_to_apply_online_prerequisites_applying, :how_to_apply_online_guidance_doc_group_1, :how_to_apply_online_guidance_doc_outro]
+      assert_match /the passport numbers of both parents/, outcome_body
+    end
+    should "show how to replace your passport online" do
+      add_response 'replacing'
+      add_response 'child'
+      assert_current_node :ips_application_result_online
+      assert_phrase_list :how_long_it_takes, [:how_long_8_weeks, :how_long_additional_info_replacing, :how_long_additional_time_online]
+      assert_phrase_list :cost, [:passport_courier_costs_replacing_ips1, :child_passport_costs_replacing_ips1]
+      assert_phrase_list :how_to_apply, [:how_to_apply_online, :how_to_apply_online_prerequisites_replacing, :how_to_apply_online_guidance_doc_group_1, :how_to_apply_online_guidance_doc_outro]
+    end
+  end
+
+  context "answer Greece, an example of online application, doc group 2" do
+    setup do
+      worldwide_api_has_organisations_for_location('greece', read_fixture_file('worldwide/greece_organisations.json'))
+      add_response 'greece'
+    end
+    should "show how to apply online" do
+      add_response 'renewing_new'
+      add_response 'adult'
+      assert_current_node :ips_application_result_online
+      assert_phrase_list :how_long_it_takes, [:how_long_6_weeks, :how_long_additional_info_renewing_new, :how_long_additional_time_online]
+      assert_phrase_list :cost, [:passport_courier_costs_ips1, :adult_passport_costs_ips1]
+      assert_phrase_list :how_to_apply, [:how_to_apply_online, :how_to_apply_online_prerequisites_renewing, :how_to_apply_online_guidance_doc_group_2, :how_to_apply_online_guidance_doc_outro]
+    end
+    should "show how to replace your passport online" do
+      add_response 'replacing'
+      add_response 'child'
+      assert_current_node :ips_application_result_online
+      assert_phrase_list :how_long_it_takes, [:how_long_8_weeks, :how_long_additional_info_replacing, :how_long_additional_time_online]
+      assert_phrase_list :cost, [:passport_courier_costs_ips1, :child_passport_costs_ips1]
+      assert_phrase_list :how_to_apply, [:how_to_apply_online, :how_to_apply_online_prerequisites_replacing, :how_to_apply_online_guidance_doc_group_2, :how_to_apply_online_guidance_doc_outro]
+    end
+  end
+
+  context "answer Vietnam, an example of online application, doc group 3" do
+    setup do
+      worldwide_api_has_organisations_for_location('vietnam', read_fixture_file('worldwide/vietnam_organisations.json'))
+      add_response 'vietnam'
+    end
+    should "show how to apply online" do
+      add_response 'renewing_new'
+      add_response 'adult'
+      assert_current_node :ips_application_result_online
+      assert_phrase_list :how_long_it_takes, [:how_long_6_weeks, :how_long_additional_info_renewing_new, :how_long_additional_time_online]
+      assert_phrase_list :cost, [:passport_courier_costs_ips1, :adult_passport_costs_ips1]
+      assert_phrase_list :how_to_apply, [:how_to_apply_online, :how_to_apply_online_prerequisites_renewing, :how_to_apply_online_guidance_doc_group_3, :how_to_apply_online_guidance_doc_outro]
+    end
+    should "use the document group of the country of birth - Spain (which is 1)" do
+      add_response 'applying'
+      add_response 'adult'
+      add_response 'spain'
+      assert_current_node :ips_application_result_online
+      assert_phrase_list :how_to_apply, [:how_to_apply_online, :how_to_apply_online_prerequisites_applying, :how_to_apply_online_guidance_doc_group_1, :birth_certificate_spain, :how_to_apply_online_guidance_doc_outro]
+    end
+  end
+
+  # Albania (an example of IPS application 2).
+  context "answer Albania" do
+    setup do
+      worldwide_api_has_organisations_for_location('albania', read_fixture_file('worldwide/albania_organisations.json'))
+      add_response 'albania'
+    end
+    should "ask if you are renewing, replacing or applying for a passport" do
+      assert_current_node :renewing_replacing_applying?
+      assert_state_variable :current_location, 'albania'
+    end
+    context "answer applying" do
+      setup do
+        add_response 'applying'
+      end
+      should "ask if the passport is for an adult or a child" do
+        assert_current_node :child_or_adult_passport?
+        assert_state_variable :application_type, 'ips_application_1'
+        assert_state_variable :ips_number, "1"
+      end
+      context "answer adult" do
+        setup do
+          add_response 'adult'
+        end
+        should "ask which country you were born in" do
+          assert_current_node :country_of_birth?
+        end
+        context "answer Spain" do
+          should "give the application result" do
+            add_response "spain"
+            assert_current_node :ips_application_result_online
+            assert_phrase_list :how_long_it_takes, [:how_long_10_weeks, :how_long_additional_info_applying, :how_long_additional_time_online]
+            assert_phrase_list :how_to_apply, [:how_to_apply_online, :how_to_apply_online_prerequisites_applying, :how_to_apply_online_guidance_doc_group_1, :birth_certificate_spain, :how_to_apply_online_guidance_doc_outro]
+            assert_phrase_list :cost, [:passport_courier_costs_ips1, :adult_passport_costs_ips1]
+            assert_phrase_list :getting_your_passport, [:getting_your_passport_ips1]
+            assert_phrase_list :contact_passport_adviceline, [:contact_passport_adviceline]
+            assert_state_variable :embassy_address, nil
+            assert_state_variable :supporting_documents, 'ips_documents_group_1'
+          end
+        end
+        context "answer UK" do
+          should "give the application result with the UK documents" do
+            add_response "united-kingdom"
+            assert_current_node :ips_application_result_online
+            assert_phrase_list :how_long_it_takes, [:how_long_10_weeks, :how_long_additional_info_applying, :how_long_additional_time_online]
+            assert_phrase_list :how_to_apply, [:how_to_apply_online, :how_to_apply_online_prerequisites_applying, :how_to_apply_online_guidance_doc_group_3, :how_to_apply_online_guidance_doc_outro]
+            assert_phrase_list :cost, [:passport_courier_costs_ips1, :adult_passport_costs_ips1]
+            assert_phrase_list :contact_passport_adviceline, [:contact_passport_adviceline]
+            assert_state_variable :embassy_address, nil
+            assert_state_variable :supporting_documents, 'ips_documents_group_3'
+          end
+        end
+      end
+    end # Applying
+  end # Albania - IPS_application_2
+
+  # Ajerbaijan (an example of IPS application 3 and UK Visa centre).
+  context "answer Azerbaijan" do
+    setup do
+      worldwide_api_has_organisations_for_location('azerbaijan', read_fixture_file('worldwide/azerbaijan_organisations.json'))
+      add_response 'azerbaijan'
+    end
+    should "ask if you are renewing, replacing or applying for a passport" do
+      assert_current_node :renewing_replacing_applying?
+      assert_state_variable :current_location, 'azerbaijan'
+    end
+    context "answer replacing adult passport" do
+      setup do
+        add_response 'replacing'
+        add_response 'adult'
+        assert_state_variable :application_type, 'ips_application_3'
+        assert_state_variable :ips_number, "3"
+      end
+      should "give the IPS application result" do
+        assert_current_node :ips_application_result
+        assert_phrase_list :how_long_it_takes, [:how_long_8_weeks, :report_loss_or_theft, :how_long_it_takes_ips3]
+        assert_phrase_list :how_to_apply, [:how_to_apply_ips3, :hmpo_1_application_form, :ips_documents_group_3]
+        assert_phrase_list :cost, [:passport_courier_costs_ips3_uk_visa, :adult_passport_costs_ips3, :passport_costs_ips3]
+        assert_phrase_list :send_your_application, [:send_application_uk_visa_apply_renew_old_replace_colour, :send_application_address_azerbaijan]
+        assert_phrase_list :getting_your_passport, [:getting_your_passport_uk_visa_centre, :getting_your_passport_contact_and_id]
+      end
+    end # Applying
+  end # Azerbaijan - IPS_application_3
+
+  # Burundi (An example of IPS 3 application with some conditional phrases).
+  context "answer Burundi" do
+    setup do
+      worldwide_api_has_organisations_for_location('burundi', read_fixture_file('worldwide/burundi_organisations.json'))
+      add_response 'burundi'
+    end
+
+    should "give the correct result when renewing new style passport" do
+      add_response 'renewing_new'
+      add_response 'adult'
+      assert_phrase_list :send_your_application,
+        [:send_application_non_uk_visa_renew_new_colour, :send_application_embassy_address]
+      assert_phrase_list :getting_your_passport, [:getting_your_passport_burundi_renew_new]
+    end
+
+    should "give the correct result when renewing old style passport" do
+      add_response 'renewing_old'
+      add_response 'adult'
+      add_response 'united-kingdom'
+      assert_phrase_list :send_your_application, [:send_application_non_uk_visa_apply_renew_old_replace_colour, :send_application_embassy_address]
+      assert_phrase_list :getting_your_passport, [:getting_your_passport_burundi, :getting_your_passport_contact_and_id]
+    end
+
+    should "give the correct result when applying for the first time" do
+      add_response 'applying'
+      add_response 'adult'
+      add_response 'united-kingdom'
+      assert_phrase_list :send_your_application, [:send_application_non_uk_visa_apply_renew_old_replace_colour, :send_application_embassy_address]
+      assert_phrase_list :getting_your_passport, [:getting_your_passport_burundi, :getting_your_passport_contact_and_id]
+    end
+
+    should "give the correct result when replacing lost or stolen passport" do
+      add_response 'replacing'
+      add_response 'adult'
+      assert_phrase_list :send_your_application, [:send_application_non_uk_visa_apply_renew_old_replace_colour, :send_application_embassy_address]
+      assert_phrase_list :getting_your_passport, [:getting_your_passport_burundi, :getting_your_passport_contact_and_id]
+    end
+  end # Burundi
+
+  context "answer Ireland, replacement, adult passport" do
+    should "give the ips online application result" do
+      worldwide_api_has_organisations_for_location('ireland', read_fixture_file('worldwide/ireland_organisations.json'))
+      add_response 'ireland'
+      add_response 'replacing'
+      add_response 'adult'
+      assert_phrase_list :how_long_it_takes, [:how_long_8_weeks, :how_long_additional_info_replacing, :how_long_additional_time_online]
+      assert_phrase_list :cost, [:passport_courier_costs_replacing_ips1, :adult_passport_costs_replacing_ips1]
+      assert_phrase_list :how_to_apply, [:how_to_apply_online, :how_to_apply_online_prerequisites_replacing, :how_to_apply_online_guidance_doc_group_1, :how_to_apply_online_guidance_doc_outro]
+      assert_phrase_list :getting_your_passport, [:getting_your_passport_ips1]
+      assert_phrase_list :contact_passport_adviceline, [:contact_passport_adviceline]
+    end
+  end # Ireland (FCO with custom phrases)
+
+  context "answer India" do
+    setup do
+      worldwide_api_has_organisations_for_location('india', read_fixture_file('worldwide/india_organisations.json'))
+      add_response 'india'
+    end
+    context "applying, adult passport" do
+      should "give the ips result" do
+        add_response 'applying'
+        add_response 'adult'
+        add_response 'india'
+        assert_current_node :ips_application_result
+        assert_phrase_list :how_long_it_takes, [:how_long_16_weeks, :how_long_it_takes_ips3]
+        assert_phrase_list :send_your_application, [:send_application_uk_visa_apply_renew_old_replace_colour,:send_application_address_india]
+        assert_phrase_list :cost, [:passport_courier_costs_ips3_uk_visa, :adult_passport_costs_ips3, :passport_costs_ips3]
+        assert_phrase_list :getting_your_passport, [:getting_your_passport_uk_visa_centre, :getting_your_passport_contact_and_id]
+      end
+    end
+    context "renewing a new adult passport" do
+      should "give the ips result" do
+        add_response 'renewing_new'
+        add_response 'adult'
+        assert_current_node :ips_application_result
+        assert_phrase_list :how_long_it_takes, [:how_long_5_weeks, :how_long_it_takes_ips3]
+      end
+    end
+    context "renewing a new adult passport" do
+      should "give the ips result" do
+        add_response 'replacing'
+        add_response 'adult'
+        assert_current_node :ips_application_result
+        assert_phrase_list :how_long_it_takes, [:how_long_10_weeks, :report_loss_or_theft, :how_long_it_takes_ips3]
+      end
+    end
+  end # India
+
+  context "answer Tanzania, replacement, adult passport" do
+    should "give the ips online result with custom phrases" do
+      worldwide_api_has_organisations_for_location('tanzania', read_fixture_file('worldwide/tanzania_organisations.json'))
+      add_response 'tanzania'
+      add_response 'applying'
+      add_response 'adult'
+      add_response 'united-kingdom'
+      assert_current_node :ips_application_result_online
+      assert_phrase_list :how_long_it_takes, [:how_long_10_weeks, :how_long_additional_info_applying, :how_long_additional_time_online]
+    end
+  end # Tanzania
+
+  context "answer Congo, replacement, adult passport" do
+    should "give the result with custom phrases" do
+      worldwide_api_has_organisations_for_location('congo', read_fixture_file('worldwide/congo_organisations.json'))
+      add_response 'congo'
+      add_response 'applying'
+      add_response 'adult'
+      add_response 'united-kingdom'
+      assert_current_node :ips_application_result
+      assert_phrase_list :fco_forms, [:adult_fco_forms]
+      assert_phrase_list :how_long_it_takes, [:how_long_10_weeks, :how_long_it_takes_ips1]
+      assert_phrase_list :cost, [:passport_courier_costs_ips1, :adult_passport_costs_ips1, :passport_costs_ips1]
+      assert_phrase_list :how_to_apply, [:how_to_apply_ips1, :hmpo_1_application_form, :ips_documents_group_3]
+      assert_phrase_list :send_your_application, [:send_application_durham]
+      assert_phrase_list :getting_your_passport, [:getting_your_passport_congo, :getting_your_passport_contact_and_id]
+      assert_phrase_list :contact_passport_adviceline, [:contact_passport_adviceline]
+    end
+  end # Congo
+
+  context "answer Malta, replacement, adult passport" do
+    should "give the fco result with custom phrases" do
+      worldwide_api_has_organisations_for_location('malta', read_fixture_file('worldwide/malta_organisations.json'))
+      add_response 'malta'
+      add_response 'replacing'
+      add_response 'adult'
+      assert_current_node :ips_application_result_online
+      assert_phrase_list :cost, [:passport_courier_costs_replacing_ips1, :adult_passport_costs_replacing_ips1]
+    end
+  end # Malta (IPS1 with custom phrases)
+
+  context "answer Italy, replacement, adult passport" do
+    should "give the IPS online result" do
+      worldwide_api_has_organisations_for_location('italy', read_fixture_file('worldwide/italy_organisations.json'))
+      add_response 'italy'
+      add_response 'replacing'
+      add_response 'adult'
+      assert_current_node :ips_application_result_online
+      assert_phrase_list :how_long_it_takes, [:how_long_8_weeks, :how_long_additional_info_replacing, :how_long_additional_time_online]
+      assert_phrase_list :cost, [:passport_courier_costs_ips1, :adult_passport_costs_ips1]
+      assert_phrase_list :how_to_apply, [:how_to_apply_online, :how_to_apply_online_prerequisites_replacing, :how_to_apply_online_guidance_doc_group_2, :how_to_apply_online_guidance_doc_outro]
+      assert_phrase_list :getting_your_passport, [:getting_your_passport_ips1]
+      assert_phrase_list :contact_passport_adviceline, [:contact_passport_adviceline]
+    end
+  end # Italy (IPS online result)
+
+  context "answer Jordan, replacement, adult passport" do
+    should "give the ips1 result with custom phrases" do
+      worldwide_api_has_organisations_for_location('jordan', read_fixture_file('worldwide/jordan_organisations.json'))
+      add_response 'jordan'
+      add_response 'applying'
+      add_response 'adult'
+      add_response 'united-kingdom'
+      assert_phrase_list :getting_your_passport, [:getting_your_passport_jordan]
+      assert_current_node :ips_application_result
+      assert_match /Millburngate House/, outcome_body
+    end
+  end # Jordan (IPS1 with custom phrases)
+
+  context "answer Pitcairn Island, applying, adult passport" do
+    should "give the IPS application result with custom phrases" do
+      worldwide_api_has_organisations_for_location('pitcairn-island', read_fixture_file('worldwide/pitcairn-island_organisations.json'))
+      add_response 'pitcairn-island'
+      add_response 'applying'
+      add_response 'adult'
+      add_response 'united-kingdom'
+      assert_current_node :ips_application_result
+      assert_phrase_list :getting_your_passport, [:"getting_your_passport_pitcairn-island"]
+      assert_phrase_list :send_your_application, [:"send_application_address_pitcairn-island"]
+      assert_phrase_list :cost, [:"passport_courier_costs_ips3_pitcairn-island", :adult_passport_costs_ips3,
+ :passport_costs_ips3]
+    end
+  end # Pitcairn Island (IPS1 with custom phrases)
+
+  context "answer Ukraine, applying, adult passport" do
+    should "give the IPS application result with custom phrases" do
+      worldwide_api_has_organisations_for_location('ukraine', read_fixture_file('worldwide/ukraine_organisations.json'))
+      add_response 'ukraine'
+      add_response 'applying'
+      add_response 'adult'
+      add_response 'united-kingdom'
+      assert_current_node :ips_application_result
+      assert_phrase_list :cost, [:passport_courier_costs_ips3_uk_visa, :adult_passport_costs_ips3, :passport_costs_ips3]
+      assert_phrase_list :getting_your_passport, [:getting_your_passport_ukraine]
+      assert_phrase_list :send_your_application, [:send_application_ips3_ukraine_apply_renew_old_replace, :send_application_address_ukraine]
+    end
+  end # Ukraine (IPS3 with custom phrases)
+
+  context "answer Ukraine, applying, adult passport" do
+    should "give the IPS application result with custom phrases" do
+      worldwide_api_has_organisations_for_location('ukraine', read_fixture_file('worldwide/ukraine_organisations.json'))
+      add_response 'ukraine'
+      add_response 'renewing_new'
+      add_response 'adult'
+      assert_current_node :ips_application_result
+      assert_phrase_list :cost, [:passport_courier_costs_ips3_uk_visa, :adult_passport_costs_ips3, :passport_costs_ips3]
+      assert_phrase_list :getting_your_passport, [:getting_your_passport_uk_visa_centre, :getting_your_passport_contact, :getting_your_passport_id_renew_new]
+      assert_phrase_list :send_your_application, [:send_application_uk_visa_renew_new_colour, :send_application_address_ukraine]
+    end
+  end # Ukraine (IPS3 with custom phrases)
+
+  context "answer nepal, renewing new, adult passport" do
+    should "give the IPS application result with custom phrases" do
+      worldwide_api_has_organisations_for_location('nepal', read_fixture_file('worldwide/nepal_organisations.json'))
+      add_response 'nepal'
+      add_response 'renewing_new'
+      add_response 'adult'
+      assert_current_node :ips_application_result
+      assert_phrase_list :send_your_application, [:send_application_uk_visa_renew_new_colour, :"send_application_address_nepal"]
+      assert_phrase_list :cost, [:passport_courier_costs_ips3_uk_visa, :adult_passport_costs_ips3, :passport_costs_ips3]
+      assert_state_variable :send_colour_photocopy_bulletpoint, nil
+    end
+  end # nepal (IPS3 with custom phrases)
+
+  context "answer nepal, lost or stolen, adult passport" do
+    should "give the IPS application result with custom phrases" do
+      worldwide_api_has_organisations_for_location('nepal', read_fixture_file('worldwide/pitcairn-island_organisations.json'))
+      add_response 'nepal'
+      add_response 'replacing'
+      add_response 'adult'
+      assert_current_node :ips_application_result
+      assert_phrase_list :send_your_application, [:send_application_uk_visa_apply_renew_old_replace_colour, :"send_application_address_nepal"]
+      assert_phrase_list :cost, [:passport_courier_costs_ips3_uk_visa, :adult_passport_costs_ips3, :passport_costs_ips3]
+      assert_state_variable :send_colour_photocopy_bulletpoint, nil
+    end
+  end # nepal (IPS1 with custom phrases)
+
+  context "answer Iran" do
+    should "give a bespoke outcome stating an application is not possible in Iran" do
+      worldwide_api_has_organisations_for_location('iran', read_fixture_file('worldwide/iran_organisations.json'))
+      add_response 'iran'
+      assert_current_node :cannot_apply
+      assert_phrase_list :body_text, [:body_iran]
+    end
+  end # Iran - no application outcome
+
+  context "answer Syria" do
+    should "give a bespoke outcome stating an application is not possible in Syria" do
+      worldwide_api_has_organisations_for_location('syria', read_fixture_file('worldwide/syria_organisations.json'))
+      add_response 'syria'
+      assert_current_node :cannot_apply
+      assert_phrase_list :body_text, [:body_syria]
+    end
+  end # Syria - no application outcome
+
+  context "answer Cameroon, renewing, adult passport" do
+    should "give the generic result with custom phrases" do
+      worldwide_api_has_organisations_for_location('cameroon', read_fixture_file('worldwide/cameroon_organisations.json'))
+      add_response 'cameroon'
+      add_response 'renewing_new'
+      add_response 'adult'
+      assert_current_node :ips_application_result
+      assert_phrase_list :cost, [:passport_courier_costs_ips1, :adult_passport_costs_ips1, :passport_costs_ips1]
+      assert_phrase_list :getting_your_passport, [:getting_your_passport_cameroon, :getting_your_passport_contact_and_id]
+      assert_match /Millburngate House/, outcome_body
+    end
+  end # Cameroon (custom phrases)
+
+  context "answer Kenya, applying, adult passport" do
+    should "give the generic result with custom phrases" do
+      worldwide_api_has_organisations_for_location('kenya', read_fixture_file('worldwide/kenya_organisations.json'))
+      add_response 'kenya'
+      add_response 'applying'
+      add_response 'adult'
+      add_response 'united-kingdom'
+      assert_current_node :ips_application_result
+      assert_phrase_list :how_long_it_takes, [:how_long_12_weeks, :how_long_it_takes_ips1]
+      assert_phrase_list :cost, [:passport_courier_costs_ips1, :adult_passport_costs_ips1, :passport_costs_ips1]
+      assert_phrase_list :getting_your_passport, [:getting_your_passport_kenya, :getting_your_passport_contact_and_id]
+      assert_state_variable :application_address, 'durham'
+      assert_match /Millburngate House/, outcome_body
+    end
+  end # Kenya (custom phrases)
+
+  context "answer Kenya, renewing_old, adult passport" do
+    should "give the generic result with custom phrases" do
+      worldwide_api_has_organisations_for_location('kenya', read_fixture_file('worldwide/kenya_organisations.json'))
+      add_response 'kenya'
+      add_response 'renewing_old'
+      add_response 'adult'
+      add_response 'united-kingdom'
+      assert_current_node :ips_application_result
+      assert_phrase_list :how_long_it_takes, [:how_long_12_weeks, :how_long_it_takes_ips1]
+      assert_phrase_list :cost, [:passport_courier_costs_ips1, :adult_passport_costs_ips1, :passport_costs_ips1]
+      assert_phrase_list :getting_your_passport, [:getting_your_passport_kenya, :getting_your_passport_contact_and_id]
+      assert_state_variable :application_address, 'durham'
+      assert_match /Millburngate House/, outcome_body
+    end
+  end # Kenya (custom phrases)
+
+  context "answer Yemen, applying, adult passport" do
+    should "give the IPS application result with custom phrases" do
+      worldwide_api_has_organisations_for_location('yemen', read_fixture_file('worldwide/yemen_organisations.json'))
+      add_response 'yemen'
+      add_response 'applying'
+      add_response 'adult'
+      add_response 'united-kingdom'
+      assert_current_node :ips_application_result
+      assert_phrase_list :how_long_it_takes, [:how_long_12_weeks, :how_long_it_takes_ips1]
+      assert_phrase_list :how_to_apply, [:how_to_apply_ips1, :hmpo_1_application_form, :ips_documents_group_3]
+      assert_phrase_list :cost, [:passport_courier_costs_ips1, :adult_passport_costs_ips1, :passport_costs_ips1]
+      assert_phrase_list :send_your_application, [:send_application_durham]
+      assert_phrase_list :getting_your_passport, [:getting_your_passport_yemen, :getting_your_passport_uk_visa_where_to_collect, :getting_your_passport_id_apply_renew_old_replace]
+      assert_match /Millburngate House/, outcome_body
+    end
+  end # Yemen
+
+  context "answer Haiti, renewing new, adult passport" do
+    should "give the ips result" do
+      worldwide_api_has_organisations_for_location('haiti', read_fixture_file('worldwide/haiti_organisations.json'))
+      add_response 'haiti'
+      add_response 'renewing_new'
+      add_response 'adult'
+      assert_current_node :ips_application_result_online
+      assert_phrase_list :how_long_it_takes, [:how_long_6_weeks, :how_long_additional_info_renewing_new, :how_long_additional_time_online]
+      assert_phrase_list :cost, [:passport_courier_costs_ips1, :adult_passport_costs_ips1]
+      assert_phrase_list :getting_your_passport, [:getting_your_passport_ips1]
+    end
+  end # Haiti
+
+  context "answer South Africa" do
+    context "applying, adult passport" do
+      should "give the IPS online result" do
+        worldwide_api_has_organisations_for_location('south-africa', read_fixture_file('worldwide/south-africa_organisations.json'))
+        add_response 'south-africa'
+        add_response 'applying'
+        add_response 'adult'
+        add_response 'united-kingdom'
+        assert_current_node :ips_application_result_online
+        assert_phrase_list :how_long_it_takes, [:how_long_10_weeks, :how_long_additional_info_applying, :how_long_additional_time_online]
+        assert_phrase_list :cost, [:passport_courier_costs_ips1, :adult_passport_costs_ips1]
+        assert_phrase_list :how_to_apply, [:how_to_apply_online, :how_to_apply_online_prerequisites_applying, :how_to_apply_online_guidance_doc_group_2, :how_to_apply_online_guidance_doc_outro]
+        assert_phrase_list :getting_your_passport, [:getting_your_passport_ips1]
+        assert_phrase_list :contact_passport_adviceline, [:contact_passport_adviceline]
+      end
+    end
+    context "renewing, adult passport" do
+      should "give the IPS online result" do
+        worldwide_api_has_organisations_for_location('south-africa', read_fixture_file('worldwide/south-africa_organisations.json'))
+        add_response 'south-africa'
+        add_response 'renewing_new'
+        add_response 'adult'
+        assert_current_node :ips_application_result_online
+        assert_phrase_list :how_long_it_takes, [:how_long_8_weeks, :how_long_additional_info_renewing_new, :how_long_additional_time_online]
+        assert_phrase_list :cost, [:passport_courier_costs_ips1, :adult_passport_costs_ips1]
+        assert_phrase_list :how_to_apply, [:how_to_apply_online, :how_to_apply_online_prerequisites_renewing, :how_to_apply_online_guidance_doc_group_2, :how_to_apply_online_guidance_doc_outro]
+        assert_phrase_list :getting_your_passport, [:getting_your_passport_ips1]
+        assert_phrase_list :contact_passport_adviceline, [:contact_passport_adviceline]
+      end
+    end
+  end # South Africa (IPS online application)
+
+  context "answer St Helena etc, renewing old, adult passport" do
+    setup do
+      worldwide_api_has_no_organisations_for_location('st-helena-ascension-and-tristan-da-cunha')
+    end
+    should "give the ips application result for renewing_old" do
+      add_response 'st-helena-ascension-and-tristan-da-cunha'
+      add_response 'renewing_old'
+      add_response 'adult'
+      add_response 'st-helena-ascension-and-tristan-da-cunha'
+      assert_current_node :ips_application_result
+      assert_phrase_list :how_long_it_takes, [:how_long_8_weeks, :how_long_it_takes_ips3]
+      assert_phrase_list :cost, [:passport_costs_fee_only, :adult_passport_costs_only, :passport_cost_and_admin_fee]
+      assert_phrase_list :send_your_application, [:send_application_ips3, :send_application_address_st_helena_ascension_and_tristan_da_cunha]
+      assert_phrase_list :getting_your_passport, [:"getting_your_passport_st-helena-ascension-and-tristan-da-cunha", :getting_your_passport_contact, :getting_your_passport_id_apply_renew_old_replace]
+    end
+    should "give the ips application result for renewing_new" do
+      add_response 'st-helena-ascension-and-tristan-da-cunha'
+      add_response 'renewing_new'
+      add_response 'adult'
+      assert_current_node :ips_application_result
+      assert_phrase_list :how_long_it_takes, [:how_long_8_weeks, :how_long_it_takes_ips3]
+      assert_phrase_list :cost, [:passport_costs_fee_only, :adult_passport_costs_only, :passport_cost_and_admin_fee]
+      assert_phrase_list :send_your_application, [:send_application_ips3, :renewing_new_renewing_old, :send_application_address_st_helena_ascension_and_tristan_da_cunha]
+      assert_phrase_list :getting_your_passport, [:"getting_your_passport_st-helena-ascension-and-tristan-da-cunha", :getting_your_passport_contact, :getting_your_passport_id_renew_new]
+    end
+  end # St Helena
+
+  context "answer Nigeria, applying, adult passport" do
+    should "give the result with custom phrases" do
+      worldwide_api_has_organisations_for_location('nigeria', read_fixture_file('worldwide/nigeria_organisations.json'))
+      add_response 'nigeria'
+      add_response 'applying'
+      add_response 'adult'
+      add_response 'united-kingdom'
+      assert_current_node :ips_application_result
+      assert_phrase_list :fco_forms, [:adult_fco_forms_nigeria]
+      assert_phrase_list :how_long_it_takes, [:how_long_14_weeks, :how_long_it_takes_ips1]
+      assert_phrase_list :cost, [:passport_courier_costs_ips1, :adult_passport_costs_ips1, :passport_costs_ips1]
+      assert_phrase_list :how_to_apply, [:how_to_apply_ips1, :hmpo_1_application_form, :ips_documents_group_3]
+      assert_phrase_list :send_your_application, [:send_application_durham]
+      assert_phrase_list :getting_your_passport, [:getting_your_passport_nigeria, :getting_your_passport_contact_and_id]
+      assert_phrase_list :contact_passport_adviceline, [:contact_passport_adviceline]
+    end
+  end # Nigeria
+
+  context "answer Jamaica, replacement, adult passport" do
+    should "give the ips result with custom phrase" do
+      worldwide_api_has_organisations_for_location('jamaica', read_fixture_file('worldwide/jamaica_organisations.json'))
+      add_response 'jamaica'
+      add_response 'replacing'
+      add_response 'adult'
+      assert_current_node :ips_application_result
+      assert_phrase_list :how_long_it_takes, [:how_long_10_weeks, :report_loss_or_theft, :how_long_it_takes_ips1]
+      assert_phrase_list :how_to_apply, [:how_to_apply_ips1, :hmpo_2_application_form, :ips_documents_group_3]
+      assert_phrase_list :cost, [:passport_courier_costs_ips1, :adult_passport_costs_ips1, :passport_costs_ips1]
+      assert_match /Millburngate House/, outcome_body
+    end
+  end # Jamaica
+
+  context "answer Zimbabwe, applying, adult passport" do
+    setup do
+      worldwide_api_has_organisations_for_location('zimbabwe', read_fixture_file('worldwide/zimbabwe_organisations.json'))
+      add_response 'zimbabwe'
+    end
+    should "give the ips outcome with applying phrases" do
+      add_response 'applying'
+      add_response 'adult'
+      add_response 'united-kingdom'
+      assert_current_node :ips_application_result
+      assert_phrase_list :how_long_it_takes, [:how_long_18_weeks, :how_long_it_takes_ips1]
+      assert_phrase_list :cost, [:passport_courier_costs_ips1, :adult_passport_costs_ips1, :passport_costs_ips1]
+      assert_phrase_list :getting_your_passport, [:getting_your_passport_zimbabwe, :getting_your_passport_contact_and_id]
+    end
+    should "give the ips outcome with renewing_new phrases" do
+      add_response 'renewing_new'
+      add_response 'adult'
+      assert_current_node :ips_application_result
+      assert_phrase_list :how_long_it_takes, [:how_long_8_weeks, :how_long_it_takes_ips1]
+      assert_phrase_list :cost, [:passport_courier_costs_ips1, :adult_passport_costs_ips1, :passport_costs_ips1]
+      assert_phrase_list :send_your_application, [:send_application_durham]
+      assert_phrase_list :getting_your_passport, [:getting_your_passport_zimbabwe, :getting_your_passport_contact_and_id]
+    end
+    should "give the ips outcome with replacing phrases" do
+      add_response 'replacing'
+      add_response 'adult'
+      assert_current_node :ips_application_result
+      assert_phrase_list :how_long_it_takes, [:how_long_12_weeks, :report_loss_or_theft, :how_long_it_takes_ips1]
+      assert_phrase_list :cost, [:passport_courier_costs_ips1, :adult_passport_costs_ips1, :passport_costs_ips1]
+      assert_phrase_list :send_your_application, [:send_application_durham]
+      assert_phrase_list :getting_your_passport, [:getting_your_passport_zimbabwe, :getting_your_passport_contact_and_id]
+    end
+  end # Zimbabwe
+
+  context "answer Bangladesh" do
+    setup do
+      worldwide_api_has_organisations_for_location('bangladesh', read_fixture_file('worldwide/bangladesh_organisations.json'))
+      add_response 'bangladesh'
+    end
+    context "renewing a new adult passport" do
+      should "give the ips result" do
+        add_response 'renewing_new'
+        add_response 'adult'
+        assert_current_node :ips_application_result
+        assert_phrase_list :how_long_it_takes, [:how_long_8_weeks, :how_long_it_takes_ips3]
+        assert_phrase_list :cost, [:passport_courier_costs_ips3_uk_visa, :adult_passport_costs_ips3, :passport_costs_ips3]
+        assert_phrase_list :send_your_application, [:send_application_uk_visa_renew_new_colour, :send_application_address_bangladesh]
+      end
+    end
+    context "replacing a new adult passport" do
+      should "give the ips result" do
+        add_response 'replacing'
+        add_response 'adult'
+        assert_current_node :ips_application_result
+        assert_phrase_list :how_long_it_takes, [:how_long_18_weeks, :report_loss_or_theft, :how_long_it_takes_ips3]
+        assert_phrase_list :cost, [:passport_courier_costs_ips3_uk_visa, :adult_passport_costs_ips3, :passport_costs_ips3]
+      end
+    end
+    context "applying for a new adult passport" do
+      should "give the ips result" do
+        add_response 'applying'
+        add_response 'adult'
+        add_response 'bangladesh'
+        assert_current_node :ips_application_result
+        assert_phrase_list :how_long_it_takes, [:how_long_8_months, :how_long_it_takes_ips3]
+        assert_phrase_list :cost, [:passport_courier_costs_ips3_uk_visa, :adult_passport_costs_ips3, :passport_costs_ips3]
+      end
+    end
+  end # Bangladesh
+
+  context "answer Uzbekistan" do
+    setup do
+      worldwide_api_has_organisations_for_location('uzbekistan', read_fixture_file('worldwide/uzbekistan_organisations.json'))
+      add_response 'uzbekistan'
+    end
+    context "renewing a new adult passport" do
+      should "give the ips result" do
+        add_response 'renewing_new'
+        add_response 'adult'
+        assert_current_node :ips_application_result
+        assert_phrase_list :how_long_it_takes, [:how_long_8_weeks, :how_long_it_takes_ips3]
+        assert_phrase_list :cost, [:passport_courier_costs_ips3, :adult_passport_costs_ips3, :passport_costs_ips3]
+        assert_phrase_list :how_to_apply, [:how_to_apply_ips3, :hmpo_1_application_form, :ips_documents_group_3]
+        assert_phrase_list :send_your_application, [:send_application_non_uk_visa_renew_new_colour, :send_application_embassy_address]
+        assert_phrase_list :getting_your_passport, [:getting_your_passport_ips3]
+      end
+    end
+    context "applying for a new adult passport" do
+      should "give the ips result" do
+        add_response 'applying'
+        add_response 'adult'
+        add_response 'united-kingdom'
+        assert_current_node :ips_application_result
+        assert_phrase_list :how_long_it_takes, [:how_long_10_weeks, :how_long_it_takes_ips3]
+        assert_phrase_list :cost, [:passport_courier_costs_ips3, :adult_passport_costs_ips3, :passport_costs_ips3]
+        assert_phrase_list :how_to_apply, [:how_to_apply_ips3, :hmpo_1_application_form, :ips_documents_group_3]
+        assert_phrase_list :send_your_application, [:send_application_non_uk_visa_apply_renew_old_replace_colour, :send_application_embassy_address]
+        assert_phrase_list :getting_your_passport, [:getting_your_passport_ips3]
+      end
+    end
+  end # Uzbekistan
+
+  context "answer Bahamas, applying, adult passport" do
+    should "give the IPS online outcome" do
+      worldwide_api_has_organisations_for_location('bahamas', read_fixture_file('worldwide/bahamas_organisations.json'))
+      add_response 'bahamas'
+      add_response 'applying'
+      add_response 'adult'
+      add_response 'united-kingdom'
+      assert_current_node :ips_application_result_online
+      assert_phrase_list :how_long_it_takes, [:how_long_8_weeks, :how_long_additional_info_applying, :how_long_additional_time_online]
+      assert_phrase_list :cost, [:passport_courier_costs_ips1, :adult_passport_costs_ips1]
+      assert_phrase_list :how_to_apply, [:how_to_apply_online, :how_to_apply_online_prerequisites_applying, :how_to_apply_online_guidance_doc_group_2, :how_to_apply_online_guidance_doc_outro]
+    end
+  end # Bahamas
+
+  context "answer british-indian-ocean-territory" do
+    should "go to apply_in_neighbouring_country outcome" do
+      worldwide_api_has_organisations_for_location('british-indian-ocean-territory', read_fixture_file('worldwide/british-indian-ocean-territory_organisations.json'))
+      add_response 'british-indian-ocean-territory'
+      assert_current_node :apply_in_neighbouring_country
+      assert_state_variable :title_output, 'British Indian Ocean Territory'
+    end
+  end # british-indian-ocean-territory
+
+  context "answer turkey, doc group 2" do
+    setup do
+      worldwide_api_has_organisations_for_location('turkey', read_fixture_file('worldwide/turkey_organisations.json'))
+      add_response 'turkey'
+    end
+    should "show how to apply online" do
+      add_response 'applying'
+      add_response 'adult'
+      add_response 'united-kingdom'
+      assert_current_node :ips_application_result_online
+      assert_phrase_list :how_long_it_takes, [:how_long_8_weeks, :how_long_additional_info_applying, :how_long_additional_time_online]
+      assert_phrase_list :cost, [:passport_courier_costs_ips1, :adult_passport_costs_ips1]
+      assert_phrase_list :how_to_apply, [:how_to_apply_online, :how_to_apply_online_prerequisites_applying, :how_to_apply_online_guidance_doc_group_2, :how_to_apply_online_guidance_doc_outro]
+      assert_match /the passport numbers of both parents/, outcome_body
+    end
+  end
+
+  context "answer Algeria" do
+    setup do
+      worldwide_api_has_organisations_for_location('algeria', read_fixture_file('worldwide/algeria_organisations.json'))
+      add_response 'algeria'
+    end
+    context "renewing a new adult passport" do
+      should "give the ips result" do
+        add_response 'renewing_new'
+        add_response 'adult'
+        assert_current_node :ips_application_result
+        assert_phrase_list :how_long_it_takes, [:how_long_6_weeks, :how_long_it_takes_ips3]
+        assert_phrase_list :cost, [:passport_courier_costs_ips3_uk_visa, :adult_passport_costs_ips3, :passport_costs_ips3]
+        assert_phrase_list :how_to_apply, [:how_to_apply_ips3, :hmpo_1_application_form, :ips_documents_group_3]
+        assert_phrase_list :send_your_application, [:send_application_uk_visa_renew_new_colour, :send_application_address_algeria]
+        assert_phrase_list :getting_your_passport, [:getting_your_passport_uk_visa_centre, :getting_your_passport_contact, :getting_your_passport_id_renew_new]
+      end
+    end
+    context "applying for a new adult passport" do
+      should "give the ips result" do
+        add_response 'applying'
+        add_response 'adult'
+        add_response 'united-kingdom'
+        assert_current_node :ips_application_result
+        assert_phrase_list :how_long_it_takes, [:how_long_12_weeks, :how_long_it_takes_ips3]
+        assert_phrase_list :cost, [:passport_courier_costs_ips3_uk_visa, :adult_passport_costs_ips3, :passport_costs_ips3]
+        assert_phrase_list :how_to_apply, [:how_to_apply_ips3, :hmpo_1_application_form, :ips_documents_group_3]
+        assert_phrase_list :send_your_application, [:send_application_uk_visa_apply_renew_old_replace_colour, :send_application_address_algeria]
+        assert_phrase_list :getting_your_passport, [:getting_your_passport_uk_visa_centre, :getting_your_passport_contact_and_id]
+      end
+    end
+  end # Algeria
+
+  context "answer Burma" do
+    setup do
+      worldwide_api_has_organisations_for_location('burma', read_fixture_file('worldwide/burma_organisations.json'))
+      add_response 'burma'
+    end
+    context "renewing a new adult passport" do
+      should "give the ips result" do
+        add_response 'renewing_new'
+        add_response 'adult'
+        assert_current_node :ips_application_result
+        assert_phrase_list :how_long_it_takes, [:how_long_6_weeks, :how_long_it_takes_ips3]
+        assert_phrase_list :cost, [:passport_courier_costs_ips3, :adult_passport_costs_ips3, :passport_costs_ips3]
+        assert_phrase_list :how_to_apply, [:how_to_apply_ips3, :hmpo_1_application_form, :ips_documents_group_3]
+        assert_phrase_list :send_your_application, [:send_application_non_uk_visa_renew_new_colour, :send_application_embassy_address]
+        assert_phrase_list :getting_your_passport, [:getting_your_passport_burma, :getting_your_passport_contact, :getting_your_passport_id_renew_new]
+      end
+    end
+    context "applying for a new adult passport" do
+      should "give the ips result" do
+        add_response 'applying'
+        add_response 'adult'
+        add_response 'united-kingdom'
+        assert_current_node :ips_application_result
+        assert_phrase_list :how_long_it_takes, [:how_long_16_weeks, :how_long_it_takes_ips3]
+        assert_phrase_list :cost, [:passport_courier_costs_ips3, :adult_passport_costs_ips3, :passport_costs_ips3]
+        assert_phrase_list :how_to_apply, [:how_to_apply_ips3, :hmpo_1_application_form, :ips_documents_group_3]
+        assert_phrase_list :send_your_application, [:send_application_non_uk_visa_apply_renew_old_replace_colour, :send_application_embassy_address]
+        assert_phrase_list :getting_your_passport, [:getting_your_passport_burma, :getting_your_passport_contact, :getting_your_passport_id_apply_renew_old_replace]
+      end
+    end
+  end # Burma
+
+  context "answer Cambodia, testing getting your passport" do
+    setup do
+      worldwide_api_has_organisations_for_location('cambodia', read_fixture_file('worldwide/cambodia_organisations.json'))
+      add_response 'cambodia'
+    end
+    context "renewing a new adult passport" do
+      should "give the ips result" do
+        add_response 'renewing_new'
+        add_response 'adult'
+        assert_current_node :ips_application_result
+        assert_phrase_list :getting_your_passport, [:getting_your_passport_cambodia, :getting_your_passport_uk_visa_where_to_collect, :getting_your_passport_with_id]
+      end
+    end
+    context "applying for a new adult passport" do
+      should "give the ips result" do
+        add_response 'applying'
+        add_response 'adult'
+        add_response 'united-kingdom'
+        assert_current_node :ips_application_result
+        assert_phrase_list :getting_your_passport, [:getting_your_passport_cambodia, :getting_your_passport_uk_visa_where_to_collect, :getting_your_passport_id_apply_renew_old_replace]
+      end
+    end
+  end # Cambodia
+
+  context "answer Kyrgyzstan" do
+    should "give ips_application_result outcome with correct UK Visa centre address" do
+      worldwide_api_has_organisations_for_location('kyrgyzstan', read_fixture_file('worldwide/kyrgyzstan_organisations.json'))
+      add_response 'kyrgyzstan'
+      add_response 'renewing_new'
+      add_response 'adult'
+      assert_current_node :ips_application_result
+      assert_phrase_list :send_your_application, [:send_application_uk_visa_renew_new_colour, :send_application_address_kyrgyzstan]
+    end
+  end # Kyrgyzstan
+
+  context "answer Georgia, testing for ips2 courier costs" do
+    should "give the IPS outcome" do
+      worldwide_api_has_organisations_for_location('georgia', read_fixture_file('worldwide/georgia_organisations.json'))
+      add_response 'georgia'
+      add_response 'applying'
+      add_response 'adult'
+      add_response 'united-kingdom'
+      assert_current_node :ips_application_result
+      assert_phrase_list :cost, [:passport_courier_costs_ips2_uk_visa, :adult_passport_costs_ips2, :passport_costs_ips2]
+    end
+  end # Georgia
+
+  context "answer Timor-Leste, testing sending application" do
+    setup do
+      worldwide_api_has_organisations_for_location('timor-leste', read_fixture_file('worldwide/timor-leste_organisations.json'))
+      add_response 'timor-leste'
+    end
+    context "renewing a new adult passport" do
+      should "give the ips result" do
+        add_response 'renewing_new'
+        add_response 'adult'
+        assert_current_node :ips_application_result
+        assert_phrase_list :send_your_application, [:"send_application_timor-leste", :"send_application_address_timor-leste"]
+      end
+    end
+    context "applying for a new adult passport" do
+      should "give the ips result" do
+        add_response 'applying'
+        add_response 'adult'
+        add_response 'united-kingdom'
+        assert_current_node :ips_application_result
+        assert_phrase_list :send_your_application, [:"send_application_timor-leste", :"send_application_address_timor-leste"]
+      end
+    end
+  end # Timor-Leste
+
+  context "answer Venezuela, UK Visa Application Centre" do
+    setup do
+      worldwide_api_has_organisations_for_location('venezuela', read_fixture_file('worldwide/venezuela_organisations.json'))
+      add_response 'venezuela'
+    end
+    context "renewing a new adult passport" do
+      should "give the ips result" do
+        add_response 'renewing_new'
+        add_response 'adult'
+        assert_current_node :ips_application_result
+        assert_phrase_list :cost, [:passport_courier_costs_ips3_uk_visa, :adult_passport_costs_ips3, :passport_costs_pay_at_appointment]
+        assert_phrase_list :send_your_application, [:send_application_uk_visa_renew_new_colour, :send_application_address_venezuela]
+        assert_phrase_list :getting_your_passport, [:getting_your_passport_uk_visa_centre, :getting_your_passport_contact, :getting_your_passport_id_renew_new]
+      end
+    end
+    context "applying for a new adult passport" do
+      should "give the ips result" do
+        add_response 'applying'
+        add_response 'adult'
+        add_response 'united-kingdom'
+        assert_current_node :ips_application_result
+        assert_phrase_list :cost, [:passport_courier_costs_ips3_uk_visa, :adult_passport_costs_ips3, :passport_costs_pay_at_appointment]
+        assert_phrase_list :send_your_application, [:send_application_uk_visa_apply_renew_old_replace_colour, :send_application_address_venezuela]
+        assert_phrase_list :getting_your_passport, [:getting_your_passport_uk_visa_centre, :getting_your_passport_contact_and_id]
+      end
+    end
+  end # Venezuela
+  #australia
+  context "answer australia, test time phrase" do
+    setup do
+      worldwide_api_has_organisations_for_location('australia', read_fixture_file('worldwide/australia_organisations.json'))
+      add_response 'australia'
+    end
+    context "applying for an adult passport" do
+      should "be 8 weeks" do
+        add_response 'applying'
+        add_response 'adult'
+        add_response 'afghanistan'
+        assert_current_node :ips_application_result_online
+        assert_phrase_list :how_long_it_takes, [:how_long_8_weeks, :how_long_additional_info_applying, :how_long_additional_time_online]
+      end
+    end
+    context "replacing an adult passport" do
+      should "be 8 weeks" do
+        add_response 'replacing'
+        add_response 'adult'
+        assert_current_node :ips_application_result_online
+        assert_phrase_list :how_long_it_takes, [:how_long_8_weeks, :how_long_additional_info_replacing, :how_long_additional_time_online]
+      end
+    end
+  end
+  #china
+  context "answer china, test time phrase" do
+    setup do
+      worldwide_api_has_organisations_for_location('china', read_fixture_file('worldwide/china_organisations.json'))
+      add_response 'china'
+    end
+    context "renewing a new adult passport" do
+      should "be 6 weeks" do
+        add_response 'renewing_new'
+        add_response 'adult'
+        assert_current_node :ips_application_result
+        assert_phrase_list :how_long_it_takes, [:how_long_6_weeks, :how_long_it_takes_ips3]
+      end
+    end
+    context "renewing an old adult passport" do
+      should "be 8 weeks" do
+        add_response 'renewing_old'
+        add_response 'adult'
+        add_response 'afghanistan'
+        assert_current_node :ips_application_result
+        assert_phrase_list :how_long_it_takes, [:how_long_8_weeks, :how_long_it_takes_ips3]
+      end
+    end
+  end
+  # Testing for Pakistan
+  context "testing for pakistan outcome variations" do
+    setup do
+      worldwide_api_has_organisations_for_location('pakistan', read_fixture_file('worldwide/pakistan_organisations.json'))
+      add_response 'pakistan'
+    end
+    context "renewing_new pakistan adult passport" do
+      should "go to outcome with correct phrases" do
+        add_response 'renewing_new'
+        add_response 'adult'
+        assert_current_node :ips_application_result
+        assert_phrase_list :how_long_it_takes, [:how_long_8_weeks, :how_long_it_takes_ips3]
+        assert_phrase_list :cost, [:passport_courier_costs_ips3_uk_visa, :adult_passport_costs_ips3, :passport_costs_ips3]
+        assert_phrase_list :send_your_application, [:send_application_uk_visa_renew_new_colour, :send_application_address_pakistan]
+        assert_phrase_list :how_to_apply, [:how_to_apply_ips3, :send_application_ips1_pakistan, :hmpo_1_application_form, :ips_documents_group_3]
+        assert_phrase_list :getting_your_passport, [:getting_your_passport_uk_visa_centre, :getting_your_passport_contact, :getting_your_passport_id_renew_new]
+      end
+    end # renewing_new adult
+    context "replacing adult passport" do
+      should "give the ips result" do
+        add_response 'replacing'
+        add_response 'child'
+        assert_current_node :ips_application_result
+        assert_phrase_list :how_long_it_takes, [:how_long_14_weeks,:report_loss_or_theft, :how_long_it_takes_ips3]
+        assert_phrase_list :cost, [:passport_courier_costs_ips3_uk_visa, :child_passport_costs_ips3, :passport_costs_ips3]
+        assert_phrase_list :send_your_application, [:send_application_uk_visa_apply_renew_old_replace_colour,
+          :send_application_address_pakistan]
+        assert_phrase_list :how_to_apply, [:how_to_apply_ips3, :send_application_ips1_pakistan, :hmpo_1_application_form, :ips_documents_group_3]
+        assert_phrase_list :getting_your_passport, [:getting_your_passport_uk_visa_centre, :getting_your_passport_contact_and_id]
+      end
+    end # replacing child
+  end # Pakistan tests
+  context "test for Hong-Kong" do
+    setup do
+      worldwide_api_has_organisations_for_location('hong-kong', read_fixture_file('worldwide/hong-kong_organisations.json'))
+      add_response 'hong-kong'
+    end
+    context "renewing_new adult" do
+      should "show correct Hong Kong ID phrase" do
+        add_response 'renewing_new'
+        add_response 'adult'
+        assert_current_node :ips_application_result_online
+        assert_phrase_list :how_to_apply, [:how_to_apply_online,:how_to_apply_online_prerequisites_renewing, :how_to_apply_online_guidance_doc_group_2, :hong_kong_id_required, :how_to_apply_online_guidance_doc_outro]
+      end
+    end
+  end
+end

--- a/test/integration/smart_answer_flows/overseas_passports_v2_test.rb
+++ b/test/integration/smart_answer_flows/overseas_passports_v2_test.rb
@@ -8,7 +8,7 @@ class OverseasPassportsV2Test < ActiveSupport::TestCase
   include GdsApi::TestHelpers::Worldwide
 
   setup do
-    @location_slugs = %w(albania algeria afghanistan australia austria azerbaijan bahamas bangladesh benin british-indian-ocean-territory burma burundi cambodia cameroon china congo georgia greece haiti hong-kong india iran iraq ireland italy jamaica jordan kenya kyrgyzstan malta nepal nigeria pakistan pitcairn-island saudi-arabia syria south-africa spain sri-lanka st-helena-ascension-and-tristan-da-cunha tanzania timor-leste turkey ukraine united-kingdom united-arab-emirates usa uzbekistan yemen zimbabwe venezuela vietnam zambia)
+    @location_slugs = %w(albania algeria afghanistan australia austria azerbaijan bahamas bangladesh benin british-indian-ocean-territory burma burundi cambodia cameroon china congo georgia greece haiti hong-kong india iran iraq ireland italy jamaica jordan kenya kyrgyzstan malta nepal nigeria pakistan pitcairn-island saudi-arabia syria south-africa spain sri-lanka st-helena-ascension-and-tristan-da-cunha tajikistan tanzania timor-leste turkey turkmenistan ukraine united-kingdom united-arab-emirates usa uzbekistan yemen zimbabwe venezuela vietnam zambia)
     worldwide_api_has_locations(@location_slugs)
     setup_for_testing_flow 'overseas-passports-v2'
   end

--- a/test/integration/smart_answer_flows/overseas_passports_v2_test.rb
+++ b/test/integration/smart_answer_flows/overseas_passports_v2_test.rb
@@ -862,6 +862,76 @@ class OverseasPassportsV2Test < ActiveSupport::TestCase
     end
   end # Bangladesh
 
+  context "answer Tajikistan" do
+    context "renewing a new adult passport" do
+      setup do
+        worldwide_api_has_organisations_for_location('tajikistan', read_fixture_file('worldwide/tajikistan_organisations.json'))
+        add_response 'tajikistan'
+        add_response 'renewing_new'
+        add_response 'adult'
+      end
+      should "give the correct ips result" do
+        assert_current_node :ips_application_result
+        assert_phrase_list :how_long_it_takes, [:how_long_8_weeks, :how_long_it_takes_ips2]
+        assert_phrase_list :cost, [:passport_courier_costs_tajikistan, :adult_passport_costs_ips2, :passport_costs_ips2]
+        assert_phrase_list :how_to_apply, [:how_to_apply_ips2, :hmpo_1_application_form, :ips_documents_group_3]
+        assert_phrase_list :send_your_application, [:send_application_non_uk_visa_renew_new_colour, :send_application_embassy_address]
+        assert_phrase_list :getting_your_passport, [:getting_your_passport_tajikistan]
+      end
+    end
+  end
+
+  context "answer Turkmenistan" do
+    context "renewing a new adult passport" do
+      setup do
+        worldwide_api_has_organisations_for_location('turkmenistan', read_fixture_file('worldwide/turkmenistan_organisations.json'))
+        add_response 'turkmenistan'
+        add_response 'renewing_new'
+        add_response 'adult'
+      end
+      should "give the ips result" do
+        assert_current_node :ips_application_result
+        assert_phrase_list :how_long_it_takes, [:how_long_8_weeks, :how_long_it_takes_ips2]
+        assert_phrase_list :cost, [:passport_courier_costs_turkmenistan, :adult_passport_costs_ips2, :passport_costs_ips2]
+        assert_phrase_list :how_to_apply, [:how_to_apply_ips2, :hmpo_1_application_form, :ips_documents_group_3]
+        assert_phrase_list :send_your_application, [:send_application_non_uk_visa_renew_new_colour, :send_application_embassy_address]
+        assert_phrase_list :getting_your_passport, [:getting_your_passport_turkmenistan]
+      end
+    end
+    context "applying for a new adult passport" do
+      setup do
+        worldwide_api_has_organisations_for_location('turkmenistan', read_fixture_file('worldwide/turkmenistan_organisations.json'))
+        add_response 'turkmenistan'
+        add_response 'applying'
+        add_response 'adult'
+        add_response 'united-kingdom'
+      end
+      should "give the ips result" do
+        assert_current_node :ips_application_result
+        assert_phrase_list :how_long_it_takes, [:how_long_10_weeks, :how_long_it_takes_ips2]
+        assert_phrase_list :cost, [:passport_courier_costs_turkmenistan, :adult_passport_costs_ips2, :passport_costs_ips2]
+        assert_phrase_list :how_to_apply, [:how_to_apply_ips2, :hmpo_1_application_form, :ips_documents_group_3]
+        assert_phrase_list :send_your_application, [:send_application_non_uk_visa_apply_renew_old_replace_colour, :send_application_embassy_address]
+        assert_phrase_list :getting_your_passport, [:getting_your_passport_turkmenistan]
+      end
+    end
+    context "replacing a lost or stolen passport for a child" do
+      setup do
+        worldwide_api_has_organisations_for_location('turkmenistan', read_fixture_file('worldwide/turkmenistan_organisations.json'))
+        add_response 'turkmenistan'
+        add_response 'replacing'
+        add_response 'child'
+      end
+      should "give the specific reference to embassy location" do
+        assert_current_node :ips_application_result
+        assert_phrase_list :cost, [:passport_courier_costs_turkmenistan, :child_passport_costs_ips2, :passport_costs_ips2]
+        assert_phrase_list :how_to_apply, [:how_to_apply_ips2, :hmpo_1_application_form, :ips_documents_group_3]
+        assert_phrase_list :send_your_application, [:send_application_non_uk_visa_apply_renew_old_replace_colour, :send_application_embassy_address]
+        assert_phrase_list :getting_your_passport, [:getting_your_passport_turkmenistan]
+      end
+    end
+  end # Turkmenistan
+
   context "answer Uzbekistan" do
     setup do
       worldwide_api_has_organisations_for_location('uzbekistan', read_fixture_file('worldwide/uzbekistan_organisations.json'))
@@ -873,10 +943,10 @@ class OverseasPassportsV2Test < ActiveSupport::TestCase
         add_response 'adult'
         assert_current_node :ips_application_result
         assert_phrase_list :how_long_it_takes, [:how_long_8_weeks, :how_long_it_takes_ips3]
-        assert_phrase_list :cost, [:passport_courier_costs_ips3, :adult_passport_costs_ips3, :passport_costs_ips3]
+        assert_phrase_list :cost, [:passport_courier_costs_uzbekistan, :adult_passport_costs_ips3, :passport_costs_ips3]
         assert_phrase_list :how_to_apply, [:how_to_apply_ips3, :hmpo_1_application_form, :ips_documents_group_3]
         assert_phrase_list :send_your_application, [:send_application_non_uk_visa_renew_new_colour, :send_application_embassy_address]
-        assert_phrase_list :getting_your_passport, [:getting_your_passport_ips3]
+        assert_phrase_list :getting_your_passport, [:getting_your_passport_uzbekistan]
       end
     end
     context "applying for a new adult passport" do
@@ -886,10 +956,21 @@ class OverseasPassportsV2Test < ActiveSupport::TestCase
         add_response 'united-kingdom'
         assert_current_node :ips_application_result
         assert_phrase_list :how_long_it_takes, [:how_long_10_weeks, :how_long_it_takes_ips3]
-        assert_phrase_list :cost, [:passport_courier_costs_ips3, :adult_passport_costs_ips3, :passport_costs_ips3]
+        assert_phrase_list :cost, [:passport_courier_costs_uzbekistan, :adult_passport_costs_ips3, :passport_costs_ips3]
         assert_phrase_list :how_to_apply, [:how_to_apply_ips3, :hmpo_1_application_form, :ips_documents_group_3]
         assert_phrase_list :send_your_application, [:send_application_non_uk_visa_apply_renew_old_replace_colour, :send_application_embassy_address]
-        assert_phrase_list :getting_your_passport, [:getting_your_passport_ips3]
+        assert_phrase_list :getting_your_passport, [:getting_your_passport_uzbekistan]
+      end
+    end
+    context "replacing a lost or stolen passport for a child" do
+      should "give the specific reference to embassy location" do
+        add_response 'replacing'
+        add_response 'child'
+        assert_current_node :ips_application_result
+        assert_phrase_list :cost, [:passport_courier_costs_uzbekistan, :child_passport_costs_ips3, :passport_costs_ips3]
+        assert_phrase_list :how_to_apply, [:how_to_apply_ips3, :hmpo_1_application_form, :ips_documents_group_3]
+        assert_phrase_list :send_your_application, [:send_application_non_uk_visa_apply_renew_old_replace_colour, :send_application_embassy_address]
+        assert_phrase_list :getting_your_passport, [:getting_your_passport_uzbekistan]
       end
     end
   end # Uzbekistan

--- a/test/integration/smart_answer_flows/overseas_passports_v2_test.rb
+++ b/test/integration/smart_answer_flows/overseas_passports_v2_test.rb
@@ -551,8 +551,7 @@ class OverseasPassportsV2Test < ActiveSupport::TestCase
       assert_current_node :ips_application_result
       assert_phrase_list :getting_your_passport, [:"getting_your_passport_pitcairn-island"]
       assert_phrase_list :send_your_application, [:"send_application_address_pitcairn-island"]
-      assert_phrase_list :cost, [:"passport_courier_costs_ips3_pitcairn-island", :adult_passport_costs_ips3,
- :passport_costs_ips3]
+      assert_phrase_list :cost, [:"passport_courier_costs_ips3_pitcairn-island", :adult_passport_costs_ips3,:passport_costs_ips3]
     end
   end # Pitcairn Island (IPS1 with custom phrases)
 

--- a/test/unit/calculators/passport_and_embassy_data_query_v2_test.rb
+++ b/test/unit/calculators/passport_and_embassy_data_query_v2_test.rb
@@ -1,0 +1,43 @@
+require_relative "../../test_helper"
+
+module SmartAnswer::Calculators
+  class PassportAndEmbassyDataQueryV2Test < ActiveSupport::TestCase
+
+    context PassportAndEmbassyDataQueryV2 do
+
+      setup do
+        @query = PassportAndEmbassyDataQueryV2.new
+      end
+
+      context "find_passport_data" do
+        should "find passport data by country slug" do
+          assert_equal 'ips_application_3', @query.find_passport_data('algeria')['type']
+          assert_equal 'ips_documents_group_3', @query.find_passport_data('algeria')['group']
+          assert_equal 'hmpo_1_application_form', @query.find_passport_data('algeria')['app_form']
+          assert_equal '6_weeks', @query.find_passport_data('afghanistan')['renewing_new']
+          assert_equal '6_months', @query.find_passport_data('afghanistan')['renewing_old']
+          assert_equal '6_months', @query.find_passport_data('afghanistan')['applying']
+          assert_equal '14_weeks', @query.find_passport_data('afghanistan')['replacing']
+        end
+      end
+
+      context "retain_passport?" do
+        should "indicate whether to retain your passport when applying from the given country" do
+          assert @query.retain_passport?('angola')
+          refute @query.retain_passport?('france')
+        end
+      end
+
+      context "passport_costs" do
+        should "format passport costs" do
+          %w(south_african_rand_adult_32 south_african_rand_adult_48 south_african_rand_child
+            euros_adult_32 euros_adult_48 euros_child).each do |k|
+            assert @query.passport_costs.has_key?(k), "passport_costs should have key #{k}"
+          end
+          assert_match /^\d,\d\d\d South African Rand/, @query.passport_costs["south_african_rand_adult_48"]
+        end
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Multiple copy and logic changes to aspects of the overseas passports smart-answer including:

* Updates for Trinidad and Tobago
* Changes for Tajikistan, Turkmenistan and Uzbekistan
* Copy amendments to the "how to apply" section for 59 countries.