### PR TITLE
State pension calculator changes for 2015/16

### DIFF
--- a/lib/smart_answer/calculators/state_pension_amount_calculator_v2.rb
+++ b/lib/smart_answer/calculators/state_pension_amount_calculator_v2.rb
@@ -4,7 +4,7 @@ module SmartAnswer::Calculators
   class StatePensionAmountCalculatorV2
     include FriendlyTimeDiff
 
-    attr_reader :gender, :dob, :qualifying_years, :available_years , :starting_credits
+    attr_reader :gender, :dob, :qualifying_years, :available_years , :starting_credits, :pays_reduced_ni_rate
     attr_accessor :qualifying_years
 
     PENSION_RATES = [
@@ -22,6 +22,7 @@ module SmartAnswer::Calculators
       @qualifying_years = answers[:qualifying_years].to_i
       @available_years = ni_years_to_date_from_dob
       @starting_credits = allocate_starting_credits
+      @pays_reduced_ni_rate = answers[:pays_reduced_ni_rate]
     end
 
     def new_rules_and_less_than_10_ni? ni
@@ -215,7 +216,10 @@ module SmartAnswer::Calculators
       rre_start_date = Date.new(1953,4,6)
       rre_end_date = Date.new(1961,4,5)
 
-      true if @qualifying_years.between?(10,29) && dob.between?(rre_start_date, rre_end_date) && gender == :female
+      pays_reduced_ni_rate &&
+        gender == :female &&
+        qualifying_years.between?(10,29) &&
+        dob.between?(rre_start_date, rre_end_date)
     end
   end
 end

--- a/lib/smart_answer/calculators/state_pension_amount_calculator_v2.rb
+++ b/lib/smart_answer/calculators/state_pension_amount_calculator_v2.rb
@@ -10,7 +10,8 @@ module SmartAnswer::Calculators
     PENSION_RATES = [
       { min: Date.parse('7 April 2012'), max: Date.parse('6 April 2013'), amount: 107.45 },
       { min: Date.parse('7 April 2013'), max: Date.parse('6 April 2014'), amount: 110.15 },
-      { min: Date.parse('7 April 2014'), max: Date.parse('6 April 2015'), amount: 113.10 }
+      { min: Date.parse('7 April 2014'), max: Date.parse('6 April 2015'), amount: 113.10 },
+      { min: Date.parse('7 April 2015'), max: Date.parse('6 April 2016'), amount: 115.95 }
     ]
 
     NEW_RULES_START_DATE = Date.parse('6 April 2016')

--- a/lib/smart_answer_flows/calculate-state-pension-v2.rb
+++ b/lib/smart_answer_flows/calculate-state-pension-v2.rb
@@ -257,7 +257,7 @@ value_question :years_of_jsa? do
       ''
     end
   end
-  
+
   calculate :qualifying_years do
     jsa_years = Integer(responses.last)
     qy = (qualifying_years + jsa_years)
@@ -308,7 +308,7 @@ multiple_choice :received_child_benefit? do
     ni_and_credits = ni + calculator.starting_credits
     calculator.new_rules_and_less_than_10_ni?(ni_and_credits) && !calculator.credit_band
   }
-  
+
   define_predicate(:credit_age?) { calculator.credit_age? }
 
   next_node_if(:years_of_benefit?, responded_with("yes"))
@@ -524,7 +524,10 @@ outcome :amount_result do
 
   precalculate :calculator do
     Calculators::StatePensionAmountCalculatorV2.new(
-      gender: gender, dob: dob, qualifying_years: (qualifying_years_total)
+      gender: gender,
+      dob: dob,
+      qualifying_years: qualifying_years_total,
+      pays_reduced_ni_rate: (pays_reduced_ni_rate.to_s == 'yes')
     )
   end
 

--- a/lib/smart_answer_flows/locales/en/calculate-state-pension-v2.yml
+++ b/lib/smart_answer_flows/locales/en/calculate-state-pension-v2.yml
@@ -260,12 +260,12 @@ en-GB:
 
           ##Your State Pension estimate
 
-          You currently don’t have the 30 qualifying years needed to get a full basic State Pension of £113.10 per week.
+          You currently don’t have the 30 qualifying years needed to get a full basic State Pension of £115.95 per week.
 
           Basic State Pension | Your results
           - | -
           How much per week you may get | £%{pension_amount}
-          Difference to the full basic State Pension of £113.10 | £%{pension_loss}
+          Difference to the full basic State Pension of £115.95 | £%{pension_loss}
 
           How much State Pension you get depends on how many years of [National Insurance contributions](/national-insurance) you have.
 
@@ -300,7 +300,7 @@ en-GB:
 
           ##Your State Pension estimate
 
-          You have enough qualifying years to get a full basic State Pension of £113.10 per week.
+          You have enough qualifying years to get a full basic State Pension of £115.95 per week.
 
           How much State Pension you get depends on how many years of [National Insurance contributions](/national-insurance) you have.
 

