### PR TITLE
Statutory sick pay updates for 2015/16

### DIFF
--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator_v2.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator_v2.rb
@@ -1,0 +1,186 @@
+# -*- coding: utf-8 -*-
+module SmartAnswer::Calculators
+  class StatutorySickPayCalculatorV2
+    attr_reader :waiting_days, :normal_workdays, :pattern_days
+
+    # LEL changes on 6 April each year
+    # the two constants below are meant as 'safety' if the calculator gets a query for future dates past the latest known
+    # and should be updated to the latest known rate
+    LOWER_EARNING_LIMIT = 111.00
+    SSP_WEEKLY_RATE = 87.55
+
+    def initialize(prev_sick_days, sick_start_date, sick_end_date, days_of_the_week_worked)
+      @prev_sick_days = prev_sick_days
+      @waiting_days = (@prev_sick_days >= 3 ? 0 : 3 - @prev_sick_days)
+      @sick_start_date = sick_start_date
+      @sick_end_date = sick_end_date
+      @pattern_days = days_of_the_week_worked.length
+      @normal_workdays_missed = init_normal_workdays_missed(days_of_the_week_worked)
+      @normal_workdays = @normal_workdays_missed.length
+      @payable_days = init_payable_days
+    end
+
+    def self.earning_limit_rates
+      [
+        {min: Date.parse("6 April 2010"), max: Date.parse("5 April 2011"), lower_earning_limit_rate: 97},
+        {min: Date.parse("6 April 2011"), max: Date.parse("5 April 2012"), lower_earning_limit_rate: 102},
+        {min: Date.parse("6 April 2012"), max: Date.parse("5 April 2013"), lower_earning_limit_rate: 107},
+        {min: Date.parse("6 April 2013"), max: Date.parse("5 April 2014"), lower_earning_limit_rate: 109},
+        {min: Date.parse("6 April 2014"), max: Date.parse("5 April 2015"), lower_earning_limit_rate: 111}
+      ]
+    end
+
+    # define as static so we don't have to instantiate the calculator too early in the flow
+    def self.lower_earning_limit_on(date)
+      earning_limit_rate = earning_limit_rates.find { |c| c[:min] <= date and c[:max] >= date }
+      (earning_limit_rate ? earning_limit_rate[:lower_earning_limit_rate] : LOWER_EARNING_LIMIT)
+    end
+
+    def self.months_between(start_date, end_date)
+      end_month = end_date.month
+      current_month = start_date.next_month
+      count = 0
+      count += 1 if start_date.day < 17
+      count += 1 if end_date.day > 15
+      while current_month.month != end_month
+        count += 1
+        current_month = current_month.next_month
+      end
+      count
+    end
+
+    def self.average_weekly_earnings(args)
+      pay, pay_pattern, monthly_pattern_payments = args.values_at(:pay, :pay_pattern, :monthly_pattern_payments)
+      case pay_pattern
+      when "weekly", "fortnightly", "every_4_weeks"
+        pay / 8.0
+      when "monthly"
+        pay / monthly_pattern_payments * 12.0 / 52
+      when "irregularly"
+        relevant_period_to, relevant_period_from = args.values_at(:relevant_period_to, :relevant_period_from)
+        pay / (Date.parse(relevant_period_to) - Date.parse(relevant_period_from)).to_i * 7
+      end
+    end
+
+    # ssp weekly rate changes on 6 April each year
+    def ssp_rates
+      [
+        {min: Date.parse("6 April 2011"), max: Date.parse("5 April 2012"), ssp_weekly_rate: 81.60},
+        {min: Date.parse("6 April 2012"), max: Date.parse("5 April 2013"), ssp_weekly_rate: 85.85},
+        {min: Date.parse("6 April 2013"), max: Date.parse("5 April 2014"), ssp_weekly_rate: 86.70},
+        {min: Date.parse("6 April 2014"), max: Date.parse("5 April 2015"), ssp_weekly_rate: 87.55}
+      ]
+    end
+
+    def weekly_rate_on(date)
+      rate = ssp_rates.find { |c| c[:min] <= date and c[:max] >= date }
+      rate ? rate[:ssp_weekly_rate] : SSP_WEEKLY_RATE
+    end
+
+    def daily_rate_from_weekly(weekly_rate, pattern_days)
+      # we need to calculate the daily rate by truncating to four decimal places to match unrounded daily rates used by HMRC
+      # doing .round(6) after multiplication to avoid float precision issues
+      # Simply using .round(4) on ssp_weekly_rate/@pattern_days will be off by 0.0001 for 3 and 7 pattern days and lead to 1p difference in some statutory amount calculations
+      pattern_days > 0 ? ((((weekly_rate / pattern_days) * 10000).round(6).floor) / 10000.0) : 0.0000
+    end
+
+    def max_days_that_can_be_paid
+      (28 * @pattern_days).round(10)
+    end
+
+    def days_paid_in_linked_period
+      if @prev_sick_days > 3
+        @prev_sick_days - 3
+      else
+        0
+      end
+    end
+
+    def days_paid
+      [days_to_pay, days_that_can_be_paid_for_this_period].min
+    end
+
+    def days_that_can_be_paid_for_this_period
+      [max_days_that_can_be_paid - days_paid_in_linked_period, 0].max
+    end
+
+    def days_to_pay
+      @payable_days.length
+    end
+
+    def sick_pay_weekly_dates
+      if @sick_end_date.sunday?
+        ssp_week_end = @sick_end_date + 6
+      else
+        ssp_week_end = @sick_end_date.end_of_week - 1
+      end
+      (@sick_start_date..ssp_week_end).select { |day| day.wday == 6 }
+    end
+
+    def formatted_sick_pay_weekly_amounts
+      weekly_payments.map { |week|
+        [week.first.strftime("%e %B %Y"), sprintf("£%.2f", week.second)].join("|")
+      }.join("\n")
+    end
+
+    def ssp_payment
+      BigDecimal.new(weekly_payments.map(&:last).sum.round(10).to_s).round(2, BigDecimal::ROUND_UP).to_f
+    end
+
+    def weekly_payments
+      payments = sick_pay_weekly_dates.map { |date| [date, weekly_payment(date)] }
+      payments.pop while payments.any? and payments.last.last == 0
+      payments
+    end
+
+    def weekly_payment(week_start_date)
+      pay = 0.0
+      ((week_start_date - 6)..week_start_date).each do |date|
+        pay += daily_rate_from_weekly(weekly_rate_on(date), @pattern_days) if @payable_days.include?(date)
+      end
+      BigDecimal.new(pay.round(10).to_s).round(2, BigDecimal::ROUND_UP).to_f
+    end
+
+    def self.contractual_earnings_awe(pay, days_worked)
+      (pay / BigDecimal.new(days_worked.to_s) * 7).round(2)
+    end
+
+    def self.total_earnings_awe(pay, days_worked)
+      if days_worked % 7 == 0
+        (pay / (days_worked / 7)).round(2)
+      else
+        (pay / BigDecimal.new(days_worked.to_s) * 7).round(2)
+      end
+    end
+
+    private
+    def init_normal_workdays_missed(days_of_the_week_worked)
+      dates = @sick_start_date..@sick_end_date
+      # create an array of all dates that would have been normal workdays
+      normal_workdays_missed = []
+      dates.each do |d|
+        if days_of_the_week_worked.include?(d.wday.to_s)
+          normal_workdays_missed << d
+        end
+      end
+      normal_workdays_missed
+    end
+
+    def init_payable_days
+      # copy not to modify the instance variable we need to keep
+      payable_days_temp = @normal_workdays_missed
+      ## 1. remove up to 3 first dates from the array if there are waiting days in this period
+      payable_days_temp.shift(@waiting_days)
+      ## 2. return only the first days_that_can_be_paid_for_this_period
+      payable_days_temp.shift(days_that_can_be_paid_for_this_period)
+    end
+
+    def find_6th_april_after(date)
+      year = date.year
+      if (date.month > 4) or (date.month == 4 and date.day > 6)
+        year += 1
+      end
+      Date.new(year, 4, 6)
+    end
+  end
+end

--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator_v2.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator_v2.rb
@@ -3,12 +3,6 @@ module SmartAnswer::Calculators
   class StatutorySickPayCalculatorV2
     attr_reader :waiting_days, :normal_workdays, :pattern_days
 
-    # LEL changes on 6 April each year
-    # the two constants below are meant as 'safety' if the calculator gets a query for future dates past the latest known
-    # and should be updated to the latest known rate
-    LOWER_EARNING_LIMIT = 111.00
-    SSP_WEEKLY_RATE = 87.55
-
     def initialize(prev_sick_days, sick_start_date, sick_end_date, days_of_the_week_worked)
       @prev_sick_days = prev_sick_days
       @waiting_days = (@prev_sick_days >= 3 ? 0 : 3 - @prev_sick_days)
@@ -26,14 +20,16 @@ module SmartAnswer::Calculators
         {min: Date.parse("6 April 2011"), max: Date.parse("5 April 2012"), lower_earning_limit_rate: 102},
         {min: Date.parse("6 April 2012"), max: Date.parse("5 April 2013"), lower_earning_limit_rate: 107},
         {min: Date.parse("6 April 2013"), max: Date.parse("5 April 2014"), lower_earning_limit_rate: 109},
-        {min: Date.parse("6 April 2014"), max: Date.parse("5 April 2015"), lower_earning_limit_rate: 111}
+        {min: Date.parse("6 April 2014"), max: Date.parse("5 April 2015"), lower_earning_limit_rate: 111},
+        {min: Date.parse("6 April 2015"), max: Date.parse("5 April 2016"), lower_earning_limit_rate: 112}
       ]
     end
 
     # define as static so we don't have to instantiate the calculator too early in the flow
     def self.lower_earning_limit_on(date)
       earning_limit_rate = earning_limit_rates.find { |c| c[:min] <= date and c[:max] >= date }
-      (earning_limit_rate ? earning_limit_rate[:lower_earning_limit_rate] : LOWER_EARNING_LIMIT)
+      earning_limit_rate ||= earning_limit_rates.sort_by(&:max).last
+      earning_limit_rate[:lower_earning_limit_rate]
     end
 
     def self.months_between(start_date, end_date)
@@ -68,13 +64,15 @@ module SmartAnswer::Calculators
         {min: Date.parse("6 April 2011"), max: Date.parse("5 April 2012"), ssp_weekly_rate: 81.60},
         {min: Date.parse("6 April 2012"), max: Date.parse("5 April 2013"), ssp_weekly_rate: 85.85},
         {min: Date.parse("6 April 2013"), max: Date.parse("5 April 2014"), ssp_weekly_rate: 86.70},
