### PR TITLE
Allow to add ?debug=1 in dev env to see the current state of the answer

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ For more information, please go to the [Smartdown SmartAnswer README](lib/smartd
 Smart answers are by default expected to be in Ruby/YAML style.
 To transition a smart answer from Ruby/YML to Smartdown style, register it in the smartdown registry (`lib/smartdown/registry.rb`).
 
+**Debugging current state**
+
+If you have a URL of a Smart answer and want to debug the state of it i.e. to see PhraseList keys, saved inputs, the outcome name, append `debug=1` query parameter to the URL in development mode. This will render debug information on the Smart answer page.
+
 Installing
 ----------
 

--- a/app/controllers/smart_answers_controller.rb
+++ b/app/controllers/smart_answers_controller.rb
@@ -55,7 +55,14 @@ class SmartAnswersController < ApplicationController
     end
   end
 
+
 private
+
+  def debug?
+    Rails.env.development? && params[:debug]
+  end
+  helper_method :debug?
+
   def json_request?
     request.format == Mime::JSON
   end

--- a/app/views/smart_answers/_content.html.erb
+++ b/app/views/smart_answers/_content.html.erb
@@ -4,6 +4,7 @@
   <% content_for :head do %>
     <meta name="robots" content="noindex">
   <% end %>
+  <%= render "debug" %>
 
   <header class="page-header group">
     <div>
@@ -12,6 +13,7 @@
       </h1>
     </div>
   </header>
+
   <% if @presenter.finished? %>
     <%= render partial: "result" %>
   <% else %>

--- a/app/views/smart_answers/_debug.html.erb
+++ b/app/views/smart_answers/_debug.html.erb
@@ -1,0 +1,10 @@
+<% if debug? %>
+  <article>
+    <pre class="application-notice info-notice debug">
+      Debug info:
+      <% @presenter.current_state.to_hash.each do |k, v| %>
+        <%= "#{k}: #{v.to_s}"%>
+      <% end %>
+    </pre>
+  </article>
+<% end %>

--- a/lib/smart_answer/phrase_list.rb
+++ b/lib/smart_answer/phrase_list.rb
@@ -15,5 +15,9 @@ module SmartAnswer
       phrase_keys << phrase_key
       self
     end
+
+    def to_s
+      "#{self.class}: #{phrase_keys}"
+    end
   end
 end

--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -444,5 +444,21 @@ class SmartAnswersControllerTest < ActionController::TestCase
         assert_equal @flow.node(:do_you_like_jam?).name.to_s.humanize, data['title']
       end
     end
+
+    context "debugging" do
+      should "render debug information on the page when enabled" do
+        @controller.stubs(:debug?).returns(true)
+        get :show, id: 'sample', started: 'y', responses: "no", debug: "1"
+
+        assert_select "pre.debug"
+      end
+
+      should "not render debug information on the page when not enabled" do
+        @controller.stubs(:debug?).returns(false)
+        get :show, id: 'sample', started: 'y', responses: "no", debug: nil
+
+        assert_select "pre.debug", false, "The page should not render debug information"
+      end
+    end
   end
 end


### PR DESCRIPTION
Opening this for a discussion to see if anyone else will find this useful or suggest any alternatives.

As a new person on the project who is changing things in existing smart
answers I found myself spending a decent amount of time inspecting the
current state of the answer given a certain URL. This makes it very easy
to do that by appending a query parameter `debug=1` to the URL.

![](https://s3.amazonaws.com/f.cl.ly/items/0Z0z3y162f0O132B150T/Screen%20Shot%202015-03-16%20at%2014.25.04.png)

/cc @BenJanecke @jackscotti @svenagnew 