### PR TITLE
Backport B1 B2 visa notification for Syrians in transit #hotfix

### DIFF
--- a/lib/smart_answer_flows/check-uk-visa.rb
+++ b/lib/smart_answer_flows/check-uk-visa.rb
@@ -149,7 +149,11 @@ end
 outcome :outcome_work_m
 outcome :outcome_work_n
 outcome :outcome_transit_leaving_airport
-outcome :outcome_transit_not_leaving_airport
+outcome :outcome_transit_not_leaving_airport do
+  precalculate :if_syria do
+    PhraseList.new(:b1_b2_visa_exception) if passport_country == 'syria'
+  end
+end
 outcome :outcome_joining_family_y
 outcome :outcome_joining_family_m
 outcome :outcome_joining_family_nvn
@@ -195,6 +199,10 @@ outcome :outcome_visit_waiver do
     end
   end
 end
-outcome :outcome_transit_leaving_airport_datv
+outcome :outcome_transit_leaving_airport_datv do
+  precalculate :if_syria do
+    PhraseList.new(:b1_b2_visa_exception) if passport_country == 'syria'
+  end
+end
 outcome :outcome_taiwan_exception
 outcome :outcome_diplomatic_business

--- a/lib/smart_answer_flows/locales/en/check-uk-visa.yml
+++ b/lib/smart_answer_flows/locales/en/check-uk-visa.yml
@@ -14,6 +14,9 @@ en-GB:
           You won't need a visa if your passport has a personal ID number on the bio data page.
 
       #phrases
+        b1_b2_visa_exception: |
+          except if you have a B1 or B2 visit visa from the USA
+
         study_additional_sentence: |
           However, you should bring documents with you to show at the border. See the relevant [student visa](/browse/visas-immigration/study-visas) guide to see what documents to bring.
 
@@ -352,7 +355,7 @@ en-GB:
 
           You don’t need a visa if you have one of the following:
 
-          - a visa for Canada, New Zealand, Australia or the USA (this can be used for travel to any country)
+          - a visa for Canada, New Zealand, Australia or the USA (this can be used for travel to any country) %{if_syria}
           - a residence permit issued by Australia or New Zealand
           - you have a common format residence permit issued by an European Economic Area (EEA) country or Switzerland
           - a resident permit issued by Canada after 28 June 2002
@@ -383,8 +386,8 @@ en-GB:
 
           One of the following must also apply:
 
-          - you’re travelling to (or on part of a reasonable journey to) Australia, Canada, New Zealand or the USA and have a valid visa for that country
-          - you’re travelling from (or on part of a reasonable journey from) Australia, Canada, New Zealand or the USA and have a valid visa for that country
+          - you’re travelling to (or on part of a reasonable journey to) Australia, Canada, New Zealand or the USA and have a valid visa for that country %{if_syria}
+          - you’re travelling from (or on part of a reasonable journey from) Australia, Canada, New Zealand or the USA and have a valid visa for that country %{if_syria}
           - you’re travelling from (or on part of a reasonable journey from) Australia, Canada, New Zealand or the USA and it’s less than 6 months since you last entered that country with a valid entry visa
           - you have a residence permit issued by Australia or New Zealand
           - you have a common format residence permit issued by an European Economic Area (EEA) country or Switzerland

--- a/test/integration/smart_answer_flows/check_uk_visa_test.rb
+++ b/test/integration/smart_answer_flows/check_uk_visa_test.rb
@@ -8,7 +8,7 @@ class CheckUkVisaTest < ActiveSupport::TestCase
   include GdsApi::TestHelpers::Worldwide
 
   setup do
-    @location_slugs = %w(andorra anguilla armenia bolivia canada china colombia croatia mexico south-africa turkey yemen oman united-arab-emirates qatar taiwan venezuela)
+    @location_slugs = %w(andorra anguilla armenia bolivia canada china colombia croatia mexico south-africa syria turkey yemen oman united-arab-emirates qatar taiwan venezuela)
     worldwide_api_has_locations(@location_slugs)
     setup_for_testing_flow 'check-uk-visa'
   end
@@ -652,6 +652,25 @@ end
     end
     should "go to diplomatic and government outcome" do
       assert_current_node :outcome_diplomatic_business
+    end
+  end
+
+  context "Syria transit B1 B2 visa exceptions" do
+    setup do
+      add_response 'syria'
+      add_response 'transit'
+    end
+
+    should "mention B1 and B2 visas when leaving the airport" do
+      add_response 'yes'
+      assert_current_node :outcome_transit_leaving_airport_datv
+      assert_phrase_list :if_syria, [:b1_b2_visa_exception]
+    end
+
+    should "mention B1 and B2 visas when not leaving the airport" do
+      add_response 'no'
+      assert_current_node :outcome_transit_not_leaving_airport
+      assert_phrase_list :if_syria, [:b1_b2_visa_exception]
     end
   end
 end


### PR DESCRIPTION
Backported from V2 cause it needs to go live asap.

To test:
`/check-uk-visa/y/syria/transit/yes` should have a message with the B1/B2 exception
`/check-uk-visa/y/iran/transit/yes` should not have a message with the B1/B2 exception
`/check-uk-visa/y/syria/transit/no` should have a message with the B1/B2 exception
`/check-uk-visa/y/iran/transit/no` should not have a message with the B1/B2 exception

/cc @bradleywright 