-        {min: Date.parse("6 April 2014"), max: Date.parse("5 April 2015"), ssp_weekly_rate: 87.55}
+        {min: Date.parse("6 April 2014"), max: Date.parse("5 April 2015"), ssp_weekly_rate: 87.55},
+        {min: Date.parse("6 April 2015"), max: Date.parse("5 April 2016"), ssp_weekly_rate: 88.45}
       ]
     end
 
     def weekly_rate_on(date)
       rate = ssp_rates.find { |c| c[:min] <= date and c[:max] >= date }
-      rate ? rate[:ssp_weekly_rate] : SSP_WEEKLY_RATE
+      rate ||= ssp_rates.sort_by(&:max).last
+      rate[:ssp_weekly_rate]
     end
 
     def daily_rate_from_weekly(weekly_rate, pattern_days)

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay-v2.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay-v2.rb
@@ -1,0 +1,300 @@
+status :draft
+satisfies_need "100262"
+
+# Question 1
+checkbox_question :is_your_employee_getting? do
+  option :statutory_maternity_pay
+  option :maternity_allowance
+  option :ordinary_statutory_paternity_pay
+  option :statutory_adoption_pay
+  option :additional_statutory_paternity_pay
+
+  calculate :employee_not_entitled_pdf do
+    # this avoids lots of content duplication in the YML
+    PhraseList.new(:ssp_link)
+  end
+  calculate :paternity_maternity_warning do
+    (responses.last.split(",") & %w{ordinary_statutory_paternity_pay additional_statutory_paternity_pay statutory_adoption_pay}).any?
+  end
+  next_node_if(:employee_tell_within_limit?,
+    response_is_one_of(%w{ordinary_statutory_paternity_pay additional_statutory_paternity_pay statutory_adoption_pay none}))
+  next_node(:already_getting_maternity)
+end
+
+# Question 2
+multiple_choice :employee_tell_within_limit? do
+  option :yes
+  option :no
+
+  calculate :enough_notice_of_absence do
+    responses.last == 'yes'
+  end
+
+  next_node(:employee_work_different_days?)
+end
+
+# Question 3
+multiple_choice :employee_work_different_days? do
+  option yes: :not_regular_schedule # Answer 4
+    option no: :first_sick_day? # Question 4
+end
+
+# Question 4
+date_question :first_sick_day? do
+  from { Date.new(2011, 1, 1) }
+  to { Date.today }
+  calculate :sick_start_date do
+    Date.parse(responses.last).strftime("%e %B %Y")
+  end
+
+  next_node :last_sick_day?
+
+end
+
+# Question 5
+date_question :last_sick_day? do
+  from { Date.new(2011, 1, 1) }
+  to { Date.today }
+  calculate :sick_end_date do
+    Date.parse(responses.last).strftime("%e %B %Y")
+  end
+
+  next_node_calculation(:days_sick) do |response|
+    start_date = Date.parse(sick_start_date)
+    last_day_sick = Date.parse(response)
+    (last_day_sick - start_date).to_i + 1
+  end
+  validate { days_sick >= 1 }
+  next_node_if(:paid_at_least_8_weeks?) { days_sick > 3 }
+  next_node(:must_be_sick_for_4_days)
+end
+
+# Question 5.1
+multiple_choice :paid_at_least_8_weeks? do
+  option eight_weeks_more: :how_often_pay_employee_pay_patterns? # Question 5.2
+  option eight_weeks_less: :total_earnings_before_sick_period? # Question 8
+  option before_payday: :how_often_pay_employee_pay_patterns? # Question 5.2
+
+  save_input_as :eight_weeks_earnings
+end
+
+# Question 5.2
+multiple_choice :how_often_pay_employee_pay_patterns? do
+  option :weekly
+  option :fortnightly
+  option :every_4_weeks
+  option :monthly
+  option :irregularly
+
+  save_input_as :pay_pattern
+
+  next_node_if(:last_payday_before_sickness?, variable_matches(:eight_weeks_earnings, 'eight_weeks_more'))  # Question 6
+  next_node(:pay_amount_if_not_sick?) # Question 7
+end
+
+# Question 6
+date_question :last_payday_before_sickness? do
+  from { Date.new(2010, 1, 1) }
+  to { Date.today }
+
+  calculate :relevant_period_to do
+    Date.parse(responses.last).strftime("%e %B %Y")
+  end
+
+  calculate :pay_day_offset do
+    (Date.parse(relevant_period_to) - 8.weeks).strftime("%e %B %Y")
+  end
+
+  validate do |response|
+    payday = Date.parse(response)
+    start = Date.parse(sick_start_date)
+
+    payday < start
+  end
+
+  next_node(:last_payday_before_offset?)
+end
+
+# Question 6.1
+date_question :last_payday_before_offset? do
+  from { Date.new(2010, 1, 1) }
+  to { Date.today }
+
+  # You must enter a date on or before [pay_day_offset]
+  validate { |payday| Date.parse(payday) <= Date.parse(pay_day_offset) }
+
+  # input plus 1 day = relevant_period_from
+  calculate :relevant_period_from do
+    (Date.parse(responses.last) + 1.day).strftime("%e %B %Y")
+  end
+
+  calculate :monthly_pattern_payments do
+    start_date = Date.parse(relevant_period_from)
+    end_date = Date.parse(relevant_period_to)
+    Calculators::StatutorySickPayCalculatorV2.months_between(start_date, end_date)
+  end
+
+  next_node(:total_employee_earnings?)
+end
+
+# Question 6.2
+money_question :total_employee_earnings? do
+  save_input_as :relevant_period_pay
+
+  calculate :employee_average_weekly_earnings do
+    Calculators::StatutorySickPayCalculatorV2.average_weekly_earnings(
+      pay: relevant_period_pay, pay_pattern: pay_pattern, monthly_pattern_payments: monthly_pattern_payments,
+      relevant_period_to: relevant_period_to, relevant_period_from: relevant_period_from)
+  end
+
+  next_node :off_sick_4_days?
+end
+
+# Question 7
+money_question :pay_amount_if_not_sick? do
+  save_input_as :relevant_contractual_pay
+
+  next_node :contractual_days_covered_by_earnings?
+end
+
+# Question 7.1
+value_question :contractual_days_covered_by_earnings? do
+  save_input_as :contractual_earnings_days
+
+  calculate :employee_average_weekly_earnings do
+    pay = relevant_contractual_pay
+    days_worked = responses.last
+    Calculators::StatutorySickPayCalculatorV2.contractual_earnings_awe(pay, days_worked)
+  end
+  next_node :off_sick_4_days?
+end
+
+# Question 8
+money_question :total_earnings_before_sick_period? do
+  save_input_as :earnings
+
+  next_node :days_covered_by_earnings?
+end
+
+# Question 8.1
+value_question :days_covered_by_earnings? do
+
+  calculate :employee_average_weekly_earnings do
+    pay = earnings
+    days_worked = responses.last.to_i
+    Calculators::StatutorySickPayCalculatorV2.total_earnings_awe(pay, days_worked)
+  end
+
+  next_node :off_sick_4_days?
+end
+
+# Question 11
+multiple_choice :off_sick_4_days? do
+  option yes: :linked_sickness_start_date?
+  option :no
+
+  next_node_if(:not_earned_enough) do
+    employee_average_weekly_earnings < Calculators::StatutorySickPayCalculatorV2.lower_earning_limit_on(Date.parse(sick_start_date))
+  end
+  next_node :usual_work_days?
+end
+
+# Question 11.1
+date_question :linked_sickness_start_date? do
+  from { Date.new(2010, 1, 1) }
+  to { Date.today }
+
+  next_node_if(:not_earned_enough) do |response|
+    employee_average_weekly_earnings < Calculators::StatutorySickPayCalculatorV2.lower_earning_limit_on(Date.parse(response))
+  end
+  next_node(:how_many_days_sick?)
+end
+
+# Q12
+value_question :how_many_days_sick? do
+  save_input_as :prior_sick_days
+  next_node :usual_work_days?
+end
+
+# Q13
+checkbox_question :usual_work_days? do
+  %w{1 2 3 4 5 6 0}.each { |n| option n.to_s }
+
+  calculate :ssp_payment do
+    Money.new(calculator.ssp_payment)
+  end
+
+  calculate :formatted_sick_pay_weekly_amounts do
+    calculator = Calculators::StatutorySickPayCalculatorV2.new(prior_sick_days.to_i, Date.parse(sick_start_date), Date.parse(sick_end_date), responses.last.split(","))
+
+    if calculator.ssp_payment > 0
+      calculator.formatted_sick_pay_weekly_amounts
+    else
+      ""
+    end
+  end
+
+  next_node_calculation(:calculator) do |response|
+    Calculators::StatutorySickPayCalculatorV2.new(prior_sick_days.to_i, Date.parse(sick_start_date), Date.parse(sick_end_date), response.split(","))
+  end
+
+  # Answer 8
+  next_node_if(:maximum_entitlement_reached) do |response|
+    days_worked = response.split(',').size
+
+    prior_sick_days and prior_sick_days.to_i >= (days_worked * 28 + 3)
+  end
+
+  # Answer 6
+  next_node_if(:entitled_to_sick_pay) { calculator.ssp_payment > 0 }
+
+  # Answer 8
+  next_node_if(:maximum_entitlement_reached) { calculator.days_that_can_be_paid_for_this_period == 0 }
+
+  # Answer 7
+  next_node(:not_entitled_3_days_not_paid)
+end
+
+# Answer 1
+outcome :already_getting_maternity
+
+# Answer 2
+outcome :must_be_sick_for_4_days
+
+# Answer 4
+outcome :not_regular_schedule
+
+# Answer 5
+outcome :not_earned_enough do
+  precalculate :lower_earning_limit do
+    Calculators::StatutorySickPayCalculatorV2.lower_earning_limit_on(Date.parse(sick_start_date))
+  end
+end
+
+# Answer 6
+outcome :entitled_to_sick_pay do
+  precalculate :days_paid do calculator.days_paid end
+  precalculate :normal_workdays_out do calculator.normal_workdays end
+  precalculate :pattern_days do calculator.pattern_days end
+  precalculate :pattern_days_total do calculator.pattern_days * 28 end
+
+  precalculate :proof_of_illness do
+    PhraseList.new(:enough_notice) unless enough_notice_of_absence
+  end
+
+  precalculate :entitled_to_esa do
+    PhraseList.new(:esa) if enough_notice_of_absence
+  end
+
+  precalculate :paternity_adoption_warning do
+    PhraseList.new(:paternity_warning) if paternity_maternity_warning
+  end
+end
+
+# Answer 7
+outcome :not_entitled_3_days_not_paid do
+  precalculate :normal_workdays_out do calculator.normal_workdays end
+end
+
+# Answer 8
+outcome :maximum_entitlement_reached