--- a/test/integration/smart_answer_flows/calculate_state_pension_v2_test.rb
+++ b/test/integration/smart_answer_flows/calculate_state_pension_v2_test.rb
@@ -1358,7 +1358,7 @@ class CalculateStatePensionV2Test < ActiveSupport::TestCase
         Timecop.travel('2014-05-06')
       end
 
-      should "include rre entitlements phrase" do
+      should "include rre entitlements phrase if she paid reduced NI rate" do
         add_response :female
         add_response Date.parse("8th February 1958")
         add_response :yes # reduced rate election
@@ -1368,6 +1368,18 @@ class CalculateStatePensionV2Test < ActiveSupport::TestCase
         add_response 0 # years worked between 16 and 19
         assert_current_node :amount_result
         assert_phrase_list :result_text, [:too_few_qy_enough_remaining_years_a_intro, :ten_and_greater, :rre_entitlements, :too_few_qy_enough_remaining_years_a]
+      end
+
+      should "not include rre entitlements phrase if she did not paid reduced NI rate" do
+        add_response :female
+        add_response Date.parse("8th February 1958")
+        add_response :no # reduced rate election
+        add_response 15 # ni years
+        add_response 0 # jsa years
+        add_response :no # claimed benefit
+        add_response 0 # years worked between 16 and 19
+        assert_current_node :amount_result
+        assert_phrase_list :result_text, [:too_few_qy_enough_remaining_years_a_intro, :ten_and_greater, :too_few_qy_enough_remaining_years_a]
       end
     end
 

--- a/test/unit/calculators/state_pension_amount_calculator_v2_test.rb
+++ b/test/unit/calculators/state_pension_amount_calculator_v2_test.rb
@@ -110,25 +110,25 @@ module SmartAnswer::Calculators
         Timecop.travel(Date.parse("2014-04-08")) do
           @calculator = SmartAnswer::Calculators::StatePensionAmountCalculatorV2.new(
             gender: "male", dob: "1953-04-04", qualifying_years: 29)
-         assert_equal 109.33, @calculator.what_you_get
-         @calculator.qualifying_years = 28
-         assert_equal 105.56, @calculator.what_you_get
-         @calculator.qualifying_years = 27
-         assert_equal 101.79, @calculator.what_you_get
-         @calculator.qualifying_years = 26
-         assert_equal 98.02, @calculator.what_you_get
-         @calculator.qualifying_years = 15
-         assert_equal 56.55, @calculator.what_you_get
-         @calculator.qualifying_years = 10
-         assert_equal 37.70, @calculator.what_you_get
-         @calculator.qualifying_years = 5
-         assert_equal 18.85, @calculator.what_you_get
-         @calculator.qualifying_years = 4
-         assert_equal 15.08, @calculator.what_you_get
-         @calculator.qualifying_years = 2
-         assert_equal 7.54, @calculator.what_you_get
-         @calculator.qualifying_years = 1
-         assert_equal 3.77, @calculator.what_you_get
+          assert_equal 109.33, @calculator.what_you_get
+          @calculator.qualifying_years = 28
+          assert_equal 105.56, @calculator.what_you_get
+          @calculator.qualifying_years = 27
+          assert_equal 101.79, @calculator.what_you_get
+          @calculator.qualifying_years = 26
+          assert_equal 98.02, @calculator.what_you_get
+          @calculator.qualifying_years = 15
+          assert_equal 56.55, @calculator.what_you_get
+          @calculator.qualifying_years = 10
+          assert_equal 37.70, @calculator.what_you_get
+          @calculator.qualifying_years = 5
+          assert_equal 18.85, @calculator.what_you_get
+          @calculator.qualifying_years = 4
+          assert_equal 15.08, @calculator.what_you_get
+          @calculator.qualifying_years = 2
+          assert_equal 7.54, @calculator.what_you_get
+          @calculator.qualifying_years = 1
+          assert_equal 3.77, @calculator.what_you_get
         end
       end
 
@@ -136,7 +136,7 @@ module SmartAnswer::Calculators
         Timecop.travel('2045-01-01') do
           @calculator = SmartAnswer::Calculators::StatePensionAmountCalculatorV2.new(
             gender: "male", dob: "2000-04-04", qualifying_years: 29)
-          assert_equal 113.1, @calculator.current_weekly_rate
+          assert_equal 115.95, @calculator.current_weekly_rate
         end
       end
     end
@@ -237,7 +237,7 @@ module SmartAnswer::Calculators
       context "male born 26 years and one day ago, no qualifying_years" do
         setup do
           Timecop.travel(Date.parse("2013-03-01"))
-   dob = Date.civil(26.years.ago.year, 4, 5).to_s
+          dob = Date.civil(26.years.ago.year, 4, 5).to_s
           @calculator = SmartAnswer::Calculators::StatePensionAmountCalculatorV2.new(
             gender: "male", dob: dob, qualifying_years: nil)
         end
@@ -250,7 +250,7 @@ module SmartAnswer::Calculators
       context "32 years old with 10 qualifying_years" do
         setup do
           Timecop.travel(Date.parse("2013-03-01"))
