### PR TITLE
Remove Coming soon row from 2014-2015 outcome

### DIFF
--- a/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_eu_ft_1415_continuing.txt
+++ b/lib/smartdown_flows/student-finance-forms-v2/outcomes/outcome_eu_ft_1415_continuing.txt
@@ -4,7 +4,6 @@ To apply for a Tuition Fee Loan use form EUPR1A.
 
 Academic year | Form
 - | -
-2015 to 2016 | Coming soon
 2014 to 2015 | [EUPR1A - form (PDF, 108KB)](http://www.sfengland.slc.co.uk/media/722327/eu_eupr1a_1415_d.pdf)
 
 ##Additional information


### PR DESCRIPTION
This was implemented as a quick fix and is no longer necessary as the new 2015 outcome satisfies this need.