--- a/lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay-v2.yml
+++ b/lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay-v2.yml
@@ -1,0 +1,213 @@
+en-GB:
+  flow:
+    calculate-statutory-sick-pay-v2:
+      meta:
+        description: Statutory Sick Pay (SSP) calculator -  calculate SSP for an employee
+      title: Calculate your employee's statutory sick pay
+      phrases:
+        paternity_warning: |
+          ^ Your employee will not be able to collect Ordinary Statutory Paternity Pay or Statutory Adoption Pay while collecting Statutory Sick Pay. ^
+        enough_notice: |
+          You don’t have to pay until your employee tells you that they’re ill. You’ll have to pay any withheld amounts by the end of your employee's entitlement to sick pay if your employee is sick for more than 28 weeks.
+        esa: |
+          They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).
+        ssp_link: |
+
+
+          $D
+            [Download ‘Form SSP1, employee not entitled to SSP’ (PDF, 130KB)](http://www.dwp.gov.uk/advisers/claimforms/ssp1.pdf)
+          $D
+
+      body: |
+        Calculate Statutory Sick Pay (SSP) for your employee.
+
+        ##What you need to know
+
+        You’re only responsible for paying SSP if:
+
+        - you pay Class 1 National Insurance contributions for your employee (or would do if not for their age or their level of earnings)
+        - you don’t provide your own occupational sick pay scheme
+        - your employee was sick for 4 or more days in a row (including non-working days)
+        - your employee has told you they’re sick within your own time limit (or 7 days if you don’t have one)
+
+        ^ You can’t use the calculator for periods of sickness before 6 April 2011.^
+
+        *[SSP]: Statutory Sick Pay
+
+      options:
+        "yes": "Yes"
+        "no": "No"
+        statutory_maternity_pay: Statutory Maternity Pay
+        maternity_allowance: Maternity Allowance
+        ordinary_statutory_paternity_pay: Ordinary Statutory Paternity Pay
+        statutory_adoption_pay: Statutory Adoption Pay
+        additional_statutory_paternity_pay: Additional Statutory Paternity Pay
+
+        weekly: Weekly
+        fortnightly: Every 2 weeks
+        every_4_weeks: Every 4 weeks
+        monthly: Monthly - eg last day or Friday of a month
+        irregularly: Irregularly
+
+      # Q1
+      is_your_employee_getting?:
+        title: Is your employee getting any of the following?
+        hint: If none apply just click ‘Next step’
+
+      # Question 2
+      employee_tell_within_limit?:
+        title: Did your employee tell you they were sick and unable to come into work within 7 days of their first day of absence (or within your time limit)?
+
+      # Question 3
+      employee_work_different_days?:
+        title: Does your employee routinely work different days of the week?
+
+      # Question 4
+      first_sick_day?:
+        title: During their most recent period of sickness, when did your employee first become sick?
+        hint: This includes non-working days and bank holidays.
+
+      # Question 5
+      last_sick_day?:
+        title: Enter the last day of sickness
+        hint: This can include non-working days and bank holidays
+        error_message:  End date should be on or after start date
+
+      # Q5.1
+      paid_at_least_8_weeks?:
+        title: On %{sick_start_date} had you paid your employee at least 8 weeks of earnings?
+        options:
+          eight_weeks_more: "Yes, paid at least 8 weeks earnings"
+          eight_weeks_less: "No, paid less than 8 weeks earnings"
+          before_payday: "No, employee is new and fell sick before their first payday"
+
+      # Q5.2
+      how_often_pay_employee_pay_patterns?:
+        title: How often do you pay the employee?
+
+      # Question 6
+      last_payday_before_sickness?:
+        title: What was the last normal payday before %{sick_start_date}?
+        error_message: You must enter a date before %{sick_start_date}
+
+      # Question 6.1
+      last_payday_before_offset?:
+        title: What was the last normal payday on or before %{pay_day_offset}?
+        error_message: You must enter a date on or before %{pay_day_offset}
+
+      # Question 6.2
+      total_employee_earnings?:
+        title: Enter the total amount (before deductions like Income Tax and National Insurance) of your employee’s earnings on paydays between %{relevant_period_from} and %{relevant_period_to}.
+        body: |
+          Different rules apply for [directors of limited companies incorporated before 1 October 2009](/statutory-sick-pay-how-different-employment-types-affect-what-you-pay)
+        error_message: Please enter a number greater than 0
+
+      # Question 7
+      pay_amount_if_not_sick?:
+        title: Enter how much you would have paid the employee on their first payday if they hadn’t been sick.
+
+      # Question 7.1
+      contractual_days_covered_by_earnings?:
+        title: How many days does the period represented by these earnings cover?
+        hint: If it’s 2 weeks and 3 days enter ‘17’.
+
+      # Question 8
+      total_earnings_before_sick_period?:
+        title: Enter the total earnings paid before %{sick_start_date}.
+
+      # Question 8.1
+      days_covered_by_earnings?:
+        title: How many days does the period represented by these earnings cover?
+        hint: If it’s 2 weeks and 3 days enter ‘17’.
+
+      # Question 11
+      off_sick_4_days?:
+        title: Was your employee off sick within the previous 8 weeks for 4 or more days (including non-working days, weekends and holidays)?
+        body: |
+          These are called ‘linked Periods of Incapacity for Work (PIW)’. Check if an employee’s [PIW links to a previous one.](/government/publications/statutory-sick-pay-tables-for-linking-periods-of-incapacity-for-work)
+
+          *[PIW]: Period of Incapacity for Work
+
+      # Question 11.1
+      linked_sickness_start_date?:
+        title: Enter the start date for this linked period of sickness.
+
+      # Question 12
+      how_many_days_sick?:
+        title: During the previous illness(es), how many normal workdays did your employee take off sick?
+        hint: ‘Normal workdays’ are the days your employee works on a regular basis.
+        error_message: Please enter a number greater than 0
+
+      # Question 13:
+      usual_work_days?:
+        title: Which days of the week do they usually work?
+        options:
+          "1": Monday
+          "2": Tuesday
+          "3": Wednesday
+          "4": Thursday
+          "5": Friday
+          "6": Saturday
+          "0": Sunday
+
+      # Answer 1
+      already_getting_maternity:
+        body: |
+          Your employee isn’t entitled to statutory sick pay because they’re already receiving Statutory Maternity Pay or Maternity Allowance.
+
+      # Answer 2
+      must_be_sick_for_4_days:
+        body: |
+          Your employee must be sick for at least 4 days in a row to get Statutory Sick Pay.
+
+      # Answer 4
+      not_regular_schedule:
+        body: |
+          If your employee has an irregular work schedule, you’ll need to [work out Statutory Sick Pay manually](/statutory-sick-pay-manually-calculate-your-employees-payments).
+
+      # Answer 5
+      not_earned_enough:
+        body: |
+          Your employee isn’t entitled to Statutory Sick Pay because their average weekly earnings must be at least £%{lower_earning_limit}. Their average weekly earnings are £%{employee_average_weekly_earnings}.
+
+          You must send them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) no more than 7 days after they’ve told you they’re sick. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).
+
+
+      # Answer 6
+      entitled_to_sick_pay:
+        body: |
+          ##Statutory Sick Pay (SSP)
+
+          Your employee is entitled to SSP for %{days_paid} days out of %{normal_workdays_out} working days taken off sick between %{sick_start_date} and %{sick_end_date}
+
+          %{proof_of_illness}
+
+          Week ending | SSP amount
+          -|-
+          %{formatted_sick_pay_weekly_amounts}
+           | **Total SSP: %{ssp_payment}**
+
+          ##What you need to know
+
+          %{paternity_adoption_warning}
+
+          SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of %{pattern_days_total} days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. %{entitled_to_esa}
+
+          There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
+
+          You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
+
+          *[SSP]: Statutory Sick Pay
+      # Answer 7
+      not_entitled_3_days_not_paid:
+        body: |
+          Your employee isn’t entitled to Statutory Sick Pay because the first 3 days of illness aren’t paid.
+
+          This employee has taken %{normal_workdays_out} working days off sick between %{sick_start_date} and %{sick_end_date}.
+
+      # Answer 8
+      maximum_entitlement_reached:
+        body: |
+          Your employee isn’t entitled to Statutory Sick Pay because they’ve already received the maximum amount of SSP (28 weeks).
+
+          You must send them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of them going off sick. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/integration/smart_answer_flows/calculate_statutory_sick_pay_v2_test.rb
+++ b/test/integration/smart_answer_flows/calculate_statutory_sick_pay_v2_test.rb
@@ -1,0 +1,658 @@
+# encoding: UTF-8
+require_relative '../../test_helper'
+require_relative 'flow_test_helper'
+
+class CalculateStatutorySickPayV2Test < ActiveSupport::TestCase
+  include FlowTestHelper
+
+  setup do
+    setup_for_testing_flow 'calculate-statutory-sick-pay-v2'
+  end
+
+  context "Already getting maternity allowance" do
+    context "Getting statutory maternity pay" do
+      should "go to result A1" do
+        add_response "statutory_maternity_pay"
+        assert_current_node :already_getting_maternity # A1
+      end
+    end
+
+    context "Getting maternity allowance" do
+      should "go to result A1" do
+        add_response "maternity_allowance"
+        assert_current_node :already_getting_maternity # A1
+      end
+    end
+
+    context "Not getting maternity allowance" do
+      setup do
+        add_response "ordinary_statutory_paternity_pay,statutory_adoption_pay"
+      end
+
+      should "set adoption warning state variable" do
+        assert_state_variable :paternity_maternity_warning, true
+      end
+      should "take you to Q2" do
+        assert_current_node :employee_tell_within_limit? # Q2
+      end
+    end
+    context "Not getting maternity allowance" do
+      setup do
+        add_response "additional_statutory_paternity_pay"
+      end
+
+      should "set adoption warning state variable" do
+        assert_state_variable :paternity_maternity_warning, true
+      end
+      should "take you to Q2" do
+        assert_current_node :employee_tell_within_limit? # Q2
+      end
+
+      context "employee didn't tell employer within time limit" do
+        setup do
+          add_response :no
+        end
+        should "ask if employee works different days of the week" do
+          assert_current_node :employee_work_different_days?
+        end
+
+        context "answer no" do
+          setup do
+            add_response :no
+          end
+          should "ask when the first sick day was" do
+            assert_current_node :first_sick_day?
+          end
+
+          context "answer 2 March 2014" do
+            setup do
+              add_response Date.parse('2 March 2014')
+            end
+            should "ask when the last sick day was" do
+              assert_current_node :last_sick_day?
+            end
+
+            context "answer 2 June 2014" do
+              setup do
+                add_response Date.parse('2 June 2014')
+              end
+              should "ask if employer paid 8 weeks of earnings" do
+                assert_current_node :paid_at_least_8_weeks?
+              end
+
+              context "answer before_payday" do
+                setup do
+                  add_response 'before_payday'
+                end
+                should "ask how often employee is paid" do
+                  assert_current_node :how_often_pay_employee_pay_patterns?
+                end
+
+                context "answer irregularly" do
+                  setup do
+                    add_response 'irregularly'
+                  end
+                  should "ask how much they would have been paid on first payday" do
+                    assert_current_node :pay_amount_if_not_sick?
+                  end
+
+                  context "answer £3000" do
+                    setup do
+                      add_response '3000'
+                    end
+                    should "ask how many days earnings cover" do
+                      assert_current_node :contractual_days_covered_by_earnings?
+                    end
+
+                    context "answer 17 days" do
+                      setup do
+                        add_response '17'
+                      end
+                      should "ask if employee was off sick the previous 8 weeks for 4 days" do
+                        assert_current_node :off_sick_4_days?
+                      end
+
+                      context "answer no" do
+                        setup do
+                          add_response 'no'
+                        end
+                        should "ask which days of the week they usually work" do
+                          assert_current_node :usual_work_days?
+                        end
+
+                        context "answer monday to friday" do
+                          setup do
+                            add_response '1,2,3,4,5'
+                          end
+                          should "go to entitled_to_sick_pay outcome" do
+                            assert_current_node :entitled_to_sick_pay
+                            assert_phrase_list :proof_of_illness, [:enough_notice]
+                            assert_phrase_list :paternity_adoption_warning, [:paternity_warning]
+                          end
+                        end
+                      end
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+      end # answer no to employer told in time
+
+      context "employee told employer within time limit" do
+        setup do
+          add_response :yes
+        end
+        should "take you to Q3" do
+          assert_current_node :employee_work_different_days? # Q3
+        end
+
+        context "employee works different days of the week" do
+          setup do
+            add_response :yes
+          end
+          should "go to result A4" do
+            assert_current_node :not_regular_schedule # A4
+          end
+        end
+
+        context "employee works regular days" do
+          setup do
+            add_response :no
+          end
+          should "take them to Q4" do
+            assert_current_node :first_sick_day? # Q4
+          end
+
+          context "answering first sick day" do
+            setup do
+              add_response '02/04/2013'
+            end
+
+            should "store response and move to Q5" do
+              assert_state_variable :sick_start_date, ' 2 April 2013'
+              assert_current_node :last_sick_day? # Q5
+            end
+
+            context "answering last sick day" do
+              context "last sick day is less than 3 days after first" do
+                setup do
+                  add_response '04/04/2013'
+                end
+                should "take you to result A2" do
+                  assert_current_node :must_be_sick_for_4_days # A2
+                end
+              end
+
+              context "last sick day is 3 days or more after first" do
+                setup do
+                  add_response '10/04/2013'
+                end
+                should "store last sick day" do
+                  assert_state_variable :sick_end_date, '10 April 2013'
+                end
+
+                should "ask had you paid employee at least 8 weeks" do # Q5.1
+                  assert_current_node :paid_at_least_8_weeks?
+                end
+                # new 8 weeks question with three branches
+                context "answer yes, paid at least 8 weeks" do
+                  setup do
+                    add_response 'eight_weeks_more'
+                  end
+                  should "ask how often you pay employees" do # Q 5.2
+                    assert_current_node :how_often_pay_employee_pay_patterns?
+                    assert_state_variable :eight_weeks_earnings, 'eight_weeks_more'
+                  end
+
+                  context "answer weekly" do
+                    setup do
+                      add_response 'weekly'
+                    end
+                    should "ask for last payday before start sick date" do # Q6
+                      assert_current_node :last_payday_before_sickness?
+                      assert_state_variable :pay_pattern, 'weekly'
+                    end
+                    context "enter last payday before start of sickness" do
+                      setup do
+                        add_response '31/03/2013'
+                      end
+                      should "ask for last normal payday before payday offset" do # Q6.1
+                        assert_current_node :last_payday_before_offset?
+
+                      end
+                      context "enter last payday before offset" do
+                        setup do
+                          add_response '31/01/2013'
+                        end
+                        should "ask for total amount paid" do # Q 6.2
+                          assert_current_node :total_employee_earnings?
+                        end
+                        context "enter total amount paid between paydays" do
+                          setup do
+                            add_response '4000'
+                          end
+                          should "ask about PIW" do # Q11
+                            assert_current_node :off_sick_4_days?
+                          end
+
+                          context "answer yes" do
+                            setup do
+                              add_response :yes
+                            end
+                            should "ask for start date of linked period of sickness" do # Q11.1
+                              assert_current_node :linked_sickness_start_date?
+                            end
+                            context "enter previous sickness start date" do
+                              setup do
+                                add_response ' 1/01/2013'
+                              end
+                              should "ask how many days sick the employee had in this previous period" do # Q12
+                                assert_current_node :how_many_days_sick?
+                              end
+                              context "answer 6 days" do
+                                setup do
+                                  add_response '6'
+                                end
+                                should "ask which days of the week do they work" do # Q13
+                                  assert_current_node :usual_work_days?
+                                end
+                                context "answer weekdays" do
+                                  setup do
+                                    add_response '1,2,3,4,5'
+                                  end
+                                  should "take you to result A6" do # A6
+                                    assert_current_node :entitled_to_sick_pay
+                                  end
+                                end
+                              end
+                            end
+                          end
+                          context "answer no" do
+                            setup do
+                              add_response 'no'
+                            end
+                            should "ask which days of the week they work" do # Q13
+                              assert_current_node :usual_work_days?
+                            end
+                            context "answer weekdays" do
+                              setup do
+                                add_response '1,2,3,4,5'
+                              end
+                              should "take you to result 6 without first days (no PIW)" do
+                                assert_current_node :entitled_to_sick_pay
+                                assert_phrase_list :entitled_to_esa, [:esa]
+                                assert_phrase_list :paternity_adoption_warning, [:paternity_warning]
+                              end
+                            end
+                          end
+                        end
+                      end
+                    end
+                  end
+                end
+
+                context "answer no, employee is new and fell sick before payday" do
+                  setup do
+                    add_response 'before_payday'
+                  end
+                  should "ask how often you pay employees" do # Q 5.2
+                    assert_current_node :how_often_pay_employee_pay_patterns?
+                  end
+                  context "answer monthly" do
+                    setup do
+                      add_response 'monthly'
+                    end
+                    should "ask how much you would have paid on their first payday" do # Q7
+                      assert_current_node :pay_amount_if_not_sick?
+                    end
+                    context "answer £2000" do
+                      setup do
+                        add_response '2000'
+                      end
+                      should "ask how many days the period covers" do # Q7.1
+                        assert_current_node :contractual_days_covered_by_earnings?
+                      end
+                      context "answer 30" do
+                        setup do
+                          add_response '30'
+                        end
+                        should "ask abou PIW" do # Q11.1
+                          assert_current_node :off_sick_4_days?
+                        end
+
+                        context "answer yes" do
+                          setup do
+                            add_response 'yes'
+                          end
+                          should "ask for start date of linked sickness" do # Q11
+                            assert_current_node :linked_sickness_start_date?
+                          end
+                          context "enter previous sickness start date" do
+                            setup do
+                              add_response '12/03/2013'
+                            end
+                            should "ask how many previous sick days were taken" do # Q12
+                              assert_current_node :how_many_days_sick?
+                            end
+                            context "answer 4" do
+                              setup do
+                                add_response '4'
+                              end
+                              should "ask which days they work" do # Q13
+                                assert_current_node :usual_work_days?
+                              end
+                              context "answer three days a week" do
+                                setup do
+                                  add_response '1,2,3'
+                                end
+                                should "take you to result A6" do
+                                  assert_current_node :entitled_to_sick_pay
+                                end
+                              end
+                            end
+                          end
+                        end
+                        context "answer no" do
+                          setup do
+                            add_response 'no'
+                          end
+                          should "ask which days of the week they work" do # Q13
+                            assert_current_node :usual_work_days?
+                          end
+                          context "answer weekdays" do
+                            setup do
+                              add_response '1,2,3,4,5'
+                            end
+                            should "take you to result 6 without first days (no PIW)" do
+                              assert_current_node :entitled_to_sick_pay
+                            end
+                          end
+                        end
+                      end
+                    end
+                  end
+                end
+
+                context "answer no, paid less than 8 weeks earnings" do
+                  setup do
+                    add_response :eight_weeks_less
+                  end
+                  should "ask what total earnings before sick start date" do # Q8
+                    assert_current_node :total_earnings_before_sick_period?
+                  end
+                  context "answer £3000" do
+                    setup do
+                      add_response '3000'
+                    end
+                    should "ask how many days does this period cover" do # Q8.1
+                      assert_current_node :days_covered_by_earnings?
+                    end
+                    context "answer 35 days" do
+                      setup do
+                        add_response '35'
+                      end
+                      should "ask the PIW question" do # Q11
+                        assert_current_node :off_sick_4_days?
+                      end
+                      context "answer yes" do
+                        setup do
+                          add_response 'yes'
+                        end
+                        should "ask for start date of previous sickness" do # Q 11.1
+                          assert_current_node :linked_sickness_start_date?
+                        end
+                        context "enter previous sickness start date" do
+                          setup do
+                            add_response '24/03/2013'
+                          end
+                          should "ask how many previous sick days were taken" do # Q12
+                            assert_current_node :how_many_days_sick?
+                          end
+                          context "answer 5 days" do
+                            setup do
+                              add_response '5'
+                            end
+                            should "ask which days they work" do # Q13
+                              assert_current_node :usual_work_days?
+                            end
+                            context "answer weekdays" do
+                              setup do
+                                add_response '1,2,3,4,5'
+                              end
+                              should "take you to result A6" do
+                                assert_current_node :entitled_to_sick_pay
+                              end
+                            end
+                          end
+                        end
+                      end
+                      context "answer no" do
+                        setup do
+                          add_response 'no'
+                        end
+                        should "ask which days of the week they work" do # Q13
+                          assert_current_node :usual_work_days?
+                        end
+                        context "answer weekdays" do
+                          setup do
+                            add_response '1,2,3,4,5'
+                          end
+                          should "take you to result 6 without first days (no PIW)" do
+                            assert_current_node :entitled_to_sick_pay
+                          end
+                        end
+                      end
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+      end # answer yes to employer told in time
+    end
+  end
+  context "average weekly earnings is less than the LEL on sick start date" do
+    setup do
+      add_response 'none' # Q1
+      add_response 'yes' # Q2
+      add_response 'no' # Q3
+      add_response '10/06/2013' # Q4
+      add_response '20/06/2013' # Q5
+      add_response 'before_payday' # Q5.1
+      add_response 'weekly' # Q5.2
+      add_response '100' # Q7
+      add_response '7' # Q7.1
+      add_response 'no' # Q11
+    end
+    should "take you to result A5 as awe < LEL (as of 10/06/2013)" do
+      assert_state_variable :employee_average_weekly_earnings, 100
+      assert_current_node :not_earned_enough
+    end
+  end
+
+  context "no SSP payable as sickness period is < 4 days" do
+    setup do
+      add_response 'none'
+      add_response 'yes'
+      add_response 'no'
+      add_response '10/06/2013'
+      add_response '12/06/2013'
+    end
+    should "take you to result A7 - must be sick for at least 4 days in a row" do
+      assert_current_node :must_be_sick_for_4_days
+    end
+  end
+
+  context "no SSP payable as already had maximum" do
+    setup do
+      add_response 'none'
+      add_response 'yes'
+      add_response 'no'
+      add_response '10/06/2013'
+      add_response '20/06/2013'
+      add_response 'eight_weeks_more'
+      add_response 'monthly'
+      add_response '31/05/2013'
+      add_response '31/03/2013'
+      add_response '4000'
+      add_response 'yes'
+      add_response '01/01/2013'
+      add_response '183'
+      add_response '1,2,3,4,5'
+    end
+    should "take you to result A8 as already claimed > 28 weeks (max amount)" do
+      assert_current_node :maximum_entitlement_reached
+    end
+  end
+
+  context "tabular output for final SSP calculation" do
+    should "have the adjusted rates in place for the week crossing through 6th April" do
+      add_response :ordinary_statutory_paternity_pay
+      add_response :yes
+      add_response :no
+      add_response Date.parse("2013-01-07")
+      add_response Date.parse("2013-05-03")
+      add_response :eight_weeks_more
+      add_response :monthly
+      add_response Date.parse("2012-12-28")
+      add_response Date.parse("2012-10-26")
+      add_response 1600.0
+      add_response :yes
+      add_response Date.parse("2012-11-11")
+      add_response 8
+      add_response "3,6"
+
+      assert_current_node :entitled_to_sick_pay
+      assert_state_variable :formatted_sick_pay_weekly_amounts,
+                            ["12 January 2013|£85.85",
+                             "19 January 2013|£85.85",
+                             "26 January 2013|£85.85",
+                             " 2 February 2013|£85.85",
+                             " 9 February 2013|£85.85",
+                             "16 February 2013|£85.85",
+                             "23 February 2013|£85.85",
+                             " 2 March 2013|£85.85",
+                             " 9 March 2013|£85.85",
+                             "16 March 2013|£85.85",
+                             "23 March 2013|£85.85",
+                             "30 March 2013|£85.85",
+                             " 6 April 2013|£86.28",
+                             "13 April 2013|£86.70",
+                             "20 April 2013|£86.70",
+                             "27 April 2013|£86.70",
+                             " 4 May 2013|£43.35"].join("\n")
+    end
+
+    should "have consistent rates for all weekly rates that are produced" do
+      add_response :ordinary_statutory_paternity_pay
+      add_response :yes
+      add_response :no
+      add_response Date.parse("2013-01-07")
+      add_response Date.parse("2013-05-03")
+      add_response :eight_weeks_more
+      add_response :monthly
+      add_response Date.parse("2012-12-28")
+      add_response Date.parse("2012-10-26")
+      add_response 1250.75
+      add_response :yes
+      add_response Date.parse("2012-11-09")
+      add_response 23
+      add_response "2,3,4"
+
+      assert_current_node :entitled_to_sick_pay
+      assert_state_variable :formatted_sick_pay_weekly_amounts,
+                            ["12 January 2013|£85.85",
+                             "19 January 2013|£85.85",
+                             "26 January 2013|£85.85",
+                             " 2 February 2013|£85.85",
+                             " 9 February 2013|£85.85",
+                             "16 February 2013|£85.85",
+                             "23 February 2013|£85.85",
+                             " 2 March 2013|£85.85",
+                             " 9 March 2013|£85.85",
+                             "16 March 2013|£85.85",
+                             "23 March 2013|£85.85",
+                             "30 March 2013|£85.85",
+                             " 6 April 2013|£85.85",
+                             "13 April 2013|£86.70",
+                             "20 April 2013|£86.70",
+                             "27 April 2013|£86.70",
+                             " 4 May 2013|£86.70"].join("\n")
+    end
+
+    should "show formatted weekly payment amounts with adjusted 3 days start amount" do
+      add_response :ordinary_statutory_paternity_pay
+      add_response :yes
+      add_response :no
+      add_response Date.parse("2013-01-07")
+      add_response Date.parse("2013-05-03")
+      add_response :eight_weeks_more
+      add_response :irregularly
+      add_response Date.parse("2012-12-28")
+      add_response Date.parse("2012-10-26")
+      add_response 3000.0
+      add_response :no
+      add_response "1,2,3,4"
+
+      assert_current_node :entitled_to_sick_pay
+      assert_state_variable :formatted_sick_pay_weekly_amounts,
+                            ["12 January 2013|£21.47",
+                             "19 January 2013|£85.85",
+                             "26 January 2013|£85.85",
+                             " 2 February 2013|£85.85",
+                             " 9 February 2013|£85.85",
+                             "16 February 2013|£85.85",
+                             "23 February 2013|£85.85",
+                             " 2 March 2013|£85.85",
+                             " 9 March 2013|£85.85",
+                             "16 March 2013|£85.85",
+                             "23 March 2013|£85.85",
+                             "30 March 2013|£85.85",
+                             " 6 April 2013|£85.85",
+                             "13 April 2013|£86.70",
+                             "20 April 2013|£86.70",
+                             "27 April 2013|£86.70",
+                             " 4 May 2013|£86.70"].join("\n")
+
+    end
+
+    should "show formatted weekly payment amounts with adjusted 3 days start amount" do
+      add_response :additional_statutory_paternity_pay
+      add_response :yes
+      add_response :no
+      add_response Date.parse("2013-01-07")
+      add_response Date.parse("2013-05-03")
+      add_response :eight_weeks_more
+      add_response :irregularly
+      add_response Date.parse("2012-12-28")
+      add_response Date.parse("2012-10-26")
+      add_response 3000.0
+      add_response :no
+      add_response "1,2,3,4"
+
+      assert_current_node :entitled_to_sick_pay
+      assert_state_variable :formatted_sick_pay_weekly_amounts,
+                            ["12 January 2013|£21.47",
+                             "19 January 2013|£85.85",
+                             "26 January 2013|£85.85",
+                             " 2 February 2013|£85.85",
+                             " 9 February 2013|£85.85",
+                             "16 February 2013|£85.85",
+                             "23 February 2013|£85.85",
+                             " 2 March 2013|£85.85",
+                             " 9 March 2013|£85.85",
+                             "16 March 2013|£85.85",
+                             "23 March 2013|£85.85",
+                             "30 March 2013|£85.85",
+                             " 6 April 2013|£85.85",
+                             "13 April 2013|£86.70",
+                             "20 April 2013|£86.70",
+                             "27 April 2013|£86.70",
+                             " 4 May 2013|£86.70"].join("\n")
+
+    end
+  end
+end

