### PR TITLE
Maternity paternity calculator for employers uprate

### DIFF
--- a/lib/smart_answer/calculators/maternity_paternity_calculator_v2.rb
+++ b/lib/smart_answer/calculators/maternity_paternity_calculator_v2.rb
@@ -1,0 +1,381 @@
+require_relative "../date_helper"
+
+module SmartAnswer::Calculators
+  class MaternityPaternityCalculatorV2
+    include DateHelper
+
+    attr_reader :due_date, :expected_week, :qualifying_week, :employment_start, :notice_of_leave_deadline,
+      :leave_earliest_start_date, :adoption_placement_date, :ssp_stop,
+      :matched_week, :a_employment_start, :leave_type
+
+    attr_accessor :employment_contract, :leave_start_date, :average_weekly_earnings,
+      :a_notice_leave, :last_payday, :pre_offset_payday, :pay_date,
+        :pay_day_in_month, :pay_day_in_week, :pay_method, :pay_week_in_month, :work_days, :date_of_birth, :awe
+
+    DAYS_OF_THE_WEEK = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
+
+    def initialize(match_or_due_date, leave_type = "maternity")
+      expected_start = match_or_due_date - match_or_due_date.wday
+      qualifying_start = 15.weeks.ago(expected_start)
+
+      @due_date = @match_date = match_or_due_date
+      @leave_type = leave_type
+      @expected_week = @matched_week = expected_start .. expected_start + 6.days
+      @notice_of_leave_deadline = next_saturday(qualifying_start)
+      @qualifying_week = qualifying_start .. qualifying_start + 6.days
+      @employment_start = 25.weeks.ago(@qualifying_week.last)
+      @a_employment_start = 25.weeks.ago(@matched_week.last)
+      @leave_earliest_start_date = 11.weeks.ago(@expected_week.first)
+      @ssp_stop = 4.weeks.ago(@expected_week.first)
+
+      # Adoption instance vars
+      @a_notice_leave = @match_date + 7
+    end
+
+    def format_date(date)
+      date.strftime("%e %B %Y")
+    end
+
+    def format_date_day(date)
+      date.strftime("%A, %d %B %Y")
+    end
+
+    def payday_offset
+      8.weeks.ago(last_payday) + 1
+    end
+
+    def relevant_period
+      [pre_offset_payday, last_payday]
+    end
+
+    def formatted_relevant_period
+      relevant_period.map { |p| format_date_day(p) }.join(" and ")
+    end
+
+    def leave_end_date
+      52.weeks.since(leave_start_date) - 1
+    end
+
+    def pay_start_date
+      leave_start_date
+    end
+
+    def pay_end_date
+      pay_duration.weeks.since(pay_start_date) - 1
+    end
+
+    def pay_duration
+      case leave_type
+      when 'paternity', 'paternity_adoption'
+        2
+      else
+        39
+      end
+    end
+
+    def notice_request_pay
+      28.days.ago(pay_start_date)
+    end
+
+    # Rounds up at 2 decimal places.
+    #
+    def statutory_maternity_rate
+      average_weekly_earnings.to_f * 0.9
+    end
+
+    def statutory_maternity_rate_a
+      statutory_maternity_rate
+    end
+
+    def statutory_maternity_rate_b
+      [current_statutory_rate, statutory_maternity_rate].min
+    end
+
+    def earning_limit_rates_birth
+      [
+        {min: Date.parse("17 July 2009"), max: Date.parse("16 July 2010"), lower_earning_limit_rate: 95},
+        {min: Date.parse("17 July 2010"), max: Date.parse("16 July 2011"), lower_earning_limit_rate: 97},
+        {min: Date.parse("17 July 2011"), max: Date.parse("14 July 2012"), lower_earning_limit_rate: 102},
+        {min: Date.parse("15 July 2012"), max: Date.parse("13 July 2013"), lower_earning_limit_rate: 107},
+        {min: Date.parse("14 July 2013"), max: Date.parse("5 April 2014"), lower_earning_limit_rate: 109},
+        {min: Date.parse("6 April 2014"), max: Date.parse("5 April 2015"), lower_earning_limit_rate: 111}
+      ]
+    end
+
+    def lower_earning_limit_birth
+      earning_limit_rate = earning_limit_rates_birth.find { |c| c[:min] <= @qualifying_week.last and c[:max] >= @qualifying_week.last }
+      (earning_limit_rate ? earning_limit_rate[:lower_earning_limit_rate] : earning_limit_rates_birth.last[:lower_earning_limit_rate])
+    end
+
+    def earning_limit_rates_adoption
+      [
+        {min: Date.parse("3 April 2010"), max: Date.parse("2 April 2011"), lower_earning_limit_rate: 97},
+        {min: Date.parse("3 April 2011"), max: Date.parse("31 March 2012"), lower_earning_limit_rate: 102},
+        {min: Date.parse("1 April 2012"), max: Date.parse("31 March 2013"), lower_earning_limit_rate: 107},
+        {min: Date.parse("1 April 2013"), max: Date.parse("5 April 2014"), lower_earning_limit_rate: 109},
+        {min: Date.parse("6 April 2014"), max: Date.parse("5 April 2015"), lower_earning_limit_rate: 111}
+      ]
+    end
+
+    def lower_earning_limit_adoption
+      earning_limit_rate = earning_limit_rates_adoption.find { |c| c[:min] <= @qualifying_week.last and c[:max] >= @qualifying_week.last }
+      (earning_limit_rate ? earning_limit_rate[:lower_earning_limit_rate] : 107)
+    end
+
+    def lower_earning_limit
+      if @leave_type =~ /maternity|paternity/
+        lower_earning_limit_birth
+      else
+        lower_earning_limit_adoption
+      end
+    end
+
+    def employment_end
+      @due_date
+    end
+
+    def adoption_placement_date=(date)
+      @adoption_placement_date = date
+      @leave_earliest_start_date = 14.days.ago(date)
+    end
+
+    ## Paternity
+    ##
+    ## Statutory paternity rate
+    def statutory_paternity_rate
+      awe = (@average_weekly_earnings.to_f * 0.9).round(2)
+      [current_statutory_rate, awe].min
+    end
+
+    ## Adoption
+    ##
+    ## Statutory adoption rate
+    def statutory_adoption_rate
+      awe = (@average_weekly_earnings.to_f * 0.9).round(2)
+      [current_statutory_rate, awe].min
+    end
+
+    def pay_period_in_days
+      (last_payday + 1 - pre_offset_payday).to_i
+    end
+
+    def calculate_average_weekly_pay(pay_pattern, pay)
+      @average_weekly_earnings = sprintf("%.5f", (
+        case pay_pattern
+        when "irregularly"
+          pay.to_f / pay_period_in_days * 7
+        when "monthly"
+          pay.to_f / 2 * 12 / 52
+        else
+          pay.to_f / 8
+        end
+      )).to_f # HMRC truncation at 5 places.
+    end
+
+    def total_statutory_pay
+      paydates_and_pay.map { |h| h[:pay] }.sum.round(2)
+    end
+
+    def paydates_and_pay
+      paydates = send(:"paydates_#{pay_method}")
+      [].tap do |ary|
+        paydates.each_with_index do |paydate, index|
+          # Pay period includes the date of payment hence the range starts the day after.
+          last_paydate = index == 0 ? pay_start_date : paydates[index - 1] + 1
+          pay = pay_for_period(last_paydate, paydate)
+          ary << { date: paydate, pay: pay } if pay > 0
+        end
+      end
+    end
+
+    def paydates_every_2_weeks
+      paydates_every_n_days(14)
+    end
+
+    def paydates_every_4_weeks
+      paydates_every_n_days(28)
+    end
+
+    def paydates_first_day_of_the_month
+      start_date = pay_start_date.day == 1 ? pay_start_date : (pay_start_date + 1.month).beginning_of_month
+      end_date = (pay_end_date + 1.month).beginning_of_month
+
+      [].tap do |ary|
+        start_date.step(end_date) do |d|
+          ary << d if d.day == 1
+        end
+      end
+    end
+
+    def paydates_last_day_of_the_month
+      start_date = Date.civil(pay_start_date.year, pay_start_date.month, -1)
+      end_date = Date.civil(pay_end_date.year, pay_end_date.month, -1)
+      [].tap do |ary|
+        start_date.step(end_date) do |d|
+          ary << d if d.day == Date.new(d.year, d.month, -1).day
+        end
+      end
+    end
+
+    def paydates_last_working_day_of_the_month
+      end_date = Date.civil(pay_end_date.year, pay_end_date.month, -1)
+
+      [].tap do |ary|
+        pay_start_date.step(end_date) do |d|
+          ary << d if d.day == Date.new(d.year, d.month, last_working_day_of_the_month_offset(d)).day
+        end
+      end
+    end
+
+    def paydates_monthly
+      end_date = Date.civil(pay_end_date.year, pay_end_date.month, pay_day_in_month)
+      end_date = 1.month.since(end_date) if pay_end_date.day > pay_day_in_month
+      [].tap do |ary|
+        pay_start_date.step(end_date) do |d|
+          ary << d if d.day == pay_day_in_month
+        end
+      end
+    end
+
+    alias paydates_specific_date_each_month paydates_monthly
+
+    def paydates_weekly
+      [].tap do |ary|
+        pay_start_date.step(pay_end_date + 7) do |d|
+          ary << d if d.wday == pay_date.wday
+        end
+      end
+    end
+
+    def paydates_weekly_starting
+      [].tap do |ary|
+        pay_start_date.step(pay_end_date) do |d|
+          ary << d if d.wday == (pay_start_date - 1).wday and d > pay_start_date
+        end
+      end
+    end
+
+    def paydates_a_certain_week_day_each_month
+      [].tap do |ary|
+        months_between_dates(pay_start_date, pay_end_date).each do |date|
+          weekdays = weekdays_for_month(date, pay_day_in_week)
+          ary << weekdays.send(pay_week_in_month)
+        end
+        if ary.last and ary.last < pay_end_date
+          weekdays = weekdays_for_month(1.month.since(pay_end_date), pay_day_in_week)
+          ary << weekdays.send(pay_week_in_month)
+        end
+      end
+    end
+
+    def statutory_rate(date)
+      rates = [
+        { min: uprating_date(2012), max: uprating_date(2013), amount: 135.45 },
+        { min: uprating_date(2013), max: uprating_date(2014), amount: 136.78 },
+        { min: uprating_date(2014), max: uprating_date(2100), amount: 138.18 } ### Change year in future
+      ]
+      rate = rates.find { |r| r[:min] <= date and date < r[:max] } || rates.last
+      rate[:amount]
+    end
+
+    def current_statutory_rate
+      statutory_rate(Date.today)
+    end
+
+  private
+
+    def paydates_every_n_days(days)
+      [].tap do |ary|
+        (pay_date..40.weeks.since(pay_date)).step(days).each do |d|
+          ary << d
+        end
+      end
+    end
+
+    def months_between_dates(start_date, end_date)
+      start_date.beginning_of_month.step(end_date.beginning_of_month).select do |date|
+        date.day == 1
+      end
+    end
+
+    def within_pay_date_range?(day)
+      pay_start_date <= day and day <= pay_end_date
+    end
+
+    def rate_changes?(week)
+      rate_for(week.first) != rate_for(week.last)
+    end
+
+    def pay_for_period(start_date, end_date)
+      pay = 0.0
+      (start_date..end_date).each_slice(7) do |week|
+        if week.size < 7 or !within_pay_date_range?(week.last) or rate_changes?(week)
+          # When calculating a partial SMP pay week divide the weekly rate by 7
+          # truncating the result at 5 decimal places and increment the total pay
+          # for each day of the partial week
+          week.each do |day|
+            if within_pay_date_range?(day)
+              pay += sprintf("%.5f", (rate_for(day) / 7)).to_f
+            end
+          end
+        else
+          # When calculating a full SMP pay week round up the weekly rate at the second decimal place
+          pay += BigDecimal.new(rate_for(week.first).to_s).round(2, BigDecimal::ROUND_UP).to_f
+        end
+      end
+      # HMRC rules stipulate rounding up at 2 decimal places.
+      BigDecimal.new(pay.to_s).round(2, BigDecimal::ROUND_UP).to_f
+    end
+
+    # Gives the weekly rate for a date.
+    def rate_for(date)
+      if leave_type == 'maternity'
+        maternity_rate_for(date)
+      else
+        paternity_padoption_adoption_rate_for(date)
+      end
+    end
+
+    def maternity_rate_for(date)
+      if date < 6.weeks.since(leave_start_date)
+        statutory_maternity_rate_a
+      else
+        [statutory_rate(date), statutory_maternity_rate_a].min
+      end
+    end
+
+    def paternity_padoption_adoption_rate_for(date)
+      awe = (@average_weekly_earnings.to_f * 0.9).round(2)
+      [statutory_rate(date), awe].min
+    end
+
+    def first_sunday_in_month(month, year)
+      weekdays_for_month(Date.civil(year, month, 1), 0).first
+    end
+
+    def uprating_date(year)
+      date = first_sunday_in_month(4 , year)
+      date += leave_start_date.wday if leave_start_date
+      date
+    end
+
+    def weekdays_for_month(date, weekday)
+      date.beginning_of_month.step(date.end_of_month).select do |iter_date|
+        weekday == iter_date.wday
+      end
+    end
+
+    # Calculate the minus offset from the end of the month
+    # for the last working day.
+    def last_working_day_of_the_month_offset(date)
+      ldm = Date.new(date.year, date.month, -1) # Last day of the month.
+      ldm_index = ldm.wday
+      offset = -1
+      while !work_days.include?(ldm_index)
+        ldm_index > 0 ? ldm_index -= 1 : ldm_index = 6
+        offset -= 1
+      end
+      offset
+    end
+  end
+end

--- a/lib/smart_answer/calculators/maternity_paternity_calculator_v2.rb
+++ b/lib/smart_answer/calculators/maternity_paternity_calculator_v2.rb
@@ -98,7 +98,8 @@ module SmartAnswer::Calculators
         {min: Date.parse("17 July 2011"), max: Date.parse("14 July 2012"), lower_earning_limit_rate: 102},
         {min: Date.parse("15 July 2012"), max: Date.parse("13 July 2013"), lower_earning_limit_rate: 107},
         {min: Date.parse("14 July 2013"), max: Date.parse("5 April 2014"), lower_earning_limit_rate: 109},
-        {min: Date.parse("6 April 2014"), max: Date.parse("5 April 2015"), lower_earning_limit_rate: 111}
+        {min: Date.parse("6 April 2014"), max: Date.parse("5 April 2015"), lower_earning_limit_rate: 111},
+        {min: Date.parse("6 April 2015"), max: Date.parse("5 April 2100"), lower_earning_limit_rate: 112} ### Change year in future
       ]
     end
 
@@ -113,7 +114,8 @@ module SmartAnswer::Calculators
         {min: Date.parse("3 April 2011"), max: Date.parse("31 March 2012"), lower_earning_limit_rate: 102},
         {min: Date.parse("1 April 2012"), max: Date.parse("31 March 2013"), lower_earning_limit_rate: 107},
         {min: Date.parse("1 April 2013"), max: Date.parse("5 April 2014"), lower_earning_limit_rate: 109},
