### PR TITLE
Overseas passports v2 remaining changes

### DIFF
--- a/lib/data/passport_data.yml
+++ b/lib/data/passport_data.yml
@@ -1790,6 +1790,7 @@ tajikistan:
   type: ips_application_2
   group: ips_documents_group_3
   app_form: hmpo_1_application_form
+  application_office: true
   renewing_new: 8_weeks
   renewing_old: 10_weeks
   applying: 10_weeks
@@ -1874,6 +1875,7 @@ turkmenistan:
   type: ips_application_2
   group: ips_documents_group_3
   app_form: hmpo_1_application_form
+  application_office: true
   renewing_new: 8_weeks
   renewing_old: 10_weeks
   applying: 10_weeks
@@ -1949,6 +1951,7 @@ uzbekistan:
   type: ips_application_3
   group: ips_documents_group_3
   app_form: hmpo_1_application_form
+  application_office: true
   renewing_new: 8_weeks
   renewing_old: 10_weeks
   applying: 10_weeks

--- a/lib/data/passport_data_v2.yml
+++ b/lib/data/passport_data_v2.yml
@@ -1790,6 +1790,7 @@ tajikistan:
   type: ips_application_2
   group: ips_documents_group_3
   app_form: hmpo_1_application_form
+  application_office: true
   renewing_new: 8_weeks
   renewing_old: 10_weeks
   applying: 10_weeks
@@ -1874,6 +1875,7 @@ turkmenistan:
   type: ips_application_2
   group: ips_documents_group_3
   app_form: hmpo_1_application_form
+  application_office: true
   renewing_new: 8_weeks
   renewing_old: 10_weeks
   applying: 10_weeks
@@ -1949,6 +1951,7 @@ uzbekistan:
   type: ips_application_3
   group: ips_documents_group_3
   app_form: hmpo_1_application_form
+  application_office: true
   renewing_new: 8_weeks
   renewing_old: 10_weeks
   applying: 10_weeks

--- a/lib/smart_answer/calculators/passport_and_embassy_data_query_v2.rb
+++ b/lib/smart_answer/calculators/passport_and_embassy_data_query_v2.rb
@@ -82,7 +82,7 @@ module SmartAnswer::Calculators
     end
 
     def self.passport_data
-      @passport_data ||= YAML.load_file(Rails.root.join("lib", "data", "passport_data.yml"))
+      @passport_data ||= YAML.load_file(Rails.root.join("lib", "data", "passport_data_v2.yml"))
     end
   end
 end

--- a/lib/smart_answer_flows/locales/en/overseas-passports-v2.yml
+++ b/lib/smart_answer_flows/locales/en/overseas-passports-v2.yml
@@ -1283,6 +1283,17 @@ en-GB:
           1 October to 31 March, Monday to Friday, 8am to 3pm (local time)
           $C
 
+        send_application_address_tajikistan: |
+          $A
+          UK Visa Application Centre
+          Hyatt Regency Dushanbe
+          6/1 Ismoili Somoni Prospekt
+          Dushanbe, 743026
+          Tajikistan
+          $A
+          $C
+          Email: <hmpotajikistan@teleperformance.com>
+          $C
         send_application_address_thailand: |
           $A
           UK Visa Application Centre
@@ -1310,6 +1321,17 @@ en-GB:
           $C
           Telephone: (+670) 331 0087
           $C
+        send_application_address_turkmenistan: |
+          $A
+          UK Visa Application Centre
+          Four Points Ak Altyn Hotel, Office 106
+          Magtymguly sayoly 141/1
+          Ashgabat
+          Turkmenistan
+          $A
+          $C
+          Email: <hmpoturkmenistan@teleperformance.com>
+          $C
         send_application_address_ukraine: |
           $A
           UK Visa Application Centre
@@ -1320,6 +1342,17 @@ en-GB:
           $A
           $C
           Email: <hmpoukraine@teleperformance.com>
+          $C
+        send_application_address_uzbekistan: |
+          $A
+          UK Visa Application Centre
+          Tashkent Plaza
+          AMIR TEMUR Street 107B
+          100084 Tashkent
+          Uzbekistan
+          $A
+          $C
+          Email: <hmpouzbekistan@teleperformance.com>
           $C
         send_application_address_venezuela: |
           $A

