### PR TITLE
Marriage abroad amendments

### DIFF
--- a/lib/smart_answer_flows/locales/en/marriage-abroad-v2.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad-v2.yml
@@ -1345,7 +1345,7 @@ en-GB:
           +[data_partial:overseas_passports_embassies:overseas_passports_embassies]
           You’ll need to provide:
 
-          - proof that you’ve been resident in the area covered by the embassy for at least 21 days, eg, an employer’s letter or a bank statement (you’ll also need to sign a declaration to confirm this)
+          - proof that you’ve been living in the country where you intend to get married for at least 21 days, e.g. an employer’s letter or a bank statement (you’ll also need to sign a declaration to confirm this)
           - your original passport and [full birth certificate](/order-copy-birth-death-marriage-certificate) or [naturalisation certificate](/get-replacement-citizenship-certificate)
           - proof that you’re both over the age of 16, not within prohibited degrees of relationship to each other, and there’s no other impediment to your proposed marriage
           - equivalent document for your partner

--- a/lib/smart_answer_flows/locales/en/marriage-abroad-v2.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad-v2.yml
@@ -1045,6 +1045,17 @@ en-GB:
 
           There’s an additional fee for this - the embassy or consulate will contact you to arrange payment.
 
+        consular_cni_os_foreign_resident_ceremony_notary_public_greece: |
+          ###What happens next
+
+          An embassy or notary public can take your oath and post notice of your marriage. The notary public may charge 2 separate fees for this.
+
+          If you give notice at a notary public, you must post the signed forms and any supporting documents to the British Embassy in Athens afterwards.
+
+          Your local embassy will display your notice of marriage publicly for 7 days. They’ll then issue the CNI (as long as nobody has registered an objection).
+
+          There’s an additional fee for this ­ the embassy or consulate will contact you to arrange payment.
+
         consular_cni_os_commonwealth_resident_ceremony_italy: |
           ###What happens next
 

--- a/lib/smart_answer_flows/locales/en/marriage-abroad-v2.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad-v2.yml
@@ -44,7 +44,7 @@ en-GB:
         documents_needed_21_days_residency: |
           ##What documents you’ll need
 
-          You need to have been living in your country of residence for 21 days. You and your partner will need to sign a declaration and provide proof of residence eg, an employer’s letter or a bank statement.
+          You need to have been living in the country where you intend to marry for 21 days. You and your partner will need to sign a declaration and provide proof of residence eg, an employer’s letter or a bank statement.
         documents_needed_ss_british: |
           You’ll both need your original passports. If either of you have been divorced, widowed or in a civil partnership before, you’ll also need either:
 

--- a/lib/smart_answer_flows/locales/en/marriage-abroad-v2.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad-v2.yml
@@ -306,6 +306,13 @@ en-GB:
           You may be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
 
           The local registrar may also need a certificate of custom and law, which confirms the marriage is valid - the Embassy in Zagreb can provide this.
+        what_to_do_laos: |
+          You may be asked to provide an [affirmation of freedom to marry document](/government/uploads/system/uploads/attachment_data/file/299846/new_marriage_affirmation__2_.docx) to prove you’re allowed to marry.
+
+          Make an appointment at the British Embassy in Vientiane to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, your partner’s ID and pay a fee.
+
+          +[data_partial:overseas_passports_embassies:overseas_passports_embassies]
+
         get_legal_advice: |
           ^You should [get legal advice](/government/organisations/foreign-commonwealth-office/series/list-of-lawyers) before making any plans.^
 
@@ -907,7 +914,7 @@ en-GB:
           - proof of residence, such as a residence certificate - check with the %{embassy_or_consulate_residency_country} or notary public to find out what you need
           - equivalent documents for your partner
 
-        cambodia_consular_cni_os_partner_local: |
+        cni_os_partner_local_legislation_documents_for_appointment: |
           You'll need to pay a fee and bring the following to your appointment:
 
             - your passport
@@ -2178,3 +2185,9 @@ en-GB:
         title: Same-sex marriage and civil partnership in %{country_name_lowercase_prefix}
         body: |
           It’s not possible to get legal recognition for your same-sex relationship in %{country_name_lowercase_prefix}.
+      outcome_os_marriage_impossible_no_laos_locals:
+        title: Marriage in Laos
+        body: |
+          It’s not possible for 2 foreigners to get married in Laos. One of you must be a Lao national.
+
+          Contact the [Embassy of %{country_name_lowercase_prefix}](/government/publications/foreign-embassies-in-the-uk) to find out about local marriage laws.

--- a/lib/smart_answer_flows/locales/en/marriage-abroad-v2.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad-v2.yml
@@ -2031,7 +2031,7 @@ en-GB:
 
           If you need a certificate of custom law, you can get one from the [British Embassy in Paris](/government/world/organisations/british-embassy-paris).
 
-          Some mairies only issue a certificate of custom less than 6 months before the date of marriage. You should check with them before you apply. If your certificate is refused because you applied too early, you will need to apply and pay again.
+          Some mairies only accept a certificate of custom dated less than 6 months before the date of marriage. You should check with them before you apply. If your certificate is refused because you applied too early, you will need to apply and pay again.
 
           ###Applying for a certificate of custom law from the British Embassy
 

