### PR TITLE
Update SAP rates logic for 2015/16

### DIFF
--- a/lib/smart_answer/calculators/maternity_paternity_calculator_v2.rb
+++ b/lib/smart_answer/calculators/maternity_paternity_calculator_v2.rb
@@ -334,8 +334,19 @@ module SmartAnswer::Calculators
     def rate_for(date)
       if leave_type == 'maternity'
         maternity_rate_for(date)
+      elsif leave_type == 'adoption'
+        adoption_rate_for(date)
       else
-        paternity_padoption_adoption_rate_for(date)
+        paternity_rate_for(date)
+      end
+    end
+
+    def adoption_rate_for(date)
+      awe = (@average_weekly_earnings.to_f * 0.9).round(2)
+      if date < 6.weeks.since(leave_start_date) && @match_date >= Date.parse('5 April 2015')
+        awe
+      else
+        [statutory_rate(date), awe].min
       end
     end
 
@@ -347,7 +358,7 @@ module SmartAnswer::Calculators
       end
     end
 
-    def paternity_padoption_adoption_rate_for(date)
+    def paternity_rate_for(date)
       awe = (@average_weekly_earnings.to_f * 0.9).round(2)
       [statutory_rate(date), awe].min
     end

--- a/test/unit/calculators/maternity_paternity_calculator_test.rb
+++ b/test/unit/calculators/maternity_paternity_calculator_test.rb
@@ -464,7 +464,7 @@ module SmartAnswer::Calculators
         should "calculate last working day of the month pay dates" do
           @calculator.pay_method = 'last_working_day_of_the_month'
           @calculator.pay_day_in_week = 3 # Paid last Wednesday in the month
-   @calculator.work_days = [1, 3, 4]
+          @calculator.work_days = [1, 3, 4]
           paydates = @calculator.paydates_last_working_day_of_the_month
 
           assert_equal '2012-07-30', paydates.first.to_s
@@ -754,7 +754,8 @@ module SmartAnswer::Calculators
           assert_equal 276.36, paydates_and_pay.first[:pay]
         end
       end
-      context "test adoption table rate returned for weekly amounts" do
+
+      context "test adoption table rate returned for weekly amounts in 2013/14" do
         setup do
           @match_date = Date.parse("2 January 2014")
           @calculator = MaternityPaternityCalculator.new(@match_date, "adoption")
@@ -778,6 +779,7 @@ module SmartAnswer::Calculators
           assert_equal 138.18, paydates_and_pay.last[:pay]
         end
       end
+
       context "test adoption table rate returned for a certain weekday in each month" do
         setup do
           @match_date = Date.parse("2 January 2014")

--- a/test/unit/calculators/maternity_paternity_calculator_test_v2.rb
+++ b/test/unit/calculators/maternity_paternity_calculator_test_v2.rb
@@ -801,7 +801,7 @@ module SmartAnswer::Calculators
         end
       end
 
-      context "test adoption table rate returned for weekly amounts" do
+      context "test adoption table rate returned for weekly amounts in 2013/14" do
         setup do
           @match_date = Date.parse("2 January 2014")
           @calculator = MaternityPaternityCalculatorV2.new(@match_date, "adoption")
@@ -825,6 +825,31 @@ module SmartAnswer::Calculators
           assert_equal 138.18, paydates_and_pay.last[:pay]
         end
       end
+
+      context "test adoption table rate returned for weekly amounts in 2015/16" do
+        # based on /maternity-paternity-calculator/y/adoption/no/2015-04-10/2015-04-10/yes/yes/yes/2015-04-01/2015-03-31/2015-01-31/monthly/3000.0/weekly_starting?debug=1
+        setup do
+          @match_date = Date.parse("10 Apr 2015")
+          @calculator = MaternityPaternityCalculatorV2.new(@match_date, "adoption")
+          @calculator.pay_method = 'weekly_starting'
+          @calculator.leave_start_date = Date.parse('01 Apr 2015')
+          @calculator.pre_offset_payday = Date.parse('31 Jan 2015')
+          @calculator.last_payday = Date.parse('31 Mar 2015')
+          @calculator.adoption_placement_date = Date.parse('10 Apr 2015')
+        end
+
+        should "calculate 39 weeks of dates and pay, first 6 weeks is 90% of avg weekly pay, \
+                the remaining weeks is the minimum of 90% of avg weekly pay or 139.58" do
+
+                  expected_pay_dates = %w(2015-04-07 2015-04-14 2015-04-21 2015-04-28 2015-05-05 2015-05-12 2015-05-19 2015-05-26 2015-06-02 2015-06-09 2015-06-16 2015-06-23 2015-06-30 2015-07-07 2015-07-14 2015-07-21 2015-07-28 2015-08-04 2015-08-11 2015-08-18 2015-08-25 2015-09-01 2015-09-08 2015-09-15 2015-09-22 2015-09-29 2015-10-06 2015-10-13 2015-10-20 2015-10-27 2015-11-03 2015-11-10 2015-11-17 2015-11-24 2015-12-01 2015-12-08 2015-12-15 2015-12-22 2015-12-29)
+                  assert_equal 346.15, @calculator.calculate_average_weekly_pay('monthly', 3000).round(2)
+                  assert_equal expected_pay_dates, @calculator.paydates_and_pay.map { |p| p[:date].to_s }
+
+                  assert_equal [(346.15385 * 0.9).round(2)], @calculator.paydates_and_pay.first(6).map { |p| p[:pay] }.uniq
+                  assert_equal [139.58], @calculator.paydates_and_pay[6..-1].map { |p| p[:pay] }.uniq
+        end
+      end
+
       context "test adoption table rate returned for a certain weekday in each month" do
         setup do
           @match_date = Date.parse("2 January 2014")


### PR DESCRIPTION
New logic change: For children matched on or after 5 April 2015 the rate of SAP will be 90%
of the employee's average weekly earnings for the first 6 weeks, then £139.58 or 90% of the
employee's average weekly earnings, whichever is lower.