### PR TITLE
Student finance forms yearly document update

### DIFF
--- a/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_ccg_1314.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_ccg_1314.txt
@@ -1,0 +1,13 @@
+# Childcare Grant
+
+To apply, estimate your childcare costs on form CCG1 after you've completed your main student finance application.
+
+Academic year | Form
+- | -
+2013 to 2014 | [CCG1 - form (PDF, 220KB)](http://www.sfengland.slc.co.uk/media/559152/sfe_ccg1_1314_d.pdf)
+
+{{snippet: where-to-send-your-forms-uk}}
+
+[next_steps]
+[Childcare Grant](/childcare-grant)
+[end_next_steps]

--- a/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_ccg_1415.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_ccg_1415.txt
@@ -1,0 +1,13 @@
+# Childcare Grant
+
+To apply, estimate your childcare costs on form CCG1 after you've completed your main student finance application.
+
+Academic year | Form
+- | -
+2014 to 2015 | [CCG1 - form (PDF, 88KB)](http://www.sfengland.slc.co.uk/media/682910/sfe_ccg1_1415_d.pdf)
+
+{{snippet: where-to-send-your-forms-uk}}
+
+[next_steps]
+[Childcare Grant](/childcare-grant)
+[end_next_steps]

--- a/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_ccg_1516.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_ccg_1516.txt
@@ -1,0 +1,13 @@
+# Childcare Grant
+
+To apply, estimate your childcare costs on form CCG1 after you've completed your main student finance application.
+
+Academic year | Form
+- | -
+2015 to 2016 | [CCG1 - form (PDF, 166KB)](http://www.sfengland.slc.co.uk/media/851447/sfe_ccg1_form_1516_d.pdf)
+
+{{snippet: where-to-send-your-forms-uk}}
+
+[next_steps]
+[Childcare Grant](/childcare-grant)
+[end_next_steps]

--- a/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_ccg_expenses.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_ccg_expenses.txt
@@ -1,0 +1,22 @@
+# Childcare Grant - cost confirmation
+
+At the end of each term confirm your actual childcare costs. Use the CCG2 form for the academic year the costs relate to.
+
+Academic Year | Form
+- | -
+2015 to 2016 | CCG2 - available September 2015
+2014 to 2015 | [CCG2 - cost confirmation form (PDF, 343KB)](http://www.sfengland.slc.co.uk/media/839010/sfe_ccg2_1415_d.pdf)
+2013 to 2014 | [CCG2 – cost confirmation form (PDF, 201KB)](http://www.sfengland.slc.co.uk/media/650001/sfe_ccg2_1314_d.pdf)
+
+##Where to send your form(s)
+
+$A
+Student Finance England
+PO Box 210
+Darlington
+DL1 9HJ
+$A
+
+[next_steps]
+[Childcare Grant](/childcare-grant)
+[end_next_steps]

--- a/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_dsa_1314.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_dsa_1314.txt
@@ -1,0 +1,17 @@
+# Disabled Students' Allowances
+
+To apply, use one of the DSA1 forms. If you’ve applied for student finance use form 'DSA1 slim'. If you’re only applying for DSAs use form 'DSA1 full'.
+
+Academic Year | Form
+- | -
+2013 to 2014 | [DSA1 - slim form (PDF, 142KB)](http://www.sfengland.slc.co.uk/media/559158/sfe_dsa_slim_1314_d.pdf)
+2013 to 2014 | [DSA1 - full form (PDF, 375KB)](http://www.sfengland.slc.co.uk/media/559155/sfe_dsa_1314_d.pdf)
+2013 to 2014 | [DSA1 - guidance notes (PDF, 531KB)](http://www.sfengland.slc.co.uk/media/559161/sfe_dsa__notes_1314_d.pdf)
+
+^Open University (OU) students apply to the OU for Disabled Students’ Allowances.^
+
+{{snippet: where-to-send-your-forms-uk}}
+
+[next_steps]
+[Disabled Student's Allowances](/disabled-students-allowances-dsas)
+[end_next_steps]

--- a/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_dsa_1314_pt.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_dsa_1314_pt.txt
@@ -1,0 +1,17 @@
+# Disabled Students' Allowances
+
+To apply, use one of the DSA1 forms. If you’ve applied for student finance use form 'DSA1 slim'. If you’re only applying for DSAs use form 'DSA1 full'.
+
+Academic Year | Form
+- | -
+2013 to 2014 | [DSA1 - slim form (PDF, 142KB)](http://www.sfengland.slc.co.uk/media/559158/sfe_dsa_slim_1314_d.pdf)
+2013 to 2014 | [DSA1 - full form (PDF, 375KB)](http://www.sfengland.slc.co.uk/media/559155/sfe_dsa_1314_d.pdf)
+2013 to 2014 | [DSA1 - guidance notes (PDF, 531KB)](http://www.sfengland.slc.co.uk/media/559161/sfe_dsa__notes_1314_d.pdf)
+
+^Open University (OU) students apply to the OU for Disabled Students’ Allowances.^
+
+{{snippet: where-to-send-your-forms-uk}}
+
+[next_steps]
+[Disabled Student's Allowances](/disabled-students-allowances-dsas)
+[end_next_steps]

--- a/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_dsa_1415.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_dsa_1415.txt
@@ -1,0 +1,15 @@
+# Disabled Students' Allowances
+
+To apply, use one of the DSA1 forms. If you’ve applied for student finance use form 'DSA1 slim'. If you’re only applying for DSAs use form 'DSA1 full'.
+
+Academic Year | Form
+- | -
+2014 to 2015 | [DSA1 - slim form (PDF, 490KB)](http://www.sfengland.slc.co.uk/media/682901/sfe_dsa_slim_form_1415_d.pdf)
+2014 to 2015 | [DSA1 - full form (PDF, 653KB)](http://www.sfengland.slc.co.uk/media/682898/sfe_dsa1_form_1415_d.pdf)
+2014 to 2015 | [DSA1 - guidance notes (PDF, 90KB)](http://www.sfengland.slc.co.uk/media/682922/sfe_dsa1_notes_1415_d.pdf)
+
+{{snippet: where-to-send-your-forms-uk}}
+
+[next_steps]
+[Disabled Student's Allowances](/disabled-students-allowances-dsas)
+[end_next_steps]

--- a/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_dsa_1415_pt.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_dsa_1415_pt.txt
@@ -1,0 +1,11 @@
+# Disabled Students’Allowances
+
+To apply, use one of the DSA1 forms. If you’ve applied for student finance use form 'DSA1 slim'. If you’re only applying for DSAs use form 'DSA1 full'.
+
+Academic Year | Form
+- | -
+2014 to 2015 | [DSA1 - slim form (PDF, 490KB)](http://www.sfengland.slc.co.uk/media/682901/sfe_dsa_slim_form_1415_d.pdf)
+2014 to 2015 | [DSA1 - full form (PDF, 653KB)](http://www.sfengland.slc.co.uk/media/682898/sfe_dsa1_form_1415_d.pdf)
+2014 to 2015 | [DSA1 - guidance notes (PDF, 90KB)](http://www.sfengland.slc.co.uk/media/682922/sfe_dsa1_notes_1415_d.pdf)
+
+{{snippet: where-to-send-your-forms-uk}}

--- a/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_dsa_1516.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_dsa_1516.txt
@@ -1,0 +1,15 @@
+# Disabled Students' Allowances
+
+To apply, use one of the DSA forms. If you’ve applied for student finance use form 'DSA slim'. If you’re only applying for DSAs use form 'DSA1 full'.
+
+Academic Year | Form
+- | -
+2015 to 2016 | [DSA - slim form (PDF, 122KB)](http://www.sfengland.slc.co.uk/media/851463/sfe_dsa_slim_form_1516_d.pdf)
+2015 to 2016 | [DSA1 - full form (PDF, 282KB)](http://www.sfengland.slc.co.uk/media/851467/sfe_dsa1_form_1516_d.pdf)
+2015 to 2016 | [DSA1 - guidance notes (PDF, 78KB)](http://www.sfengland.slc.co.uk/media/851471/sfe_dsa1_notes_1516_d.pdf)
+
+{{snippet: where-to-send-your-forms-uk}}
+
+[next_steps]
+[Disabled Student's Allowances](/disabled-students-allowances-dsas)
+[end_next_steps]

--- a/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_dsa_expenses.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_dsa_expenses.txt
@@ -1,0 +1,14 @@
+# Disabled Students' Allowances – expenses
+
+Use the claim form for the academic year the expenses relate to. You reclaim these expenses at the end of the academic year.
+
+Academic year | Form
+- | -
+2015 to 2016 | [Costs claim form (PDF, 57KB)](http://www.sfengland.slc.co.uk/media/860462/sfe_dsa_claim_form_1516_d.pdf)
+2014 to 2015 | [Costs claim form (PDF, 55KB)](http://www.sfengland.slc.co.uk/media/688506/sfe_dsa_expenses_claim_form_1415_d.pdf)
+
+{{snippet: where-to-send-your-forms-uk}}
+
+[next_steps]
+[Disabled Student's Allowances](/disabled-students-allowances-dsas)
+[end_next_steps]

--- a/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_eu_ft_1314_continuing.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_eu_ft_1314_continuing.txt
@@ -1,0 +1,22 @@
+# EU full-time student
+
+To apply for a Tuition Fee Loan use form EUPR1A.
+
+Academic year | Form
+- | -
+2013 to 2014 | [EUPR1A](http://www.sfengland.slc.co.uk/media/642137/eupr1a_form_1314_d.pdf)
+
+##Additional information
+
+You may need to include additional information on the following forms.
+
+Form | When to use the form
+- | -
+[EUTFLR - form (PDF, 458KB)](http://www.sfengland.slc.co.uk/media/560156/eu_tuitionfeelrf_1314_d.pdf)  | To change the amount of loan you want to apply for
+[Evidence factsheet (PDF, 100KB)](http://www.sfengland.slc.co.uk/media/560168/eu_evidence_factsheet_1314_d.pdf) | List of evidence to send with your application - eg proof of identity or income
+[Certifier checklist (PDF, 75KB)](http://www.sfengland.slc.co.uk/media/560159/eu_certifier_checklist_1314_d.pdf) | Get the person who verifies your evidence to sign this form
+[EUCO1 - form (PDF, 100KB)](http://www.sfengland.slc.co.uk/media/560153/eu_co1_1314_d.pdf) | To update your course, name and other details
+
+^You can apply up to 9 months after the start of your course.^
+
+{{snippet: where-to-send-your-forms-non-uk}}

--- a/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_eu_ft_1314_new.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_eu_ft_1314_new.txt
@@ -1,0 +1,22 @@
+# EU full-time student
+
+To apply for a Tuition Fee Loan use form EU13N.
+
+Academic year | Form
+- | -
+2013 to 2014 | [EU13N - form and notes (PDF, 345KB)](http://www.sfengland.slc.co.uk/media/591405/eu13n_form_1314_d.pdf)
+
+##Additional information
+
+You may need to include additional information on the following forms.
+
+Form | When to use the form
+- | -
+[EUTFLR - form (PDF, 458KB)](http://www.sfengland.slc.co.uk/media/560156/eu_tuitionfeelrf_1314_d.pdf) | To change the amount of loan you want to apply for
+[Evidence factsheet (PDF, 100KB)](http://www.sfengland.slc.co.uk/media/560168/eu_evidence_factsheet_1314_d.pdf) | List of evidence to send with your application - eg proof of identity or income
+[Certifier checklist (PDF, 75KB)](http://www.sfengland.slc.co.uk/media/560159/eu_certifier_checklist_1314_d.pdf) | Get the person who verifies your evidence to sign this form
+[EUCO1 - form (PDF, 100KB)](http://www.sfengland.slc.co.uk/media/560153/eu_co1_1314_d.pdf) | To update your course, name and other details
+
+^You can apply up to 9 months after the start of your course.^
+
+{{snippet: where-to-send-your-forms-non-uk}}

--- a/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_eu_ft_1415_continuing.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_eu_ft_1415_continuing.txt
@@ -1,0 +1,23 @@
+# EU full-time student
+
+To apply for a Tuition Fee Loan use form EUPR1A.
+
+Academic year | Form
+- | -
+2015 to 2016 | Coming soon
+2014 to 2015 | [EUPR1A - form (PDF, 108KB)](http://www.sfengland.slc.co.uk/media/722327/eu_eupr1a_1415_d.pdf)
+
+##Additional information
+
+You may need to include additional information on the following forms.
+
+Form | When to use the form
+- | -
+[EUTFLR - form (PDF, 421KB)](http://www.sfengland.slc.co.uk/media/722318/eu_tlrf_1415_d.pdf) | To change the amount of loan you want to apply for
+[Evidence factsheet (PDF, 468KB)](http://www.sfengland.slc.co.uk/media/722312/eu_evidence_factsheet_d.pdf) | List of evidence to send with your application - eg proof of identity or income
+[Certifier checklist (PDF, 477KB)](http://www.sfengland.slc.co.uk/media/722309/eu_certifier_checklist_d.pdf) | Get the person who verifies your evidence to sign this form
+[EUCO1 - form (PDF, 483KB)](http://www.sfengland.slc.co.uk/media/722315/eu_co1_1415_d.pdf) | To update your course, name and other details
+
+^You can apply up to 9 months after the start of your course.^
+
+{{snippet: where-to-send-your-forms-non-uk}}

--- a/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_eu_ft_1415_new.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_eu_ft_1415_new.txt
@@ -1,0 +1,24 @@
+# EU full-time student
+
+To apply for a Tuition Fee Loan use form EU14N.
+
+Academic year | Form
+- | -
+2014 to 2015 | [EU14N - form and notes (PDF, 200KB)](http://www.sfengland.slc.co.uk/media/722324/eu_eu14n_1415_d.pdf)
+
+
+##Additional information
+
+You may need to include additional information on the following forms.
+
+
+Form | When to use the form
+- | -
+[EUTFLR - form (PDF, 200KB)](http://www.sfengland.slc.co.uk/media/722318/eu_tlrf_1415_d.pdf) | To change the amount of loan you want to apply for 
+[Evidence factsheet (PDF, 100KB)](http://www.sfengland.slc.co.uk/media/722312/eu_evidence_factsheet_d.pdf) | List of evidence to send with your application - eg proof of identity or income 
+[Certifier checklist (PDF, 75KB)](http://www.sfengland.slc.co.uk/media/722309/eu_certifier_checklist_d.pdf) | Get the person who verifies your evidence to sign this form
+[EUCO1 - form (PDF, 100KB)](http://www.sfengland.slc.co.uk/media/722315/eu_co1_1415_d.pdf) | To update your course, name and other details
+
+^You can apply up to 9 months after the start of your course.^
+
+{{snippet: where-to-send-your-forms-non-uk}}

--- a/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_eu_ft_1516_continuing.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_eu_ft_1516_continuing.txt
@@ -1,0 +1,22 @@
+# EU full-time student
+
+To apply for a Tuition Fee Loan use form EUPR1A.
+
+Academic year | Form
+- | -
+2015 to 2016 | [EUPR1A - form (PDF, 109KB)](http://www.sfengland.slc.co.uk/media/873477/eu_eupr1a_form_1516_d.pdf)
+
+##Additional information
+
+You may need to include additional information on the following forms.
+
+Form | When to use the form
+- | -
+[EUTFLR - form (PDF, 441KB)](http://www.sfengland.slc.co.uk/media/873481/eu_tuition_fee_loan_request_form_1516_d.pdf)  | To change the amount of loan you want to apply for
+[Evidence factsheet (PDF, 82KB)](http://www.sfengland.slc.co.uk/media/873356/eu_evidence_fact_sheet_1516_d.pdf) | List of evidence to send with your application - eg proof of identity or income
+[Certifier checklist (PDF, 60KB)](http://www.sfengland.slc.co.uk/media/873116/eu_certifier_checklist_1516_d.pdf) | Get the person who verifies your evidence to sign this form
+[EUCO1 - form (PDF, 116KB)](http://www.sfengland.slc.co.uk/media/873352/eu_euco1_form_1516_d.pdf) | To update your course, name and other details
+
+^You can apply up to 9 months after the start of your course.^
+
+{{snippet: where-to-send-your-forms-non-uk}}

--- a/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_eu_ft_1516_continuing.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_eu_ft_1516_continuing.txt
@@ -4,7 +4,7 @@ To apply for a Tuition Fee Loan use form EUPR1A.
 
 Academic year | Form
 - | -
-2015 to 2016 | [EUPR1A - form (PDF, 109KB)](http://www.sfengland.slc.co.uk/media/873477/eu_eupr1a_form_1516_d.pdf)
+2015 to 2016 | [EUPR1A - form (PDF, 107KB)](http://www.sfengland.slc.co.uk/media/873477/eu_eupr1a_form_1516_d.pdf)
 
 ##Additional information
 

--- a/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_eu_ft_1516_new.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_eu_ft_1516_new.txt
@@ -1,0 +1,22 @@
+# EU full-time student
+
+To apply for a Tuition Fee Loan use form EU15N.
+
+Academic year | Form
+- | -
+2015 to 2016 | [EU15N - form and notes (PDF, 253KB)](http://www.sfengland.slc.co.uk/media/873210/eu_eu15n_form_1516_d.pdf)
+
+##Additional information
+
+You may need to include additional information on the following forms.
+
+Form | When to use the form
+- | -
+[EUTFLR - form (PDF, 441KB)](http://www.sfengland.slc.co.uk/media/873481/eu_tuition_fee_loan_request_form_1516_d.pdf) | To change the amount of loan you want to apply for
+[Evidence factsheet (PDF, 82KB)](http://www.sfengland.slc.co.uk/media/873356/eu_evidence_fact_sheet_1516_d.pdf) | List of evidence to send with your application - eg proof of identity or income
+[Certifier checklist (PDF, 60KB)](http://www.sfengland.slc.co.uk/media/873116/eu_certifier_checklist_1516_d.pdf) | Get the person who verifies your evidence to sign this form
+[EUCO1 - form (PDF, 116KB)](http://www.sfengland.slc.co.uk/media/873352/eu_euco1_form_1516_d.pdf) | To update your course, name and other details
+
+^You can apply up to 9 months after the start of your course.^
+
+{{snippet: where-to-send-your-forms-non-uk}}

--- a/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_eu_pt_1314_continuing.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_eu_pt_1314_continuing.txt
@@ -1,0 +1,30 @@
+# EU part-time student
+
+To apply for a Tuition Fee Loan use form EUPTLC.
+
+Academic year | Form
+- | -
+2013 to 2014 | [EUPTLC - form (PDF, 900KB)](http://www.sfengland.slc.co.uk/media/596584/eu_ptlc_form_1314_d.pdf)
+2013 to 2014 | [EUPTLC - guidance notes (PDF, 500KB)](http://www.sfengland.slc.co.uk/media/596587/eu_ptlc_notes_1314_d.pdf)
+
+If you started your course before 1 September 2012 you may be eligible for a Tuition Fee Grant. Apply using the form EUPTG1.
+
+Academic year | Form
+- | -
+2013 to 2014 | [EUPTG1 - form (PDF, 421KB)](http://www.sfengland.slc.co.uk/media/635675/euptg1_1314_d.pdf)
+2013 to 2014 | [EUPTG1 - guidance notes (PDF, 115KB)](http://www.sfengland.slc.co.uk/media/640499/eu_ptg1_notes_1314_d.pdf)
+
+##Additional information
+
+You may need to include additional information on the following forms.
+
+Form | When to use the form
+- | -
+[EUTFLR - form (PDF, 200KB)](http://www.sfengland.slc.co.uk/media/560156/eu_tuitionfeelrf_1314_d.pdf) | To change the amount of loan you want to apply for
+[Evidence factsheet (PDF, 100KB)](http://www.sfengland.slc.co.uk/media/560168/eu_evidence_factsheet_1314_d.pdf) | List of evidence to send with your application - eg proof of identity or income
+[Certifier checklist (PDF, 75KB)](http://www.sfengland.slc.co.uk/media/560159/eu_certifier_checklist_1314_d.pdf) | Get the person who verifies your evidence to sign this form
+[EUCO1 - form (PDF, 100KB)](http://www.sfengland.slc.co.uk/media/560153/eu_co1_1314_d.pdf) | To update your course, name and other details
+
+^You can apply up to 9 months after the start of your course.^
+
+{{snippet: where-to-send-your-forms-non-uk}}

--- a/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_eu_pt_1314_new.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_eu_pt_1314_new.txt
@@ -1,0 +1,31 @@
+# EU part-time student
+
+To apply for a Tuition Fee Loan use form EUPTL1.
+
+Academic year | Form
+- | -
+2013 to 2014 | [EUPTL1 - form (PDF, 900KB)](http://www.slc.co.uk/media/596581/eu_ptl1_1314_d.pdf)
+2013 to 2014 | [EUPTL1 - guidance notes (PDF, 500KB)](http://www.slc.co.uk/media/596578/eu_ptl1_notes_1314_d.pdf)
+
+If you started your course before 1 September 2012 and you haven't applied for student finance before, you may be eligible for a Tuition Fee Grant. Apply using the form EUPTG1.
+
+Academic year | Form
+- | -
+2013 to 2014 | [EUPTG1 - form (PDF, 421KB)](http://www.sfengland.slc.co.uk/media/635675/euptg1_1314_d.pdf)
+2013 to 2014 | [EUPTG1 - guidance notes (PDF, 115KB)](http://www.sfengland.slc.co.uk/media/640499/eu_ptg1_notes_1314_d.pdf)
+
+##Additional information
+
+You may need to include additional information on the following forms.
+
+Form | When to use the form
+- | -
+[EUTFLR - form (PDF, 200KB)](http://www.sfengland.slc.co.uk/media/560156/eu_tuitionfeelrf_1314_d.pdf) | To change the amount of loan you want to apply for
+[Evidence factsheet (PDF, 100KB)](http://www.sfengland.slc.co.uk/media/560168/eu_evidence_factsheet_1314_d.pdf) | List of evidence to send with your application - eg proof of identity or income
+[Certifier checklist (PDF, 75KB)](http://www.sfengland.slc.co.uk/media/560159/eu_certifier_checklist_1314_d.pdf) | Get the person who verifies your evidence to sign this form
+[EUCO1 - form (PDF, 100KB)](http://www.sfengland.slc.co.uk/media/560153/eu_co1_1314_d.pdf) | To update your course, name and other details
+
+^You can apply up to 9 months after the start of your course.^
+
+{{snippet: where-to-send-your-forms-non-uk}}
+

--- a/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_eu_pt_1415_continuing.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_eu_pt_1415_continuing.txt
@@ -1,0 +1,30 @@
+# EU part-time student
+
+If you started your course on or after 1 September 2012 you may be eligible for for a Tuition Fee Loan. Apply using form EUPTLC.
+
+Academic year | Form
+- | -
+2014 to 2015 | [EUPTLC - form (PDF, 133KB)](http://www.sfengland.slc.co.uk/media/755099/eu_ptlc_1415_d.pdf)
+2014 to 2015 | [EUPTLC - guidance notes (PDF, 96KB)](http://www.sfengland.slc.co.uk/media/755103/eu_ptlc_notes_1415_d.pdf)
+
+If you started your course before 1 September 2012 you may be eligible for a Tuition Fee Grant.
+
+Academic year | Form
+- | -
+2014 to 2015 | [EUPTG1 - form (PDF, 634KB)](http://www.sfengland.slc.co.uk/media/791834/eu_ptg1_1415_d.pdf)
+2014 to 2015 | [EUPTG1 - guidance notes (PDF, 483KB)](http://www.sfengland.slc.co.uk/media/791838/eu_ptg1_notes_1415_d.pdf)
+
+##Additional information
+You may need to include additional information on the following forms.
+
+Form | When to use the form
+- | -
+[EUTFLR - form (PDF, 421KB)](http://www.sfengland.slc.co.uk/media/722318/eu_tlrf_1415_d.pdf) | To change the amount of loan you want to apply for
+[Evidence factsheet (PDF, 468KB)](http://www.sfengland.slc.co.uk/media/722312/eu_evidence_factsheet_d.pdf) | List of evidence to send with your application - eg proof of identity or income
+[Certifier checklist (PDF, 75KB)](http://www.sfengland.slc.co.uk/media/560159/eu_certifier_checklist_1314_d.pdf) | Get the person who verifies your evidence to sign this form
+[EUCO1 - form (PDF, 483KB)](http://www.sfengland.slc.co.uk/media/722315/eu_co1_1415_d.pdf) | To update your course, name and other details
+
+
+^You can apply up to 9 months after the start of your course.^
+
+{{snippet: where-to-send-your-forms-non-uk}}

--- a/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_eu_pt_1415_new.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_eu_pt_1415_new.txt
@@ -1,0 +1,22 @@
+# EU part-time student
+
+To apply for a Tuition Fee Loan use form EUPTL1.
+
+Academic year | Form
+- | -
+2014 to 2015 | [EUPTL1 - form (PDF, 900KB)](http://www.sfengland.slc.co.uk/media/755091/eu_ptl1_1415_d.pdf)
+2014 to 2015 | [EUPTL1 - guidance notes (PDF, 102KB)](http://www.sfengland.slc.co.uk/media/755095/eu_ptl1_notes_1415_d.pdf)
+
+##Additional information
+You may need to include additional information on the following forms.
+
+Form | When to use the form
+- | -
+[EUTFLR - form (PDF, 421KB)](http://www.sfengland.slc.co.uk/media/722318/eu_tlrf_1415_d.pdf) | To change the amount of loan you want to apply for
+[Evidence factsheet (PDF, 468KB)](http://www.sfengland.slc.co.uk/media/722312/eu_evidence_factsheet_d.pdf) | List of evidence to send with your application - eg proof of identity or income
+[Certifier checklist (PDF, 75KB)](http://www.sfengland.slc.co.uk/media/560159/eu_certifier_checklist_1314_d.pdf) | Get the person who verifies your evidence to sign this form
+[EUCO1 - form (PDF, 483KB)](http://www.sfengland.slc.co.uk/media/722315/eu_co1_1415_d.pdf) | To update your course, name and other details
+
+^You can apply up to 9 months after the start of your course.^
+
+{{snippet: where-to-send-your-forms-non-uk}}

--- a/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_parent_partner_1314.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_parent_partner_1314.txt
@@ -1,0 +1,21 @@
+# Parents and partners - forms
+
+Some student finance (eg a Maintenance Grant) is based on income.
+
+You must send your income details for the 2011 to 2012 tax year. Do this using form PFF2.
+
+If you think your income has dropped by 15% or more since the 2011 to 2012 tax year you’ll need to do both of the following:
+
++ submit your 2011 to 2012 income details using form PFF2
++ complete a CYI form (to ask for the student finance to be based on your expected 2013 to 2014 tax year income)
+
+Academic year | Form
+- | -
+2013 to 2014 | [PFF2 - income details form (PDF, 634KB)](http://www.sfengland.slc.co.uk/media/559149/sfe_pff2_1314_d.pdf)
+2013 to 2014 | [CYI - current tax year income details form (PDF, 525KB)](http://www.sfengland.slc.co.uk/media/592412/sfe_cyi_1314_d.pdf)
+
+{{snippet: where-to-send-your-forms-uk}}
+
+[next_steps]
+[How to support an application](/apply-for-student-finance/parents-and-partners)
+[end_next_steps]

--- a/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_parent_partner_1415.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_parent_partner_1415.txt
@@ -1,0 +1,24 @@
+# Parents and partners - forms
+
+Some student finance (eg a Maintenance Grant) is based on income.
+
+You must send your income details for the 2012 to 2013 tax year. Do this online as part of the student's [online application](/apply-online-for-student-finance). If you can't do it online, use form PFF2.
+
+If you think your income has dropped by 15% or more since the 2012 to 2013 tax year you’ll need to do both of the following:
+
++ submit your 2012 to 2013 income details online or using form PFF2
++ complete a CYI form (to ask for the student finance to be based on your expected 2014 to 2015 tax year income)
+
+Academic year | Form
+- | -
+2014 to 2015 | [PFF2 - income details form (PDF, 579KB)](http://www.sfengland.slc.co.uk/media/682907/sfe_pff2_1415_d.pdf)
+2014 to 2015 | [CYI - current tax year income details form (PDF, 522KB)](http://www.sfengland.slc.co.uk/media/728027/sfe_cyi_1415_d.pdf)
+
+
+%Income means your [household income](/apply-for-student-finance/household-income).%
+
+{{snippet: where-to-send-your-forms-uk}}
+
+[next_steps]
+[How to support an application](/apply-for-student-finance/parents-and-partners)
+[end_next_steps]

--- a/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_parent_partner_1516.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_parent_partner_1516.txt
@@ -1,0 +1,24 @@
+# Parents and partners - forms
+
+Some student finance (eg a Maintenance Grant) is based on income.
+
+You must send your income details for the 2013 to 2014 tax year. Do this using form PFF2.
+
+If you think your income has dropped by 15% or more since the 2013 to 2014 tax year you’ll need to do both of the following:
+
++ submit your 2013 to 2014 income details using form PFF2
++ complete a CYI form (to ask for the student finance to be based on your expected 2015 to 2016 tax year income)
+
+Academic year | Form
+- | -
+2015 to 2016 | [PFF2 - income details form (PDF, 678KB)](http://www.sfengland.slc.co.uk/media/851499/sfe_pff2_form_1516_d.pdf)
+2015 to 2016 | [CYI - current tax year income details form (PDF, 589KB)](http://www.sfengland.slc.co.uk/media/851459/sfe_current_year_income_form_1516_d.pdf)
+
+
+%Income means your [household income](/apply-for-student-finance/household-income).%
+
+{{snippet: where-to-send-your-forms-uk}}
+
+[next_steps]
+[How to support an application](/apply-for-student-finance/parents-and-partners)
+[end_next_steps]

--- a/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_proof_identity_1314.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_proof_identity_1314.txt
@@ -1,0 +1,16 @@
+# Proof of identity
+
+To prove your identity, include your UK passport details in your application. If you forget, use the passport details form. If you don't have a passport  (or it has expired), send your birth or adoption certificate using the certificate form.
+
+Academic year | Form
+- | -
+2013 to 2014 | [UK passport details form (PDF, 51KB)](http://www.sfengland.slc.co.uk/media/559143/sfe_passport_details_form_1314_d.pdf)
+2013 to 2014 | [Birth or adoption certificate form (PDF, 475KB)](http://www.sfengland.slc.co.uk/media/559146/sfe_birth_adoption_cert_1314_d.pdf)
+
+^Don’t send your UK passport.^
+
+{{snippet: where-to-send-your-forms-uk}}
+
+[next_steps]
+[How to apply for student finance](/apply-for-student-finance)
+[end_next_steps]

--- a/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_proof_identity_1415.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_proof_identity_1415.txt
@@ -1,0 +1,16 @@
+# Proof of identity
+
+If you haven’t included your UK passport details in your application, use the passport details form. If you don’t have a passport (or it has expired), send your birth or adoption certificate using the certificate form.
+
+Academic year | Form
+- | -
+2014 to 2015 | [UK passport details form (PDF, 428KB)](http://www.sfengland.slc.co.uk/media/685458/sfe_uk_passport_details_1415_d.pdf)
+2014 to 2015 | [Birth or adoption certificate form (PDF, 85KB)](http://www.sfengland.slc.co.uk/media/682913/sfe_birth_adopt_cert_form_1415_d.pdf)
+
+^Don't send your UK passport.^
+
+{{snippet: where-to-send-your-forms-uk}}
+
+[next_steps]
+[How to apply for student finance](/apply-for-student-finance)
+[end_next_steps]

--- a/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_proof_identity_1516.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_proof_identity_1516.txt
@@ -1,0 +1,16 @@
+# Proof of identity
+
+If you haven’t included your UK passport details in your application, use the passport details form. If you don’t have a passport (or it has expired), send your UK birth or adoption certificate using the certificate form.
+
+Academic year | Form
+- | -
+2015 to 2016 | [UK passport details form (PDF, 67KB)](http://www.sfengland.slc.co.uk/media/860458/sfe_ukpp_details_form_1516_d.pdf)
+2015 to 2016 | [Birth or adoption certificate form (PDF, 493KB)](http://www.sfengland.slc.co.uk/media/851503/sfe_birth_adoption_form_1516_d.pdf)
+
+^Don't send your UK passport.^
+
+{{snippet: where-to-send-your-forms-uk}}
+
+[next_steps]
+[How to apply for student finance](/apply-for-student-finance)
+[end_next_steps]

--- a/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_travel.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_travel.txt
@@ -1,0 +1,14 @@
+# Travel Grants
+
+You need to complete the two forms listed below if you’re studying abroad:
+
+- [Travel Abroad Expenses Form (PDF, 110KB)](http://www.sfengland.slc.co.uk/media/851483/sfe_travel_expenses_form_1516_d.pdf) - this should be completed by you 
+- Course Abroad Form - your university or college will need to complete this form (or contact the Student Loans Company to confirm your study abroad details)
+
+If you’re on a clinical placement as part of your medicine or dentistry course you must complete the ‘Clinical Study Travel Expenses Form’ - this is available on request.
+
+Once you have applied for your student finance we’ll automatically send you these forms if you’re eligible to apply. 
+
+[next_steps]
+[Travel grants](/travel-grants-medical-dental-students-england)
+[end_next_steps]

--- a/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_uk_ft_1415_continuing.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_uk_ft_1415_continuing.txt
@@ -1,0 +1,19 @@
+# Student finance - application form
+
+You should [apply online](/apply-online-for-student-finance) for help with your tuition and living costs.
+
+If you can't apply online, use form PR1.
+
+Academic Year | Form
+- | -
+2014 to 2015 | [Apply online](/apply-online-for-student-finance "Apply for student finance online")
+2014 to 2015 | [PR1 - form (PDF, 596KB)](http://www.sfengland.slc.co.uk/media/682895/sfe_pr1_form_1415_d.pdf)
+2014 to 2015 | [PR1 - guidance notes (PDF, 601KB)](http://www.sfengland.slc.co.uk/media/682919/sfe_pr1_notes_1415_d.pdf)
+
+^You can apply up to 9 months after the start of your course.^
+
+{{snippet: where-to-send-your-forms-uk}}
+
+[next_steps]
+[How to apply for student finance](/apply-for-student-finance)
+[end_next_steps]

--- a/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_uk_ft_1415_new.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_uk_ft_1415_new.txt
@@ -1,0 +1,19 @@
+# Student finance - application form
+
+You should [apply online](/apply-online-for-student-finance) for help with your tuition and living costs.
+
+If you can't apply online, use form PN1.
+
+Academic Year | Form
+- | -
+2014 to 2015 | [Apply online](/apply-online-for-student-finance)
+2014 to 2015 | [PN1 - form (PDF, 823KB)](http://www.sfengland.slc.co.uk/media/682892/sfe_pn1_form_1415_d.pdf)
+2014 to 2015 | [PN1 - guidance notes (PDF, 537KB)](http://www.sfengland.slc.co.uk/media/682916/sfe_pn1_notes_1415_d.pdf)
+
+^You can apply up to 9 months after the start of your course.^
+
+{{snippet: where-to-send-your-forms-uk}}
+
+[next_steps]
+[How to apply for student finance](/apply-for-student-finance)
+[end_next_steps]

--- a/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_uk_ft_1516_continuing.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_uk_ft_1516_continuing.txt
@@ -1,0 +1,18 @@
+# Student finance - application form
+
+You should [apply online](/apply-online-for-student-finance) for help with your tuition and living costs.
+
+If you can't apply online, use form PR1.
+
+Academic Year | Form
+- | -
+2015 to 2016 | [PR1 - form (PDF, 569KB)](http://www.sfengland.slc.co.uk/media/860450/sfe_pr1_form_1516_d.pdf)
+2015 to 2016 | [PR1 - guidance notes (PDF, 199KB)](http://www.sfengland.slc.co.uk/media/860454/sfe_pr1_notes_1516_d.pdf)
+
+^You can apply up to 9 months after the start of your course.^
+
+{{snippet: where-to-send-your-forms-uk}}
+
+[next_steps]
+[How to apply for student finance](/apply-for-student-finance)
+[end_next_steps]

--- a/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_uk_ft_1516_new.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_uk_ft_1516_new.txt
@@ -1,0 +1,18 @@
+# Student finance - application form
+
+You should [apply online](/apply-online-for-student-finance) for help with your tuition and living costs.
+
+If you can't apply online, use form PN1.
+
+Academic Year | Form
+- | -
+2015 to 2016 | [PN1 - form (PDF, 468KB)](http://www.sfengland.slc.co.uk/media/860442/sfe_pn1_form_1516_d.pdf)
+2015 to 2016 | [PN1 - guidance notes (PDF, 223KB)](http://www.sfengland.slc.co.uk/media/860446/sfe_pn1_notes_1516_d.pdf)
+
+^You can apply up to 9 months after the start of your course.^
+
+{{snippet: where-to-send-your-forms-uk}}
+
+[next_steps]
+[How to apply for student finance](/apply-for-student-finance)
+[end_next_steps]

--- a/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_uk_pt_1314_continuing.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_uk_pt_1314_continuing.txt
@@ -1,0 +1,17 @@
+# Student finance – application form
+
+You should [apply online](/apply-online-for-student-finance) for a Tuition Fee Loan. If you can’t apply online, use form PTLC.
+
+Academic Year | Form
+- | -
+2013 to 2014 | [Apply online](/apply-online-for-student-finance)
+2013 to 2014 | [PTLC - form (PDF, 222KB)](http://www.sfengland.slc.co.uk/media/593370/sfe_ptlc_form_1314_d.pdf)
+2013 to 2014 | [PTLC - guidance notes (PDF, 97KB)](http://www.sfengland.slc.co.uk/media/593373/sfe_ptlc_notes_1314_d.pdf)
+
+^You can apply up to 9 months after the start of your course.^
+
+{{snippet: where-to-send-your-forms-uk}}
+
+[next_steps]
+[How to apply for student finance](/apply-for-student-finance)
+[end_next_steps]

--- a/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_uk_pt_1314_grant.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_uk_pt_1314_grant.txt
@@ -1,0 +1,26 @@
+# Student finance – application form
+
+To apply for a Fee Grant and Course Grant use form PTGC (or PTGN if you're applying for student finance for the first time).
+
+Academic year | Form
+- | -
+2013 to 2014 | [PTGC - form (PDF, 549KB)](http://www.sfengland.slc.co.uk/media/635660/ptgc_1314_d.pdf)
+2013 to 2014 | [PTGC - guidance notes (PDF, 516KB)](http://www.sfengland.slc.co.uk/media/640247/ptgc_notes_1314_d.pdf)
+2013 to 2014 | [PTGN - form (PDF, 635KB)](http://www.sfengland.slc.co.uk/media/635663/ptgn_1314_d.pdf) – if you’re applying for the first time
+2013 to 2014 | [PTGN - guidance notes (PDF, 529KB)](http://www.sfengland.slc.co.uk/media/639169/sfe_ptgn_notes_1314_d.pdf)
+
+^You can apply up to 9 months after the start of your course.^
+
+##Additional forms
+
+You may need to include additional information on the following forms.
+
+Form | When to use the form
+- | -
+[CO2 - change of circumstances (PDF, 97KB)](http://www.sfengland.slc.co.uk/media/593367/sfe_co2_form_1314_d.pdf) | Your course, university or contact details change
+[PTCI2 - income confirmation (PDF, 85KB)](http://www.sfengland.slc.co.uk/media/635654/ptci2_1314_d.pdf) | You don't have a P60, P11D or payslips to prove your income
+[CB1 - benefits confirmation (PDF, 121KB)](http://www.sfengland.slc.co.uk/media/635657/ptcb1_1314_d.pdf) | You or your partner get certain benefits (check the form for details)
+
+[next_steps]
+[How to apply for student finance](/apply-for-student-finance)
+[end_next_steps]

--- a/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_uk_pt_1314_new.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_uk_pt_1314_new.txt
@@ -1,0 +1,17 @@
+# Student finance – application form
+
+You should [apply online](/apply-online-for-student-finance) for a Tuition Fee Loan. If you can’t apply online, use form PTL1.
+
+Academic Year | Form
+- | -
+2013 to 2014 | [Apply online](/apply-online-for-student-finance)
+2013 to 2014 | [PTL1 - form (PDF, 400KB)](http://www.sfengland.slc.co.uk/media/596780/sfe_ptl1_form_d.pdf)
+2013 to 2014 | [PTL1 - guidance notes (PDF, 182KB)](http://www.sfengland.slc.co.uk/media/596326/sfe_ptl1_notes_1314_d.pdf)
+
+^You can apply up to 9 months after the start of your course.^
+
+{{snippet: where-to-send-your-forms-uk}}
+
+[next_steps]
+[How to apply for student finance](/apply-for-student-finance)
+[end_next_steps]

--- a/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_uk_pt_1415_continuing.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_uk_pt_1415_continuing.txt
@@ -1,0 +1,13 @@
+# Student finance - application form
+
+You should [apply online](/apply-online-for-student-finance) for a Tuition Fee Loan. If you can't apply online, use form PTLC.
+
+Academic Year | Form
+- | -
+2014 to 2015 | [Apply online](/apply-online-for-student-finance)
+2014 to 2015 | [PTLC - form (PDF, 128KB)](http://www.sfengland.slc.co.uk/media/710746/sfe_ptlc_1415_d.pdf)
+2014 to 2015 | [PTLC - guidance notes (PDF, 96KB)](http://www.sfengland.slc.co.uk/media/710758/sfe_ptlc_notes_1415_d.pdf)
+
+^You can apply up to 9 months after the start of your course.^
+
+{{snippet: where-to-send-your-forms-uk}}

--- a/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_uk_pt_1415_grant.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_uk_pt_1415_grant.txt
@@ -1,0 +1,20 @@
+To apply for a Fee Grant and Course Grant use form PTGC (or PTGN if you’re applying for student finance for the first time).
+
+Academic year | Form
+- | -
+2014 to 2015 | [PTGC - form (PDF, 400KB)](http://www.sfengland.slc.co.uk/media/710752/sfe_ptgc_1415_d.pdf)
+2014 to 2015 | [PTGC - guidance notes (PDF, 100KB)](http://www.sfengland.slc.co.uk/media/710764/sfe_ptgc_notes_1415_d.pdf)
+2014 to 2015 | [PTGN - form (PDF, 615KB)](http://www.sfengland.slc.co.uk/media/710749/sfe_ptgn_1415_d.pdf) – if you’re applying for the first time
+2014 to 2015 | [PTGN - guidance notes (PDF, 100KB)](http://www.sfengland.slc.co.uk/media/710761/sfe_ptgn_notes_1415_d.pdf)
+
+^You can apply up to 9 months after the start of your course.^
+
+##Additional forms
+
+
+You may need to include additional information on the following forms.
+
+Form | When to use the form
+- | -
+[CO2 - change of circumstances (PDF, 98KB)](http://www.sfengland.slc.co.uk/media/755527/sfe_co2_form_1415_d.pdf) | Your course, university or contact details change
+[CB1 - benefits confirmation (PDF, 463KB)](http://www.sfengland.slc.co.uk/media/789731/sfe_cb1_1415_d.pdf) | You or your partner get certain benefits (check the form for details)

--- a/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_uk_pt_1415_new.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_uk_pt_1415_new.txt
@@ -1,0 +1,13 @@
+# Student finance - application form
+
+You should [apply online](/apply-online-for-student-finance) for a Tuition Fee Loan. If you can't apply online, use form PTL1.
+
+Academic Year | Form
+- | -
+2014 to 2015 | [Apply online](/apply-online-for-student-finance)
+2014 to 2015 | [PTL1 - form (PDF, 237KB)](http://www.sfengland.slc.co.uk/media/710743/sfe_ptl1_1415_d.pdf)
+2014 to 2015 | [PTL1 - guidance notes (PDF, 182KB)](http://www.sfengland.slc.co.uk/media/710755/sfe_ptl1_notes_1415_d.pdf)
+
+^You can apply up to 9 months after the start of your course.^
+
+{{snippet: where-to-send-your-forms-uk}}

--- a/lib/smartdown_flows/student-finance-forms-v2/questions/continuing_student.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/questions/continuing_student.txt
@@ -1,0 +1,32 @@
+# Are you a continuing student?
+
+You’re usually a continuing student if you got student finance last year.
+
+[choice: continuing_student]
+* continuing-student: Yes
+* new-student: No
+
+* type_of_student is 'eu-full-time'
+  * what_year is 'year-1415'
+    * continuing_student is 'continuing-student' => outcome_eu_ft_1415_continuing
+    * continuing_student is 'new-student' => outcome_eu_ft_1415_new
+  * what_year is 'year-1516'
+    * continuing_student is 'continuing-student' => outcome_eu_ft_1415_continuing
+    * continuing_student is 'new-student' => outcome_eu_ft_1516_new
+* type_of_student is 'eu-part-time'
+  * what_year is 'year-1314'
+    * continuing_student is 'continuing-student' => outcome_eu_pt_1314_continuing
+    * continuing_student is 'new-student' => outcome_eu_pt_1314_new
+  * what_year is 'year-1415'
+    * continuing_student is 'continuing-student' => outcome_eu_pt_1415_continuing
+    * continuing_student is 'new-student' => outcome_eu_pt_1415_new
+* type_of_student is 'uk-full-time'
+  * what_year is 'year-1415'
+    * form_needed_for_1 is 'apply-loans-grants'
+      * continuing_student is 'continuing-student' => outcome_uk_ft_1415_continuing
+      * continuing_student is 'new-student' => outcome_uk_ft_1415_new
+  * what_year is 'year-1516'
+    * form_needed_for_1 is 'apply-loans-grants'
+      * continuing_student is 'continuing-student' => outcome_uk_ft_1516_continuing
+      * continuing_student is 'new-student' => outcome_uk_ft_1516_new
+* type_of_student is 'uk-part-time' => pt_course_start

--- a/lib/smartdown_flows/student-finance-forms-v2/questions/continuing_student.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/questions/continuing_student.txt
@@ -11,7 +11,7 @@ You’re usually a continuing student if you got student finance last year.
     * continuing_student is 'continuing-student' => outcome_eu_ft_1415_continuing
     * continuing_student is 'new-student' => outcome_eu_ft_1415_new
   * what_year is 'year-1516'
-    * continuing_student is 'continuing-student' => outcome_eu_ft_1415_continuing
+    * continuing_student is 'continuing-student' => outcome_eu_ft_1516_continuing
     * continuing_student is 'new-student' => outcome_eu_ft_1516_new
 * type_of_student is 'eu-part-time'
   * what_year is 'year-1314'

--- a/lib/smartdown_flows/student-finance-forms-v2/questions/form_needed_for_1.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/questions/form_needed_for_1.txt
@@ -1,0 +1,16 @@
+# What do you need the form for?
+
+[choice: form_needed_for_1]
+* apply-loans-grants: Apply for student loans and grants
+* proof-identity: Send proof of identity
+* income-details: Send parent or partner’s income detail - eg PFF2 or CYI
+* apply-dsa: Apply for Disabled Students’ Allowances
+* dsa-expenses: Claim Disabled Students’ Allowances expenses
+* apply-ccg: Apply for Childcare Grant
+* ccg-expenses: Childcare Grant costs confirmation
+* travel-grant: Travel Grant
+
+* form_needed_for_1 is 'dsa-expenses' => outcome_dsa_expenses
+* form_needed_for_1 is 'ccg-expenses' => outcome_ccg_expenses
+* form_needed_for_1 is 'travel-grant' => outcome_travel
+* otherwise => what_year_uk_fulltime

--- a/lib/smartdown_flows/student-finance-forms-v2/questions/form_needed_for_2.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/questions/form_needed_for_2.txt
@@ -1,0 +1,10 @@
+# What do you need the form for?
+
+[choice: form_needed_for_2]
+* apply-loans-grants: Apply for student loans and grants
+* proof-identity: Send proof of identity
+* apply-dsa: Apply for Disabled Students’ Allowances
+* dsa-expenses: Claim Disabled Students’ Allowances expenses
+
+* form_needed_for_2 is 'dsa-expenses' => outcome_dsa_expenses
+* otherwise => what_year

--- a/lib/smartdown_flows/student-finance-forms-v2/questions/pt_course_start.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/questions/pt_course_start.txt
@@ -1,0 +1,16 @@
+# Did your part-time course start before 1 September 2012?
+
+[choice: pt_course_start]
+* course-start-before-01092012: Yes
+* course-start-after-01092012: No
+
+* what_year is 'year-1314'
+  * pt_course_start is 'course-start-before-01092012' => outcome_uk_pt_1314_grant
+  * pt_course_start is 'course-start-after-01092012'
+    * continuing_student is 'continuing-student' => outcome_uk_pt_1314_continuing
+    * continuing_student is 'new-student' => outcome_uk_pt_1314_new
+* what_year is 'year-1415'
+  * pt_course_start is 'course-start-before-01092012' => outcome_uk_pt_1415_grant
+  * pt_course_start is 'course-start-after-01092012'
+    * continuing_student is 'continuing-student' => outcome_uk_pt_1415_continuing
+    * continuing_student is 'new-student' => outcome_uk_pt_1415_new

--- a/lib/smartdown_flows/student-finance-forms-v2/questions/type_of_student.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/questions/type_of_student.txt
@@ -1,0 +1,12 @@
+# What type of a student are you?
+
+[choice: type_of_student]
+* uk-full-time: English student - full-time
+* uk-part-time: English student - part-time
+* eu-full-time: EU student - full-time
+* eu-part-time: EU student - part-time
+
+* type_of_student is 'uk-full-time' => form_needed_for_1
+* type_of_student is 'uk-part-time' => form_needed_for_2
+* type_of_student is 'eu-full-time' => what_year_eu_fulltime
+* type_of_student is 'eu-part-time' => what_year

--- a/lib/smartdown_flows/student-finance-forms-v2/questions/what_year.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/questions/what_year.txt
@@ -1,0 +1,30 @@
+# What academic year do you want funding for?
+
+[choice: what_year]
+* year-1314: 2013 to 2014
+* year-1415: 2014 to 2015
+
+* type_of_student is 'eu-full-time' => continuing_student
+* type_of_student is 'eu-part-time' => continuing_student
+* type_of_student is 'uk-full-time'
+  * form_needed_for_1 is 'proof-identity'
+    * what_year is 'year-1314' => outcome_proof_identity_1314
+    * what_year is 'year-1415' => outcome_proof_identity_1415
+  * form_needed_for_1 is 'income-details'
+    * what_year is 'year-1314' => outcome_parent_partner_1314
+    * what_year is 'year-1415' => outcome_parent_partner_1415
+  * form_needed_for_1 is 'apply-dsa'
+    * what_year is 'year-1314' => outcome_dsa_1314
+    * what_year is 'year-1415' => outcome_dsa_1415
+  * form_needed_for_1 is 'apply-ccg'
+      * what_year is 'year-1314' => outcome_ccg_1314
+      * what_year is 'year-1415' => outcome_ccg_1415
+  * form_needed_for_1 is 'apply-loans-grants' => continuing_student
+* type_of_student is 'uk-part-time'
+  * form_needed_for_2 is 'proof-identity'
+    * what_year is 'year-1314' => outcome_proof_identity_1314
+    * what_year is 'year-1415' => outcome_proof_identity_1415
+  * form_needed_for_2 is 'apply-dsa'
+    * what_year is 'year-1314' => outcome_dsa_1314_pt
+    * what_year is 'year-1415' => outcome_dsa_1415_pt
+  * form_needed_for_2 is 'apply-loans-grants' => continuing_student

--- a/lib/smartdown_flows/student-finance-forms-v2/questions/what_year_eu_fulltime.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/questions/what_year_eu_fulltime.txt
@@ -1,0 +1,7 @@
+# What academic year do you want funding for?
+
+[choice: what_year]
+* year-1516: 2015 to 2016
+* year-1415: 2014 to 2015
+
+* type_of_student is 'eu-full-time' => continuing_student

--- a/lib/smartdown_flows/student-finance-forms-v2/questions/what_year_uk_fulltime.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/questions/what_year_uk_fulltime.txt
@@ -1,0 +1,19 @@
+# What academic year do you want funding for?
+
+[choice: what_year]
+* year-1516: 2015 to 2016
+* year-1415: 2014 to 2015
+
+* form_needed_for_1 is 'proof-identity'
+  * what_year is 'year-1415' => outcome_proof_identity_1415
+  * what_year is 'year-1516' => outcome_proof_identity_1516
+* form_needed_for_1 is 'income-details'
+  * what_year is 'year-1415' => outcome_parent_partner_1415
+  * what_year is 'year-1516' => outcome_parent_partner_1516
+* form_needed_for_1 is 'apply-dsa'
+  * what_year is 'year-1415' => outcome_dsa_1415
+  * what_year is 'year-1516' => outcome_dsa_1516
+* form_needed_for_1 is 'apply-ccg'
+  * what_year is 'year-1415' => outcome_ccg_1415
+  * what_year is 'year-1516' => outcome_ccg_1516
+* form_needed_for_1 is 'apply-loans-grants' => continuing_student

--- a/lib/smartdown_flows/student-finance-forms-v2/scenarios/eu-students.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/scenarios/eu-students.txt
@@ -11,7 +11,7 @@ outcome_eu_ft_1415_new
 - type_of_student: eu-full-time
 - what_year: year-1516
 - continuing_student: continuing-student
-outcome_eu_ft_1415_continuing
+outcome_eu_ft_1516_continuing
 
 - type_of_student: eu-full-time
 - what_year: year-1516

--- a/lib/smartdown_flows/student-finance-forms-v2/scenarios/eu-students.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/scenarios/eu-students.txt
@@ -1,0 +1,39 @@
+- type_of_student: eu-full-time
+- what_year: year-1415
+- continuing_student: continuing-student
+outcome_eu_ft_1415_continuing
+
+- type_of_student: eu-full-time
+- what_year: year-1415
+- continuing_student: new-student
+outcome_eu_ft_1415_new
+
+- type_of_student: eu-full-time
+- what_year: year-1516
+- continuing_student: continuing-student
+outcome_eu_ft_1415_continuing
+
+- type_of_student: eu-full-time
+- what_year: year-1516
+- continuing_student: new-student
+outcome_eu_ft_1516_new
+
+- type_of_student: eu-part-time
+- what_year: year-1314
+- continuing_student: continuing-student
+outcome_eu_pt_1314_continuing
+
+- type_of_student: eu-part-time
+- what_year: year-1314
+- continuing_student: new-student
+outcome_eu_pt_1314_new
+
+- type_of_student: eu-part-time
+- what_year: year-1415
+- continuing_student: continuing-student
+outcome_eu_pt_1415_continuing
+
+- type_of_student: eu-part-time
+- what_year: year-1415
+- continuing_student: new-student
+outcome_eu_pt_1415_new

--- a/lib/smartdown_flows/student-finance-forms-v2/scenarios/uk-students.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/scenarios/uk-students.txt
@@ -1,0 +1,167 @@
+- type_of_student: uk-full-time
+- form_needed_for_1: apply-loans-grants
+- what_year: year-1415
+- continuing_student: continuing-student
+outcome_uk_ft_1415_continuing
+
+- type_of_student: uk-full-time
+- form_needed_for_1: apply-loans-grants
+- what_year: year-1415
+- continuing_student: new-student
+outcome_uk_ft_1415_new
+
+- type_of_student: uk-full-time
+- form_needed_for_1: apply-loans-grants
+- what_year: year-1516
+- continuing_student: continuing-student
+outcome_uk_ft_1516_continuing
+
+- type_of_student: uk-full-time
+- form_needed_for_1: apply-loans-grants
+- what_year: year-1516
+- continuing_student: new-student
+outcome_uk_ft_1516_new
+
+- type_of_student: uk-full-time
+- form_needed_for_1: proof-identity
+- what_year: year-1415
+outcome_proof_identity_1415
+
+- type_of_student: uk-full-time
+- form_needed_for_1: proof-identity
+- what_year: year-1516
+outcome_proof_identity_1516
+
+- type_of_student: uk-full-time
+- form_needed_for_1: income-details
+- what_year: year-1415
+outcome_parent_partner_1415
+
+- type_of_student: uk-full-time
+- form_needed_for_1: income-details
+- what_year: year-1516
+outcome_parent_partner_1516
+
+- type_of_student: uk-full-time
+- form_needed_for_1: apply-dsa
+- what_year: year-1415
+outcome_dsa_1415
+
+- type_of_student: uk-full-time
+- form_needed_for_1: apply-dsa
+- what_year: year-1516
+outcome_dsa_1516
+
+- type_of_student: uk-full-time
+- form_needed_for_1: dsa-expenses
+outcome_dsa_expenses
+
+- type_of_student: uk-full-time
+- form_needed_for_1: dsa-expenses
+outcome_dsa_expenses
+
+- type_of_student: uk-full-time
+- form_needed_for_1: apply-ccg
+- what_year: year-1415
+outcome_ccg_1415
+
+- type_of_student: uk-full-time
+- form_needed_for_1: apply-ccg
+- what_year: year-1516
+outcome_ccg_1516
+
+- type_of_student: uk-full-time
+- form_needed_for_1: ccg-expenses
+outcome_ccg_expenses
+
+- type_of_student: uk-full-time
+- form_needed_for_1: travel-grant
+outcome_travel
+
+- type_of_student: uk-full-time
+- form_needed_for_1: ccg-expenses
+outcome_ccg_expenses
+
+- type_of_student: uk-full-time
+- form_needed_for_1: travel-grant
+outcome_travel
+
+- type_of_student: uk-part-time
+- form_needed_for_2: apply-loans-grants
+- what_year: year-1314
+- continuing_student: continuing-student
+- pt_course_start: course-start-before-01092012
+outcome_uk_pt_1314_grant
+
+- type_of_student: uk-part-time
+- form_needed_for_2: apply-loans-grants
+- what_year: year-1314
+- continuing_student: continuing-student
+- pt_course_start: course-start-after-01092012
+outcome_uk_pt_1314_continuing
+
+- type_of_student: uk-part-time
+- form_needed_for_2: apply-loans-grants
+- what_year: year-1314
+- continuing_student: new-student
+- pt_course_start: course-start-before-01092012
+outcome_uk_pt_1314_grant
+
+- type_of_student: uk-part-time
+- form_needed_for_2: apply-loans-grants
+- what_year: year-1314
+- continuing_student: new-student
+- pt_course_start: course-start-after-01092012
+outcome_uk_pt_1314_new
+
+- type_of_student: uk-part-time
+- form_needed_for_2: apply-loans-grants
+- what_year: year-1415
+- continuing_student: continuing-student
+- pt_course_start: course-start-before-01092012
+outcome_uk_pt_1415_grant
+
+- type_of_student: uk-part-time
+- form_needed_for_2: apply-loans-grants
+- what_year: year-1415
+- continuing_student: continuing-student
+- pt_course_start: course-start-after-01092012
+outcome_uk_pt_1415_continuing
+
+- type_of_student: uk-part-time
+- form_needed_for_2: apply-loans-grants
+- what_year: year-1415
+- continuing_student: new-student
+- pt_course_start: course-start-before-01092012
+outcome_uk_pt_1415_grant
+
+- type_of_student: uk-part-time
+- form_needed_for_2: apply-loans-grants
+- what_year: year-1415
+- continuing_student: new-student
+- pt_course_start: course-start-after-01092012
+outcome_uk_pt_1415_new
+
+- type_of_student: uk-part-time
+- form_needed_for_2: proof-identity
+- what_year: year-1314
+outcome_proof_identity_1314
+
+- type_of_student: uk-part-time
+- form_needed_for_2: proof-identity
+- what_year: year-1415
+outcome_proof_identity_1415
+
+- type_of_student: uk-part-time
+- form_needed_for_2: apply-dsa
+- what_year: year-1314
+outcome_dsa_1314_pt
+
+- type_of_student: uk-part-time
+- form_needed_for_2: apply-dsa
+- what_year: year-1415
+outcome_dsa_1415_pt
+
+- type_of_student: uk-part-time
+- form_needed_for_2: dsa-expenses
+outcome_dsa_expenses

--- a/lib/smartdown_flows/student-finance-forms-v2/snippets/where-to-send-your-forms-non-uk.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/snippets/where-to-send-your-forms-non-uk.txt
@@ -1,0 +1,11 @@
+##Where to send your forms
+
+$A
+Student Finance Services non-UK Team
+Student Loans Company
+PO Box 89
+Darlington
+County Durham
+England
+DL1 9AZ
+$A

--- a/lib/smartdown_flows/student-finance-forms-v2/snippets/where-to-send-your-forms-uk.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/snippets/where-to-send-your-forms-uk.txt
@@ -1,0 +1,8 @@
+##Where to send your form(s)
+
+$A
+Student Finance England
+PO Box 210
+Darlington
+DL1 9HJ
+$A

--- a/lib/smartdown_flows/student-finance-forms-v2/student-finance-forms-v2.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/student-finance-forms-v2.txt
@@ -1,0 +1,33 @@
+---
+meta_description: Download Student Finance England application forms and guidance notes - including forms PN1, PR1, PTG1, PFF2 and CYI
+satisfies_need: 100982
+status: draft
+---
+
+# Student finance forms
+
+Download student finance forms and guidance notes for Student Finance England including:
+
++ forms PN1, PR1, PTL1, PFF2 and CYI
++ forms for parents
++ forms for EU students
+
+[start: type_of_student?]
+
+##Before you start
+
+The forms are different for students from [Scotland](http://www.saas.gov.uk), [Wales](http://www.studentfinancewales.co.uk) and [Northern Ireland](http://www.studentfinanceni.co.uk).
+
+For braille or alternative formats contact the helpline. If you email, include your contact details and the format you need.
+
+
+$C
+**Helpline - alternative formats only**
+
+0141 243 3686<br />
+<brailleandlargefonts@slc.co.uk>
+$C
+
+You can [call Student Finance England](https://www.gov.uk/contact-student-finance-england) if you want to [apply online](https://www.gov.uk/apply-online-for-student-finance) but you can't use a computer without help.
+
+* otherwise => type_of_student


### PR DESCRIPTION
https://govuk.zendesk.com/agent/tickets/972939

2015 to 2016 forms for continuing EU full-time students will be available from Monday 16 March.

This path:
https://www.gov.uk/student-finance-forms/y/eu-full-time/year-1516/continuing-student

needs to lead to this outcome:
https://github.com/alphagov/smart-answers/blob/master/lib/smartdown_flows/student-finance-forms/outcomes/outcome_eu_ft_1516_continuing.txt

and the file size for the first file needs to change from 109 to 107KB