### PR TITLE
Correctly display bulleted list in Childcare Costs for Tax Credits SA

### DIFF
--- a/lib/smart_answer_flows/locales/en/childcare-costs-for-tax-credits.yml
+++ b/lib/smart_answer_flows/locales/en/childcare-costs-for-tax-credits.yml
@@ -90,7 +90,7 @@ en-GB:
       #Q11
       pay_same_each_time?:
         title: "Do you pay the same each time?"
-        hint: |
+        body: |
           Sometimes you may pay - or expect to pay - different amounts for childcare (known as ‘variable costs’), for example:
 
           - you regularly use childcare, but pay more during school holidays than you do at term time


### PR DESCRIPTION
- This text with bullets wasn't displaying as with bullets, but in one
  large block, because it was marked as of the `hint` type, not of the
  `body` type. The `body` type seems to consistently support bullet
  points delimited by `-`, instead of the `hint` type.

Before:

![screen shot 2015-03-20 at 12 13 09](https://cloud.githubusercontent.com/assets/355033/6751328/bacabb00-cefa-11e4-8f01-d48ca5bd90a1.png)

After:

![screen shot 2015-03-20 at 12 25 36](https://cloud.githubusercontent.com/assets/355033/6751491/3d5f1fec-cefc-11e4-8328-acc065923d96.png)