-   dob = Date.civil(32.years.ago.year, 4, 6).to_s
+          dob = Date.civil(32.years.ago.year, 4, 6).to_s
           @calculator = SmartAnswer::Calculators::StatePensionAmountCalculatorV2.new(
             gender: "female", dob: dob, qualifying_years: 10)
         end
@@ -432,14 +432,15 @@ module SmartAnswer::Calculators
           @calculator = SmartAnswer::Calculators::StatePensionAmountCalculatorV2.new(
             gender: "male", dob: 49.years.ago.to_s, qualifying_years: 25)
           assert_equal 5, @calculator.available_years_sum
-   assert_equal 5, @calculator.years_can_be_entered(@calculator.available_years_sum, 22)
+          assert_equal 5, @calculator.years_can_be_entered(@calculator.available_years_sum, 22)
         end
+
         should "should return 22" do
           Timecop.travel("2013-04-20")
           @calculator = SmartAnswer::Calculators::StatePensionAmountCalculatorV2.new(
             gender: "male", dob: 49.years.ago.to_s, qualifying_years: 5)
           assert_equal 25, @calculator.available_years_sum
-   assert_equal 22, @calculator.years_can_be_entered(@calculator.available_years_sum, 22)
+          assert_equal 22, @calculator.years_can_be_entered(@calculator.available_years_sum, 22)
         end
       end
 
@@ -724,7 +725,7 @@ module SmartAnswer::Calculators
       setup do
         Timecop.travel("2014-04-01")
         @calculator = SmartAnswer::Calculators::StatePensionAmountCalculatorV2.new(
-   gender: "male", dob: "6 May 1958", qualifying_years: "50")
+          gender: "male", dob: "6 May 1958", qualifying_years: "50")
       end
 
       should "be 36 based on birthday not having happened yet" do

--- a/test/unit/calculators/state_pension_amount_calculator_v2_test.rb
+++ b/test/unit/calculators/state_pension_amount_calculator_v2_test.rb
@@ -54,12 +54,25 @@ module SmartAnswer::Calculators
     end
 
     context "female, born 1953 - 1962, from 10 to 29 qualifying years" do
-      setup do
-        @calculator = SmartAnswer::Calculators::StatePensionAmountCalculatorV2.new(gender: "female", dob: "1958-02-08", qualifying_years: 15)
+
+      context "pays reduced NI rate" do
+        setup do
+          @calculator = SmartAnswer::Calculators::StatePensionAmountCalculatorV2.new(gender: "female", dob: "1958-02-08", qualifying_years: 15, pays_reduced_ni_rate: true)
+        end
+
+        should "be eligible for rre entitlements" do
+          assert @calculator.qualifies_for_rre_entitlements?
+        end
       end
 
-      should "be eligible for rre entitlements" do
-        assert @calculator.qualifies_for_rre_entitlements?
+      context "pays full NI rate" do
+        setup do
+          @calculator = SmartAnswer::Calculators::StatePensionAmountCalculatorV2.new(gender: "female", dob: "1958-02-08", qualifying_years: 15, pays_reduced_ni_rate: false)
+        end
+
+        should "be eligible for rre entitlements" do
+          assert !@calculator.qualifies_for_rre_entitlements?
+        end
       end
     end
 
@@ -129,6 +142,34 @@ module SmartAnswer::Calculators
           assert_equal 7.54, @calculator.what_you_get
           @calculator.qualifying_years = 1
           assert_equal 3.77, @calculator.what_you_get
+        end
+      end
+
+      should "uprate on or after 8th April 2015" do
+        Timecop.travel(Date.parse("2015-04-08")) do
+          @calculator = SmartAnswer::Calculators::StatePensionAmountCalculatorV2.new(
+            gender: "male", dob: "1953-04-04", qualifying_years: 29)
+          assert_equal 112.09, @calculator.what_you_get
+          @calculator.qualifying_years = 28
+          assert_equal 108.22, @calculator.what_you_get
+          @calculator.qualifying_years = 27
+          assert_equal 104.36, @calculator.what_you_get
+          @calculator.qualifying_years = 26
+          assert_equal 100.49, @calculator.what_you_get
+          @calculator.qualifying_years = 15
+          assert_equal 57.98, @calculator.what_you_get
+          @calculator.qualifying_years = 10
+          assert_equal 38.65, @calculator.what_you_get
+          @calculator.qualifying_years = 5
+          assert_equal 19.33, @calculator.what_you_get
+          @calculator.qualifying_years = 4
+          assert_equal 15.46, @calculator.what_you_get
+          @calculator.qualifying_years = 2
+          assert_equal 7.73, @calculator.what_you_get
+          @calculator.qualifying_years = 1
+          assert_equal 3.87, @calculator.what_you_get
+          @calculator.qualifying_years = 0
+          assert_equal 0.0, @calculator.what_you_get
         end
       end
 


### PR DESCRIPTION
- Update the rate for the new fiscal year to 115.95
- Fix the logic for REE entitlement
- Whitespace changes

All V2 changes