### PR TITLE
Fixes for overseas passports

### DIFF
--- a/lib/smart_answer_flows/locales/en/overseas-passports-v2.yml
+++ b/lib/smart_answer_flows/locales/en/overseas-passports-v2.yml
@@ -80,7 +80,7 @@ en-GB:
 
           You’ll need to send a photocopy of your passport, and a letter to explain why you’ve not sent the original.
 
-          When you get your new passport, send your old one to the [nearest British embassy, high commission or governors office](/government/world/organisations).
+          When you get your new passport, send your old one to the [nearest British Embassy, high commission or governors office](/government/world/organisations).
 
         how_to_apply_incomplete_application_deadline: |
 
@@ -384,15 +384,15 @@ en-GB:
         getting_your_passport_st-helena-ascension-and-tristan-da-cunha: |
           Your passport will be delivered to the office where you applied - you must collect it in person.
         getting_your_passport_tajikistan: |
-          Your passport will be delivered to the British embassy in Dushanbe - you must collect it in person.
+          Your passport will be delivered to the British Embassy in Dushanbe - you must collect it in person.
 
           They'll contact you - using the details on your application form - when your passport is ready to collect. You must bring photo ID with you. If you're renewing or replacing a passport, you must bring your existing passport as photo ID.
         getting_your_passport_turkmenistan: |
-          Your passport will be delivered to the British embassy in Ashgabat - you must collect it in person.
+          Your passport will be delivered to the British Embassy in Ashgabat - you must collect it in person.
 
           They'll contact you - using the details on your application form - when your passport is ready to collect. You must bring photo ID with you. If you're renewing or replacing a passport, you must bring your existing passport as photo ID.
         getting_your_passport_uzbekistan: |
-          Your passport will be delivered to the British embassy in Tashkent - you must collect it in person.
+          Your passport will be delivered to the British Embassy in Tashkent - you must collect it in person.
 
           They'll contact you - using the details on your application form - when your passport is ready to collect. You must bring photo ID with you. If you're renewing or replacing a passport, you must bring your existing passport as photo ID.
         getting_your_passport_uk_visa_centre: |
@@ -518,7 +518,7 @@ en-GB:
           Don’t book travel until you have a valid passport. If you need to travel more urgently, you may be able to apply for an [Emergency Travel Document.](/emergency-travel-document)
 
         passport_courier_costs_ips2: |
-          You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the British embassy, high commission or consulate where you applied for you to collect.
+          You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
 
         passport_courier_costs_tajikistan: |
           You’ll have to pay a fee for your passport and a courier fee of £24.72.
@@ -574,7 +574,7 @@ en-GB:
           Bring original supporting documents and a photocopy of each one. The original documents will be returned to you.
 
         getting_your_passport_ips2: |
-          Your passport will be delivered to the British embassy, high commission or consulate where you applied  - you must collect it in person.
+          Your passport will be delivered to the British Embassy, high commission or consulate where you applied  - you must collect it in person.
 
           They will contact you - using the details on your application form - when your passport is ready to collect. You must bring photo ID with you. If you’re renewing or replacing a passport, you must bring your existing passport as photo ID.
 
@@ -595,7 +595,7 @@ en-GB:
           | Child passport | £53.00 |
 
         passport_courier_costs_ips3: |
-          You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British embassy, high commission or consulate where you applied for you to collect.
+          You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
 
         passport_courier_costs_ips2_uk_visa: |
           You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
@@ -1347,7 +1347,7 @@ en-GB:
           $C
 
         getting_your_passport_ips3: |
-          Your passport will be delivered to the British embassy, high commission or consulate where you applied - you must collect it in person.
+          Your passport will be delivered to the British Embassy, high commission or consulate where you applied - you must collect it in person.
 
           They will contact you - using the details on your application form - when your passport is ready to collect. You must bring photo ID with you. If you’re renewing or replacing a passport, you must bring your existing passport as photo ID.
 

--- a/lib/smart_answer_flows/locales/en/overseas-passports.yml
+++ b/lib/smart_answer_flows/locales/en/overseas-passports.yml
@@ -80,7 +80,7 @@ en-GB:
 
           You’ll need to send a photocopy of your passport, and a letter to explain why you’ve not sent the original.
 
-          When you get your new passport, send your old one to the [nearest British embassy, high commission or governors office](/government/world/organisations).
+          When you get your new passport, send your old one to the [nearest British Embassy, high commission or governors office](/government/world/organisations).
 
         adult_fco_forms: |
           __Smart application form__
@@ -502,7 +502,7 @@ en-GB:
           Don’t book travel until you have a valid passport. If you need to travel more urgently, you may be able to apply for an [Emergency Travel Document.](/emergency-travel-document)
 
         passport_courier_costs_ips2: |
-          You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the British embassy, high commission or consulate where you applied for you to collect.
+          You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
 
         adult_passport_costs_ips2: |
           | Passport type | Passport fee | Total to pay (including courier fee) |
@@ -543,7 +543,7 @@ en-GB:
           Bring original supporting documents and a photocopy of each one. The original documents will be returned to you.
 
         getting_your_passport_ips2: |