-        {min: Date.parse("6 April 2014"), max: Date.parse("5 April 2015"), lower_earning_limit_rate: 111}
+        {min: Date.parse("6 April 2014"), max: Date.parse("5 April 2015"), lower_earning_limit_rate: 111},
+        {min: Date.parse("6 April 2015"), max: Date.parse("5 April 2100"), lower_earning_limit_rate: 112} ### Change year in future
       ]
     end
 
@@ -272,7 +274,8 @@ module SmartAnswer::Calculators
       rates = [
         { min: uprating_date(2012), max: uprating_date(2013), amount: 135.45 },
         { min: uprating_date(2013), max: uprating_date(2014), amount: 136.78 },
-        { min: uprating_date(2014), max: uprating_date(2100), amount: 138.18 } ### Change year in future
+        { min: uprating_date(2014), max: uprating_date(2015), amount: 138.18 },
+        { min: uprating_date(2014), max: uprating_date(2100), amount: 139.58 } ### Change year in future
       ]
       rate = rates.find { |r| r[:min] <= date and date < r[:max] } || rates.last
       rate[:amount]

--- a/lib/smart_answer_flows/locales/en/maternity-paternity-calculator-v2.yml
+++ b/lib/smart_answer_flows/locales/en/maternity-paternity-calculator-v2.yml
@@ -1,0 +1,524 @@
+en-GB:
+  flow:
+    maternity-paternity-calculator-v2:
+      meta:
+        description: Calculate an employee’s maternity pay (SMP), paternity or adoption pay, qualifying week, relevant period and average weekly earnings
+      title:
+        Maternity and paternity calculator for employers
+      options:
+        "no": "No"
+        "yes": "Yes"
+        "maternity": "Maternity"
+        "paternity": "Paternity"
+        "adoption": "Adoption"
+        "one_week": "One Week"
+        "two_weeks": "Two Weeks"
+        "weekly": "Weekly"
+      body: |
+        Calculate your employee’s:
+
+        + statutory maternity pay (SMP), paternity pay, adoption pay
+        + qualifying week
+        + relevant employment period and average weekly earnings
+        + leave period
+
+      post_body: |
+        ##What you need
+
+        You need:
+
+        + the baby’s due date
+        + date of birth - for paternity
+        + your employee’s salary details - eg weekly rates of pay
+        + the dates for adoption - eg match date or date of placement
+
+
+        You can’t use the calculator for:
+
+        + births 15 weeks before the due date
+        + [Additional paternity Leave or Pay](/additional-paternity-leave-pay-employees)
+        + paternity leave or pay for [overseas adoptions](/paternity-leave-pay-employees)
+      phrases:
+        not_worked_long_enough: + they must have started working for you on or before %{employment_start}
+        must_be_on_payroll: + you must be liable for their secondary Class 1 National Insurance contributions - ie you will be if they’re on your payroll
+        must_earn_over_threshold: + their average weekly earnings (£%{average_weekly_earnings}) between %{relevant_period} must be at least £%{lower_earning_limit}
+        paternity_adoption_must_be_employed_by_you: + they must still be employed by you on %{ap_adoption_date_formatted}
+        paternity_must_be_employed_by_you: + they must still be employed by you on %{due_date}
+        paternity_adoption_not_responsible_for_upbringing: + aren’t responsible for the child’s upbringing or the adopter’s partner
+        paternity_not_responsible_for_upbringing: + aren't responsible for the child's upbringing or the biological father or mother's partner
+        paternity_spp_claim_link: |
+          The latest date for them to [claim SPP](/employers-paternity-pay-leave/notice-period) is usually 28 days before they want it to start.
+        paternity_adoption_spp_claim_link: |
+          The latest date for them to [claim SPP](/employers-paternity-pay-leave/adoption) is usually 28 days before they want it to start.
+        maternity_leave_table: |
+          ##Statutory Maternity Leave
+
+          The employee is entitled to up to 52 weeks Statutory Maternity Leave.
+
+          |Leave                         | Key dates                    |
+          |------------------------------|------------------------------|
+          |Start                         | %{leave_start_date}          |
+          |End                           | %{leave_end_date}            |
+          |Latest date to [claim leave](/maternity-leave-pay-employees/notice-period "Notice period")    | %{notice_of_leave_deadline}  |
+          |Earliest date leave can start | %{leave_earliest_start_date} |
+
+        not_entitled_to_statutory_maternity_leave: |
+          ##Statutory Maternity Leave
+
+          The employee is not entitled to Statutory Maternity Leave because they don’t have an employment contract with you.
+
+          Write to them within 28 days of their leave request confirming this.
+
+        maternity_pay_table: |
+          ##Statutory Maternity Pay
+
+          The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they [claim SMP in time](/maternity-leave-pay-employees/notice-period "Notice period") and give [proof of the pregnancy](/maternity-leave-pay-employees/eligibility "Proof of pregnancy").
+
+          Pay | Key facts
+          -|-
+          Average weekly earnings | £%{average_weekly_earnings} (don't round this up or down)
+          Latest date to claim SMP | %{notice_request_pay}
+          SMP start date due to pregnancy related illness| %{ssp_stop}
+          Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
+
+        paydates_table: |
+          ## SMP calculation
+
+          Date | SMP amount
+          -|-
+          %{pay_dates_and_pay}
+           | **Total SMP: £%{total_smp}**
+
+        not_entitled_to_smp_intro: |
+          ##Statutory maternity pay
+
+          The employee is not entitled to statutory maternity pay. To qualify:
+
+        not_entitled_to_smp_intro_with_awe: |
+          ##Statutory maternity pay
+
+          The employee is not entitled to statutory maternity pay.
+          Their average weekly earnings are £%{average_weekly_earnings} (you can’t round this figure up or down). To qualify:
+
+        not_entitled_to_smp_outro: |
+          You must write confirming this within 28 days of their maternity pay request.
+
+          Send them form SMP1 within 7 days of your decision. They must get this form within 28 days of their pay request or the birth (whichever is earlier).
+
+
+          $D
+            [Download Form SMP1, Non-payment of Statutory Maternity Pay (PDF, 59KB)](http://www.dwp.gov.uk/advisers/claimforms/smp1_print.pdf){:rel="external"}
+          $D
+
+        paternity_entitled_to_leave: |
+          ##Statutory Paternity Leave
+
+          The employee is entitled to Statutory Paternity Leave.
+
+          |Leave                         | Key dates                    |
+          |------------------------------|------------------------------|
+          |Start                         | %{leave_start_date}          |
+          |End                           | %{leave_end_date}            |
+          |Latest date to [claim leave](/employers-paternity-pay-leave/%{leave_spp_claim_link})     | %{notice_of_leave_deadline}  |
+
+          ^Leave must finish within 56 days of the birth (or due date if the baby is early).^
+
+        #Result 2
+        paternity_not_entitled_to_leave: |
+          ##Statutory Paternity Leave
+
+          The employee is not entitled to Statutory Paternity Leave because they don’t have an employment contract with you.
+
+          Write to them within 28 days of their leave request confirming this.
+
+        paternity_entitled_to_pay: |
+          ##Statutory Paternity Pay (SPP)
+
+          The employee is entitled to SPP.
+
+          Their average weekly earnings are: £%{average_weekly_earnings}
+
+          ## SPP calculation
+
+          Date | SPP amount
+          -|-
+          %{pay_dates_and_pay}
+           | **Total SPP: £%{total_spp}**
+
+
+        paternity_not_entitled_to_leave_or_pay_intro: |
+          ##Not entitled to Statutory Paternity Pay or Leave
+
+          The employee is not entitled to Statutory Paternity Leave or Pay because:
+
+        paternity_not_entitled_to_leave_or_pay_outro: |
+
+          You must write confirming this. Also, send them form OSP1 confirming they’re not entitled to pay within 28 days of their pay request.
+
+          $D [Download Form OSPP1, refusing Statutory Paternity Pay (PDF, 100KB)](http://www.hmrc.gov.uk/forms/spp1.pdf){:rel="external"} $D
+
+        # Result 3
+        paternity_not_entitled_to_pay_intro: |
+          ##Statutory Paternity Pay
+
+          The employee is not entitled to Statutory Paternity Pay. To qualify:
+
+        paternity_not_entitled_to_pay_outro: |
+
+          Send them form OSPP1 confirming this within 28 days of their pay request.
+
+
+          $D [Download Form OSPP1, refusing Statutory Paternity Pay (PDF, 100KB)](http://www.hmrc.gov.uk/forms/spp1.pdf){:rel="external"} $D
+
+
+        adoption_leave_table: |
+          ##Statutory Adoption Leave
+
+          The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [claim the leave on time](/employers-adoption-pay-leave/notice-period).
+
+          |Leave                         | Key dates                   |
+          |------------------------------|-----------------------------|
+          |Start                         | %{leave_start_date}         |
+          |End                           | %{leave_end_date}           |
+
+        adoption_not_entitled_to_leave: |
+          ##Statutory Adoption Leave
+
+          The employee is not entitled to Statutory Adoption Leave because they don’t have an employment contract with you.
+
+          Write to them within 28 days of their leave request confirming this.
+
+        adoption_pay_table: |
+          ##Statutory Adoption Pay
+
+          The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
+
+          The employee’s average weekly earnings are: £%{average_weekly_earnings}.
+
+          Date | SAP amount
+          -|-
+          %{pay_dates_and_pay}
+           | **Total SAP: £%{total_sap}**
+
+
+        adoption_not_entitled_to_pay_intro: |
+          ##Statutory Adoption Pay
+
+          The employee is not entitled to Statutory Adoption Pay. To qualify:
+
+        adoption_not_entitled_to_pay_outro: |
+          Send them form SAP1 within 7 days of your decision. They must get this form within 28 days of their pay request or the date they were matched with the child (whichever is earlier).
+
+
+          $D [Download Form SAP1, Non-payment of Statutory Adoption Pay (PDF, 59KB)](http://www.hmrc.gov.uk/forms/sap1.pdf){:rel="external"} $D
+
+      ## Q1
+      what_type_of_leave?:
+        title: What do you want to check?
+      ## QM1
+      baby_due_date_maternity?:
+        title: What is the baby’s due date?
+      ## QM2
+      employment_contract?:
+        title: Does the employee have an employment contract with you?
+      ## QM3
+      date_leave_starts?:
+        title: When does the employee want to start their leave?
+        hint: Based on the baby's due date, leave usually can’t start before %{leave_earliest_start_date}.
+        error_message: Please enter a valid date
+      ## QM4
+      did_the_employee_work_for_you?:
+        title: Did the employee work for you on or before %{employment_start}?
+      ## QM5
+      is_the_employee_on_your_payroll?:
+        title: Is the employee on your payroll?
+      ## QM5.2
+      last_normal_payday?:
+        title: What was the last normal payday on or before %{to_saturday}?
+        error_message: You must enter a date on or before %{to_saturday}
+      ## QM5.3
+      payday_eight_weeks?:
+        title: What was the last normal payday before %{payday_offset}?
+        error_message: You must enter a date before %{payday_offset}
+      ## QM5.4
+      pay_frequency?:
+        title: How often do you pay the employee?
+        hint: If they’re paid irregularly choose ‘weekly’.
+        options:
+          "weekly": "Weekly"
+          "every_2_weeks": "Every 2 weeks"
+          "every_4_weeks": "Every 4 weeks"
+          "monthly": "Monthly"
+      ## QM5.5
+      earnings_for_pay_period?:
+        title: What were the employee’s total earnings between %{relevant_period}?
+        hint: This is their earnings before deductions like PAYE, pension or National Insurance contributions.
+      ## QM7
+      how_do_you_want_the_smp_calculated?:
+        title: How do you want the SMP calculated?
+        options:
+          "weekly_starting": "weekly starting %{leave_start_date}"
+          "usual_paydates": "based on their usual paydates"
+      ## QM8
+      when_is_your_employees_next_pay_day?:
+        title: When is your employee’s next pay day on or after %{pay_start_date}?
+      ## QM9
+      when_in_the_month_is_the_employee_paid?:
+        hint: If the pay date is the 29th, 30th or 31st choose 'Last working day of the month'.
+        options:
+          "first_day_of_the_month": First day of the month
+          "last_day_of_the_month": Last day of the month
+          "specific_date_each_month": Specific date each month
+          "last_working_day_of_the_month": Last working day of the month
+          "a_certain_week_day_each_month": A certain week day each month
+      ## QM10
+      what_specific_date_each_month_is_the_employee_paid?:
+        title: What specific date each month is the employee paid?
+        hint: If they’re paid on the 25th enter "25". The calculator will treat an employee as paid on the last day of the month if you enter 29, 30 or 31.
+        error_message: Enter a date between 1 and 31.
+      ## QM11
+      what_days_does_the_employee_work?:
+        title: What days does the employee work?
+        options:
+          "0": "Sunday"
+          "1": "Monday"
+          "2": "Tuesday"
+          "3": "Wednesday"
+          "4": "Thursday"
+          "5": "Friday"
+          "6": "Saturday"
+      ## QM12
+      what_particular_day_of_the_month_is_the_employee_paid?:
+        title: What particular day of the month is the employee paid?
+      ## QM13
+      which_week_in_month_is_the_employee_paid?:
+        title: Is the employee paid on the 1st, 2nd, 3rd, 4th or last %{pay_day_in_week}?
+        options:
+          "first": "1st"
+          "second": "2nd"
+          "third": "3rd"
+          "fourth": "4th"
+          "last": "last"
+      ## Combined result for maternity leave and pay.
+      maternity_leave_and_pay_result:
+        next_steps: |
+          Read the [guide to Statutory Maternity Pay and Leave](/maternity-leave-pay-employees "Maternity leave and pay")
+        body: |
+          %{maternity_leave_info}
+
+          %{maternity_pay_info}
+
+          *[SMP]: Statutory Maternity Pay
+
+      ## QP0
+      leave_or_pay_for_adoption?:
+        title: Is the paternity leave or pay for an adoption?
+      ## QP1
+      baby_due_date_paternity?:
+        title: What is the baby’s due date?
+      ## QP2
+      baby_birth_date_paternity?:
+        title: What is the actual birth date?
+        hint: If unknown enter the due date.
+      ## QP3
+      employee_responsible_for_upbringing?:
+        title: Is the employee responsible for the child’s upbringing and either the biological father or the mother’s husband or partner?
+      ## QP4
+      employee_work_before_employment_start?:
+        title: Did the employee work for you on or before %{employment_start}?
+      ## QP5
+      employee_has_contract_paternity?:
+        title: Does the employee have an employment contract with you?
+      ## QP6
+      employee_on_payroll_paternity?:
+        title: Is the employee on your payroll?
+      ## QP7
+      employee_still_employed_on_birth_date?:
+        title: Will the employee still be employed by you on %{still_employed_date}?
+      ## QP8
+      employee_start_paternity?:
+        title: When does the employee want to start their paternity leave?
+        hint: Leave cannot start before %{start_leave_hint}.
+      ## QP9
+      employee_paternity_length?:
+        title: How long is the employee's paternity leave?
+        options:
+          "one_week": "One week"
+          "two_weeks": "Two weeks"
+      ## QP10
+      last_normal_payday_paternity?:
+        title: What was the last normal payday on or before %{to_saturday}
+        error_message: You must enter a date on or before %{to_saturday}
+      ## QP11
+      payday_eight_weeks_paternity?:
+        title: What was the last normal payday before %{payday_offset}
+        error_message: You must enter a date on or before %{payday_offset}
+      ## QP12
+      pay_frequency_paternity?:
+        title: How often do you pay the employee?
+        hint: If they are paid irregularly choose 'weekly'.
+        options:
+          "weekly": "Weekly"
+          "every_2_weeks": "Every 2 weeks"
+          "every_4_weeks": "Every 4 weeks"
+          "monthly": "Monthly"
+      ## QP13
+      earnings_for_pay_period_paternity?:
+        title: What were the employee's total earnings between %{relevant_period}?
+        hint: This is the earnings before deductions like PAYE, pendion or National Insurance contributions.
+      ## QP14
+      how_do_you_want_the_spp_calculated?:
+        title: How do you want the paternity pay calculated?
+        options:
+          "weekly_starting": "Weekly starting %{leave_start_date}"
+          "usual_paydates": "Based on their usual paydates"
+      ## QP15
+      next_pay_day_paternity?:
+        title: When is your employee's next pay day on or after %{leave_start_date}
+      ## QP16
+      monthly_pay_paternity?:
+        title: When in the month is the employee paid?
+        hint: If the pay date is the 29th, 30th or 31st choose 'Last working day of the month'.
+        options:
+          "first_day_of_the_month": "First day of the month"
+          "last_day_of_the_month": "Last day of the month"
+          "specific_date_each_month": "Specific date each month"
+          "last_working_day_of_the_month": "Last working day of the month"
+          "a_certain_week_day_each_month": "A certain week day each month"
+      ## QP17
+      specific_date_each_month_paternity?:
+        title: What specific date each month is the employee paid?
+        hint: If they are paid on the 25th enter '25'. The calculator will treat an employee as paid on the last day of the month if you enter '29', '30' or '31'.
+        error_message: Enter a date between 1 and 31.
+      ## QP18
+      days_of_the_week_paternity?:
+        title: What days does the employee work?
+        options:
+          "0": "Sunday"
+          "1": "Monday"
+          "2": "Tuesday"
+          "3": "Wednesday"
+          "4": "Thursday"
+          "5": "Friday"
+          "6": "Saturday"
+      ## QP19
+      day_of_the_month_paternity?:
+        title: What particular day of the month is the employee paid?
+        options:
+          "0": "Sunday"
+          "1": "Monday"
+          "2": "Tuesday"
+          "3": "Wednesday"
+          "4": "Thursday"
+          "5": "Friday"
+          "6": "Saturday"
+      ## QP20
+      pay_date_options_paternity?:
+        title: Is the employee paid on the 1st, 2nd, 3rd, 4th or last %{pay_day_in_week}?
+        options:
+          "first": "1st"
+          "second": "2nd"
+          "third": "3rd"
+          "fourth": "4th"
+          "last": "last"
+      ## Paternity Results:
+      paternity_leave_and_pay:
+        next_steps: |
+          Read the [guide to Statutory Paternity Pay and Leave](/paternity-leave-pay-employees "Paternity leave and pay")
+        body: |
+          %{paternity_info}
+
+      paternity_not_entitled_to_leave_or_pay:
+        next_steps: |
+          Read the [guide to Statutory Paternity Pay and Leave](/paternity-leave-pay-employees "Paternity leave and pay")
+        body: |
+          %{not_entitled_reason}
+
+      ## Paternity Adoption
+      ## QAP1
+      employee_date_matched_paternity_adoption?:
+        title: When was the child matched with the employee?
+      ## QAP2
+      padoption_date_of_adoption_placement?:
+        title: When will the child be placed with the employee?
+        error_message: Placement date can't be before matching date
+      ## QAP3
+      padoption_employee_responsible_for_upbringing?:
+        title: Is the employee responsible for the child's upbringing and the husband or partner of the adopter or the child's adopter?
+
+      ## Adoption
+      ## QA0
+      taking_paternity_leave_for_adoption?:
+        title: Is the employee taking paternity leave to adopt a child?
+      ## QA1
+      date_of_adoption_match?:
+        title: When was the child matched with the employee?
+        hint: For overseas adoptions, enter the official notification date (the permission to adopt from abroad).
+      ## QA2
+      date_of_adoption_placement?:
+        title: When will the child be placed with the employee?
+        hint: For overseas adoptions enter the date of arrival in the UK.
+        error_message: Placement date can't be before matching date
+      ## QA3
+      adoption_did_the_employee_work_for_you?:
+        title: Did the employee work for you on or before %{employment_start}?
+      ## QA4
+      adoption_employment_contract?:
+        title: Does the employee have an employment contract with you?
+      ## QA5
+      adoption_is_the_employee_on_your_payroll?:
+        title: Is the employee on your payroll?
+      ## QA6
+      adoption_date_leave_starts?:
+        title: When does the employee want to start their leave?
+        hint: Leave can't start before %{a_leave_earliest_start} or within 28 days of the child arriving in the UK (overseas adoptions only).
+        error_message: Please enter a valid date
+      ## QA7
+      last_normal_payday_adoption?:
+        title: What was the last normal payday on or before %{to_saturday}?
+        error_message: You must enter a date on or before %{to_saturday}
+      ## QA8
+      payday_eight_weeks_adoption?:
+        title: What was the last normal payday before %{payday_offset}?
+        error_message: You must enter a date before %{payday_offset}
+      ## QA9
+      pay_frequency_adoption?:
+        title: How often do you pay the employee?
+        hint: If they’re paid irregularly choose ‘weekly’.
+        options:
+          "weekly": "Weekly"
+          "every_2_weeks": "Every 2 weeks"
+          "every_4_weeks": "Every 4 weeks"
+          "monthly": "Monthly"
+      ## QA10
+      earnings_for_pay_period_adoption?:
+        title: What were the employee’s total earnings between %{relevant_period}?
+        hint: This is their earnings before deductions like PAYE, pension or National Insurance contributions.
+        error_message: Please enter a number greater than 0
+      ## QA11
+      how_do_you_want_the_sap_calculated?:
+        title: How do you want the adoption pay calculated?
+        options:
+          "weekly_starting": "Weekly starting %{leave_start_date}"
+          "usual_paydates": "Based on their usual paydates"
+      ## Adoption outcomes
+      adoption_leave_and_pay:
+        next_steps: |
+          Read the [guide to Statutory Adoption Pay and Leave](/adoption-leave-pay-employees "Adoption leave and pay")
+        body: |
+          %{adoption_leave_info}
+
+          %{adoption_pay_info}
+
+      adoption_not_entitled_to_leave_or_pay:
+        next_steps: |
+          Read the [guide to Statutory Adoption Pay and Leave](/adoption-leave-pay-employees "Adoption leave and pay")
+        body: |
+          ##Not entitled to Statutory Adoption Leave and Pay
+
+          The employee is not entitled to Statutory Adoption Leave or Pay because they must have started working for you on %{employment_start}
+
+          You must write confirming this. Also, send them form SAP1 confirming they’re not entitled to pay within 28 days of their pay request.
+
+
+          $D [Download Form SAP1, Non-payment of Statutory Adoption Pay (PDF, 59KB)](http://www.hmrc.gov.uk/forms/sap1.pdf){:rel="external"} $D

--- a/lib/smart_answer_flows/maternity-paternity-calculator-v2.rb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator-v2.rb
@@ -1,0 +1,14 @@
+status :published
+satisfies_need "100990"
+
+## Q1
+multiple_choice :what_type_of_leave? do
+  save_input_as :leave_type
+  option maternity: :baby_due_date_maternity?
+  option paternity: :leave_or_pay_for_adoption?
+  option adoption: :taking_paternity_leave_for_adoption?
+end
+
+use_shared_logic ("adoption-calculator-v2")
+use_shared_logic ("paternity-calculator-v2")
+use_shared_logic ("maternity-calculator-v2")

--- a/lib/smart_answer_flows/shared_logic/adoption-calculator-v2.rb
+++ b/lib/smart_answer_flows/shared_logic/adoption-calculator-v2.rb
@@ -1,0 +1,277 @@
+## QA0
+multiple_choice :taking_paternity_leave_for_adoption? do
+  option yes: :employee_date_matched_paternity_adoption? #QAP1
+  option no: :date_of_adoption_match? # QA1
+end
+
+## QA1
+date_question :date_of_adoption_match? do
+  calculate :match_date do
+    Date.parse(responses.last)
+  end
+  calculate :calculator do
+    Calculators::MaternityPaternityCalculatorV2.new(match_date, "adoption")
+  end
+
+  next_node :date_of_adoption_placement?
+end
+
+## QA2
+date_question :date_of_adoption_placement? do
+  calculate :adoption_placement_date do
+    placement_date = Date.parse(responses.last)
+    raise SmartAnswer::InvalidResponse if placement_date < match_date
+    calculator.adoption_placement_date = placement_date
+    placement_date
+  end
+
+  calculate :a_leave_earliest_start do
+    calculator.format_date (adoption_placement_date - 14)
+  end
+
+  calculate :employment_start do
+    calculator.a_employment_start
+  end
+  next_node :adoption_did_the_employee_work_for_you?
+end
+
+## QA3
+multiple_choice :adoption_did_the_employee_work_for_you? do
+  option yes: :adoption_employment_contract?
+  option no: :adoption_not_entitled_to_leave_or_pay
+
+  calculate :adoption_leave_info do
+    PhraseList.new(:adoption_not_entitled_to_leave_or_pay)
+  end
+end
+
+## QA4
+multiple_choice :adoption_employment_contract? do
+  option :yes
+  option :no
+
+  save_input_as :employee_has_contract_adoption
+
+  #not entitled to leave if no contract; keep asking questions to check eligibility
+  calculate :adoption_leave_info do
+    if responses.last == 'no'
+      PhraseList.new(:adoption_not_entitled_to_leave)
+    end
+  end
+
+  next_node :adoption_is_the_employee_on_your_payroll?
+end
+
+## QA5
+multiple_choice :adoption_is_the_employee_on_your_payroll? do
+  option :yes
+  option :no
+
+  save_input_as :on_payroll
+
+  calculate :adoption_pay_info do
+    if responses.last == 'no'
+      PhraseList.new(
+        :adoption_not_entitled_to_pay_intro,
+        :must_be_on_payroll,
+        :adoption_not_entitled_to_pay_outro
+      )
+    end
+  end
+
+  calculate :to_saturday do
+    calculator.format_date_day calculator.matched_week.last
+  end
+
+  define_predicate(:no_contract_not_on_payroll?) do |response|
+    employee_has_contract_adoption == 'no' && response == 'no'
+  end
+
+  next_node_if(:adoption_not_entitled_to_leave_or_pay, no_contract_not_on_payroll?)
+  next_node :adoption_date_leave_starts?
+end
+
+## QA6
+date_question :adoption_date_leave_starts? do
+  calculate :adoption_date_leave_starts do
+    ald_start = Date.parse(responses.last)
+    raise SmartAnswer::InvalidResponse if ald_start < Date.parse(a_leave_earliest_start)
+    calculator.leave_start_date = ald_start
+  end
+
+  calculate :leave_start_date do
+    calculator.leave_start_date
+  end
+
+  calculate :leave_end_date do
+    calculator.leave_end_date
+  end
+
+  calculate :pay_start_date do
+    calculator.pay_start_date
+  end
+
+  calculate :pay_end_date do
+    calculator.pay_end_date
+  end
+
+  calculate :a_notice_leave do
+    calculator.format_date calculator.a_notice_leave
+  end
+
+  calculate :adoption_leave_info do
+    if adoption_leave_info.nil?
+      PhraseList.new(:adoption_leave_table)
+    else
+      adoption_leave_info
+    end
+  end
+
+  define_predicate(:has_contract_not_on_payroll?) do
+    employee_has_contract_adoption == 'yes' && on_payroll == 'no'
+  end
+
+  next_node_if(:adoption_leave_and_pay, has_contract_not_on_payroll?)
+  next_node :last_normal_payday_adoption?
+end
+
+# QA7
+date_question :last_normal_payday_adoption? do
+  from { 2.years.ago(Date.today) }
+  to { 2.years.since(Date.today) }
+
+  calculate :last_payday do
+    calculator.last_payday = Date.parse(responses.last)
+    raise SmartAnswer::InvalidResponse if calculator.last_payday > Date.parse(to_saturday)
+    calculator.last_payday
+  end
+  next_node :payday_eight_weeks_adoption?
+end
+
+# QA8
+date_question :payday_eight_weeks_adoption? do
+  from { 2.year.ago(Date.today) }
+  to { 2.years.since(Date.today) }
+
+  precalculate :payday_offset do
+    calculator.format_date_day calculator.payday_offset
+  end
+
+  calculate :last_payday_eight_weeks do
+    payday = Date.parse(responses.last)
+    raise SmartAnswer::InvalidResponse if payday > Date.parse(payday_offset)
+    calculator.pre_offset_payday = payday
+    payday
+  end
+
+  calculate :relevant_period do
+    calculator.formatted_relevant_period
+  end
+
+  next_node :pay_frequency_adoption?
+end
+
+# QA9
+multiple_choice :pay_frequency_adoption? do
+  option weekly: :earnings_for_pay_period_adoption?
+  option every_2_weeks: :earnings_for_pay_period_adoption?
+  option every_4_weeks: :earnings_for_pay_period_adoption?
+  option monthly: :earnings_for_pay_period_adoption?
+  save_input_as :pay_pattern
+
+  calculate :calculator do
+    calculator.pay_method = responses.last
+    calculator
+  end
+end
+
+## QA10
+money_question :earnings_for_pay_period_adoption? do
+
+ calculate :lower_earning_limit do
+   sprintf("%.2f", calculator.lower_earning_limit)
+ end
+
+  calculate :average_weekly_earnings do
+    sprintf("%.2f", calculator.average_weekly_earnings)
+  end
+
+  calculate :above_lower_earning_limit? do
+    calculator.average_weekly_earnings > calculator.lower_earning_limit
+  end
+
+  next_node_calculation :calculator do |response|
+    calculator.calculate_average_weekly_pay(pay_pattern, response)
+    calculator
+  end
+
+  define_predicate(:average_weekly_earnings_under_lower_earning_limit?) do
+    calculator.average_weekly_earnings < calculator.lower_earning_limit
+  end
+
+   calculate :adoption_pay_info do
+    if calculator.average_weekly_earnings < calculator.lower_earning_limit
+      PhraseList.new(
+        :adoption_not_entitled_to_pay_intro,
+        :must_earn_over_threshold,
+        :adoption_not_entitled_to_pay_outro
+      )
+    else
+      PhraseList.new(:adoption_pay_table)
+    end
+  end
+
+  next_node_if(:adoption_leave_and_pay, average_weekly_earnings_under_lower_earning_limit?)
+  next_node :how_do_you_want_the_sap_calculated?
+end
+
+## QA11
+multiple_choice :how_do_you_want_the_sap_calculated? do
+  option :weekly_starting
+  option :usual_paydates
+
+  save_input_as :sap_calculation_method
+
+  calculate :adoption_pay_info do
+    PhraseList.new(:adoption_pay_table)
+  end
+
+  next_node_if(:adoption_leave_and_pay, responded_with('weekly_starting'))
+  next_node_if(:monthly_pay_paternity?, variable_matches(:pay_pattern, 'monthly')) ## Shared with paternity calculator
+  next_node :next_pay_day_paternity? ## Shared with paternity calculator
+end
+
+outcome :adoption_leave_and_pay do
+
+  precalculate :pay_method do
+    calculator.pay_method = (
+      if monthly_pay_method
+        if monthly_pay_method == 'specific_date_each_month' and pay_day_in_month > 28
+          'last_day_of_the_month'
+        else
+          monthly_pay_method
+        end
+      elsif sap_calculation_method == 'weekly_starting'
+        sap_calculation_method
+      else
+        pay_pattern
+      end
+    )
+  end
+
+  precalculate :pay_dates_and_pay do
+    if above_lower_earning_limit?
+      calculator.paydates_and_pay.map do |date_and_pay|
+        %Q(#{date_and_pay[:date].strftime("%e %B %Y")}|£#{sprintf("%.2f", date_and_pay[:pay])})
+      end.join("\n")
+    end
+  end
+
+  precalculate :total_sap do
+    if above_lower_earning_limit?
+      sprintf("%.2f", calculator.total_statutory_pay)
+    end
+  end
+end
+
+outcome :adoption_not_entitled_to_leave_or_pay

--- a/lib/smart_answer_flows/shared_logic/maternity-calculator-v2.rb
+++ b/lib/smart_answer_flows/shared_logic/maternity-calculator-v2.rb
@@ -1,0 +1,305 @@
+
+days_of_the_week = Calculators::MaternityPaternityCalculatorV2::DAYS_OF_THE_WEEK
+
+## QM1
+date_question :baby_due_date_maternity? do
+  from { 1.year.ago(Date.today) }
+  to { 2.years.since(Date.today) }
+
+  calculate :calculator do
+    Calculators::MaternityPaternityCalculatorV2.new(Date.parse(responses.last))
+  end
+  next_node :employment_contract?
+end
+
+## QM2
+multiple_choice :employment_contract? do
+  option :yes
+  option :no
+  calculate :maternity_leave_info do
+    if responses.last == 'yes'
+      PhraseList.new(:maternity_leave_table)
+    else
+      PhraseList.new(:not_entitled_to_statutory_maternity_leave)
+    end
+  end
+  next_node :date_leave_starts?
+end
+
+## QM3
+date_question :date_leave_starts? do
+  from { 2.years.ago(Date.today) }
+  to { 2.years.since(Date.today) }
+
+  precalculate :leave_earliest_start_date do
+    calculator.leave_earliest_start_date
+  end
+
+  calculate :leave_start_date do
+    ls_date = Date.parse(responses.last)
+    raise SmartAnswer::InvalidResponse if ls_date < leave_earliest_start_date
+    calculator.leave_start_date = ls_date
+    calculator.leave_start_date
+  end
+
+  calculate :leave_end_date do
+    calculator.leave_end_date
+  end
+  calculate :leave_earliest_start_date do
+    calculator.leave_earliest_start_date
+  end
+  calculate :notice_of_leave_deadline do
+    calculator.notice_of_leave_deadline
+  end
+
+  calculate :pay_start_date do
+    calculator.pay_start_date
+  end
+  calculate :pay_end_date do
+    calculator.pay_end_date
+  end
+  calculate :employment_start do
+    calculator.employment_start
+  end
+  calculate :ssp_stop do
+    calculator.ssp_stop
+  end
+  next_node :did_the_employee_work_for_you?
+end
+
+## QM4
+multiple_choice :did_the_employee_work_for_you? do
+  option yes: :is_the_employee_on_your_payroll?
+  option no: :maternity_leave_and_pay_result
+  calculate :not_entitled_to_pay_reason do
+    responses.last == 'no' ? :not_worked_long_enough : nil
+  end
+end
+
+## QM5
+multiple_choice :is_the_employee_on_your_payroll? do
+  option yes: :last_normal_payday? # NOTE: goes to shared questions
+  option no: :maternity_leave_and_pay_result
+
+  calculate :not_entitled_to_pay_reason do
+    responses.last == 'no' ? :must_be_on_payroll : nil
+  end
+
+  calculate :to_saturday do
+    calculator.format_date_day calculator.qualifying_week.last
+  end
+end
+
+## QM6
+date_question :last_normal_payday? do
+  from { 2.years.ago(Date.today) }
+  to { 2.years.since(Date.today) }
+
+  calculate :last_payday do
+    calculator.last_payday = Date.parse(responses.last)
+    raise SmartAnswer::InvalidResponse if calculator.last_payday > Date.parse(to_saturday)
+    calculator.last_payday
+  end
+  next_node :payday_eight_weeks?
+end
+
+## QM7
+date_question :payday_eight_weeks? do
+  from { 2.year.ago(Date.today) }
+  to { 2.years.since(Date.today) }
+
+  precalculate :payday_offset do
+    calculator.format_date_day calculator.payday_offset
+  end
+
+  calculate :last_payday_eight_weeks do
+    payday = Date.parse(responses.last)
+    payday += 1 if leave_type == 'maternity'
+    raise SmartAnswer::InvalidResponse if payday > Date.parse(payday_offset)
+    calculator.pre_offset_payday = payday
+    payday
+  end
+
+  calculate :relevant_period do
+    calculator.formatted_relevant_period
+  end
+
+  next_node :pay_frequency?
+end
+
+## QM8
+multiple_choice :pay_frequency? do
+  save_input_as :pay_pattern
+  option :weekly
+  option :every_2_weeks
+  option :every_4_weeks
+  option :monthly
+
+  next_node(:earnings_for_pay_period?)
+end
+
+## QM9 Maternity only onwards
+money_question :earnings_for_pay_period? do
+  calculate :calculator do
+    calculator.calculate_average_weekly_pay(pay_pattern, responses.last)
+    calculator
+  end
+  calculate :average_weekly_earnings do
+    calculator.average_weekly_earnings
+  end
+  next_node :how_do_you_want_the_smp_calculated?
+end
+
+## QM10
+multiple_choice :how_do_you_want_the_smp_calculated? do
+  option :weekly_starting
+  option :usual_paydates
+
+  save_input_as :smp_calculation_method
+
+  on_condition(responded_with("usual_paydates")) do
+    next_node_if(:when_in_the_month_is_the_employee_paid?, variable_matches(:pay_pattern, "monthly"))
+    next_node(:when_is_your_employees_next_pay_day?)
+  end
+  next_node(:maternity_leave_and_pay_result)
+end
+
+## QM11
+date_question :when_is_your_employees_next_pay_day? do
+  calculate :next_pay_day do
+    calculator.pay_date = Date.parse(responses.last)
+    calculator.pay_date
+  end
+
+  next_node :maternity_leave_and_pay_result
+end
+
+## QM12
+multiple_choice :when_in_the_month_is_the_employee_paid? do
+  option first_day_of_the_month: :maternity_leave_and_pay_result
+  option last_day_of_the_month: :maternity_leave_and_pay_result
+  option specific_date_each_month: :what_specific_date_each_month_is_the_employee_paid?
+  option last_working_day_of_the_month: :what_days_does_the_employee_work?
+  option a_certain_week_day_each_month: :what_particular_day_of_the_month_is_the_employee_paid?
+
+  save_input_as :monthly_pay_method
+end
+
+## QM13
+value_question :what_specific_date_each_month_is_the_employee_paid? do
+  calculate :pay_day_in_month do
+    day = responses.last.to_i
+    raise InvalidResponse unless day > 0 and day < 32
+    calculator.pay_day_in_month = day
+  end
+
+  next_node :maternity_leave_and_pay_result
+end
+
+## QM14
+checkbox_question :what_days_does_the_employee_work? do
+  (0...days_of_the_week.size).each { |i| option i.to_s.to_sym }
+
+  calculate :last_day_in_week_worked do
+    calculator.work_days = responses.last.split(",").map(&:to_i)
+    calculator.pay_day_in_week = responses.last.split(",").sort.last.to_i
+  end
+  next_node :maternity_leave_and_pay_result
+end
+
+## QM15
+multiple_choice :what_particular_day_of_the_month_is_the_employee_paid? do
+  days_of_the_week.each { |d| option d.to_sym }
+
+  calculate :pay_day_in_week do
+    calculator.pay_day_in_week = days_of_the_week.index(responses.last)
+    responses.last
+  end
+  next_node :which_week_in_month_is_the_employee_paid?
+end
+
+## QM16
+multiple_choice :which_week_in_month_is_the_employee_paid? do
+  option :"first"
+  option :"second"
+  option :"third"
+  option :"fourth"
+  option :"last"
+
+  calculate :pay_week_in_month do
+    calculator.pay_week_in_month = responses.last
+  end
+  next_node :maternity_leave_and_pay_result
+end
+
+## Maternity outcomes
+outcome :maternity_leave_and_pay_result do
+
+  precalculate :pay_method do
+    calculator.pay_method = (
+      if monthly_pay_method
+        if monthly_pay_method == 'specific_date_each_month' and pay_day_in_month > 28
+          'last_day_of_the_month'
+        else
+          monthly_pay_method
+        end
+      elsif smp_calculation_method == 'weekly_starting'
+        smp_calculation_method
+      elsif pay_pattern
+        pay_pattern
+      end
+    )
+  end
+  precalculate :smp_a do
+    sprintf("%.2f", calculator.statutory_maternity_rate_a)
+  end
+  precalculate :smp_b do
+    sprintf("%.2f", calculator.statutory_maternity_rate_b)
+  end
+  precalculate :lower_earning_limit do
+    sprintf("%.2f", calculator.lower_earning_limit)
+  end
+
+  precalculate :notice_request_pay do
+    calculator.notice_request_pay
+  end
+
+  precalculate :below_threshold do
+    calculator.average_weekly_earnings and
+      calculator.average_weekly_earnings < calculator.lower_earning_limit
+  end
+
+  precalculate :not_entitled_to_pay_reason do
+    if below_threshold
+      :must_earn_over_threshold
+    else
+      not_entitled_to_pay_reason
+    end
+  end
+
+  precalculate :total_smp do
+    unless not_entitled_to_pay_reason.present?
+      sprintf("%.2f", calculator.total_statutory_pay)
+    end
+  end
+
+  precalculate :maternity_pay_info do
+    if not_entitled_to_pay_reason.present?
+      pay_info = PhraseList.new(calculator.average_weekly_earnings ?
+                                :not_entitled_to_smp_intro_with_awe : :not_entitled_to_smp_intro)
+      pay_info << not_entitled_to_pay_reason
+      pay_info << :not_entitled_to_smp_outro
+    else
+      pay_info = PhraseList.new(:maternity_pay_table, :paydates_table)
+    end
+    pay_info
+  end
+
+  precalculate :pay_dates_and_pay do
+    unless not_entitled_to_pay_reason.present?
+      calculator.paydates_and_pay.map do |date_and_pay|
+        %Q(#{date_and_pay[:date].strftime("%e %B %Y")}|£#{sprintf("%.2f", date_and_pay[:pay])})
+      end.join("\n")
+    end
+  end
+end

--- a/lib/smart_answer_flows/shared_logic/paternity-calculator-v2.rb
+++ b/lib/smart_answer_flows/shared_logic/paternity-calculator-v2.rb
@@ -1,0 +1,507 @@
+days_of_the_week = Calculators::MaternityPaternityCalculatorV2::DAYS_OF_THE_WEEK
+
+## QP0
+multiple_choice :leave_or_pay_for_adoption? do
+  option yes: :employee_date_matched_paternity_adoption?
+  option no: :baby_due_date_paternity?
+end
+
+## QP1
+date_question :baby_due_date_paternity? do
+  calculate :due_date do
+    Date.parse(responses.last)
+  end
+
+  calculate :calculator do
+    Calculators::MaternityPaternityCalculatorV2.new(due_date, 'paternity')
+  end
+
+  next_node :baby_birth_date_paternity?
+end
+
+## QAP1 - Paternity Adoption
+date_question :employee_date_matched_paternity_adoption? do
+  calculate :matched_date do
+    Date.parse(responses.last)
+  end
+
+  calculate :calculator do
+    Calculators::MaternityPaternityCalculatorV2.new(matched_date, 'paternity_adoption')
+  end
+
+  calculate :leave_type do
+    'paternity_adoption'
+  end
+
+  calculate :paternity_adoption? do
+    leave_type == 'paternity_adoption'
+  end
+
+  next_node :padoption_date_of_adoption_placement?
+end
+
+## QP2
+date_question :baby_birth_date_paternity? do
+  calculate :date_of_birth do
+    Date.parse(responses.last)
+  end
+
+  calculate :calculator do
+    calculator.date_of_birth = date_of_birth
+    calculator
+  end
+
+  next_node :employee_responsible_for_upbringing?
+end
+
+## QAP2 - Paternity Adoption
+date_question :padoption_date_of_adoption_placement? do
+
+  calculate :ap_adoption_date do
+    placement_date = Date.parse(responses.last)
+    raise SmartAnswer::InvalidResponse if placement_date < matched_date
+    calculator.adoption_placement_date = placement_date
+    placement_date
+  end
+
+  calculate :ap_adoption_date_formatted do
+    calculator.format_date_day ap_adoption_date
+  end
+
+  calculate :matched_date_formatted do
+    calculator.format_date_day matched_date
+  end
+
+  next_node :padoption_employee_responsible_for_upbringing?
+end
+
+## QP3
+multiple_choice :employee_responsible_for_upbringing? do
+  option yes: :employee_work_before_employment_start?
+  option no: :paternity_not_entitled_to_leave_or_pay
+  save_input_as :paternity_responsible
+
+  calculate :employment_start do
+    calculator.employment_start
+  end
+
+  calculate :employment_end do
+    due_date
+  end
+
+  calculate :p_notice_leave do
+    calculator.notice_of_leave_deadline
+  end
+end
+
+## QAP3 - Paternity Adoption
+multiple_choice :padoption_employee_responsible_for_upbringing? do
+  option yes: :employee_work_before_employment_start? # Combined flow
+  option no: :paternity_not_entitled_to_leave_or_pay
+  save_input_as :paternity_responsible
+
+  calculate :employment_start do
+    calculator.a_employment_start
+  end
+
+  calculate :employment_end do
+    matched_date
+  end
+end
+
+## QP4 - Shared flow onwards
+multiple_choice :employee_work_before_employment_start? do
+  option yes: :employee_has_contract_paternity?
+  option no: :paternity_not_entitled_to_leave_or_pay
+  save_input_as :paternity_employment_start ## Needed only in outcome
+end
+
+## QP5
+multiple_choice :employee_has_contract_paternity? do
+  option :yes
+  option :no
+  save_input_as :has_contract
+
+  next_node :employee_on_payroll_paternity?
+end
+
+## QP6
+multiple_choice :employee_on_payroll_paternity? do
+  option :yes => :employee_still_employed_on_birth_date?
+  option :no
+  save_input_as :on_payroll
+
+  calculate :leave_spp_claim_link do
+    paternity_adoption? ? 'adoption' : 'notice-period'
+  end
+
+  calculate :not_entitled_reason do
+    if responses.last == 'no' && has_contract == 'no'
+      PhraseList.new(
+        :paternity_not_entitled_to_leave,
+        :paternity_not_entitled_to_pay_intro,
+        :must_be_on_payroll,
+        :paternity_not_entitled_to_pay_outro
+      )
+    end
+  end
+
+  calculate :to_saturday do
+    if paternity_adoption?
+      calculator.format_date_day calculator.matched_week.last
+    else
+      calculator.format_date_day calculator.qualifying_week.last
+    end
+  end
+
+  calculate :still_employed_date do
+    paternity_adoption? ? calculator.employment_end : date_of_birth
+  end
+
+  calculate :start_leave_hint do
+    paternity_adoption? ? ap_adoption_date_formatted : date_of_birth
+  end
+
+  next_node_if(:paternity_not_entitled_to_leave_or_pay, variable_matches(:has_contract, 'no'))
+  next_node :employee_start_paternity?
+end
+
+## QP7
+multiple_choice :employee_still_employed_on_birth_date? do
+  option :yes
+  option :no
+  save_input_as :employed_dob
+
+  calculate :not_entitled_reason do
+    if responses.last == 'no' and has_contract == 'no'
+      PhraseList.new(
+        :paternity_not_entitled_to_leave,
+        :paternity_not_entitled_to_pay_intro,
+        :"#{leave_type}_must_be_employed_by_you",
+        :paternity_not_entitled_to_pay_outro
+      )
+    end
+  end
+
+  next_node_if(:paternity_not_entitled_to_leave_or_pay, variable_matches(:has_contract, 'no') & responded_with('no'))
+  next_node :employee_start_paternity?
+end
+
+## QP8
+date_question :employee_start_paternity? do
+  from { 2.years.ago(Date.today) }
+  to { 2.years.since(Date.today) }
+
+  save_input_as :employee_leave_start
+
+  calculate :leave_start_date do
+    calculator.leave_start_date = Date.parse(responses.last)
+    if paternity_adoption?
+      raise SmartAnswer::InvalidResponse if calculator.leave_start_date < ap_adoption_date
+    else
+      raise SmartAnswer::InvalidResponse if calculator.leave_start_date < date_of_birth
+    end
+    calculator.leave_start_date
+  end
+
+  calculate :notice_of_leave_deadline do
+    calculator.notice_of_leave_deadline
+  end
+
+  next_node :employee_paternity_length?
+end
+
+## QP9
+multiple_choice :employee_paternity_length? do
+  option :one_week
+  option :two_weeks
+  save_input_as :leave_amount
+
+  calculate :leave_end_date do
+    unless leave_start_date.nil?
+      if responses.last == 'one_week'
+        1.week.since(leave_start_date)
+      else
+        2.weeks.since(leave_start_date)
+      end
+    end
+  end
+
+  calculate :not_entitled_reason do
+    if has_contract == 'yes'
+      if employed_dob == 'no'
+        PhraseList.new(
+          :paternity_entitled_to_leave,
+          :paternity_not_entitled_to_pay_intro,
+          :"#{leave_type}_must_be_employed_by_you",
+          :paternity_not_entitled_to_pay_outro
+        )
+      elsif on_payroll == 'no'
+        PhraseList.new(
+          :paternity_entitled_to_leave,
+          :paternity_not_entitled_to_pay_intro,
+          :must_be_on_payroll,
+          :paternity_not_entitled_to_pay_outro
+        )
+      end
+    end
+  end
+
+  next_node_if(:paternity_not_entitled_to_leave_or_pay, variable_matches(:has_contract, 'yes') &
+    (variable_matches(:on_payroll, 'no') | variable_matches(:employed_dob, 'no')))
+  next_node :last_normal_payday_paternity?
+end
+
+## QP10
+date_question :last_normal_payday_paternity? do
+  from { 2.years.ago(Date.today) }
+  to { 2.years.since(Date.today) }
+
+  calculate :calculator do
+    calculator.last_payday = Date.parse(responses.last)
+    raise SmartAnswer::InvalidResponse if calculator.last_payday > Date.parse(to_saturday)
+    calculator
+  end
+
+  next_node :payday_eight_weeks_paternity?
+end
+
+## QP11
+date_question :payday_eight_weeks_paternity? do
+  from { 2.years.ago(Date.today) }
+  to { 2.years.since(Date.today) }
+
+  precalculate :payday_offset do
+    calculator.payday_offset
+  end
+
+  calculate :pre_offset_payday do
+    payday = Date.parse(responses.last)
+    raise SmartAnswer::InvalidResponse if payday > calculator.payday_offset
+    calculator.pre_offset_payday = payday
+    payday
+  end
+
+  calculate :relevant_period do
+    calculator.formatted_relevant_period
+  end
+
+  next_node :pay_frequency_paternity?
+end
+
+## QP12
+multiple_choice :pay_frequency_paternity? do
+  option weekly: :earnings_for_pay_period_paternity?
+  option every_2_weeks: :earnings_for_pay_period_paternity?
+  option every_4_weeks: :earnings_for_pay_period_paternity?
+  option monthly: :earnings_for_pay_period_paternity?
+  save_input_as :pay_pattern
+
+  calculate :calculator do
+    calculator.pay_method = responses.last
+    calculator
+  end
+
+end
+
+## QP13
+money_question :earnings_for_pay_period_paternity? do
+  save_input_as :earnings
+
+  next_node_calculation :calculator do |response|
+    calculator.calculate_average_weekly_pay(pay_pattern, response)
+    calculator
+  end
+
+  define_predicate(:average_weekly_earnings_under_lower_earning_limit?) do
+    calculator.average_weekly_earnings < calculator.lower_earning_limit
+  end
+
+  next_node_if(:paternity_leave_and_pay, average_weekly_earnings_under_lower_earning_limit?)
+  next_node :how_do_you_want_the_spp_calculated?
+end
+
+## QP14
+multiple_choice :how_do_you_want_the_spp_calculated? do
+  option :weekly_starting
+  option :usual_paydates
+
+  save_input_as :spp_calculation_method
+
+  next_node_if(:paternity_leave_and_pay, responded_with('weekly_starting'))
+  next_node_if(:monthly_pay_paternity?, variable_matches(:pay_pattern, 'monthly'))
+  next_node :next_pay_day_paternity?
+end
+
+## QP15 - Also shared with adoption calculator here onwards
+date_question :next_pay_day_paternity? do
+  from { 2.years.ago(Date.today) }
+  to { 2.years.since(Date.today) }
+  save_input_as :next_pay_day
+
+  calculate :calculator do
+    calculator.pay_date = Date.parse(responses.last)
+    calculator
+  end
+  next_node :paternity_leave_and_pay
+end
+
+## QP16
+multiple_choice :monthly_pay_paternity? do
+  option :first_day_of_the_month
+  option :last_day_of_the_month
+  option specific_date_each_month: :specific_date_each_month_paternity?
+  option last_working_day_of_the_month: :days_of_the_week_paternity?
+  option a_certain_week_day_each_month: :day_of_the_month_paternity?
+
+  save_input_as :monthly_pay_method
+
+  next_node_if(:adoption_leave_and_pay, variable_matches(:leave_type, 'adoption'))
+  next_node :paternity_leave_and_pay
+end
+
+## QP17
+value_question :specific_date_each_month_paternity? do
+
+  calculate :pay_day_in_month do
+    day = responses.last.to_i
+    raise InvalidResponse unless day > 0 and day < 32
+    calculator.pay_day_in_month = day
+  end
+
+  next_node_if(:adoption_leave_and_pay, variable_matches(:leave_type, 'adoption'))
+  next_node :paternity_leave_and_pay
+end
+
+## QP18
+checkbox_question :days_of_the_week_paternity? do
+  (0...days_of_the_week.size).each { |i| option i.to_s.to_sym }
+
+  calculate :last_day_in_week_worked do
+    calculator.work_days = responses.last.split(",").map(&:to_i)
+    calculator.pay_day_in_week = responses.last.split(",").sort.last.to_i
+  end
+
+  next_node_if(:adoption_leave_and_pay, variable_matches(:leave_type, 'adoption'))
+  next_node :paternity_leave_and_pay
+end
+
+## QP19
+multiple_choice :day_of_the_month_paternity? do
+  option :"0"
+  option :"1"
+  option :"2"
+  option :"3"
+  option :"4"
+  option :"5"
+  option :"6"
+
+  calculate :pay_day_in_week do
+    calculator.pay_day_in_week = responses.last.to_i
+    days_of_the_week[responses.last.to_i]
+  end
+
+  next_node :pay_date_options_paternity?
+end
+
+## QP20
+multiple_choice :pay_date_options_paternity? do
+  option :"first"
+  option :"second"
+  option :"third"
+  option :"fourth"
+  option :"last"
+
+  calculate :pay_week_in_month do
+    calculator.pay_week_in_month = responses.last
+  end
+
+  next_node_if(:adoption_leave_and_pay, variable_matches(:leave_type, 'adoption'))
+  next_node :paternity_leave_and_pay
+end
+
+# Paternity outcomes
+outcome :paternity_leave_and_pay do
+
+  precalculate :pay_method do
+    calculator.pay_method = (
+      if monthly_pay_method
+        if monthly_pay_method == 'specific_date_each_month' and pay_day_in_month > 28
+          'last_day_of_the_month'
+        else
+          monthly_pay_method
+        end
+      elsif spp_calculation_method == 'weekly_starting'
+        spp_calculation_method
+      else
+        pay_pattern
+      end
+    )
+  end
+
+  precalculate :above_lower_earning_limit? do
+    calculator.average_weekly_earnings > calculator.lower_earning_limit
+  end
+
+  precalculate :paternity_info do
+    phrases = PhraseList.new
+
+    if has_contract == "no"
+      phrases << :paternity_not_entitled_to_leave
+    else
+      phrases << :paternity_entitled_to_leave
+    end
+
+    unless above_lower_earning_limit?
+      phrases << :paternity_not_entitled_to_pay_intro <<
+                  :must_earn_over_threshold <<
+                  :paternity_not_entitled_to_pay_outro
+    else
+      phrases << :paternity_entitled_to_pay << :"#{leave_type}_spp_claim_link"
+    end
+    phrases
+  end
+
+  precalculate :lower_earning_limit do
+    sprintf("%.2f", calculator.lower_earning_limit)
+  end
+
+  precalculate :entitled_to_pay? do
+    !paternity_info.nil? && paternity_info.phrase_keys.include?(:paternity_entitled_to_pay)
+  end
+
+  precalculate :pay_dates_and_pay do
+    if entitled_to_pay? && above_lower_earning_limit?
+      calculator.paydates_and_pay.map do |date_and_pay|
+        %Q(#{date_and_pay[:date].strftime("%e %B %Y")}|£#{sprintf("%.2f", date_and_pay[:pay])})
+      end.join("\n")
+    end
+  end
+
+  precalculate :total_spp do
+    if above_lower_earning_limit?
+      sprintf("%.2f", calculator.total_statutory_pay)
+    end
+  end
+
+  precalculate :average_weekly_earnings do
+    sprintf("%.2f", calculator.average_weekly_earnings)
+  end
+
+end
+
+outcome :paternity_not_entitled_to_leave_or_pay do
+  precalculate :not_entitled_reason do
+    if not_entitled_reason.nil?
+      phrases = PhraseList.new(:paternity_not_entitled_to_leave_or_pay_intro)
+      phrases << :"#{leave_type}_not_responsible_for_upbringing" if paternity_responsible == 'no'
+      phrases << :not_worked_long_enough if paternity_employment_start == "no"
+      phrases << :paternity_entitled_to_leave if on_payroll == "no"
+      phrases << :paternity_not_entitled_to_pay_a if has_contract == "no"
+      phrases << :paternity_not_entitled_to_leave_or_pay_outro
+      phrases
+    else
+      not_entitled_reason
+    end
+  end
+end

--- a/test/unit/calculators/maternity_paternity_calculator_test_v2.rb
+++ b/test/unit/calculators/maternity_paternity_calculator_test_v2.rb
@@ -1,0 +1,803 @@
+require_relative "../../test_helper"
+require_relative "../../../lib/smart_answer/date_helper"
+
+module SmartAnswer::Calculators
+  class MaternityPaternityCalculatorV2Test < ActiveSupport::TestCase
+    include DateHelper
+
+    context MaternityPaternityCalculatorV2 do
+      context "due date 4 months in future" do
+        setup do
+          @due_date = 4.months.since(Date.today)
+          @start_of_week_in_four_months = @due_date - @due_date.wday
+          @calculator = MaternityPaternityCalculatorV2.new(@due_date)
+          Timecop.travel('25 March 2013')
+        end
+
+        should "calculate expected birth week" do
+          assert_equal @start_of_week_in_four_months, @calculator.expected_week.first
+        end
+
+        should "calculate qualifying week" do
+          assert_equal 15.weeks.ago(@start_of_week_in_four_months), @calculator.qualifying_week.first
+        end
+
+        should "calculate notice of leave deadline" do
+          assert_equal next_saturday(15.weeks.ago(@start_of_week_in_four_months)), @calculator.notice_of_leave_deadline
+        end
+
+        should "calculate the earliest leave start date" do
+          assert_equal 11.weeks.ago(@start_of_week_in_four_months), @calculator.leave_earliest_start_date
+        end
+
+        should "calculate the relevant period" do
+          @dd = Date.parse("2012-10-12")
+          @calculator = MaternityPaternityCalculatorV2.new(@dd)
+          @calculator.last_payday = @calculator.qualifying_week.last
+          payday = @calculator.last_payday.julian - (7 * 9)
+          @calculator.pre_offset_payday = payday
+          assert_equal "Saturday, 15 April 2012 and Saturday, 30 June 2012", @calculator.formatted_relevant_period
+        end
+
+        should "calculate payday offset" do
+          @calculator.last_payday = Date.parse("2012-03-28")
+          assert_equal Date.parse("2012-02-02"), @calculator.payday_offset
+        end
+
+        should "calculate the ssp_stop date" do
+          @calculator = MaternityPaternityCalculatorV2.new(Date.parse("2012 Oct 12"))
+          expected_week = @calculator.expected_week.first
+          assert_equal expected_week.julian - (7 * 4), @calculator.ssp_stop
+        end
+
+        context "with a requested leave date in one month's time" do
+          setup do
+            @leave_start_date = 1.month.since(Date.parse("2013 Mar 12"))
+            @calculator.leave_start_date = @leave_start_date
+          end
+
+          should "make the leave end date 52 weeks from the leave start date" do
+            assert_equal Date.parse("2014 Apr 10"), @calculator.leave_end_date
+          end
+
+          should "make the leave end date after the leave start date" do
+            assert @calculator.leave_end_date > @calculator.leave_start_date, "Leave end date should come after leave start date"
+          end
+
+          should "make the pay start date the same date" do
+            assert_equal @leave_start_date, @calculator.pay_start_date
+          end
+
+          should "make the pay end date 39 weeks from the start date" do
+            assert_equal 39.weeks.since(@leave_start_date) - 1, @calculator.pay_end_date
+          end
+
+          should "have a notice request date 28 days before the leave start date" do
+            assert_equal 28.days.ago(@leave_start_date), @calculator.notice_request_pay
+          end
+        end
+
+        context "with a weekly income of 193.00" do
+          setup do
+            @calculator.average_weekly_earnings = 193.00
+            @calculator.leave_start_date = Date.new(2012, 1, 1)
+          end
+
+          should "calculate the statutory maternity rate" do
+            assert_equal (193.00 * 0.9).round(2), @calculator.statutory_maternity_rate.round(2)
+          end
+
+          should "calculate the maternity pay at rate A" do
+            assert_equal (193.00 * 0.9).round(2), @calculator.statutory_maternity_rate_a.round(2)
+          end
+
+          should "calculate the maternity pay at rate B using the base rate" do
+            assert_equal 135.45, @calculator.statutory_maternity_rate_b
+          end
+
+          should "calculate the maternity pay at rate B using the percentage of weekly income" do
+            @calculator.average_weekly_earnings = 135.40
+            assert_equal 121.86, @calculator.statutory_maternity_rate_b.round(2)
+          end
+
+        end
+
+        should "calculate the paternity rate as the standard rate" do
+          @calculator.average_weekly_earnings = 500.55
+          @calculator.leave_start_date = Date.new(2012, 1, 1)
+          assert_equal 135.45, @calculator.statutory_paternity_rate
+        end
+
+        should "calculate the paternity rate as 90 percent of weekly earnings" do
+          @calculator.average_weekly_earnings = 120.55
+          @calculator.leave_start_date = Date.new(2012, 1, 1)
+          assert_equal ((120.55 * 0.9).to_f).round(2), @calculator.statutory_paternity_rate
+        end
+
+        context "with an adoption placement date of a week ago" do
+          setup do
+            @one_week_ago = 1.week.ago(Date.today)
+            @calculator.adoption_placement_date = @one_week_ago
+          end
+
+          should "make the earliest leave start date 14 days before the placement date" do
+            assert_equal 1.fortnight.ago(@one_week_ago), @calculator.leave_earliest_start_date
+          end
+        end
+      end
+
+      context "test for 2013 to 2014 rate" do
+        setup do
+          @due_date = Date.parse("1 September 2013")
+          @start_of_week_in_four_months = @due_date - @due_date.wday
+          @calculator = MaternityPaternityCalculatorV2.new(@due_date)
+          Timecop.travel('1 September 2013')
+        end
+
+        should "calculate the paternity rate as the standard rate for 2014" do
+          @calculator.average_weekly_earnings = 500.55
+          @calculator.leave_start_date = Date.new(2014, 1, 1)
+          assert_equal 136.78, @calculator.statutory_paternity_rate
+        end
+
+        should "calculate the paternity rate as 90 percent of weekly earnings" do
+          @calculator.average_weekly_earnings = 120.55
+          @calculator.leave_start_date = Date.new(2014, 1, 1)
+          assert_equal ((120.55 * 0.9).to_f).round(2), @calculator.statutory_paternity_rate
+        end
+      end
+
+      context "test for 2014 to 2015 rate" do
+        setup do
+          @due_date = Date.parse("1 September 2014")
+          @start_of_week_in_four_months = @due_date - @due_date.wday
+          @calculator = MaternityPaternityCalculatorV2.new(@due_date)
+          Timecop.travel('1 September 2014')
+        end
+
+        should "calculate the paternity rate as the standard rate for 2015" do
+          @calculator.average_weekly_earnings = 500.55
+          @calculator.leave_start_date = Date.new(2015, 1, 1)
+          assert_equal 138.18, @calculator.statutory_paternity_rate
+        end
+
+        should "calculate the paternity rate as 90 percent of weekly earnings" do
+          @calculator.average_weekly_earnings = 120.55
+          @calculator.leave_start_date = Date.new(2015, 1, 1)
+          assert_equal ((120.55 * 0.9).to_f).round(2), @calculator.statutory_paternity_rate
+        end
+      end
+
+      context "specific date tests (for lower_earning_limits) for birth" do
+        should "return lower_earning_limit 107" do
+          @due_date = Date.parse("1 January 2013")
+          @calculator = MaternityPaternityCalculatorV2.new(@due_date)
+          assert_equal @calculator.lower_earning_limit, 107
+        end
+
+        should "return 109 when due is in 2013/2014 tax year" do
+          @due_date = Date.parse("14 November 2013")
+          @calculator = MaternityPaternityCalculatorV2.new(@due_date)
+          assert_equal @calculator.lower_earning_limit, 109
+        end
+
+        should "return 111 for due dates after 14/07/2014" do
+          @due_date = Date.parse("14 July 2015")
+          @calculator = MaternityPaternityCalculatorV2.new(@due_date)
+          assert_equal @calculator.lower_earning_limit, 111
+        end
+
+        should "return lower_earning_limit 109" do
+          @due_date = Date.parse("15 July 2014")
+          @calculator = MaternityPaternityCalculatorV2.new(@due_date)
+          assert_equal @calculator.lower_earning_limit, 109
+        end
+
+        should "return lower_earning_limit 107" do
+          @due_date = Date.parse("15 July 2013")
+          @calculator = MaternityPaternityCalculatorV2.new(@due_date)
+          assert_equal @calculator.lower_earning_limit, 107
+        end
+
+        should "return lower_earning_limit 102" do
+          @due_date = Date.parse("15 July 2012")
+          @calculator = MaternityPaternityCalculatorV2.new(@due_date)
+          assert_equal @calculator.lower_earning_limit, 102
+        end
+
+        should "return lower_earning_limit 102" do
+          @due_date = Date.parse("14 July 2012")
+          @calculator = MaternityPaternityCalculatorV2.new(@due_date)
+          assert_equal @calculator.lower_earning_limit, 102
+        end
+
+        should "return lower_earning_limit 102" do
+          @due_date = Date.parse("1 January 2012")
+          @calculator = MaternityPaternityCalculatorV2.new(@due_date)
+          assert_equal @calculator.lower_earning_limit, 102
+        end
+
+        should "return lower_earning_limit 97" do
+          @due_date = Date.parse("1 January 2011")
+          @calculator = MaternityPaternityCalculatorV2.new(@due_date)
+          assert_equal @calculator.lower_earning_limit, 97
+        end
+
+        should "return lower_earning_limit 95" do
+          @due_date = Date.parse("1 January 2010")
+          @calculator = MaternityPaternityCalculatorV2.new(@due_date)
+          assert_equal @calculator.lower_earning_limit, 95
+        end
+      end
+
+      context "specific date tests (for lower_earning_limits) for adoption" do
+        should "return lower_earning_limit 107" do
+          @match_date = Date.parse("1 September 2012")
+          @calculator = MaternityPaternityCalculatorV2.new(@match_date, "adoption")
+          assert_equal @calculator.lower_earning_limit, 107
+        end
+
+        should "return lower_earning_limit 102" do
+          @match_date = Date.parse("31 March 2012")
+          @calculator = MaternityPaternityCalculatorV2.new(@match_date, "adoption")
+          assert_equal @calculator.lower_earning_limit, 102
+        end
+
+        should "return lower_earning_limit 97" do
+          @match_date = Date.parse("2 April 2011")
+          @calculator = MaternityPaternityCalculatorV2.new(@match_date, "adoption")
+          assert_equal @calculator.lower_earning_limit, 97
+        end
+      end
+
+      context "qualifying_week tests" do
+        # due, qualifying_week, latest employment start, start of 11th week before due, start of 4th week
+        # 08/04/12 to 14/04/12 25/12/11 to 31/12/11 09/07/2011 22/01/2012 11/03/2012
+        should "due Monday 9th April 2012" do
+          @due_date = Date.parse("2012 Apr 09")
+          @calculator = MaternityPaternityCalculatorV2.new(@due_date)
+          assert_equal Date.parse("09 Apr 2012"), @calculator.employment_end
+          assert_equal Date.parse("08 Apr 2012")..Date.parse("14 Apr 2012"), @calculator.expected_week
+          assert_equal Date.parse("25 Dec 2011"), 15.weeks.ago(@calculator.expected_week.first)
+          assert_equal Date.parse("31 Dec 2011"), 15.weeks.ago(@calculator.expected_week.first) + 6
+          assert_equal Date.parse("25 Dec 2011")..Date.parse("31 Dec 2011"), @calculator.qualifying_week
+          # assert_equal 26, (Date.parse(" Dec 2011").julian - Date.parse("09 Jul 2011").julian).to_i / 7
+          # assert_equal 26, (Date.parse("14 Apr 2012").julian - Date.parse("15 Oct 2011").julian).to_i / 7
+          # FIXME: this should work but 25 weeks rather than 26
+          assert_equal Date.parse("09 Jul 2011"), @calculator.employment_start
+          assert_equal Date.parse("22 Jan 2012"), @calculator.leave_earliest_start_date
+          assert_equal Date.parse("11 Mar 2012"), @calculator.ssp_stop
+        end
+        # 15/07/12 to 21/07/12 01/04/12 to 07/04/12 15/10/2011 29/04/2012 17/06/2012
+        should "due Wednesday 18 July 2012" do
+          @due_date = Date.parse("2012 Jul 18")
+          @calculator = MaternityPaternityCalculatorV2.new(@due_date)
+          assert_equal Date.parse("18 Jul 2012"), @calculator.employment_end
+          assert_equal Date.parse("15 Jul 2012")..Date.parse("21 Jul 2012"), @calculator.expected_week
+          assert_equal Date.parse("01 Apr 2012")..Date.parse("07 Apr 2012"), @calculator.qualifying_week
+          # DEBUG test
+          # assert_equal 26, (Date.parse("21 Jul 2012").julian - Date.parse("15 Oct 2011").julian).to_i / 7
+          # FIXME: ...
+          assert_equal Date.parse("15 Oct 2011"), @calculator.employment_start
+          assert_equal Date.parse("29 Apr 2012"), @calculator.leave_earliest_start_date
+          assert_equal Date.parse("17 Jun 2012"), @calculator.ssp_stop
+        end
+        # 09/09/12 to 15/09/12 27/05/12 to 02/06/12 10/12/2011 24/06/2012 12/08/2012
+        should "due Wednesday 14 Sep 2012" do
+          @due_date = Date.parse("2012 Sep 14")
+          @calculator = MaternityPaternityCalculatorV2.new(@due_date)
+          assert_equal Date.parse("14 Sep 2012"), @calculator.employment_end
+          assert_equal Date.parse("09 Sep 2012")..Date.parse("15 Sep 2012"), @calculator.expected_week
+          assert_equal Date.parse("27 May 2012")..Date.parse("02 Jun 2012"), @calculator.qualifying_week
+          assert_equal Date.parse("10 Dec 2011"), @calculator.employment_start
+          assert_equal Date.parse("24 Jun 2012"), @calculator.leave_earliest_start_date
+          assert_equal Date.parse("12 Aug 2012"), @calculator.ssp_stop
+        end
+        # 07/04/13 to 13/04/13 23/12/12 to 29/12/12 07/07/2012 20/01/2013 10/03/2013
+        # 27/01/13 to 02/02/13 14/10/12 to 20/10/12 28/04/2012 11/11/2012 30/12/2012
+        # 03/02/13 to 09/02/13 21/10/12 to 27/10/12 05/05/2012 18/11/2012 06/01/2013
+      end
+
+      context "adoption employment start tests" do
+        # 27/05/12 to 02/06/12 10/12/11
+        should "matched_date Monday 28th May 2012" do
+          @matched_date = Date.parse("2012 May 28")
+          @calculator = MaternityPaternityCalculatorV2.new(@matched_date, "adoption")
+          assert_equal Date.parse("2012 May 27")..Date.parse("2012 Jun 02"), @calculator.matched_week
+          assert_equal Date.parse("2011 Dec 10"), @calculator.a_employment_start
+        end
+        # 15/07/12 to 21/07/12 28/01/12
+        should "matched_date Wednesday 18th July 2012" do
+          @matched_date = Date.parse("2012 Jul 18")
+          @calculator = MaternityPaternityCalculatorV2.new(@matched_date, "adoption")
+          assert_equal Date.parse("2012 Jul 15")..Date.parse("2012 Jul 21"), @calculator.matched_week
+          assert_equal Date.parse("2012 Jan 28"), @calculator.a_employment_start
+          assert_equal 25, (Date.parse("2012 Jul 21").julian - Date.parse("2012 Jan 28").julian).to_i / 7
+        end
+        # 16/09/12 to 22/09/12 31/03/12
+        # 09/12/12 to 15/12/12 23/06/12
+        # 10/03/13 to 16/03/13 22/09/12
+      end
+
+      context "calculate_average_weekly_pay" do
+        setup do
+          @calculator = MaternityPaternityCalculatorV2.new(4.months.since(Date.today))
+        end
+
+        should "make no calculation for a weekly pay pattern" do
+          assert_equal 665.15, @calculator.calculate_average_weekly_pay("weekly", 5321.20)
+        end
+
+        should "work out the weekly average for a fortnightly pay pattern" do
+          assert_equal 399.32, @calculator.calculate_average_weekly_pay("every_2_weeks", 3194.56)
+        end
+
+        should "work out the weekly average for a four week pay pattern" do
+          assert_equal 382.06, @calculator.calculate_average_weekly_pay("every_4_weeks", 3056.48)
+        end
+
+        should "work out the weekly average for a monthly pay pattern" do
+          assert_equal 1846.15385, @calculator.calculate_average_weekly_pay("monthly", 16000)
+        end
+
+        should "work out the weekly average for a irregular pay pattern" do
+          @calculator.last_payday = 15.days.ago(Date.today)
+          @calculator.pre_offset_payday = 55.days.ago(@calculator.last_payday)
+          assert_equal 56, @calculator.pay_period_in_days
+          assert_equal 974.82875, @calculator.calculate_average_weekly_pay("irregularly", 7798.63)
+        end
+      end
+      context "HMRC scenarios" do
+        setup do
+          @calculator = MaternityPaternityCalculatorV2.new(Date.parse("2013-02-22"))
+        end
+
+        should "calculate AWE for weekly pay patterns" do
+          assert_equal 200, @calculator.calculate_average_weekly_pay("weekly", 1600)
+          assert_equal 151, @calculator.calculate_average_weekly_pay("weekly", 1208)
+          assert_equal 150, @calculator.calculate_average_weekly_pay("weekly", 1200)
+        end
+
+        should "calculate AWE for monthly pay patterns" do
+          @calculator.last_payday = Date.parse("2012-10-31")
+          assert_equal 184.61538, @calculator.calculate_average_weekly_pay("monthly", 1600)
+          @calculator.last_payday = Date.parse("2012-10-26")
+          assert_equal 144.31731, @calculator.calculate_average_weekly_pay("monthly", 1250.75)
+        end
+
+        should "calculate AWE for irregular pay patterns" do
+          @calculator.last_payday = Date.parse("2012-11-06")
+          @calculator.pre_offset_payday = Date.parse("2012-08-01")
+          assert_equal 214.28571, @calculator.calculate_average_weekly_pay("irregularly", 3000)
+        end
+      end
+
+      context "total_statutory_pay" do
+        setup do
+          @calculator = MaternityPaternityCalculatorV2.new(Date.parse('3 August 2012'))
+          @calculator.leave_start_date = Date.parse('12 July 2012')
+          @calculator.pay_method = 'weekly_starting'
+        end
+
+        should "be statutory leave times statutory rates A and B" do
+          @calculator.average_weekly_earnings = 120.40
+          assert_equal 4226.43, @calculator.total_statutory_pay
+        end
+
+        should "be statutory leave times statutory higher rate A and statutory rate B" do
+          @calculator.average_weekly_earnings = 235.40
+          assert_equal 5741.01, @calculator.total_statutory_pay.round(2)
+        end
+      end
+
+      context "pay dates for pay method from 12 August 2012" do
+        setup do
+          @calculator = MaternityPaternityCalculatorV2.new(Date.parse('12 August 2012'))
+          @calculator.leave_start_date = Date.parse('12 July 2012')
+          # The maternity pay period runs from Thursday 12 July 2012 until 11th April 2013
+        end
+        should "calculate SMP weekly pay dates" do
+          @calculator.pay_method = 'weekly_starting'
+          paydates = @calculator.paydates_weekly_starting
+
+          assert_equal '2012-07-18', paydates.first.to_s
+          assert_equal '2012-07-25', paydates.second.to_s
+          assert_equal '2012-08-01', paydates.third.to_s
+          assert_equal '2012-08-08', paydates.fourth.to_s
+          assert_equal '2013-04-10', paydates.last.to_s
+        end
+        should "calculate usual weekly pay dates" do
+          @calculator.pay_method = 'weekly'
+          @calculator.pay_date = Date.parse('12 July 2012')
+          paydates = @calculator.paydates_weekly
+          assert_equal 40, paydates.size
+          assert_equal '2012-07-12', paydates.first.to_s
+          assert_equal '2012-07-19', paydates.second.to_s
+          assert_equal '2013-04-11', paydates.last.to_s
+        end
+        should "calculate bi-weekly pay dates" do
+          @calculator.pay_method = 'every_2_weeks'
+          @calculator.pay_date = Date.parse('11 July 2012')
+          paydates = @calculator.paydates_every_2_weeks
+          assert_equal '2012-07-11', paydates.first.to_s
+          assert_equal '2012-07-25', paydates.second.to_s
+          assert_equal '2012-08-08', paydates.third.to_s
+        end
+        should "calculate bi-fortnightly pay dates" do
+          @calculator.pay_method = 'every_4_weeks'
+          @calculator.pay_date = Date.parse('11 July 2012')
+          paydates = @calculator.paydates_every_4_weeks
+          assert_equal '2012-07-11', paydates.first.to_s
+          assert_equal '2012-08-08', paydates.second.to_s
+          assert_equal '2012-09-05', paydates.third.to_s
+        end
+        should "calculate monthly pay dates" do
+          @calculator.pay_method = 'monthly'
+          @calculator.pay_day_in_month = 9
+          paydates = @calculator.paydates_monthly
+          assert_equal '2012-08-09', paydates.first.to_s
+          assert_equal '2013-05-09', paydates.last.to_s
+        end
+        should "calculate first day of the month pay dates" do
+          @calculator.pay_method = 'first_day_of_the_month'
+          paydates = @calculator.paydates_first_day_of_the_month
+
+          assert_equal '2012-08-01', paydates.first.to_s
+          assert_equal '2012-09-01', paydates.second.to_s
+          assert_equal '2013-05-01', paydates.last.to_s
+        end
+        should "calculate last day of the month pay dates" do
+          @calculator.pay_method = 'last_day_of_the_month'
+          paydates = @calculator.paydates_last_day_of_the_month
+
+          assert_equal '2012-07-31', paydates.first.to_s
+          assert_equal '2012-08-31', paydates.second.to_s
+          assert_equal '2013-04-30', paydates.last.to_s
+        end
+        should "calculate specific monthly pay dates" do
+          @calculator.pay_method = 'specific_date_each_month'
+          @calculator.pay_day_in_month = 5
+          paydates = @calculator.paydates_specific_date_each_month
+          assert_equal '2012-08-05', paydates.first.to_s
+          assert_equal '2013-05-05', paydates.last.to_s
+        end
+        should "calculate last working day of the month pay dates" do
+          @calculator.pay_method = 'last_working_day_of_the_month'
+          @calculator.pay_day_in_week = 3 # Paid last Wednesday in the month
+   @calculator.work_days = [1, 3, 4]
+          paydates = @calculator.paydates_last_working_day_of_the_month
+
+          assert_equal '2012-07-30', paydates.first.to_s
+          assert @calculator.work_days.include?(paydates.first.wday)
+          assert_equal '2012-08-30', paydates.second.to_s
+          assert_equal '2012-09-27', paydates.third.to_s
+          assert_equal '2013-04-29', paydates.last.to_s
+        end
+        should "calculate the particular weekday of the month pay dates" do
+          @calculator.pay_method = 'a_certain_week_day_each_month'
+          @calculator.pay_week_in_month = "second"
+          @calculator.pay_day_in_week = 1
+          # Monday 2nd week in the month
+          paydates = @calculator.paydates_a_certain_week_day_each_month.map(&:to_s)
+
+          assert_equal '2012-07-09', paydates.first.to_s
+          assert_equal '2012-08-13', paydates.second.to_s
+          assert_equal '2012-09-10', paydates.third.to_s
+          assert_equal '2012-10-08', paydates.fourth.to_s
+          assert_equal '2013-05-13', paydates.last
+        end
+      end
+      context "pay date on leave start date" do
+        setup do
+          @calculator = MaternityPaternityCalculatorV2.new(Date.parse('21 March 2013'))
+          @calculator.leave_start_date = Date.parse('1 March 2013')
+          @calculator.pay_method = 'first_day_of_the_month'
+          @calculator.average_weekly_earnings = 300.0
+
+        end
+        should "pay on the leave start date" do
+          assert_equal '2013-03-01', @calculator.paydates_first_day_of_the_month.first.to_s
+          assert_equal '2013-03-01', @calculator.paydates_and_pay.first[:date].to_s
+          assert_equal 38.58, @calculator.paydates_and_pay.first[:pay]
+          assert @calculator.paydates_and_pay.last[:date] > @calculator.pay_end_date, "Last paydate should be after SMP end date"
+          assert @calculator.paydates_and_pay.last[:pay] > 0
+        end
+      end
+      context "variable statutory pay rate" do
+        setup do
+          @calculator = MaternityPaternityCalculatorV2.new(Date.parse('21 April 2013'))
+          @calculator.leave_start_date = Date.parse('29 March 2013')
+
+        end
+        context "for 2012 rates" do
+          should "give the correct rate for the period" do
+            assert_equal 135.45, @calculator.statutory_rate(Date.parse('6 April 2012'))
+          end
+        end
+        context "correct rates for 2013/2014" do
+          setup do
+            Timecop.travel('1 Feb 2014')
+          end
+
+          should "give the correct rate for the period" do
+            assert_equal 136.78, @calculator.statutory_rate(Date.parse('12 April 2013'))
+          end
+
+          should "calculate the paternity rate as the standard rate" do
+            @calculator.average_weekly_earnings = 500.55
+            @calculator.leave_start_date = Date.new(2014, 2, 1)
+            assert_equal 136.78, @calculator.statutory_paternity_rate
+          end
+
+          should "calculate the paternity rate as 90 percent of weekly earnings" do
+            @calculator.average_weekly_earnings = 120.55
+            @calculator.leave_start_date = Date.new(2014, 2, 1)
+            assert_equal ((120.55 * 0.9).to_f).round(2), @calculator.statutory_paternity_rate
+          end
+        end
+
+        context "for 2043 rates" do
+          should "give a default rate for a date in the future" do
+            assert_equal 138.18, @calculator.statutory_rate(Date.parse('6 April 2043'))
+          end
+        end
+      end
+      context "paydates and pay" do
+        setup do
+          @calculator = MaternityPaternityCalculatorV2.new(Date.parse('21 January 2013'))
+          @calculator.leave_start_date = Date.parse('03 January 2013')
+        end
+        should "calculate pay due for each pay date on a weekly cycle" do
+          @calculator.pay_date = Date.parse('28 December 2012') # Friday before maternity leave/pay starts.
+          @calculator.pay_method = 'weekly'
+          @calculator.calculate_average_weekly_pay('weekly', 2000)
+
+          paydates_and_pay = @calculator.paydates_and_pay
+          assert_equal 40, paydates_and_pay.size
+
+          assert paydates_and_pay.first[:date].friday?, "Paydates should all be fridays"
+
+          assert_equal 64.29, paydates_and_pay.first[:pay]
+          assert_equal '2013-01-04', paydates_and_pay.first[:date].to_s
+
+          assert_equal 225, paydates_and_pay.second[:pay]
+          assert_equal '2013-01-11', paydates_and_pay.second[:date].to_s
+
+          assert_equal 97.7, paydates_and_pay.last[:pay]
+          assert_equal '2013-10-04', paydates_and_pay.last[:date].to_s
+        end
+        should "calculate pay due for each pay date on a bi-weekly cycle" do
+          @calculator.pay_date = Date.parse('03 January 2013')
+          @calculator.pay_method = 'every_2_weeks'
+          @calculator.calculate_average_weekly_pay('weekly', 2000)
+
+          paydates_and_pay = @calculator.paydates_and_pay
+
+          assert_equal ["2013-01-03", "2013-01-17", "2013-01-31", "2013-02-14", "2013-02-28",
+          "2013-03-14", "2013-03-28", "2013-04-11", "2013-04-25", "2013-05-09",
+          "2013-05-23", "2013-06-06", "2013-06-20", "2013-07-04", "2013-07-18",
+          "2013-08-01", "2013-08-15", "2013-08-29", "2013-09-12", "2013-09-26",
+          "2013-10-10"], paydates_and_pay.map { |p| p[:date].to_s }
+          assert_equal 32.15, paydates_and_pay.first[:pay]
+          assert_equal 450, paydates_and_pay.second[:pay]
+          assert_equal 270.9, paydates_and_pay[4][:pay]
+          assert_equal 117.24, paydates_and_pay.last[:pay]
+        end
+        should "calculate pay due for each pay date on a monthly cycle" do
+          @calculator.pay_day_in_month = 5
+          @calculator.pay_method = 'specific_date_each_month'
+          @calculator.average_weekly_earnings = 250.0
+          paydates_and_pay = @calculator.paydates_and_pay
+
+          assert_equal 10, paydates_and_pay.size
+
+          assert_equal '2013-01-05', paydates_and_pay.first[:date].to_s
+          assert_equal 96.43, paydates_and_pay.first[:pay]
+          assert_equal '2013-10-05', paydates_and_pay.last[:date].to_s
+          assert_equal 527.59, paydates_and_pay.last[:pay]
+        end
+        should "calculate pay due on the first day of the month" do
+          @calculator.pay_method = 'first_day_of_the_month'
+          @calculator.average_weekly_earnings = 250.0
+          paydates_and_pay = @calculator.paydates_and_pay
+
+          assert_equal 10, paydates_and_pay.size
+          assert_equal '2013-02-01', paydates_and_pay.first[:date].to_s
+          assert_equal 964.29, paydates_and_pay.first[:pay]
+          assert_equal '2013-11-01', paydates_and_pay.last[:date].to_s
+          assert_equal 19.54, paydates_and_pay.last[:pay]
+        end
+        should "calculate pay due on the last day of the month" do
+          @calculator.pay_method = 'last_day_of_the_month'
+          @calculator.average_weekly_earnings = 250.0
+          paydates_and_pay = @calculator.paydates_and_pay
+
+          assert_equal 10, paydates_and_pay.size
+          assert_equal '2013-01-31', paydates_and_pay.first[:date].to_s
+          assert_equal 932.15, paydates_and_pay.first[:pay]
+          assert_equal '2013-10-31', paydates_and_pay.last[:date].to_s
+          assert_equal 39.08, paydates_and_pay.last[:pay]
+        end
+        should "calculate pay due for a certain weekday each month" do
+          @calculator.pay_method = 'a_certain_week_day_each_month'
+          @calculator.pay_day_in_week = 5
+          @calculator.pay_week_in_month = "second" # 2nd Friday of the month
+          @calculator.average_weekly_earnings = 250.0
+
+          paydates_and_pay = @calculator.paydates_and_pay
+
+          assert_equal 10, paydates_and_pay.size
+          assert_equal '2013-01-11', paydates_and_pay.first[:date].to_s
+          assert_equal 289.29, paydates_and_pay.first[:pay]
+          assert_equal '2013-10-11', paydates_and_pay.last[:date].to_s
+          assert_equal 371.27, paydates_and_pay.last[:pay]
+        end
+        should "calculate pay due for the last working day of the month" do
+          @calculator.pay_method = 'last_working_day_of_the_month'
+          @calculator.pay_day_in_week = 5
+   @calculator.work_days = [1, 2, 4]
+          @calculator.average_weekly_earnings = 250.0
+
+          paydates_and_pay = @calculator.paydates_and_pay
+        end
+      end
+      context "HMRC test scenario for SMP Pay week offset" do
+        setup do
+          @calculator = MaternityPaternityCalculatorV2.new(Date.parse('22 February 2013'))
+          @calculator.leave_start_date = Date.parse('25 January 2013')
+          @calculator.pay_method = 'weekly'
+          @calculator.pay_date = Date.parse('25 January 2013')
+          @calculator.average_weekly_earnings = 200
+        end
+        should "calculate pay on paydates with April 2013 uprating" do
+          paydates_and_pay =  @calculator.paydates_and_pay
+
+          assert_equal 25.72, paydates_and_pay.first[:pay]
+          assert_equal 180.0, paydates_and_pay.second[:pay]
+          assert_equal 173.64, paydates_and_pay[6][:pay]
+          assert_equal 173.64, paydates_and_pay.find { |p| p[:date].to_s == '2013-03-08' }[:pay]
+          assert_equal 135.45, paydates_and_pay.find { |p| p[:date].to_s == '2013-04-05' }[:pay]
+          assert_equal 135.64, paydates_and_pay.find { |p| p[:date].to_s == '2013-04-12' }[:pay]
+          assert_equal 136.78, paydates_and_pay.find { |p| p[:date].to_s == '2013-04-19' }[:pay]
+        end
+      end
+      context "HMRC test scenario for SMP paid a certain day of the month" do
+        setup do
+          @calculator = MaternityPaternityCalculatorV2.new(Date.parse('22 February 2013'))
+          @calculator.leave_start_date = Date.parse('25 January 2013')
+          @calculator.pay_method = 'a_certain_week_day_each_month'
+          @calculator.pay_day_in_week = 5
+          @calculator.pay_week_in_month = 'last'
+          @calculator.average_weekly_earnings = 144.32
+        end
+        should "calculate pay on paydates with April 2013 uprating" do
+          paydates_and_pay =  @calculator.paydates_and_pay
+          assert_equal({ date: Date.parse('25 January 2013'), pay: 18.56 }, paydates_and_pay.first)
+          assert_equal({ date: Date.parse('29 March 2013'), pay: 649.45 }, paydates_and_pay.third)
+          assert_equal({ date: Date.parse('31 May 2013'), pay: 649.45 }, paydates_and_pay[4])
+        end
+      end
+
+      context "pay date starting month is December" do
+        setup do
+          Timecop.travel("26 Jul 2013")
+
+          @calculator = MaternityPaternityCalculatorV2.new(Date.parse("14 January 2014"))
+          @calculator.leave_start_date = Date.parse("12 December 2013")
+          @calculator.pay_method = "monthly"
+          @calculator.pay_date = Date.parse("1 December 2013")
+          @calculator.average_weekly_earnings = 200
+        end
+
+        should "produce a list of the paydates adjust one month forward" do
+          assert_equal [Date.parse("Wed, 01 Jan 2014"),
+                        Date.parse("Sat, 01 Feb 2014"),
+                        Date.parse("Sat, 01 Mar 2014"),
+                        Date.parse("Tue, 01 Apr 2014"),
+                        Date.parse("Thu, 01 May 2014"),
+                        Date.parse("Sun, 01 Jun 2014"),
+                        Date.parse("Tue, 01 Jul 2014"),
+                        Date.parse("Fri, 01 Aug 2014"),
+                        Date.parse("Mon, 01 Sep 2014"),
+                        Date.parse("Wed, 01 Oct 2014")],
+                       @calculator.paydates_first_day_of_the_month
+        end
+      end
+
+      context "test for paternity pay weekly dates and pay" do
+        setup do
+          @due_date = Date.parse("1 May 2014")
+          @calculator = MaternityPaternityCalculatorV2.new(@due_date, "paternity")
+          @calculator.leave_start_date = Date.parse('1 May 2014')
+          @calculator.pay_method = "weekly_starting"
+          @calculator.average_weekly_earnings = '125.00'
+        end
+
+        should "produce 2 weeks of pay dates and pay at 90% of wage" do
+          paydates_and_pay =  @calculator.paydates_and_pay
+          assert_equal '2014-05-07', paydates_and_pay.first[:date].to_s
+          assert_equal 112.5, paydates_and_pay.first[:pay]
+          assert_equal '2014-05-14', paydates_and_pay.last[:date].to_s
+          assert_equal 112.5, paydates_and_pay.last[:pay]
+        end
+      end
+
+      context "test for paternity pay monthly dates and pay prior to uprating for 2014" do
+        setup do
+          Timecop.travel('9 April 2014')
+          @due_date = Date.parse("1 May 2014")
+          @calculator = MaternityPaternityCalculatorV2.new(@due_date, "paternity")
+          @calculator.leave_start_date = Date.parse('1 May 2014')
+          @calculator.pay_method = "last_day_of_the_month"
+          @calculator.average_weekly_earnings = '500.00'
+        end
+
+        should "produce 1 week of pay dates and pay at maximum amount" do
+          paydates_and_pay =  @calculator.paydates_and_pay
+          assert_equal '2014-05-31', paydates_and_pay.first[:date].to_s
+          assert_equal 276.36, paydates_and_pay.first[:pay]
+        end
+      end
+      context "test for paternity pay monthly dates and pay uprated for 2014" do
+        setup do
+          Timecop.travel('10 April 2014')
+          @due_date = Date.parse("1 May 2014")
+          @calculator = MaternityPaternityCalculatorV2.new(@due_date, "paternity")
+          @calculator.leave_start_date = Date.parse('1 May 2014')
+          @calculator.pay_method = "last_day_of_the_month"
+          @calculator.average_weekly_earnings = '500.00'
+        end
+
+        should "produce 1 week of pay dates and pay at maximum amount" do
+          paydates_and_pay =  @calculator.paydates_and_pay
+          assert_equal '2014-05-31', paydates_and_pay.first[:date].to_s
+          assert_equal 276.36, paydates_and_pay.first[:pay]
+        end
+      end
+      context "test adoption table rate returned for weekly amounts" do
+        setup do
+          @match_date = Date.parse("2 January 2014")
+          @calculator = MaternityPaternityCalculatorV2.new(@match_date, "adoption")
+        end
+        should "calculate 39 weeks of dates and pay" do
+          @calculator.pay_method = 'weekly_starting'
+          @calculator.leave_start_date = Date.parse('20 January 2014')
+          @calculator.calculate_average_weekly_pay('monthly', 3000)
+          paydates_and_pay = @calculator.paydates_and_pay
+          assert_equal ["2014-01-26", "2014-02-02", "2014-02-09", "2014-02-16", "2014-02-23",
+          "2014-03-02", "2014-03-09", "2014-03-16", "2014-03-23", "2014-03-30",
+          "2014-04-06", "2014-04-13", "2014-04-20", "2014-04-27", "2014-05-04",
+          "2014-05-11", "2014-05-18", "2014-05-25", "2014-06-01", "2014-06-08",
+          "2014-06-15", "2014-06-22", "2014-06-29", "2014-07-06", "2014-07-13",
+          "2014-07-20", "2014-07-27", "2014-08-03", "2014-08-10", "2014-08-17",
+          "2014-08-24", "2014-08-31", "2014-09-07", "2014-09-14", "2014-09-21",
+          "2014-09-28", "2014-10-05", "2014-10-12", "2014-10-19"], paydates_and_pay.map { |p| p[:date].to_s }
+          assert_equal 136.78, paydates_and_pay.first[:pay]
+          assert_equal 136.78, paydates_and_pay[9][:pay]
+          assert_equal 138.18, paydates_and_pay[11][:pay]
+          assert_equal 138.18, paydates_and_pay.last[:pay]
+        end
+      end
+      context "test adoption table rate returned for a certain weekday in each month" do
+        setup do
+          @match_date = Date.parse("2 January 2014")
+          @calculator = MaternityPaternityCalculatorV2.new(@match_date, "adoption")
+        end
+        should "calculate 10 months of dates and pay" do
+          @calculator.leave_start_date = Date.parse('20 January 2014')
+          @calculator.pay_method = 'a_certain_week_day_each_month'
+          @calculator.pay_day_in_week = 5
+          @calculator.pay_week_in_month = 'last'
+          @calculator.calculate_average_weekly_pay('monthly', 3000)
+          paydates_and_pay = @calculator.paydates_and_pay
+          assert_equal ["2014-01-31", "2014-02-28", "2014-03-28",
+          "2014-04-25", "2014-05-30", "2014-06-27", "2014-07-25",
+          "2014-08-29", "2014-09-26", "2014-10-31"], paydates_and_pay.map { |p| p[:date].to_s }
+          assert_equal 234.48, paydates_and_pay.first[:pay]
+          assert_equal 550.93, paydates_and_pay[3][:pay]
+          assert_equal 454.03, paydates_and_pay.last[:pay]
+        end
+      end
+    end
+  end
+end

--- a/test/unit/calculators/maternity_paternity_calculator_test_v2.rb
+++ b/test/unit/calculators/maternity_paternity_calculator_test_v2.rb
@@ -168,85 +168,112 @@ module SmartAnswer::Calculators
         end
       end
 
-      context "specific date tests (for lower_earning_limits) for birth" do
-        should "return lower_earning_limit 107" do
-          @due_date = Date.parse("1 January 2013")
+      context "test for 2015 to 2016 rate" do
+        setup do
+          @due_date = Date.parse("1 September 2015")
+          @start_of_week_in_four_months = @due_date - @due_date.wday
           @calculator = MaternityPaternityCalculatorV2.new(@due_date)
-          assert_equal @calculator.lower_earning_limit, 107
+          Timecop.travel('1 September 2015')
         end
 
-        should "return 109 when due is in 2013/2014 tax year" do
-          @due_date = Date.parse("14 November 2013")
+        should "calculate the paternity rate as the standard rate for 2016" do
+          @calculator.average_weekly_earnings = 500.55
+          @calculator.leave_start_date = Date.new(2016, 1, 1)
+          assert_equal 139.58, @calculator.statutory_paternity_rate
+        end
+      end
+
+      context "specific date tests (for lower_earning_limits) for birth" do
+        should "return 112 for due dates after 6/04/2015" do
+          @due_date = Date.parse("16 December 2015")
           @calculator = MaternityPaternityCalculatorV2.new(@due_date)
-          assert_equal @calculator.lower_earning_limit, 109
+          assert_equal 112, @calculator.lower_earning_limit
         end
 
         should "return 111 for due dates after 14/07/2014" do
-          @due_date = Date.parse("14 July 2015")
+          @due_date = Date.parse("24 July 2014")
           @calculator = MaternityPaternityCalculatorV2.new(@due_date)
-          assert_equal @calculator.lower_earning_limit, 111
+          assert_equal 111, @calculator.lower_earning_limit
         end
 
         should "return lower_earning_limit 109" do
           @due_date = Date.parse("15 July 2014")
           @calculator = MaternityPaternityCalculatorV2.new(@due_date)
-          assert_equal @calculator.lower_earning_limit, 109
+          assert_equal 109, @calculator.lower_earning_limit
+        end
+
+        should "return 109 when due is in 2013/2014 tax year" do
+          @due_date = Date.parse("14 November 2013")
+          @calculator = MaternityPaternityCalculatorV2.new(@due_date)
+          assert_equal 109, @calculator.lower_earning_limit
+        end
+
+        should "return lower_earning_limit 107" do
+          @due_date = Date.parse("1 January 2013")
+          @calculator = MaternityPaternityCalculatorV2.new(@due_date)
+          assert_equal 107, @calculator.lower_earning_limit
         end
 
         should "return lower_earning_limit 107" do
           @due_date = Date.parse("15 July 2013")
           @calculator = MaternityPaternityCalculatorV2.new(@due_date)
-          assert_equal @calculator.lower_earning_limit, 107
+          assert_equal 107, @calculator.lower_earning_limit
         end
 
         should "return lower_earning_limit 102" do
           @due_date = Date.parse("15 July 2012")
           @calculator = MaternityPaternityCalculatorV2.new(@due_date)
-          assert_equal @calculator.lower_earning_limit, 102
+          assert_equal 102, @calculator.lower_earning_limit
         end
 
         should "return lower_earning_limit 102" do
           @due_date = Date.parse("14 July 2012")
           @calculator = MaternityPaternityCalculatorV2.new(@due_date)
-          assert_equal @calculator.lower_earning_limit, 102
+          assert_equal 102, @calculator.lower_earning_limit
         end
 
         should "return lower_earning_limit 102" do
           @due_date = Date.parse("1 January 2012")
           @calculator = MaternityPaternityCalculatorV2.new(@due_date)
-          assert_equal @calculator.lower_earning_limit, 102
+          assert_equal 102, @calculator.lower_earning_limit
         end
 
         should "return lower_earning_limit 97" do
           @due_date = Date.parse("1 January 2011")
           @calculator = MaternityPaternityCalculatorV2.new(@due_date)
-          assert_equal @calculator.lower_earning_limit, 97
+          assert_equal 97, @calculator.lower_earning_limit
         end
 
         should "return lower_earning_limit 95" do
           @due_date = Date.parse("1 January 2010")
           @calculator = MaternityPaternityCalculatorV2.new(@due_date)
-          assert_equal @calculator.lower_earning_limit, 95
+          assert_equal 95, @calculator.lower_earning_limit
         end
       end
 
       context "specific date tests (for lower_earning_limits) for adoption" do
+        should "return lower_earning_limit 112" do
+          @match_date = Date.parse("1 September 2015")
+          @calculator = MaternityPaternityCalculatorV2.new(@match_date, "adoption")
+          assert_equal 112, @calculator.lower_earning_limit
+        end
+
         should "return lower_earning_limit 107" do
           @match_date = Date.parse("1 September 2012")
           @calculator = MaternityPaternityCalculatorV2.new(@match_date, "adoption")
-          assert_equal @calculator.lower_earning_limit, 107
+          assert_equal 107, @calculator.lower_earning_limit
         end
 
         should "return lower_earning_limit 102" do
           @match_date = Date.parse("31 March 2012")
           @calculator = MaternityPaternityCalculatorV2.new(@match_date, "adoption")
-          assert_equal @calculator.lower_earning_limit, 102
+          assert_equal 102, @calculator.lower_earning_limit
         end
 
         should "return lower_earning_limit 97" do
           @match_date = Date.parse("2 April 2011")
           @calculator = MaternityPaternityCalculatorV2.new(@match_date, "adoption")
-          assert_equal @calculator.lower_earning_limit, 97
+          assert_equal 97, @calculator.lower_earning_limit
         end
       end
 
@@ -464,7 +491,7 @@ module SmartAnswer::Calculators
         should "calculate last working day of the month pay dates" do
           @calculator.pay_method = 'last_working_day_of_the_month'
           @calculator.pay_day_in_week = 3 # Paid last Wednesday in the month
-   @calculator.work_days = [1, 3, 4]
+          @calculator.work_days = [1, 3, 4]
           paydates = @calculator.paydates_last_working_day_of_the_month
 
           assert_equal '2012-07-30', paydates.first.to_s
@@ -503,17 +530,19 @@ module SmartAnswer::Calculators
           assert @calculator.paydates_and_pay.last[:pay] > 0
         end
       end
+
       context "variable statutory pay rate" do
         setup do
           @calculator = MaternityPaternityCalculatorV2.new(Date.parse('21 April 2013'))
           @calculator.leave_start_date = Date.parse('29 March 2013')
-
         end
-        context "for 2012 rates" do
-          should "give the correct rate for the period" do
+
+        context "for 2012 and before" do
+          should "return 135.45 rate" do
             assert_equal 135.45, @calculator.statutory_rate(Date.parse('6 April 2012'))
           end
         end
+
         context "correct rates for 2013/2014" do
           setup do
             Timecop.travel('1 Feb 2014')
@@ -538,7 +567,7 @@ module SmartAnswer::Calculators
 
         context "for 2043 rates" do
           should "give a default rate for a date in the future" do
-            assert_equal 138.18, @calculator.statutory_rate(Date.parse('6 April 2043'))
+            assert_equal 139.58, @calculator.statutory_rate(Date.parse('6 April 2043'))
           end
         end
       end
@@ -635,7 +664,7 @@ module SmartAnswer::Calculators
         should "calculate pay due for the last working day of the month" do
           @calculator.pay_method = 'last_working_day_of_the_month'
           @calculator.pay_day_in_week = 5
-   @calculator.work_days = [1, 2, 4]
+          @calculator.work_days = [1, 2, 4]
           @calculator.average_weekly_earnings = 250.0
 
           paydates_and_pay = @calculator.paydates_and_pay
@@ -754,6 +783,24 @@ module SmartAnswer::Calculators
           assert_equal 276.36, paydates_and_pay.first[:pay]
         end
       end
+
+      context "test for paternity pay monthly dates and pay uprated for 2015" do
+        setup do
+          Timecop.travel('10 April 2015')
+          @due_date = Date.parse("1 May 2015")
+          @calculator = MaternityPaternityCalculatorV2.new(@due_date, "paternity")
+          @calculator.leave_start_date = Date.parse('1 May 2015')
+          @calculator.pay_method = "last_day_of_the_month"
+          @calculator.average_weekly_earnings = '500.00'
+        end
+
+        should "produce 1 week of pay dates and pay at maximum amount" do
+          paydates_and_pay =  @calculator.paydates_and_pay
+          assert_equal '2015-05-31', paydates_and_pay.first[:date].to_s
+          assert_equal (139.58 * 2), paydates_and_pay.first[:pay]
+        end
+      end
+
       context "test adoption table rate returned for weekly amounts" do
         setup do
           @match_date = Date.parse("2 January 2014")


### PR DESCRIPTION
Uprate Maternity and paternity for 2015/16

# Changes (draft)

## Lower earnings limit 
For SAP / SPP / ASSPP (adoption): £112.00 gross a week and the adoption agency told the
adopter that they had been matched with a child between 6 April 2015 and 5 April 2016 (end date TBC)

For Adoption from overseas: 6 April 2015 to 5 April 2016 is £112.00 (end date TBC)

For SMP / SPP / ASPP (birth): £112.00 for babies due between 6 April 2015 and 5 April 2016
(end date TBC)

## Statutory rate

For SMP / SPP / ASPP / SAP
£139.58 - from 6 April 2015

## Reviewing

See the latest commit in this PR to see the changes without the noise of V2