--- a/test/unit/calculators/statutory_sick_pay_calculator_v2_test.rb
+++ b/test/unit/calculators/statutory_sick_pay_calculator_v2_test.rb
@@ -76,7 +76,7 @@ module SmartAnswer::Calculators
     context "daily rate test for 7 days per week worked" do
       setup do
         @start_date = Date.parse("1 October 2012")
- @calculator = StatutorySickPayCalculatorV2.new(5, @start_date, Date.parse("7 October 2012"), ['0', '1', '2', '3', '4', '5', '6'])
+        @calculator = StatutorySickPayCalculatorV2.new(5, @start_date, Date.parse("7 October 2012"), ['0', '1', '2', '3', '4', '5', '6'])
       end
 
       should "return daily rate of 12.2642" do
@@ -87,7 +87,7 @@ module SmartAnswer::Calculators
     context "daily rate test for 6 days per week worked" do
       setup do
         @start_date = Date.parse("1 October 2012")
- @calculator = StatutorySickPayCalculatorV2.new(5, @start_date, Date.parse("7 October 2012"), ['1', '2', '3', '4', '5', '6'])
+        @calculator = StatutorySickPayCalculatorV2.new(5, @start_date, Date.parse("7 October 2012"), ['1', '2', '3', '4', '5', '6'])
       end
 
       should "return daily rate of 14.3083" do