--- a/lib/smart_answer_flows/locales/en/marriage-abroad-v2.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad-v2.yml
@@ -2019,7 +2019,7 @@ en-GB:
 
           If you’re not in France, [your closest French embassy](http://www.mfe.org/index.php/Annuaires/Ambassades-et-consulats-francais-a-l-etranger) may also be able to give you advice, or put you in touch with the relevant local authorities if you don’t know who to contact.
 
-          ^You should [get legal advice](/government/organisations/foreign-commonwealth-office/series/list-of-lawyers) before making any plans.^
+          ^You should [get legal advice](/government/publications/france­list­of­lawyers) before making any plans.^
 
           ##What you need to do
 
@@ -2094,7 +2094,7 @@ en-GB:
 
           If you’re not in France, [your closest French embassy](http://www.mfe.org/index.php/Annuaires/Ambassades-et-consulats-francais-a-l-etranger) may also be able to give you advice, or put you in touch with the relevant local authorities if you don’t know who to contact.
 
-          ^You should [get legal advice](/government/organisations/foreign-commonwealth-office/series/list-of-lawyers) before making any plans.^
+          ^You should [get legal advice](/government/publications/france­list­of­lawyers) before making any plans.^
 
           ##What you need to do
 

--- a/lib/smart_answer_flows/locales/en/marriage-abroad-v2.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad-v2.yml
@@ -155,6 +155,8 @@ en-GB:
 # payment methods
         pay_by_cash_or_credit_card_no_cheque: |
           You can pay by cash or credit card, but not by personal cheque.
+        pay_by_cash_or_us_dollars_only: |
+          You can only pay fees for consular services in US dollars and in cash.
         pay_in_local_currency: |
           ^You can only pay by cash in %{country_name_lowercase_prefix}. This must be in the local currency.^
         pay_in_local_currency_ceremony_country_name: |

--- a/lib/smart_answer_flows/locales/en/marriage-abroad-v2.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad-v2.yml
@@ -215,6 +215,14 @@ en-GB:
           Contact the local British embassy or consulate in %{country_name_lowercase_prefix} to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
         appointment_for_affidavit: |
           Make an appointment at the local British embassy or consulate in %{country_name_lowercase_prefix} to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
+        appointment_for_affidavit_indonesia: |
+          Make an appointment at the local British embassy or consulate in Indonesia to swear an affidavit (written statement of facts) that you’re free to marry.
+
+          Before the appointment you’ll need to pay a fee to the British Embassy in Jakarta. You can do this by credit card or in cash in the local currency. You also need to complete 2 copies of the ‘​Affidavit for marriage’ form.​
+
+          Send one copy to the British Embassy in Jakarta by email or post. Take the other one with you when you go to your local appointment, along with your passport.
+
+          ^Allow the embassy at least 2 days to process your paperwork before turning up for your appointment.^
         appointment_for_affidavit_china_addition: |
           Your partner will need to bring a Hukou book (family registration book).
         appointment_for_affidavit_notary: |

--- a/lib/smart_answer_flows/locales/en/marriage-abroad-v2.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad-v2.yml
@@ -2104,7 +2104,7 @@ en-GB:
 
           If you need a certificate of custom law, you can get one from the [British Embassy in Paris](/government/world/organisations/british-embassy-paris).
 
-          Some tribunals only issue a certificate of custom less than 6 months before the date of your PACS. You should check with them before you apply. If your certificate is refused because you applied too early, you will need to apply and pay again.
+          Some tribunals only accept a certificate of custom dated less than 6 months before the date of your PACS. You should check with them before you apply. If your certificate is refused because you applied too early, you will need to apply and pay again.
 
           ###Applying for a certificate of custom law from the British Embassy
 

--- a/lib/smart_answer_flows/marriage-abroad-v2.rb
+++ b/lib/smart_answer_flows/marriage-abroad-v2.rb
@@ -524,6 +524,7 @@ outcome :outcome_os_consular_cni do
     cni_posted_after_7_days_countries = %w(albania algeria angola armenia austria azerbaijan bahrain bolivia bosnia-and-herzegovina bulgaria cambodia chile croatia cuba ecuador estonia georgia greece hong-kong iceland iran italy japan kazakhstan kuwait kyrgyzstan libya lithuania luxembourg macedonia mexico montenegro nicaragua norway poland russia spain sweden tajikistan tunisia turkmenistan ukraine uzbekistan venezuela)
 
     cni_notary_public_countries = %w(albania algeria angola armenia austria azerbaijan bahrain bolivia bosnia-and-herzegovina bulgaria croatia cuba estonia georgia greece iceland kazakhstan kuwait kyrgyzstan libya lithuania luxembourg mexico moldova montenegro norway poland russia serbia sweden tajikistan tunisia turkmenistan ukraine uzbekistan venezuela)
+    no_document_download_link_countries = %w(albania algeria angola armenia austria azerbaijan bahrain bolivia bosnia-and-herzegovina bulgaria croatia cuba estonia georgia greece iceland italy japan kazakhstan kuwait kyrgyzstan libya lithuania luxembourg macedonia mexico moldova montenegro nicaragua norway poland russia spain serbia sweden tajikistan tunisia turkmenistan ukraine uzbekistan venezuela)
 
     cni_posted_after_14_days_countries = %w(oman jordan qatar saudi-arabia united-arab-emirates yemen)
     not_italy_or_spain = %w(italy spain).exclude?(ceremony_country)

--- a/lib/smart_answer_flows/marriage-abroad-v2.rb
+++ b/lib/smart_answer_flows/marriage-abroad-v2.rb
@@ -773,6 +773,7 @@ outcome :outcome_os_consular_cni do
     if ceremony_country != 'germany' and resident_of == 'other'
       phrases << :consular_cni_os_not_uk_resident_ceremony_not_germany
     end
+
     if resident_of == 'other'
       if ceremony_country == 'italy' and resident_of == 'other'
         phrases << :consular_cni_os_other_resident_ceremony_italy
@@ -780,12 +781,15 @@ outcome :outcome_os_consular_cni do
         phrases << :consular_cni_os_other_resident_ceremony_not_germany_or_spain
       end
     end
+
     if ceremony_country == residency_country and ceremony_country == 'spain'
       phrases << :spain_os_consular_cni_three
     end
+
     if ceremony_country == 'italy' and resident_of == 'other'
       phrases << :wait_300_days_before_remarrying
     end
+
     if ceremony_country == residency_country
       if ceremony_country == 'japan'
         phrases << :consular_cni_os_download_documents_notary_public
@@ -797,7 +801,7 @@ outcome :outcome_os_consular_cni do
         end
       end
     else
-      if cni_notary_public_countries.include?(ceremony_country) and ceremony_country != 'greece' or %w(italy japan macedonia spain).include?(ceremony_country) and ceremony_country != 'tunisia'
+      if resident_of == 'other' && cni_notary_public_countries.include?(ceremony_country) and ceremony_country != 'greece' or %w(italy japan macedonia spain).include?(ceremony_country) and ceremony_country != 'tunisia'
         phrases << :consular_cni_os_download_documents_notary_public
       elsif data_query.non_commonwealth_country?(residency_country) and residency_country != 'ireland' and ceremony_country != 'germany'
         phrases << :consular_cni_os_local_resident_not_germany_or_spain_or_foreign_resident_not_germany
@@ -815,9 +819,11 @@ outcome :outcome_os_consular_cni do
     elsif data_query.requires_7_day_notice?(ceremony_country, residency_country)
       phrases << :display_notice_of_marriage_7_days
     end
+
     if data_query.non_commonwealth_country?(residency_country) and residency_country != residency_uk_region and ceremony_country == 'greece'
       phrases << :consular_cni_os_foreign_resident_ceremony_notary_public_greece
     end
+
     if data_query.non_commonwealth_country?(residency_country) and residency_country != 'ireland' and ceremony_country != residency_country  and ceremony_country != 'greece'
       if cni_notary_public_countries.include?(ceremony_country) or %w(italy japan macedonia spain).include?(ceremony_country)
         phrases << :consular_cni_os_foreign_resident_ceremony_notary_public
@@ -827,6 +833,7 @@ outcome :outcome_os_consular_cni do
         phrases << :consular_cni_os_foreign_resident_ceremony_not_italy
       end
     end
+
     if %w(italy germany).exclude?(ceremony_country)
       if data_query.commonwealth_country?(residency_country) and ceremony_country != residency_country
         phrases << :consular_cni_os_commonwealth_resident_ceremony_not_italy

--- a/lib/smart_answer_flows/marriage-abroad-v2.rb
+++ b/lib/smart_answer_flows/marriage-abroad-v2.rb
@@ -797,7 +797,7 @@ outcome :outcome_os_consular_cni do
         end
       end
     else
-      if cni_notary_public_countries.include?(ceremony_country) or %w(italy japan macedonia spain).include?(ceremony_country) and ceremony_country != 'tunisia'
+      if cni_notary_public_countries.include?(ceremony_country) and ceremony_country != 'greece' or %w(italy japan macedonia spain).include?(ceremony_country) and ceremony_country != 'tunisia'
         phrases << :consular_cni_os_download_documents_notary_public
       elsif data_query.non_commonwealth_country?(residency_country) and residency_country != 'ireland' and ceremony_country != 'germany'
         phrases << :consular_cni_os_local_resident_not_germany_or_spain_or_foreign_resident_not_germany

--- a/lib/smart_answer_flows/marriage-abroad-v2.rb
+++ b/lib/smart_answer_flows/marriage-abroad-v2.rb
@@ -820,12 +820,10 @@ outcome :outcome_os_consular_cni do
       phrases << :display_notice_of_marriage_7_days
     end
 
-    if data_query.non_commonwealth_country?(residency_country) and residency_country != residency_uk_region and ceremony_country == 'greece'
-      phrases << :consular_cni_os_foreign_resident_ceremony_notary_public_greece
-    end
-
-    if data_query.non_commonwealth_country?(residency_country) and residency_country != 'ireland' and ceremony_country != residency_country  and ceremony_country != 'greece'
-      if cni_notary_public_countries.include?(ceremony_country) or %w(italy japan macedonia spain).include?(ceremony_country)
+    if data_query.non_commonwealth_country?(residency_country) and residency_country != 'ireland' and ceremony_country != residency_country
+      if ceremony_country == 'greece'
+        phrases << :consular_cni_os_foreign_resident_ceremony_notary_public_greece
+      elsif cni_notary_public_countries.include?(ceremony_country) or %w(italy japan macedonia spain).include?(ceremony_country)
         phrases << :consular_cni_os_foreign_resident_ceremony_notary_public
       elsif cni_posted_after_7_days_countries.include?(ceremony_country)
         phrases << :consular_cni_os_foreign_resident_ceremony_7_days

--- a/lib/smart_answer_flows/marriage-abroad-v2.rb
+++ b/lib/smart_answer_flows/marriage-abroad-v2.rb
@@ -814,7 +814,10 @@ outcome :outcome_os_consular_cni do
     elsif data_query.requires_7_day_notice?(ceremony_country, residency_country)
       phrases << :display_notice_of_marriage_7_days
     end
-    if data_query.non_commonwealth_country?(residency_country) and residency_country != 'ireland' and ceremony_country != residency_country
+    if data_query.non_commonwealth_country?(residency_country) and residency_country != residency_uk_region and ceremony_country == 'greece'
+      phrases << :consular_cni_os_foreign_resident_ceremony_notary_public_greece
+    end
+    if data_query.non_commonwealth_country?(residency_country) and residency_country != 'ireland' and ceremony_country != residency_country  and ceremony_country != 'greece'
       if cni_notary_public_countries.include?(ceremony_country) or %w(italy japan macedonia spain).include?(ceremony_country)
         phrases << :consular_cni_os_foreign_resident_ceremony_notary_public
       elsif cni_posted_after_7_days_countries.include?(ceremony_country)

--- a/lib/smart_answer_flows/marriage-abroad-v2.rb
+++ b/lib/smart_answer_flows/marriage-abroad-v2.rb
@@ -1079,12 +1079,14 @@ outcome :outcome_os_affirmation do
       if ceremony_country == 'monaco'
         phrases << :list_of_consular_fees_france
       else
-        phrases << :list_of_consular_fees
+        phrases << :list_of_consular_fees unless ceremony_country == 'cambodia'
       end
       if ceremony_country == 'finland'
         phrases << :pay_in_euros_or_visa_electron
       elsif ceremony_country == 'philippines'
         phrases << :pay_in_cash_or_manager_cheque
+      elsif ceremony_country == 'cambodia'
+        phrases << :pay_by_cash_or_us_dollars_only
       else
         phrases << :pay_by_cash_or_credit_card_no_cheque
       end

--- a/lib/smart_answer_flows/marriage-abroad-v2.rb
+++ b/lib/smart_answer_flows/marriage-abroad-v2.rb
@@ -385,7 +385,7 @@ end
 outcome :outcome_os_indonesia do
   precalculate :indonesia_os_phraselist do
     PhraseList.new(
-      :appointment_for_affidavit,
+      :appointment_for_affidavit_indonesia,
       :complete_affidavit_with_download_link,
       :embassies_data,
       :documents_for_divorced_or_widowed,

--- a/lib/smart_answer_flows/marriage-abroad-v2.rb
+++ b/lib/smart_answer_flows/marriage-abroad-v2.rb
@@ -954,7 +954,7 @@ outcome :outcome_os_affirmation do
       phrases << :affirmation_os_all_what_you_need_to_do unless %w(cambodia ecuador morocco ).include? ceremony_country
       phrases << :affirmation_os_uae if ceremony_country == 'united-arab-emirates'
     end
-#What you need to do section
+    #What you need to do section
     if %w(turkey egypt china).include?(ceremony_country)
       phrases << :what_you_need_to_do
     elsif ceremony_country == 'finland' and partner_nationality == 'partner_irish' and resident_of == 'uk'
@@ -1055,7 +1055,7 @@ outcome :outcome_os_affirmation do
     end
     phrases << :consular_cni_os_all_names_but_germany if ceremony_country == 'cambodia'
 
-#fee tables
+    #fee tables
     if %w(south-korea thailand turkey vietnam).include?(ceremony_country)
       phrases << :fee_table_affidavit_55
     elsif %w(cambodia ecuador morocco).include? ceremony_country

--- a/test/integration/smart_answer_flows/flow_test_helper.rb
+++ b/test/integration/smart_answer_flows/flow_test_helper.rb
@@ -50,7 +50,13 @@ module FlowTestHelper
   def assert_phrase_list(variable_name, expected_keys)
     phrase_list = current_state.send(variable_name)
     assert phrase_list.is_a?(SmartAnswer::PhraseList), "State variable #{variable_name} is not a PhraseList"
-    assert_equal expected_keys, phrase_list.phrase_keys
+
+    missing_keys = expected_keys - phrase_list.phrase_keys
+    unexpected_keys = phrase_list.phrase_keys - expected_keys
+    message = ""
+    message += "Missing keys: #{missing_keys}\n" if missing_keys.present?
+    message += "Unexpected keys: #{unexpected_keys}" if unexpected_keys.present?
+    assert_equal expected_keys, phrase_list.phrase_keys, message
   end
 
   def assert_calendar

--- a/test/integration/smart_answer_flows/marriage_abroad_v2_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_v2_test.rb
@@ -8,7 +8,7 @@ class MarriageAbroadV2Test < ActiveSupport::TestCase
   include GdsApi::TestHelpers::Worldwide
 
   setup do
-    @location_slugs = %w(albania american-samoa anguilla argentina armenia aruba australia austria azerbaijan bahamas belarus belgium bonaire-st-eustatius-saba brazil british-indian-ocean-territory burma burundi cambodia canada china cote-d-ivoire croatia colombia cyprus czech-republic denmark ecuador egypt estonia finland france germany indonesia iran ireland italy japan jordan kazakhstan latvia lebanon lithuania macedonia malta mayotte mexico monaco morocco netherlands nicaragua north-korea guatemala paraguay peru philippines poland portugal qatar russia rwanda san-marino saudi-arabia serbia slovakia south-africa st-maarten south-korea spain sweden switzerland thailand turkey turkmenistan united-arab-emirates usa uzbekistan vietnam wallis-and-futuna yemen zimbabwe)
+    @location_slugs = %w(albania american-samoa anguilla argentina armenia aruba australia austria azerbaijan bahamas belarus belgium bonaire-st-eustatius-saba brazil british-indian-ocean-territory burma burundi cambodia canada china cote-d-ivoire croatia colombia cyprus czech-republic denmark ecuador egypt estonia finland france germany greece indonesia iran ireland italy japan jordan kazakhstan latvia lebanon lithuania macedonia malta mayotte mexico monaco morocco netherlands nicaragua north-korea guatemala paraguay peru philippines poland portugal qatar russia rwanda san-marino saudi-arabia serbia slovakia south-africa st-maarten south-korea spain sweden switzerland thailand turkey turkmenistan united-arab-emirates usa uzbekistan vietnam wallis-and-futuna yemen zimbabwe)
     worldwide_api_has_locations(@location_slugs)
     setup_for_testing_flow 'marriage-abroad-v2'
   end

--- a/test/integration/smart_answer_flows/marriage_abroad_v2_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_v2_test.rb
@@ -2443,4 +2443,19 @@ class MarriageAbroadV2Test < ActiveSupport::TestCase
       assert_phrase_list :brazil_phraselist_not_in_the_uk, [:local_resident_os_consular_cni,:check_travel_advice,:get_legal_advice,:what_you_need_to_do,:make_an_appointment_bring_passport_and_pay_55_brazil,:list_of_consular_fees,:pay_by_cash_or_credit_card_no_cheque,:embassies_data,:download_affidavit_forms_but_do_not_sign,:download_affidavit_brazil,:documents_for_divorced_or_widowed,:affirmation_os_partner_not_british_turkey]
     end
   end
+
+  context "ceremony in Greece, not resident in Uk (resident in Greece), all opposite-sex outcomes" do
+    setup do
+      worldwide_api_has_organisations_for_location('greece', read_fixture_file('worldwide/greece_organisations.json'))
+      add_response 'greece'
+      add_response 'other'
+      add_response 'usa'
+      add_response 'partner_other'
+      add_response 'opposite_sex'
+    end
+    should "include the Greek specific notary public phrase list" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:local_resident_os_consular_cni,:italy_os_consular_cni_ceremony_not_italy_or_spain,:consular_cni_all_what_you_need_to_do,:consular_cni_os_ceremony_not_spain_or_italy,:consular_cni_os_foreign_resident_ceremony_not_germany_italy,:check_with_embassy_consulate_or_notary_public,:embassies_data,:living_in_residence_country_3_days,:consular_cni_variant_local_resident_or_foreign_resident_notary_public,:consular_cni_os_not_uk_resident_ceremony_not_germany,:consular_cni_os_other_resident_ceremony_not_germany_or_spain,:consular_cni_os_download_documents_notary_public,:consular_cni_os_foreign_resident_ceremony_notary_public_greece]
+    end
+  end
 end

--- a/test/integration/smart_answer_flows/marriage_abroad_v2_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_v2_test.rb
@@ -1078,7 +1078,7 @@ class MarriageAbroadV2Test < ActiveSupport::TestCase
     end
     should "go to os affirmation outcome" do
       assert_current_node :outcome_os_affirmation
-      assert_phrase_list :affirmation_os_outcome, [:affirmation_os_local_resident, :what_you_need_to_do_affirmation, :appointment_for_affidavit, :embassies_data, :cambodia_consular_cni_os_partner_local, :affirmation_os_translation_in_local_language_text, :documents_for_divorced_or_widowed_cambodia, :change_of_name_evidence, :partner_equivalent_document_warning, :affirmation_os_partner_not_british, :consular_cni_os_all_names_but_germany, :fee_table_affirmation_55, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+      assert_phrase_list :affirmation_os_outcome, [:affirmation_os_local_resident, :what_you_need_to_do_affirmation, :appointment_for_affidavit, :embassies_data, :cambodia_consular_cni_os_partner_local, :affirmation_os_translation_in_local_language_text, :documents_for_divorced_or_widowed_cambodia, :change_of_name_evidence, :partner_equivalent_document_warning, :affirmation_os_partner_not_british, :consular_cni_os_all_names_but_germany, :fee_table_affirmation_55, :pay_by_cash_or_us_dollars_only]
     end
   end
 

--- a/test/integration/smart_answer_flows/marriage_abroad_v2_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_v2_test.rb
@@ -8,7 +8,7 @@ class MarriageAbroadV2Test < ActiveSupport::TestCase
   include GdsApi::TestHelpers::Worldwide
 
   setup do
-    @location_slugs = %w(albania american-samoa anguilla argentina armenia aruba australia austria azerbaijan bahamas belarus belgium bonaire-st-eustatius-saba brazil british-indian-ocean-territory burma burundi cambodia canada china cote-d-ivoire croatia colombia cyprus czech-republic denmark ecuador egypt estonia finland france germany greece indonesia iran ireland italy japan jordan kazakhstan latvia lebanon lithuania macedonia malta mayotte mexico monaco morocco netherlands nicaragua north-korea guatemala paraguay peru philippines poland portugal qatar russia rwanda san-marino saudi-arabia serbia slovakia south-africa st-maarten south-korea spain sweden switzerland thailand turkey turkmenistan united-arab-emirates usa uzbekistan vietnam wallis-and-futuna yemen zimbabwe)
+    @location_slugs = %w(albania american-samoa anguilla argentina armenia aruba australia austria azerbaijan bahamas belarus belgium bonaire-st-eustatius-saba brazil british-indian-ocean-territory burma burundi cambodia canada china cote-d-ivoire croatia colombia cyprus czech-republic denmark ecuador egypt estonia finland france germany greece indonesia iran ireland italy japan jordan kazakhstan laos latvia lebanon lithuania macedonia malta mayotte mexico monaco morocco netherlands nicaragua north-korea guatemala paraguay peru philippines poland portugal qatar russia rwanda san-marino saudi-arabia serbia slovakia south-africa st-maarten south-korea spain sweden switzerland thailand turkey turkmenistan united-arab-emirates usa uzbekistan vietnam wallis-and-futuna yemen zimbabwe)
     worldwide_api_has_locations(@location_slugs)
     setup_for_testing_flow 'marriage-abroad-v2'
   end
@@ -1078,7 +1078,7 @@ class MarriageAbroadV2Test < ActiveSupport::TestCase
     end
     should "go to os affirmation outcome" do
       assert_current_node :outcome_os_affirmation
-      assert_phrase_list :affirmation_os_outcome, [:affirmation_os_local_resident, :what_you_need_to_do_affirmation, :appointment_for_affidavit, :embassies_data, :cambodia_consular_cni_os_partner_local, :affirmation_os_translation_in_local_language_text, :documents_for_divorced_or_widowed_cambodia, :change_of_name_evidence, :partner_equivalent_document_warning, :affirmation_os_partner_not_british, :consular_cni_os_all_names_but_germany, :fee_table_affirmation_55, :pay_by_cash_or_us_dollars_only]
+      assert_phrase_list :affirmation_os_outcome, [:affirmation_os_local_resident, :what_you_need_to_do_affirmation, :appointment_for_affidavit, :embassies_data, :cni_os_partner_local_legislation_documents_for_appointment, :affirmation_os_translation_in_local_language_text, :documents_for_divorced_or_widowed_cambodia, :change_of_name_evidence, :partner_equivalent_document_warning, :affirmation_os_partner_not_british, :consular_cni_os_all_names_but_germany, :fee_table_affirmation_55, :pay_by_cash_or_us_dollars_only]
     end
   end
 
@@ -2460,7 +2460,7 @@ class MarriageAbroadV2Test < ActiveSupport::TestCase
     end
   end
 
-  context "ceremony in Uzbekistan, resident in the Uk, partner from anywhere, opposite sex" do
+  context "ceremony in Uzbekistan, resident in the UK, partner from anywhere, opposite sex" do
     setup do
       worldwide_api_has_organisations_for_location('uzbekistan', read_fixture_file('worldwide/uzbekistan_organisations.json'))
       add_response 'uzbekistan'
@@ -2472,6 +2472,38 @@ class MarriageAbroadV2Test < ActiveSupport::TestCase
     should "not include the links to download documents" do
       assert_current_node :outcome_os_consular_cni
       assert_phrase_list :consular_cni_os_start, [:uk_resident_os_consular_cni,:italy_os_consular_cni_ceremony_not_italy_or_spain,:consular_cni_all_what_you_need_to_do,:consular_cni_os_ceremony_not_spain_or_italy,:cni_at_local_register_office_notary_public,:consular_cni_os_uk_resident_legalisation,:consular_cni_os_uk_resident_not_italy_or_portugal]
+    end
+  end
+
+  context "ceremony in Laos" do
+    context "resident in the UK, opposite sex partner from Laos" do
+      setup do
+        worldwide_api_has_organisations_for_location('laos', read_fixture_file('worldwide/laos_organisations.json'))
+        add_response 'laos'
+        add_response 'uk'
+        add_response 'uk_england'
+        add_response 'partner_local'
+        add_response 'opposite_sex'
+      end
+      should "lead to outcome_os_consular_cni" do
+        assert_current_node :outcome_os_consular_cni
+        assert_phrase_list :consular_cni_os_start, [:uk_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :what_to_do_laos, :legalisation_and_translation, :cni_os_partner_local_legislation_documents_for_appointment, :affirmation_os_translation_in_local_language_text, :docs_decree_and_death_certificate, :divorced_or_widowed_evidences, :change_of_name_evidence]
+        assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :consular_cni_os_naturalisation, :fee_table_affirmation_55, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+      end
+    end
+
+    context "opposite sex partner, no Laos nationals" do
+      setup do
+        worldwide_api_has_organisations_for_location('laos', read_fixture_file('worldwide/laos_organisations.json'))
+        add_response 'laos'
+        add_response 'uk'
+        add_response 'uk_england'
+        add_response 'partner_other'
+        add_response 'opposite_sex'
+      end
+      should "lead to outcome_os_marriage_impossible_no_laos_locals" do
+        assert_current_node :outcome_os_marriage_impossible_no_laos_locals
+      end
     end
   end
 end

--- a/test/integration/smart_answer_flows/marriage_abroad_v2_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_v2_test.rb
@@ -2458,4 +2458,19 @@ class MarriageAbroadV2Test < ActiveSupport::TestCase
       assert_phrase_list :consular_cni_os_start, [:local_resident_os_consular_cni,:italy_os_consular_cni_ceremony_not_italy_or_spain,:consular_cni_all_what_you_need_to_do,:consular_cni_os_ceremony_not_spain_or_italy,:consular_cni_os_foreign_resident_ceremony_not_germany_italy,:check_with_embassy_consulate_or_notary_public,:embassies_data,:living_in_residence_country_3_days,:consular_cni_variant_local_resident_or_foreign_resident_notary_public,:consular_cni_os_not_uk_resident_ceremony_not_germany,:consular_cni_os_other_resident_ceremony_not_germany_or_spain,:consular_cni_os_download_documents_notary_public,:consular_cni_os_foreign_resident_ceremony_notary_public_greece]
     end
   end
+
+  context "ceremony in Uzbekistan, resident in the Uk, partner from anywhere, opposite sex" do
+    setup do
+      worldwide_api_has_organisations_for_location('uzbekistan', read_fixture_file('worldwide/uzbekistan_organisations.json'))
+      add_response 'uzbekistan'
+      add_response 'uk'
+      add_response 'uk_england'
+      add_response 'partner_other'
+      add_response 'opposite_sex'
+    end
+    should "not include the links to download documents" do
+      assert_current_node :outcome_os_consular_cni
+      assert_phrase_list :consular_cni_os_start, [:uk_resident_os_consular_cni,:italy_os_consular_cni_ceremony_not_italy_or_spain,:consular_cni_all_what_you_need_to_do,:consular_cni_os_ceremony_not_spain_or_italy,:cni_at_local_register_office_notary_public,:consular_cni_os_uk_resident_legalisation,:consular_cni_os_uk_resident_not_italy_or_portugal]
+    end
+  end
 end

--- a/test/integration/smart_answer_flows/marriage_abroad_v2_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_v2_test.rb
@@ -2037,7 +2037,7 @@ class MarriageAbroadV2Test < ActiveSupport::TestCase
       add_response 'partner_british'
       add_response 'opposite_sex'
       assert_current_node :outcome_os_indonesia
-      assert_phrase_list :indonesia_os_phraselist, [:appointment_for_affidavit, :complete_affidavit_with_download_link, :embassies_data, :documents_for_divorced_or_widowed, :partner_affidavit_needed, :fee_table_45_70_55]
+      assert_phrase_list :indonesia_os_phraselist, [:appointment_for_affidavit_indonesia, :complete_affidavit_with_download_link, :embassies_data, :documents_for_divorced_or_widowed, :partner_affidavit_needed, :fee_table_45_70_55]
     end
   end
   context "aruba opposite sex outcome" do

--- a/test/integration/smart_answer_flows/marriage_abroad_v2_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_v2_test.rb
@@ -486,7 +486,7 @@ class MarriageAbroadV2Test < ActiveSupport::TestCase
     end
     should "go to consular cni os outcome" do
       assert_current_node :outcome_os_consular_cni
-      assert_phrase_list :consular_cni_os_start, [:uk_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :cni_at_local_register_office_notary_public, :consular_cni_os_uk_resident_legalisation, :consular_cni_os_uk_resident_not_italy_or_portugal, :consular_cni_os_download_documents_notary_public]
+      assert_phrase_list :consular_cni_os_start, [:uk_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :cni_at_local_register_office_notary_public, :consular_cni_os_uk_resident_legalisation, :consular_cni_os_uk_resident_not_italy_or_portugal]
       assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :consular_cni_os_naturalisation, :consular_cni_os_fees_not_italy_not_uk, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
     end
   end
@@ -501,7 +501,7 @@ class MarriageAbroadV2Test < ActiveSupport::TestCase
     end
     should "go to consular cni os outcome" do
       assert_current_node :outcome_os_consular_cni
-      assert_phrase_list :consular_cni_os_start, [:uk_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :cni_at_local_register_office_notary_public, :consular_cni_os_uk_resident_legalisation, :consular_cni_os_uk_resident_not_italy_or_portugal, :consular_cni_os_download_documents_notary_public]
+      assert_phrase_list :consular_cni_os_start, [:uk_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :cni_at_local_register_office_notary_public, :consular_cni_os_uk_resident_legalisation, :consular_cni_os_uk_resident_not_italy_or_portugal]
       assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :consular_cni_os_naturalisation, :consular_cni_os_fees_not_italy_not_uk, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
     end
   end
@@ -898,7 +898,7 @@ class MarriageAbroadV2Test < ActiveSupport::TestCase
     end
     should "go to consular cni os outcome" do
       assert_current_node :outcome_os_consular_cni
-      assert_phrase_list :consular_cni_os_start, [:uk_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :cni_at_local_register_office_notary_public, :consular_cni_os_uk_resident_legalisation, :consular_cni_os_uk_resident_not_italy_or_portugal, :consular_cni_os_download_documents_notary_public]
+      assert_phrase_list :consular_cni_os_start, [:uk_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :cni_at_local_register_office_notary_public, :consular_cni_os_uk_resident_legalisation, :consular_cni_os_uk_resident_not_italy_or_portugal]
       assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :consular_cni_os_naturalisation, :consular_cni_os_fees_not_italy_not_uk, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
     end
   end
@@ -914,7 +914,7 @@ class MarriageAbroadV2Test < ActiveSupport::TestCase
     end
     should "go to consular cni os outcome" do
       assert_current_node :outcome_os_consular_cni
-      assert_phrase_list :consular_cni_os_start, [:uk_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :cni_at_local_register_office_notary_public, :consular_cni_os_uk_resident_legalisation, :consular_cni_os_uk_resident_not_italy_or_portugal, :consular_cni_os_download_documents_notary_public]
+      assert_phrase_list :consular_cni_os_start, [:uk_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :cni_at_local_register_office_notary_public, :consular_cni_os_uk_resident_legalisation, :consular_cni_os_uk_resident_not_italy_or_portugal]
       assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :consular_cni_os_naturalisation, :consular_cni_os_fees_not_italy_not_uk, :list_of_consular_fees, :pay_in_local_currency_ceremony_country_name]
     end
   end
@@ -2333,7 +2333,7 @@ class MarriageAbroadV2Test < ActiveSupport::TestCase
     end
     should "show the same content of Albania" do
       assert_current_node :outcome_os_consular_cni
-      assert_phrase_list :consular_cni_os_start, [:uk_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :cni_at_local_register_office_notary_public, :consular_cni_os_uk_resident_legalisation, :consular_cni_os_uk_resident_not_italy_or_portugal, :consular_cni_os_download_documents_notary_public]
+      assert_phrase_list :consular_cni_os_start, [:uk_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :cni_at_local_register_office_notary_public, :consular_cni_os_uk_resident_legalisation, :consular_cni_os_uk_resident_not_italy_or_portugal]
       assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_local_resident_ceremony_not_italy_not_germany_partner_british, :consular_cni_os_all_names_but_germany, :consular_cni_os_fees_not_italy_not_uk, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
     end
   end
@@ -2349,7 +2349,7 @@ class MarriageAbroadV2Test < ActiveSupport::TestCase
     end
     should "show Albania outcome" do
       assert_current_node :outcome_os_consular_cni
-      assert_phrase_list :consular_cni_os_start, [:uk_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :cni_at_local_register_office_notary_public, :consular_cni_os_uk_resident_legalisation, :consular_cni_os_uk_resident_not_italy_or_portugal, :consular_cni_os_download_documents_notary_public]
+      assert_phrase_list :consular_cni_os_start, [:uk_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :cni_at_local_register_office_notary_public, :consular_cni_os_uk_resident_legalisation, :consular_cni_os_uk_resident_not_italy_or_portugal]
       assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_local_resident_ceremony_not_italy_not_germany_partner_british, :consular_cni_os_all_names_but_germany, :consular_cni_os_fees_not_italy_not_uk, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
     end
   end

--- a/test/integration/smart_answer_flows/marriage_abroad_v2_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_v2_test.rb
@@ -8,7 +8,7 @@ class MarriageAbroadV2Test < ActiveSupport::TestCase
   include GdsApi::TestHelpers::Worldwide
 
   setup do
-    @location_slugs = %w(albania american-samoa anguilla argentina armenia aruba australia austria azerbaijan bahamas belarus belgium bonaire-st-eustatius-saba brazil british-indian-ocean-territory burma burundi cambodia canada china cote-d-ivoire croatia colombia cyprus czech-republic denmark ecuador egypt estonia finland france germany indonesia iran ireland italy japan jordan kazakhstan latvia lebanon lithuania macedonia malta mayotte mexico monaco morocco netherlands nicaragua north-korea guatemala paraguay peru philippines poland portugal qatar russia rwanda san-marino saudi-arabia serbia slovakia south-africa st-maarten south-korea spain sweden switzerland thailand turkey turkmenistan united-arab-emirates usa vietnam wallis-and-futuna yemen zimbabwe)
+    @location_slugs = %w(albania american-samoa anguilla argentina armenia aruba australia austria azerbaijan bahamas belarus belgium bonaire-st-eustatius-saba brazil british-indian-ocean-territory burma burundi cambodia canada china cote-d-ivoire croatia colombia cyprus czech-republic denmark ecuador egypt estonia finland france germany indonesia iran ireland italy japan jordan kazakhstan latvia lebanon lithuania macedonia malta mayotte mexico monaco morocco netherlands nicaragua north-korea guatemala paraguay peru philippines poland portugal qatar russia rwanda san-marino saudi-arabia serbia slovakia south-africa st-maarten south-korea spain sweden switzerland thailand turkey turkmenistan united-arab-emirates usa uzbekistan vietnam wallis-and-futuna yemen zimbabwe)
     worldwide_api_has_locations(@location_slugs)
     setup_for_testing_flow 'marriage-abroad-v2'
   end

--- a/test/integration/smart_answer_flows/marriage_abroad_v2_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_v2_test.rb
@@ -2447,6 +2447,7 @@ class MarriageAbroadV2Test < ActiveSupport::TestCase
   context "ceremony in Greece, not resident in Uk (resident in Greece), all opposite-sex outcomes" do
     setup do
       worldwide_api_has_organisations_for_location('greece', read_fixture_file('worldwide/greece_organisations.json'))
+      worldwide_api_has_organisations_for_location('usa', read_fixture_file('worldwide/usa_organisations.json'))
       add_response 'greece'
       add_response 'other'
       add_response 'usa'
@@ -2455,7 +2456,7 @@ class MarriageAbroadV2Test < ActiveSupport::TestCase
     end
     should "include the Greek specific notary public phrase list" do
       assert_current_node :outcome_os_consular_cni
-      assert_phrase_list :consular_cni_os_start, [:local_resident_os_consular_cni,:italy_os_consular_cni_ceremony_not_italy_or_spain,:consular_cni_all_what_you_need_to_do,:consular_cni_os_ceremony_not_spain_or_italy,:consular_cni_os_foreign_resident_ceremony_not_germany_italy,:check_with_embassy_consulate_or_notary_public,:embassies_data,:living_in_residence_country_3_days,:consular_cni_variant_local_resident_or_foreign_resident_notary_public,:consular_cni_os_not_uk_resident_ceremony_not_germany,:consular_cni_os_other_resident_ceremony_not_germany_or_spain,:consular_cni_os_download_documents_notary_public,:consular_cni_os_foreign_resident_ceremony_notary_public_greece]
+      assert_phrase_list :consular_cni_os_start, [:other_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :consular_cni_os_foreign_resident_ceremony_not_germany_italy, :consular_cni_os_foreign_resident_3_days_notary_public, :consular_cni_variant_local_resident_or_foreign_resident_notary_public, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :consular_cni_os_local_resident_not_germany_or_spain_or_foreign_resident_not_germany, :consular_cni_os_foreign_resident_ceremony_notary_public_greece]
     end
   end
 


### PR DESCRIPTION
### Marriage abroad amendments

This is a draft (V2) for requested amendments. We want to submit this for Fact Check even though Part 8 is not done yet.

[A Google Doc](https://docs.google.com/a/digital.cabinet-office.gov.uk/document/d/1B82Ijw_6C38FL_2qRUS-4AuA4AZhcyxAHax9ru18CiM) and [Pivotal ticket](https://www.pivotaltracker.com/n/projects/1270592/stories/89270592) for those who have access.

### Summary of changes
PART ONE
Change a line of text on all outcomes for same-sex countries (26)
```
CHANGE FROM:
You need to have been living in your country of residence for 21 days.

TO:
You need to have been living in the country where you intend to marry for 21 days.
```
Add the same line of text to consular opposite-sex countries (5) and Saudi Arabia (1)

PART TWO
Replace the affidavit and notice of marriage forms for CNI countries (45)
New attachments.

PART THREE
Remove text and attachments from CNI countries (41)
```
CHANGES APPLY TO: married in [country above] > living in UK > partner from anywhere > opposite sex 

REMOVE:
You’ll need to fill in forms for your notice of marriage, and an oath or affidavit (written statement of facts) stating that you’re free to marry.
You can download and fill in (but not sign) the forms in advance.

Download ‘Notice of marriage’ (PDF, 96KB)
Download ‘Affidavit for marriage’ (PDF, 58KB)
```
PART FOUR
Marriage in Indonesia – changes to first few lines of text
```
CHANGES APPLY TO: all outcomes > opposite sex

CHANGE FROM: 
Make an appointment at the local British embassy or consulate in Indonesia to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee. 

You’ll need to complete an ‘Affidavit for marriage’ form that will be used for your affidavit. Take the completed form with you to your appointment. 

TO:
Make an appointment at the local British embassy or consulate in Indonesia to swear an affidavit (written statement of facts) that you’re free to marry.

Before the appointment you’ll need to pay a fee to the British Embassy in Jakarta. You can do this by credit card or in cash in the local currency. You also need to complete 2 copies of the ‘Affidavit for marriage’ form. 

Send one copy to the British Embassy in Jakarta by email or post. Take the other one with you when you go to your local appointment, along with your passport.

^Allow the embassy at least 2 days to process your paperwork before turning up for your appointment.^
```

PART FIVE
Marriage in Cambodia – single line of text change
```
CHANGE FROM:
You normally have to pay fees for consular services in the local currency - these are shown in the list of consular fees for Cambodia.
You can pay by cash or credit card, but not by personal cheque.

TO:
You can only pay fees for consular services in US dollars and in cash.
```

PART SIX
Marriage in Greece – replace four lines of text in the same section
```
CHANGES APPLY TO: all outcomes where a British national is not a UK resident

CHANGE FROM: 
The embassy or notary public will charge a fee for taking the oath.
If you give notice at a notary public, you must post the signed forms and any supporting documents to your nearest British embassy or consulate afterwards.
The embassy or consulate may charge a fee to return your documents to you.
The consulate will display your notice of marriage publicly for 7 days. They’ll then send all of your documentation to the nearest British embassy or consulate in Greece to where you’re getting married, who will issue your CNI(as long as nobody has registered an objection).
There’s an additional fee for this - the embassy or consulate will contact you to arrange payment.

TO:
An embassy or notary public can take your oath and post notice of your marriage. The notary public may charge 2 separate fees for this.

If you give notice at a notary public, you must post the signed forms and any supporting documents to the British Embassy in Athens afterwards.

Your local embassy will display your notice of marriage publicly for 7 days. They’ll then issue the CNI (as long as nobody has registered an objection).

There’s an additional fee for this - the embassy or consulate will contact you to arrange payment.
```
PART SEVEN
Marriage in Laos – several text changes and Embassy addresses from the API added
Changes details in the commit message: https://github.com/alphagov/smart-answers/commit/3cb2007334951c215240fb56b317542f474cdff9

PART EIGHT
Marriage in Jordan – text changes throughout the page
**Not done as a part of this PR, will submit as a separate PR**

PART NINE
Marriage in France - single line of text change

```
CHANGES RELATE TO:
https://www.gov.uk/marriage-abroad/y/france/marriage
https://www.gov.uk/marriage-abroad/y/france/pacs

1) On both pages the text currently says:

CHANGE
Some mairies only issue a certificate of custom less than 6 months before the date of marriage. You should check with them before you apply. If your certificate is refused because you applied too early, you will need to apply and pay again.

TO: 
Some mairies only accept a certificate of custom dated less than 6 months before the date of marriage. You should check with them before you apply. If your certificate is refused because you applied too early, you will need to apply and pay again.

2) Third paragraph on both pages currently says: 

^You should get legal advice before making any plans^

CHANGE LINK TO:
https://www.gov.uk/government/publications/france-list-of-lawyers
```