--- a/lib/smart_answer_flows/locales/en/overseas-passports-v2.yml
+++ b/lib/smart_answer_flows/locales/en/overseas-passports-v2.yml
@@ -84,7 +84,7 @@ en-GB:
 
         how_to_apply_incomplete_application_deadline: |
 
-          ^You'll be contacted if your application is incomplete. You must return all the missing information within 6 weeks or your application will be cancelled - you won't get a refund.^
+          ^You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.^
 
         adult_fco_forms: |
           __Smart application form__

--- a/lib/smart_answer_flows/locales/en/overseas-passports-v2.yml
+++ b/lib/smart_answer_flows/locales/en/overseas-passports-v2.yml
@@ -84,7 +84,7 @@ en-GB:
 
         how_to_apply_incomplete_application_deadline: |
 
-          ^You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.^
+          %You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
         adult_fco_forms: |
           __Smart application form__

--- a/lib/smart_answer_flows/overseas-passports-v2.rb
+++ b/lib/smart_answer_flows/overseas-passports-v2.rb
@@ -103,7 +103,7 @@ multiple_choice :renewing_replacing_applying? do
 
   calculate :incomplete_application_deadline do
     phrases = PhraseList.new
-    incomplete_deadline_countries = %w(australia austria bahrain bangladesh barbados belgium brazil canada china denmark egypt ethiopia finland france germany ghana greece hong-kong india indonesia iraq ireland israel italy jamaica japan kenya laos lebanon malawi malaysia netherlands new-zealand nigeria norway pakistan philippines portugal qatar russia saudi-arabia sierra-leone singapore south-africa spain sri-lanka sudan sweden switzerland thailand trinidad-and-tobago turkey uganda united-arab-emirates usa venezuela vietnam zambia zimbabwe)
+    incomplete_deadline_countries = %w(afghanistan australia austria bahrain bangladesh barbados belgium brazil canada china denmark egypt ethiopia finland france germany ghana greece hong-kong india indonesia iraq ireland israel italy jamaica japan kenya lebanon malawi malaysia netherlands new-zealand nigeria norway pakistan philippines portugal qatar russia saudi-arabia sierra-leone singapore south-africa spain sri-lanka sudan sweden switzerland thailand trinidad-and-tobago turkey uganda united-arab-emirates usa venezuela vietnam zambia zimbabwe)
     if incomplete_deadline_countries.include?(current_location)
       phrases << :how_to_apply_incomplete_application_deadline
     end

--- a/test/integration/smart_answer_flows/overseas_passports_v2_test.rb
+++ b/test/integration/smart_answer_flows/overseas_passports_v2_test.rb
@@ -875,7 +875,7 @@ class OverseasPassportsV2Test < ActiveSupport::TestCase
         assert_phrase_list :how_long_it_takes, [:how_long_8_weeks, :how_long_it_takes_ips2]
         assert_phrase_list :cost, [:passport_courier_costs_tajikistan, :adult_passport_costs_ips2, :passport_costs_ips2]
         assert_phrase_list :how_to_apply, [:how_to_apply_ips2, :hmpo_1_application_form, :ips_documents_group_3]
-        assert_phrase_list :send_your_application, [:send_application_non_uk_visa_renew_new_colour, :send_application_embassy_address]
+        assert_phrase_list :send_your_application, [:send_application_address_tajikistan]
         assert_phrase_list :getting_your_passport, [:getting_your_passport_tajikistan]
       end
     end
@@ -894,7 +894,7 @@ class OverseasPassportsV2Test < ActiveSupport::TestCase
         assert_phrase_list :how_long_it_takes, [:how_long_8_weeks, :how_long_it_takes_ips2]
         assert_phrase_list :cost, [:passport_courier_costs_turkmenistan, :adult_passport_costs_ips2, :passport_costs_ips2]
         assert_phrase_list :how_to_apply, [:how_to_apply_ips2, :hmpo_1_application_form, :ips_documents_group_3]
-        assert_phrase_list :send_your_application, [:send_application_non_uk_visa_renew_new_colour, :send_application_embassy_address]
+        assert_phrase_list :send_your_application, [:send_application_address_turkmenistan]
         assert_phrase_list :getting_your_passport, [:getting_your_passport_turkmenistan]
       end
     end