@@ -98,7 +98,7 @@ module SmartAnswer::Calculators
     context "daily rate test for 2 days per week worked" do
       setup do
         @start_date = Date.parse("1 October 2012")
- @calculator = StatutorySickPayCalculatorV2.new(5, @start_date, Date.parse("7 October 2012"), ['4', '5'])
+        @calculator = StatutorySickPayCalculatorV2.new(5, @start_date, Date.parse("7 October 2012"), ['4', '5'])
       end
 
       should "return daily rate of 42.9250" do
@@ -169,7 +169,7 @@ module SmartAnswer::Calculators
     context "historic rate test 1" do
       setup do
         @start_date = Date.parse("5 April 2012")
- @calculator = StatutorySickPayCalculatorV2.new(3, @start_date, Date.parse("10 April 2012"), ['1', '2', '3', '4', '5'])
+        @calculator = StatutorySickPayCalculatorV2.new(3, @start_date, Date.parse("10 April 2012"), ['1', '2', '3', '4', '5'])
       end
 
       should "use ssp rate and lel for 2011-12" do
@@ -182,7 +182,7 @@ module SmartAnswer::Calculators
     context "test scenario 1 - M-F, no waiting days, cross tax years" do
       setup do
         @start_date = Date.parse("26 March 2012")
- @calculator = StatutorySickPayCalculatorV2.new(0, @start_date, Date.parse("13 April 2012"), ['1', '2', '3', '4', '5'])
+        @calculator = StatutorySickPayCalculatorV2.new(0, @start_date, Date.parse("13 April 2012"), ['1', '2', '3', '4', '5'])
       end
 
       should "give correct ssp calculation" do  # 15 days with 3 waiting days, so 6 days at lower weekly rate, 6 days at higher rate