-          Your passport will be delivered to the British embassy, high commission or consulate where you applied  - you must collect it in person.
+          Your passport will be delivered to the British Embassy, high commission or consulate where you applied  - you must collect it in person.
 
           They will contact you - using the details on your application form - when your passport is ready to collect. You must bring photo ID with you. If you’re renewing or replacing a passport, you must bring your existing passport as photo ID.
 
@@ -564,7 +564,7 @@ en-GB:
           | Child passport | £53.00 |
 
         passport_courier_costs_ips3: |
-          You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British embassy, high commission or consulate where you applied for you to collect.
+          You’ll have to pay a fee for your passport and a courier fee of £23.01. The courier fee pays for your passport to be sent securely to the British Embassy, high commission or consulate where you applied for you to collect.
 
         passport_courier_costs_ips2_uk_visa: |
           You’ll have to pay a fee for your passport and a courier fee of £24.72. The courier fee pays for your passport to be sent securely to the UK Visa Application Centre where you applied for you to collect.
@@ -1313,7 +1313,7 @@ en-GB:
           $C
 
         getting_your_passport_ips3: |
-          Your passport will be delivered to the British embassy, high commission or consulate where you applied - you must collect it in person.
+          Your passport will be delivered to the British Embassy, high commission or consulate where you applied - you must collect it in person.
 
           They will contact you - using the details on your application form - when your passport is ready to collect. You must bring photo ID with you. If you’re renewing or replacing a passport, you must bring your existing passport as photo ID.
 

--- a/lib/smart_answer_flows/overseas-passports-v2.rb
+++ b/lib/smart_answer_flows/overseas-passports-v2.rb
@@ -103,7 +103,7 @@ multiple_choice :renewing_replacing_applying? do
 
   calculate :incomplete_application_deadline do
     phrases = PhraseList.new
-    incomplete_deadline_countries = %w(afghanistan australia austria bahrain bangladesh barbados belgium brazil canada china denmark egypt ethiopia finland france germany ghana greece hong-kong india indonesia iraq ireland israel italy jamaica japan kenya lebanon malawi malaysia netherlands new-zealand nigeria norway pakistan philippines portugal qatar russia saudi-arabia sierra-leone singapore south-africa spain sri-lanka sudan sweden switzerland thailand trinidad-and-tobago turkey uganda united-arab-emirates usa venezuela vietnam zambia zimbabwe)
+    incomplete_deadline_countries = %w(australia austria bahrain bangladesh barbados belgium brazil canada china denmark egypt ethiopia finland france germany ghana greece hong-kong india indonesia iraq ireland israel italy jamaica japan kenya laos lebanon malawi malaysia netherlands new-zealand nigeria norway pakistan philippines portugal qatar russia saudi-arabia sierra-leone singapore south-africa spain sri-lanka sudan sweden switzerland thailand trinidad-and-tobago turkey uganda united-arab-emirates usa venezuela vietnam zambia zimbabwe)
     if incomplete_deadline_countries.include?(current_location)
       phrases << :how_to_apply_incomplete_application_deadline
     end

--- a/lib/smart_answer_flows/overseas-passports-v2.rb
+++ b/lib/smart_answer_flows/overseas-passports-v2.rb
@@ -106,8 +106,6 @@ multiple_choice :renewing_replacing_applying? do
     incomplete_deadline_countries = %w(afghanistan australia austria bahrain bangladesh barbados belgium brazil canada china denmark egypt ethiopia finland france germany ghana greece hong-kong india indonesia iraq ireland israel italy jamaica japan kenya lebanon malawi malaysia netherlands new-zealand nigeria norway pakistan philippines portugal qatar russia saudi-arabia sierra-leone singapore south-africa spain sri-lanka sudan sweden switzerland thailand trinidad-and-tobago turkey uganda united-arab-emirates usa venezuela vietnam zambia zimbabwe)
     if incomplete_deadline_countries.include?(current_location)
       phrases << :how_to_apply_incomplete_application_deadline
-    else
-      phrases << ''
     end
     phrases
   end

--- a/test/integration/smart_answer_flows/overseas_passports_v2_test.rb
+++ b/test/integration/smart_answer_flows/overseas_passports_v2_test.rb
@@ -79,7 +79,7 @@ class OverseasPassportsV2Test < ActiveSupport::TestCase
           add_response 'adult'
           assert_state_variable :application_type, 'ips_application_3'
           assert_current_node :ips_application_result
-   assert_phrase_list :how_long_it_takes, [:how_long_14_weeks, :report_loss_or_theft, :how_long_it_takes_ips3]
+          assert_phrase_list :how_long_it_takes, [:how_long_14_weeks, :report_loss_or_theft, :how_long_it_takes_ips3]
         end
       end
     end


### PR DESCRIPTION
- Some raw yaml was printed on the outcome pages for countries that do not have an incomplete application deadline
- Capitalisation of British Embassy was incorrect

There are some outstanding issues with this smart answer but these changes will make it easier to reason about them on the `preview`.

@jackscotti :eyes: 