@@ -911,7 +911,7 @@ class OverseasPassportsV2Test < ActiveSupport::TestCase
         assert_phrase_list :how_long_it_takes, [:how_long_10_weeks, :how_long_it_takes_ips2]
         assert_phrase_list :cost, [:passport_courier_costs_turkmenistan, :adult_passport_costs_ips2, :passport_costs_ips2]
         assert_phrase_list :how_to_apply, [:how_to_apply_ips2, :hmpo_1_application_form, :ips_documents_group_3]
-        assert_phrase_list :send_your_application, [:send_application_non_uk_visa_apply_renew_old_replace_colour, :send_application_embassy_address]
+        assert_phrase_list :send_your_application, [:send_application_address_turkmenistan]
         assert_phrase_list :getting_your_passport, [:getting_your_passport_turkmenistan]
       end
     end
@@ -926,7 +926,7 @@ class OverseasPassportsV2Test < ActiveSupport::TestCase
         assert_current_node :ips_application_result
         assert_phrase_list :cost, [:passport_courier_costs_turkmenistan, :child_passport_costs_ips2, :passport_costs_ips2]
         assert_phrase_list :how_to_apply, [:how_to_apply_ips2, :hmpo_1_application_form, :ips_documents_group_3]
-        assert_phrase_list :send_your_application, [:send_application_non_uk_visa_apply_renew_old_replace_colour, :send_application_embassy_address]
+        assert_phrase_list :send_your_application, [:send_application_address_turkmenistan]
         assert_phrase_list :getting_your_passport, [:getting_your_passport_turkmenistan]
       end
     end
@@ -945,7 +945,7 @@ class OverseasPassportsV2Test < ActiveSupport::TestCase
         assert_phrase_list :how_long_it_takes, [:how_long_8_weeks, :how_long_it_takes_ips3]
         assert_phrase_list :cost, [:passport_courier_costs_uzbekistan, :adult_passport_costs_ips3, :passport_costs_ips3]
         assert_phrase_list :how_to_apply, [:how_to_apply_ips3, :hmpo_1_application_form, :ips_documents_group_3]
-        assert_phrase_list :send_your_application, [:send_application_non_uk_visa_renew_new_colour, :send_application_embassy_address]
+        assert_phrase_list :send_your_application, [:send_application_address_uzbekistan]
         assert_phrase_list :getting_your_passport, [:getting_your_passport_uzbekistan]
       end
     end
@@ -958,7 +958,7 @@ class OverseasPassportsV2Test < ActiveSupport::TestCase
         assert_phrase_list :how_long_it_takes, [:how_long_10_weeks, :how_long_it_takes_ips3]
         assert_phrase_list :cost, [:passport_courier_costs_uzbekistan, :adult_passport_costs_ips3, :passport_costs_ips3]
         assert_phrase_list :how_to_apply, [:how_to_apply_ips3, :hmpo_1_application_form, :ips_documents_group_3]
-        assert_phrase_list :send_your_application, [:send_application_non_uk_visa_apply_renew_old_replace_colour, :send_application_embassy_address]
+        assert_phrase_list :send_your_application, [:send_application_address_uzbekistan]
         assert_phrase_list :getting_your_passport, [:getting_your_passport_uzbekistan]
       end
     end
@@ -969,7 +969,7 @@ class OverseasPassportsV2Test < ActiveSupport::TestCase
         assert_current_node :ips_application_result
         assert_phrase_list :cost, [:passport_courier_costs_uzbekistan, :child_passport_costs_ips3, :passport_costs_ips3]
         assert_phrase_list :how_to_apply, [:how_to_apply_ips3, :hmpo_1_application_form, :ips_documents_group_3]
-        assert_phrase_list :send_your_application, [:send_application_non_uk_visa_apply_renew_old_replace_colour, :send_application_embassy_address]
+        assert_phrase_list :send_your_application, [:send_application_address_uzbekistan]
         assert_phrase_list :getting_your_passport, [:getting_your_passport_uzbekistan]
       end
     end


### PR DESCRIPTION
All V2 changes

- Changes addresses for passport application insitution addresses in Tajikistan, Turkmenistan, and Uzbekistan (V2 only). 
- Undoes the change where Afganistan was removed from the list of changes and Laos was added. This was a mistake.
- Highlights the late application warning with an exclamation mark.

:warning: We'll need to remember to merge `passport_data_v2.yml` alongside other V2 files when this goes to production