@@ -193,15 +193,26 @@ module SmartAnswer::Calculators
       end
     end
 
-    context "test date in future" do
+    context "test date 4 May 2014" do
       setup do
         @start_date = Date.parse("4 May 2014")
- @calculator = StatutorySickPayCalculatorV2.new(3, @start_date, Date.parse("3 August 2014"), ['1', '2', '3', '4', '5'])
+        @calculator = StatutorySickPayCalculatorV2.new(3, @start_date, Date.parse("3 August 2014"), ['1', '2', '3', '4', '5'])
       end
 
       should "use ssp rate and lel for 2014-15" do
         assert_equal StatutorySickPayCalculatorV2.lower_earning_limit_on(@start_date), 111
         assert_equal @calculator.daily_rate_from_weekly(@calculator.weekly_rate_on(@start_date), 5), 17.51
+      end
+    end
+
+    context "weekly rate fallback. When date is not covered by any known ranges" do
+      setup do
+        @start_date = Date.parse("4 May 2054")
+        @calculator = StatutorySickPayCalculatorV2.new(3, @start_date, @start_date + 1.month, ['1', '2', '3', '4', '5'])
+      end
+
+      should "use ssp rate for the latest know fiscal year (2015-16)" do
+        assert_equal 88.45, @calculator.weekly_rate_on(@start_date)
       end
     end
 
@@ -352,54 +363,78 @@ module SmartAnswer::Calculators
       end
     end
 
-    context "LEL test 1" do
-      setup do
-        @date = Date.parse("1 April 2012")
-        @lel = StatutorySickPayCalculatorV2.lower_earning_limit_on(@date)
+    context "lower earnings limit (LEL)" do
+      context "in 2011/2012" do
+        setup do
+          @date = Date.parse("1 April 2012")
+          @lel = StatutorySickPayCalculatorV2.lower_earning_limit_on(@date)
+        end
+
+        should "be 102" do
+          assert_equal 102.00, @lel
+        end
       end
 
-      should "give correct LEL for date" do
-        assert_equal @lel, 102.00
-      end
-    end
+      context "in the beginning of 2012/2013" do
+        setup do
+          @date = Date.parse("6 April 2012")
+          @lel = StatutorySickPayCalculatorV2.lower_earning_limit_on(@date)
+        end
 
-    context "LEL test 2" do
-      setup do
-        @date = Date.parse("6 April 2012")
-        @lel = StatutorySickPayCalculatorV2.lower_earning_limit_on(@date)
-      end
-
-      should "give correct LEL for date" do
-        assert_equal @lel, 107.00
-      end
-    end
-
-    context "LEL test 3" do
-      setup do
-        @date = Date.parse("6 April 2013")
-        @lel = StatutorySickPayCalculatorV2.lower_earning_limit_on(@date)
+        should "be 107" do
+          assert_equal 107.00, @lel
+        end
       end
 
-      should "give correct LEL for date" do
-        assert_equal @lel, 109.00
-      end
-    end
+      context "in the beginning of 2013/2014" do
+        setup do
+          @date = Date.parse("6 April 2013")
+          @lel = StatutorySickPayCalculatorV2.lower_earning_limit_on(@date)
+        end
 
-    context "LEL test 4" do
-      setup do
-        @date = Date.parse("6 April 2014")
-        @lel = StatutorySickPayCalculatorV2.lower_earning_limit_on(@date)
+        should "be 109" do
+          assert_equal 109.00, @lel
+        end
       end
 
-      should "give correct LEL for date" do
-        assert_equal @lel, 111.00
+      context "in the beginning of 2014/2015" do
+        setup do
+          @date = Date.parse("6 April 2014")
+          @lel = StatutorySickPayCalculatorV2.lower_earning_limit_on(@date)
+        end
+
+        should "be 111" do
+          assert_equal 111.00, @lel
+        end
+      end
+
+      context "in the beginning of 2015/2016" do
+        setup do
+          @date = Date.parse("6 April 2015")
+          @lel = StatutorySickPayCalculatorV2.lower_earning_limit_on(@date)
+        end
+
+        should "be 112" do
+          assert_equal 112.00, @lel
+        end
+      end
+
+      context "fallback when no dates are matching" do
+        setup do
+          @date = Date.parse("6 April 2056")
+          @lel = StatutorySickPayCalculatorV2.lower_earning_limit_on(@date)
+        end
+
+        should "be the rate of the latest available fiscal year" do
+          assert_equal 112.00, @lel
+        end
       end
     end
 
     context "sick_pay_weekly_dates" do
       should "produce a list of Saturdays for the provided sick period" do
         calculator = StatutorySickPayCalculatorV2.new(
-    42, Date.parse("7 January 2013"), Date.parse("3 May 2013"), ['2', '3', '4'])
+                      42, Date.parse("7 January 2013"), Date.parse("3 May 2013"), ['2', '3', '4'])
 
         assert_equal [Date.parse("12 Jan 2013"),
                       Date.parse("19 Jan 2013"),
@@ -425,7 +460,7 @@ module SmartAnswer::Calculators
     context "sick_pay_weekly_amounts" do
       should "return the payable weeks by taking into account the final SSP payment" do
         calculator = StatutorySickPayCalculatorV2.new(
-    42, Date.parse("7 January 2013"), Date.parse("3 May 2013"), ['2', '3', '4'])
+                      42, Date.parse("7 January 2013"), Date.parse("3 May 2013"), ['2', '3', '4'])
 
         assert_equal [[Date.parse("12 Jan 2013"), 85.85],
                       [Date.parse("19 Jan 2013"), 85.85],
@@ -447,7 +482,7 @@ module SmartAnswer::Calculators
 
       should "have the same reduced value as the ssp_payment value" do
         calculator = StatutorySickPayCalculatorV2.new(
-    42, Date.parse("7 January 2013"), Date.parse("3 May 2013"), ['2', '3', '4'])
+                      42, Date.parse("7 January 2013"), Date.parse("3 May 2013"), ['2', '3', '4'])
 
         assert_equal calculator.ssp_payment,
                      calculator.weekly_payments.map(&:second).sum
