### PR TITLE
Inform about discontinued 12-month passport extensions on /overseas-passports

### DIFF
--- a/lib/smart_answer_flows/locales/en/overseas-passports.yml
+++ b/lib/smart_answer_flows/locales/en/overseas-passports.yml
@@ -7,7 +7,9 @@ en-GB:
       body: |
         Get the forms, prices and application details you need if you're a British national and you want to renew or apply for a British passport from overseas.
 
-        %If you can't wait for a new passport, you can get details on how to apply for a [12-month extension](/get-an-emergency-passport-extension-or-child-travel-document) to your British passport.%
+        %You will not be able to get a 12-month extension on an existing passport after 10 April. If you already have an appointment, you will still be able to attend.%
+
+        You may be able to [apply for an emergency travel document](/emergency-travel-document) if you need to travel urgently.
 
         ##Dual nationals
 


### PR DESCRIPTION
`/overseas-passports`

Remove:

If you can’t wait for a new passport, you can get details on how to apply for a 12-month extension to your British passport.

Replace with:

%You will not be able to get a 12-month extension on an existing passport after 10 April. If you already have an appointment, you will still be able to attend.%

You may be able to [apply for an emergency travel document](/emergency-travel-document) if you need to travel urgently.

@jackscotti this needs to go live today, can I get your :eyes: on this?

Preview:

![screen shot 2015-03-31 at 14 18 58](https://cloud.githubusercontent.com/assets/218239/6919669/f8d2aa5c-d7b0-11e4-8b84-d455f62be522.png)
