### PR TITLE
Fix the UK visa checker country list caching issue

### DIFF
--- a/app/models/ukba_country.rb
+++ b/app/models/ukba_country.rb
@@ -6,6 +6,6 @@ class UkbaCountry < OpenStruct
   end
 
   def self.v2_all
-    @countries ||= YAML.load_file(Rails.root.join('lib', 'data', 'ukba_additional_countries_v2.yml')).map {|c| self.new(c) }
+    @countries_v2 ||= YAML.load_file(Rails.root.join('lib', 'data', 'ukba_additional_countries_v2.yml')).map {|c| self.new(c) }
   end
 end


### PR DESCRIPTION
\<facepalm>
    It was using the same class instance variable to cache two lists, so depending on which one (V1 or V2) was hit first (per app instance) it would cache and serve the same list for both methods 
\</facepalm>