@@ -457,7 +492,7 @@ module SmartAnswer::Calculators
     context "formatted_sick_pay_weekly_amounts" do
       should "produce a markdown (value) formatted string of weekly SSP dates and pay rates" do
         calculator = StatutorySickPayCalculatorV2.new(
-    42, Date.parse("7 January 2013"), Date.parse("3 May 2013"), ['2', '3', '4'])
+                      42, Date.parse("7 January 2013"), Date.parse("3 May 2013"), ['2', '3', '4'])
 
         assert_equal ["12 January 2013|£85.85",
                       "19 January 2013|£85.85",

--- a/test/unit/calculators/statutory_sick_pay_calculator_v2_test.rb
+++ b/test/unit/calculators/statutory_sick_pay_calculator_v2_test.rb
@@ -1,0 +1,524 @@
+# -*- coding: utf-8 -*-
+require_relative "../../test_helper"
+
+module SmartAnswer::Calculators
+  class StatutorySickPayCalculatorV2Test < ActiveSupport::TestCase
+
+    context ".months_between" do
+      should "calculate number of months between dates" do
+        months = StatutorySickPayCalculatorV2.months_between(Date.parse("04/02/2012"), Date.parse("17/05/2012"))
+        assert_equal 4, months
+      end
+
+      should "not count the first month if it's later than the 17th" do
+        months = StatutorySickPayCalculatorV2.months_between(Date.parse("18/02/2012"), Date.parse("17/05/2012"))
+        assert_equal 3, months
+      end
+
+      should "not count the last month if it's before the 15th" do
+        months = StatutorySickPayCalculatorV2.months_between(Date.parse("13/02/2012"), Date.parse("14/05/2012"))
+        assert_equal 3, months
+      end
+    end # end .months_between
+
+    context ".average_weekly_earnings" do
+      should "calculate AWE for weekly pay patterns" do
+        assert_equal 100, StatutorySickPayCalculatorV2.average_weekly_earnings(pay: 800, pay_pattern: 'weekly')
+        assert_equal 100, StatutorySickPayCalculatorV2.average_weekly_earnings(pay: 800, pay_pattern: 'fortnightly')
+        assert_equal 100, StatutorySickPayCalculatorV2.average_weekly_earnings(pay: 800, pay_pattern: 'every_4_weeks')
+      end
+      should "calculate AWE for monthly pay patterns" do
+        assert_equal 92.31, StatutorySickPayCalculatorV2.average_weekly_earnings(
+          pay: 1200, pay_pattern: 'monthly', monthly_pattern_payments: 3).round(2)
+      end
+      should "calculate AWE for irregular pay patterns" do
+        assert_equal 700, StatutorySickPayCalculatorV2.average_weekly_earnings(
+          pay: 1000, pay_pattern: 'irregularly', relevant_period_to: "31 December 2013", relevant_period_from: "21 December 2013")
+      end
+    end # end .average_weekly_earnings
+
+    context "prev_sick_days is 5, M-F, 7 days out" do
+      setup do
+        @start_date = Date.parse("1 October 2012")
+        @calculator = StatutorySickPayCalculatorV2.new(5, @start_date, Date.parse("7 October 2012"), ['1', '2', '3', '4', '5'])
+      end
+
+      should "return waiting_days of 0" do
+        assert_equal @calculator.waiting_days, 0
+      end
+
+      should "return daily rate of 17.1700" do
+        @weekly_rate = @calculator.weekly_rate_on(@start_date)
+        assert_equal @weekly_rate, 85.8500
+        assert_equal @calculator.daily_rate_from_weekly(@weekly_rate, 5), 17.1700
+      end
+
+      should "normal working days missed is 5" do
+        assert_equal @calculator.normal_workdays, 5
+      end
+
+      should "return correct ssp_payment" do
+        assert_equal 85.85, @calculator.ssp_payment
+      end
+    end
+
+    context "daily rate test for 3 days per week worked (M-W-F)" do
+      setup do
+        @start_date = Date.parse("1 October 2012")
+        @calculator = StatutorySickPayCalculatorV2.new(5, @start_date, Date.parse("7 October 2012"), ['1', '3', '5'])
+      end
+
+      should "return daily rate of 28.6166" do
+        assert_equal @calculator.daily_rate_from_weekly(@calculator.weekly_rate_on(@start_date), 3), 28.6166 # should be 28.6166 according to HMRC table
+      end
+    end
+
+    context "daily rate test for 7 days per week worked" do
+      setup do
+        @start_date = Date.parse("1 October 2012")
+ @calculator = StatutorySickPayCalculatorV2.new(5, @start_date, Date.parse("7 October 2012"), ['0', '1', '2', '3', '4', '5', '6'])
+      end
+
+      should "return daily rate of 12.2642" do
+        assert_equal @calculator.daily_rate_from_weekly(@calculator.weekly_rate_on(@start_date), 7), 12.2642 # unrounded, matches the HMRC SSP daily rate table
+      end
+    end
+
+    context "daily rate test for 6 days per week worked" do
+      setup do
+        @start_date = Date.parse("1 October 2012")
+ @calculator = StatutorySickPayCalculatorV2.new(5, @start_date, Date.parse("7 October 2012"), ['1', '2', '3', '4', '5', '6'])
+      end
+
+      should "return daily rate of 14.3083" do
+        assert_equal @calculator.daily_rate_from_weekly(@calculator.weekly_rate_on(@start_date), 6), 14.3083
+      end
+    end
+
+    context "daily rate test for 2 days per week worked" do
+      setup do
+        @start_date = Date.parse("1 October 2012")
+ @calculator = StatutorySickPayCalculatorV2.new(5, @start_date, Date.parse("7 October 2012"), ['4', '5'])
+      end
+
+      should "return daily rate of 42.9250" do
+        assert_equal @calculator.daily_rate_from_weekly(@calculator.weekly_rate_on(@start_date), 2), 42.9250
+      end
+    end
+
+    context "waiting days if prev_sick_days is 2" do
+      setup do
+        @calculator = StatutorySickPayCalculatorV2.new(2, Date.parse("6 April 2012"), Date.parse("6 May 2012"), ['1', '2', '3'])
+      end
+
+      should "return waiting_days of 1" do
+        assert_equal @calculator.waiting_days, 1
+      end
+    end
+
+    context "waiting days if prev_sick_days is 1" do
+      setup do
+        @calculator = StatutorySickPayCalculatorV2.new(1, Date.parse("6 April 2012"), Date.parse("17 April 2012"), ['1', '2', '3'])
+      end
+
+      should "return waiting_days of 2" do
+        assert_equal @calculator.waiting_days, 2
+        assert_equal @calculator.normal_workdays, 5
+        assert_equal @calculator.days_to_pay, 3
+
+      end
+    end
+
+    context "waiting days if prev_sick_days is 0" do
+      setup do
+        @calculator = StatutorySickPayCalculatorV2.new(0, Date.parse("6 April 2012"), Date.parse("12 April 2012"), ['1', '2', '3'])
+      end
+
+      should "return waiting_days of 3, ssp payment of 0" do
+        assert_equal @calculator.waiting_days, 3
+        assert_equal @calculator.days_to_pay, 0
+        assert_equal @calculator.normal_workdays, 3
+        assert_equal @calculator.ssp_payment, 0.00
+      end
+    end
+
+    context "maximum days payable for 5 days a week" do
+      setup do
+        @calculator = StatutorySickPayCalculatorV2.new(0, Date.parse("6 April 2012"), Date.parse("6 December 2012"), ['1', '2', '3', '4', '5'])
+      end
+
+      should "have a max of 140 days payable" do
+        assert_equal @calculator.days_to_pay, 140
+        assert_equal @calculator.normal_workdays, 175
+        assert_equal @calculator.ssp_payment, 2403.80 #140 * 17.1700 or 28 * 85.85
+      end
+    end
+
+    context "maximum days payable for 3 days a week" do
+      setup do
+        @calculator = StatutorySickPayCalculatorV2.new(0, Date.parse("6 April 2012"), Date.parse("6 December 2012"), ['2', '3', '4'])
+      end
+
+      should "have a max of 84 days payable" do
+        assert_equal @calculator.days_to_pay, 84
+        assert_equal @calculator.normal_workdays, 105
+        assert_equal @calculator.ssp_payment, 2403.80 #28 weeks at 85.85 a week
+      end
+    end
+
+    context "historic rate test 1" do
+      setup do
+        @start_date = Date.parse("5 April 2012")
+ @calculator = StatutorySickPayCalculatorV2.new(3, @start_date, Date.parse("10 April 2012"), ['1', '2', '3', '4', '5'])
+      end
+
+      should "use ssp rate and lel for 2011-12" do
+        assert_equal StatutorySickPayCalculatorV2.lower_earning_limit_on(@start_date), 102
+        assert_equal @calculator.daily_rate_from_weekly(@calculator.weekly_rate_on(@start_date), 5), 16.3200
+      end
+    end
+
+    # Monday - Friday
+    context "test scenario 1 - M-F, no waiting days, cross tax years" do
+      setup do
+        @start_date = Date.parse("26 March 2012")
+ @calculator = StatutorySickPayCalculatorV2.new(0, @start_date, Date.parse("13 April 2012"), ['1', '2', '3', '4', '5'])
+      end
+
+      should "give correct ssp calculation" do  # 15 days with 3 waiting days, so 6 days at lower weekly rate, 6 days at higher rate
+        assert_equal @calculator.waiting_days, 3
+        assert_equal @calculator.days_to_pay, 12
+        assert_equal @calculator.normal_workdays, 15
+        assert_equal @calculator.ssp_payment, 200.94
+      end
+    end
+
+    context "test date in future" do
+      setup do
+        @start_date = Date.parse("4 May 2014")
+ @calculator = StatutorySickPayCalculatorV2.new(3, @start_date, Date.parse("3 August 2014"), ['1', '2', '3', '4', '5'])
+      end
+
+      should "use ssp rate and lel for 2014-15" do
+        assert_equal StatutorySickPayCalculatorV2.lower_earning_limit_on(@start_date), 111
+        assert_equal @calculator.daily_rate_from_weekly(@calculator.weekly_rate_on(@start_date), 5), 17.51
+      end
+    end
+
+    # Tuesday to Friday
+    context "test scenario 2 - T-F, 7 waiting days, cross tax years" do
+      setup do
+        @calculator = StatutorySickPayCalculatorV2.new(7, Date.parse("28 February 2012"), Date.parse("7 April 2012"), ['2', '3', '4', '5'])
+      end
+
+      should "give correct ssp calculation" do # 24 days with no waiting days, so 22 days at lower weekly rate, 2 days at higher rate
+        assert_equal @calculator.normal_workdays, 24
+        assert_equal @calculator.days_to_pay, 24
+        assert_equal @calculator.ssp_payment, 490.67
+      end
+    end
+
+    # Monday, Wednesday, Friday
+    context "test scenario 3" do
+      setup do
+        @calculator = StatutorySickPayCalculatorV2.new(24, Date.parse("25 July 2012"), Date.parse("4 September 2012"), ['1', '3', '5'])
+      end
+
+      should "give correct ssp calculation" do
+        assert_equal @calculator.days_to_pay, 18
+        assert_equal @calculator.ssp_payment, 515.11
+      end
+    end
+
+    #  Saturday and Sunday
+    context "test scenario 4" do
+      setup do
+        @calculator = StatutorySickPayCalculatorV2.new(0, Date.parse("23 November 2012"), Date.parse("31 December 2012"), ['0', '6'])
+      end
+
+      should "give correct ssp calculation" do # 12 days with 3 waiting days, all at 2012-13 daily rate
+        assert_equal @calculator.waiting_days, 3
+        assert_equal @calculator.days_to_pay, 9
+        assert_equal @calculator.normal_workdays, 12
+        assert_equal @calculator.ssp_payment, 386.33
+      end
+    end
+
+    # Monday - Thursday
+    context "test scenario 5" do
+      setup do
+        @calculator = StatutorySickPayCalculatorV2.new(99, Date.parse("29 March 2012"), Date.parse("6 May 2012"), ['1', '2', '3', '4'])
+      end
+
+      should "give correct ssp calculation" do # max of 16 days that can still be paid with no waiting days, first four days at 2011-12,  2012-13 daily rate
+        assert_equal @calculator.days_to_pay, 16
+        assert_equal @calculator.ssp_payment, 338.09
+      end
+    end
+
+    # Monday - Thursday
+    context "test scenario 6" do
+      setup do
+        @calculator = StatutorySickPayCalculatorV2.new(115, Date.parse("29 March 2012"), Date.parse("6 May 2012"), ['1', '2', '3', '4'])
+      end
+
+      should "give correct ssp calculation" do # there should be no more days for which employee can receive pay
+        assert_equal @calculator.ssp_payment, 0
+      end
+    end
+
+    # Wednesday
+    context "test scenario 7" do
+      setup do
+        @calculator = StatutorySickPayCalculatorV2.new(0, Date.parse("28 August 2012"), Date.parse("6 October 2012"), ['3'])
+      end
+
+      should "give correct ssp calculation" do # there should be 3 normal workdays to pay
+        assert_equal @calculator.days_to_pay, 3
+        assert_equal @calculator.waiting_days, 3
+        assert_equal @calculator.ssp_payment, 257.55
+      end
+    end
+
+    #  additional test scenario - rates for previous tax year
+    context "test scenario 6a - 1 day max to pay" do
+      setup do
+        @calculator = StatutorySickPayCalculatorV2.new(114, Date.parse("29 March 2012"), Date.parse("10 April 2012"), ['1', '2', '3', '4'])
+      end
+
+      should "give correct ssp calculation" do # there should be max 1 day for which employee can receive pay
+        assert_equal @calculator.days_to_pay, 1
+        assert_equal @calculator.ssp_payment, 20.40
+      end
+    end
+
+    # new test scenario 2 - SSP spanning 2013/14 tax year, Tue - Thu, rate above LEL, no previous sickness
+    context "2013/14 test scenario 1" do
+      setup do
+        @calculator = StatutorySickPayCalculatorV2.new(0, Date.parse("26 March 2013"), Date.parse("12 April 2013"), ['2', '3', '4'])
+      end
+
+      should "give correct SSP calculation" do
+        assert_equal @calculator.days_to_pay, 6 # first 3 days are waiting days, so no pay
+        assert_equal @calculator.ssp_payment, 172.55 # one week at 85.85 plus one week at 86.70
+      end
+    end
+
+    # new test scenario 2 - SSP spanning 2013/14 tax year, Mon - Thu, no previous sickness
+    context "2013/14 test scenario 2" do
+      setup do
+        @calculator = StatutorySickPayCalculatorV2.new(0, Date.parse("7 January 2013"), Date.parse("3 May 2013"), ['1', '2', '3', '4'])
+      end
+
+      should "give correct SSP calculation" do
+        assert_equal @calculator.days_to_pay, 65 # 1 day + 16 weeks (4 days/week)
+        assert_equal @calculator.ssp_payment, 1398.47 # see spreadsheet
+      end
+    end
+
+    # new test scenario 3 - SSP spanning 2013/14 tax year, Wed and Sat, previous sickness of 8 days
+    context "2013/14 test scenario 3" do
+      setup do
+        @calculator = StatutorySickPayCalculatorV2.new(8, Date.parse("7 January 2013"), Date.parse("3 May 2013"), ['3', '6'])
+      end
+
+      should "give correct SSP calculation" do
+        assert_equal @calculator.days_to_pay, 33 # 1 day + 16 weeks (2 days/week)
+        assert_equal @calculator.ssp_payment, 1419.93 # see spreadsheet
+      end
+    end
+
+    # new test scenario 4 - SSP spanning 2013/14 tax year, Tue, Wed, Thu previous sickness of 42 days
+    context "2013/14 test scenario 4" do
+      setup do
+        @calculator = StatutorySickPayCalculatorV2.new(42, Date.parse("7 January 2013"), Date.parse("3 May 2013"), ['2', '3', '4'])
+      end
+
+      should "give correct SSP calculation" do
+        assert_equal @calculator.days_to_pay, 45 # 15 weeks (3 days/week)
+        assert_equal @calculator.ssp_payment, 1289.45 # see spreadsheet
+      end
+    end
+
+    # new test 5 - SSP spanning 2014/2015 tax year, Mon to Fri
+    context "2014/2015 scenario 5" do
+      setup do
+        @calculator = StatutorySickPayCalculatorV2.new(10, Date.parse("10 July 2014"), Date.parse("20 July 2014"), ['1', '2', '3', '4', '5'])
+      end
+
+      should "give correct SSP calculation" do
+        assert_equal @calculator.days_to_pay, 7
+        assert_equal @calculator.ssp_payment, 122.57
+      end
+    end
+
+    context "LEL test 1" do
+      setup do
+        @date = Date.parse("1 April 2012")
+        @lel = StatutorySickPayCalculatorV2.lower_earning_limit_on(@date)
+      end
+
+      should "give correct LEL for date" do
+        assert_equal @lel, 102.00
+      end
+    end
+
+    context "LEL test 2" do
+      setup do
+        @date = Date.parse("6 April 2012")
+        @lel = StatutorySickPayCalculatorV2.lower_earning_limit_on(@date)
+      end
+
+      should "give correct LEL for date" do
+        assert_equal @lel, 107.00
+      end
+    end
+
+    context "LEL test 3" do
+      setup do
+        @date = Date.parse("6 April 2013")
+        @lel = StatutorySickPayCalculatorV2.lower_earning_limit_on(@date)
+      end
+
+      should "give correct LEL for date" do
+        assert_equal @lel, 109.00
+      end
+    end
+
+    context "LEL test 4" do
+      setup do
+        @date = Date.parse("6 April 2014")
+        @lel = StatutorySickPayCalculatorV2.lower_earning_limit_on(@date)
+      end
+
+      should "give correct LEL for date" do
+        assert_equal @lel, 111.00
+      end
+    end
+
+    context "sick_pay_weekly_dates" do
+      should "produce a list of Saturdays for the provided sick period" do
+        calculator = StatutorySickPayCalculatorV2.new(
+    42, Date.parse("7 January 2013"), Date.parse("3 May 2013"), ['2', '3', '4'])
+
+        assert_equal [Date.parse("12 Jan 2013"),
+                      Date.parse("19 Jan 2013"),
+                      Date.parse("26 Jan 2013"),
+                      Date.parse("02 Feb 2013"),
+                      Date.parse("09 Feb 2013"),
+                      Date.parse("16 Feb 2013"),
+                      Date.parse("23 Feb 2013"),
+                      Date.parse("02 Mar 2013"),
+                      Date.parse("09 Mar 2013"),
+                      Date.parse("16 Mar 2013"),
+                      Date.parse("23 Mar 2013"),
+                      Date.parse("30 Mar 2013"),
+                      Date.parse("06 Apr 2013"),
+                      Date.parse("13 Apr 2013"),
+                      Date.parse("20 Apr 2013"),
+                      Date.parse("27 Apr 2013"),
+                      Date.parse("04 May 2013")],
+                     calculator.sick_pay_weekly_dates
+      end
+    end
+
+    context "sick_pay_weekly_amounts" do
+      should "return the payable weeks by taking into account the final SSP payment" do
+        calculator = StatutorySickPayCalculatorV2.new(
+    42, Date.parse("7 January 2013"), Date.parse("3 May 2013"), ['2', '3', '4'])
+
+        assert_equal [[Date.parse("12 Jan 2013"), 85.85],
+                      [Date.parse("19 Jan 2013"), 85.85],
+                      [Date.parse("26 Jan 2013"), 85.85],
+                      [Date.parse("02 Feb 2013"), 85.85],
+                      [Date.parse("09 Feb 2013"), 85.85],
+                      [Date.parse("16 Feb 2013"), 85.85],
+                      [Date.parse("23 Feb 2013"), 85.85],
+                      [Date.parse("02 Mar 2013"), 85.85],
+                      [Date.parse("09 Mar 2013"), 85.85],
+                      [Date.parse("16 Mar 2013"), 85.85],
+                      [Date.parse("23 Mar 2013"), 85.85],
+                      [Date.parse("30 Mar 2013"), 85.85],
+                      [Date.parse("06 Apr 2013"), 85.85],
+                      [Date.parse("13 Apr 2013"), 86.7],
+                      [Date.parse("20 Apr 2013"), 86.7]],
+                    calculator.weekly_payments
+      end
+
+      should "have the same reduced value as the ssp_payment value" do
+        calculator = StatutorySickPayCalculatorV2.new(
+    42, Date.parse("7 January 2013"), Date.parse("3 May 2013"), ['2', '3', '4'])
+
+        assert_equal calculator.ssp_payment,
+                     calculator.weekly_payments.map(&:second).sum
+      end
+    end
+
+    context "formatted_sick_pay_weekly_amounts" do
+      should "produce a markdown (value) formatted string of weekly SSP dates and pay rates" do
+        calculator = StatutorySickPayCalculatorV2.new(
+    42, Date.parse("7 January 2013"), Date.parse("3 May 2013"), ['2', '3', '4'])
+
+        assert_equal ["12 January 2013|£85.85",
+                      "19 January 2013|£85.85",
+                      "26 January 2013|£85.85",
+                      " 2 February 2013|£85.85",
+                      " 9 February 2013|£85.85",
+                      "16 February 2013|£85.85",
+                      "23 February 2013|£85.85",
+                      " 2 March 2013|£85.85",
+                      " 9 March 2013|£85.85",
+                      "16 March 2013|£85.85",
+                      "23 March 2013|£85.85",
+                      "30 March 2013|£85.85",
+                      " 6 April 2013|£85.85",
+                      "13 April 2013|£86.70",
+                      "20 April 2013|£86.70"].join("\n"),
+                     calculator.formatted_sick_pay_weekly_amounts
+      end
+    end
+
+    context "average weekly earnings for new employees who fell sick before first payday" do
+      should "give the average weekly earnings" do
+        pay = SmartAnswer::Money.new(100)
+        days_worked = 7
+        awe = StatutorySickPayCalculatorV2.contractual_earnings_awe(pay, days_worked)
+        assert_equal 100, awe
+      end
+    end
+
+    context "average weekly earnings for new employees who fell sick before first payday - using decimal place" do
+      should "give the average weekly earnings" do
+        pay = SmartAnswer::Money.new(100)
+        days_worked = 10.5
+        awe = StatutorySickPayCalculatorV2.contractual_earnings_awe(pay, days_worked)
+        assert_equal 66.67, awe
+      end
+    end
+
+    context "xx average weekly earnings for employees who've been paid less than 8 weeks with exact weeks pay" do
+      should "give the average weekly earnings" do
+        pay = SmartAnswer::Money.new(532)
+        days_worked = 42
+        awe = StatutorySickPayCalculatorV2.total_earnings_awe(pay, days_worked)
+        assert_equal 88.67, awe.to_f
+      end
+    end
+
+    context "average weekly earnings for employees who've been paid less than 8 weeks with in-exact weeks pay" do
+      should "give the average weekly earnings" do
+        pay = SmartAnswer::Money.new(600)
+        days_worked = 43
+        awe = StatutorySickPayCalculatorV2.total_earnings_awe(pay, days_worked)
+        assert_equal 97.67, awe
+      end
+    end
+
+    context "when the last working day of the sick period is a Sunday" do
+      should "calculate the sick period including the Sunday" do
+        calc = StatutorySickPayCalculatorV2.new(0, Date.parse("24 October 2013"), Date.parse("27 October 2013"), ['0', '1', '3', '4', '5', '6'])
+        assert_equal 14.45, calc.ssp_payment
+      end
+    end
+  end # SSP calculator
+end


### PR DESCRIPTION
### Statutory sick pay updates for 2015/16

1) New SSP weekly rate £88.45
2) New lower Earnings limit £112
3) Refactoring: do not duplicate the latest rate values in a constant
4) Whitespace fixes in tests

See [this commit](https://github.com/alphagov/smart-answers/commit/31cabbad642ab693a3d427986912e3470a53f8df) for a more readable diff, the first one is just creating a V2.