### PR TITLE
Married couples allowance rates 2015-16

### DIFF
--- a/lib/data/married_couples_allowance_rates.yml
+++ b/lib/data/married_couples_allowance_rates.yml
@@ -1,0 +1,21 @@
+---
+# the year denotes a starting year of the fiscal year
+# e.g. 2014 for 6th Apr 2014 - 5th April 2015
+personal_allowance:
+  2013: 9440
+  2014: 10000
+over_65_allowance:
+  2013: 10500
+  2014: 10500
+over_75_allowance:
+  2013: 10660
+  2014: 10660
+income_limit_for_personal_allowances:
+  2013: 26100.0
+  2014: 27000.0
+maximum_married_couple_allowance:
+  2013: 7915
+  2014: 8165
+minimum_married_couple_allowance:
+  2013: 3040
+  2014: 3140

--- a/lib/data/married_couples_allowance_rates.yml
+++ b/lib/data/married_couples_allowance_rates.yml
@@ -4,18 +4,24 @@
 personal_allowance:
   2013: 9440
   2014: 10000
+  2015: 10600
 over_65_allowance:
   2013: 10500
   2014: 10500
+  2015: 10600
 over_75_allowance:
   2013: 10660
   2014: 10660
+  2015: 10660
 income_limit_for_personal_allowances:
   2013: 26100.0
   2014: 27000.0
+  2015: 27700.0
 maximum_married_couple_allowance:
   2013: 7915
   2014: 8165
+  2015: 8355
 minimum_married_couple_allowance:
   2013: 3040
   2014: 3140
+  2015: 3220

--- a/lib/smart_answer/calculators/married_couples_allowance_rate_query.rb
+++ b/lib/smart_answer/calculators/married_couples_allowance_rate_query.rb
@@ -1,0 +1,30 @@
+module SmartAnswer::Calculators
+  class MarriedCouplesAllowanceRateQuery
+    def self.data
+      @data ||= YAML.load_file(Rails.root.join("lib", "data", "married_couples_allowance_rates.yml"))
+    end
+
+    data.keys.each do |rate_name|
+      define_method rate_name do
+        data[rate_name][current_fiscal_year] || data[rate_name].values.last
+      end
+    end
+
+    def current_fiscal_year
+      @current_fiscal_year ||= begin
+        today = Date.today
+        current_year = today.year
+        threshold = "#{current_year}-04-05".to_date
+        if today <= threshold
+          current_year - 1
+        else
+          current_year
+        end
+      end
+    end
+
+    def data
+      self.class.data
+    end
+  end
+end

--- a/lib/smart_answer/married_couples_allowance_calculator.rb
+++ b/lib/smart_answer/married_couples_allowance_calculator.rb
@@ -1,12 +1,9 @@
 module SmartAnswer
   class MarriedCouplesAllowanceCalculator
+    attr_accessor :validate_income
 
-    def initialize(current_figures = {})
-      @maximum_mca = current_figures[:maximum_mca]
-      @minimum_mca = current_figures[:minimum_mca]
-      @income_limit = current_figures[:income_limit]
-      @personal_allowance = current_figures[:personal_allowance]
-      @validate_income = current_figures[:validate_income].nil? ? true : current_figures[:validate_income]
+    def initialize(validate_income: true)
+      @validate_income = validate_income
     end
 
     def calculate_adjusted_net_income(income, gross_pension_contributions, net_pension_contributions, gift_aided_donations)
@@ -14,29 +11,29 @@ module SmartAnswer
     end
 
     def calculate_allowance(age_related_allowance, income)
-      validate(income) if @validate_income
+      validate(income) if validate_income
       income = 1 if income < 1
 
-      mca_entitlement = @maximum_mca
+      mca_entitlement = maximum_mca
 
-      if income > @income_limit
-        attempted_reduction = (income - @income_limit) / 2
+      if income > income_limit_for_personal_allowances
+        attempted_reduction = (income - income_limit_for_personal_allowances) / 2
 
         # \/ this reduction actually applies across the board for personal allowances,
         # but extracting that was more than required for this piece of work. Please see
         # note in AgeRelatedAllowanceChooser
-        maximum_reduction_of_allowances = age_related_allowance - @personal_allowance
+        maximum_reduction_of_allowances = age_related_allowance - personal_allowance
         remaining_reduction = attempted_reduction - maximum_reduction_of_allowances
 
         if remaining_reduction > 0
-          reduced_mca = @maximum_mca - remaining_reduction
-          if reduced_mca > @minimum_mca
+          reduced_mca = maximum_mca - remaining_reduction
+          if reduced_mca > minimum_mca
             mca_entitlement = reduced_mca
           else
-            mca_entitlement = @minimum_mca
+            mca_entitlement = minimum_mca
           end
         else
-          mca_entitlement = @maximum_mca
+          mca_entitlement = maximum_mca
         end
       end
 
@@ -46,6 +43,26 @@ module SmartAnswer
 
     def validate(income)
       raise SmartAnswer::InvalidResponse if income < 1
+    end
+
+    def maximum_mca
+      rates.maximum_married_couple_allowance
+    end
+
+    def minimum_mca
+      rates.minimum_married_couple_allowance
+    end
+
+    def income_limit_for_personal_allowances
+      rates.income_limit_for_personal_allowances
+    end
+
+    def personal_allowance
+      rates.personal_allowance
+    end
+
+    def rates
+      @rates ||= SmartAnswer::Calculators::MarriedCouplesAllowanceRateQuery.new
     end
   end
 end

--- a/lib/smart_answer_flows/calculate-married-couples-allowance.rb
+++ b/lib/smart_answer_flows/calculate-married-couples-allowance.rb
@@ -5,34 +5,17 @@ multiple_choice :were_you_or_your_partner_born_on_or_before_6_april_1935? do
   option yes: :did_you_marry_or_civil_partner_before_5_december_2005?
   option no: :sorry
 
-  calculate :is_before_april_changes do
-    Date.today < Date.civil(2014, 04, 06)
-  end
-
-  calculate :personal_allowance do
-    is_before_april_changes ? 9440 : 10000
-  end
-
-  calculate :earner_limit do
-    is_before_april_changes ? 26100.0 : 27000.0
-  end
-
   calculate :age_related_allowance_chooser do
+    rates = SmartAnswer::Calculators::MarriedCouplesAllowanceRateQuery.new
     AgeRelatedAllowanceChooser.new(
-      personal_allowance: personal_allowance,
-      over_65_allowance: 10500,
-      over_75_allowance: 10660
+      personal_allowance: rates.personal_allowance,
+      over_65_allowance: rates.over_65_allowance,
+      over_75_allowance: rates.over_75_allowance
     )
   end
 
   calculate :calculator do
-    MarriedCouplesAllowanceCalculator.new(
-      maximum_mca: (is_before_april_changes ? 7915 : 8165),
-      minimum_mca: (is_before_april_changes ? 3040 : 3140),
-      income_limit: (is_before_april_changes ? 26100 : 27000),
-      personal_allowance: personal_allowance,
-      validate_income: false
-    )
+    MarriedCouplesAllowanceCalculator.new(validate_income: false)
   end
 
 end

--- a/test/integration/smart_answer_flows/calculate_married_couples_allowance_test.rb
+++ b/test/integration/smart_answer_flows/calculate_married_couples_allowance_test.rb
@@ -440,34 +440,4 @@ class CalculateMarriedCouplesAllowanceTest < ActiveSupport::TestCase
       end # income < 25400
     end # after 2005
   end
-
-  context "testing 2014/5 time-specific dates" do
-    context "answering before april 6th 2014" do
-      setup do
-        add_response :yes
-      end
-
-      should "use the old rating values" do
-        Timecop.travel("2014-04-05") do
-          assert_state_variable :is_before_april_changes, true
-          assert_state_variable :personal_allowance, 9440
-          assert_state_variable :earner_limit, 26100.0
-        end
-      end
-    end
-
-    context "answering after april 6th 2014" do
-      setup do
-        add_response :yes
-      end
-
-      should "use the new rating values" do
-        Timecop.travel("2014-04-13") do
-          assert_state_variable :is_before_april_changes, false
-          assert_state_variable :personal_allowance, 10_000
-          assert_state_variable :earner_limit, 27_000.0
-        end
-      end
-    end
-  end
 end

--- a/test/integration/smart_answer_flows/calculate_married_couples_allowance_test.rb
+++ b/test/integration/smart_answer_flows/calculate_married_couples_allowance_test.rb
@@ -103,9 +103,9 @@ class CalculateMarriedCouplesAllowanceTest < ActiveSupport::TestCase
 
                 should "calculate allowance using calculators" do
                   SmartAnswer::MarriedCouplesAllowanceCalculator.any_instance.
-                    expects(:calculate_adjusted_net_income).
-      with(30000.0, 1000.0, 500.0, 100.0).
-                    returns("Adjusted net income")
+                    expects(:calculate_adjusted_net_income)
+                      .with(30000.0, 1000.0, 500.0, 100.0)
+                      .returns("Adjusted net income")
 
                   SmartAnswer::AgeRelatedAllowanceChooser.any_instance.
                     expects(:get_age_related_allowance).
@@ -145,9 +145,9 @@ class CalculateMarriedCouplesAllowanceTest < ActiveSupport::TestCase
 
             should "calculate allowance using calculators" do
               SmartAnswer::MarriedCouplesAllowanceCalculator.any_instance.
-                expects(:calculate_adjusted_net_income).
-  with(30000.0, 40000.0, 0, 0).
-                returns("Adjusted net income")
+                expects(:calculate_adjusted_net_income)
+                  .with(30000.0, 40000.0, 0, 0)
+                  .returns("Adjusted net income")
 
               SmartAnswer::AgeRelatedAllowanceChooser.any_instance.
                 expects(:get_age_related_allowance).
@@ -184,9 +184,9 @@ class CalculateMarriedCouplesAllowanceTest < ActiveSupport::TestCase
 
             should "calculate allowance using calculators" do
               SmartAnswer::MarriedCouplesAllowanceCalculator.any_instance.
-                expects(:calculate_adjusted_net_income).
-  with(30000.0, 0, 0, 100.0).
-                returns("Adjusted net income")
+                expects(:calculate_adjusted_net_income)
+                  .with(30000.0, 0, 0, 100.0)
+                  .returns("Adjusted net income")
 
               SmartAnswer::AgeRelatedAllowanceChooser.any_instance.
                 expects(:get_age_related_allowance).
@@ -212,9 +212,9 @@ class CalculateMarriedCouplesAllowanceTest < ActiveSupport::TestCase
 
             should "calculate allowance using calculators" do
               SmartAnswer::MarriedCouplesAllowanceCalculator.any_instance.
-                expects(:calculate_adjusted_net_income).
-  with(30000.0, 0, 0, 0).
-                returns("Adjusted net income")
+                expects(:calculate_adjusted_net_income)
+                  .with(30000.0, 0, 0, 0)
+                  .returns("Adjusted net income")
 
               SmartAnswer::AgeRelatedAllowanceChooser.any_instance.
                 expects(:get_age_related_allowance).
@@ -318,9 +318,9 @@ class CalculateMarriedCouplesAllowanceTest < ActiveSupport::TestCase
 
                 should "calculate allowance using calculators" do
                   SmartAnswer::MarriedCouplesAllowanceCalculator.any_instance.
-                    expects(:calculate_adjusted_net_income).
-      with(30000.0, 1000.0, 500.0, 100.0).
-                    returns("Adjusted net income")
+                    expects(:calculate_adjusted_net_income)
+                      .with(30000.0, 1000.0, 500.0, 100.0)
+                      .returns("Adjusted net income")
 
                   SmartAnswer::AgeRelatedAllowanceChooser.any_instance.
                     expects(:get_age_related_allowance).
@@ -368,9 +368,9 @@ class CalculateMarriedCouplesAllowanceTest < ActiveSupport::TestCase
 
             should "calculate allowance using calculators" do
               SmartAnswer::MarriedCouplesAllowanceCalculator.any_instance.
-                expects(:calculate_adjusted_net_income).
-  with(30000.0, 0, 0, 100.0).
-                returns("Adjusted net income")
+                expects(:calculate_adjusted_net_income)
+                  .with(30000.0, 0, 0, 100.0)
+                  .returns("Adjusted net income")
 
               SmartAnswer::AgeRelatedAllowanceChooser.any_instance.
                 expects(:get_age_related_allowance).
@@ -396,9 +396,9 @@ class CalculateMarriedCouplesAllowanceTest < ActiveSupport::TestCase
 
             should "calculate allowance using calculators" do
               SmartAnswer::MarriedCouplesAllowanceCalculator.any_instance.
-                expects(:calculate_adjusted_net_income).
-  with(30000.0, 0, 0, 0).
-                returns("Adjusted net income")
+                expects(:calculate_adjusted_net_income)
+                  .with(30000.0, 0, 0, 0)
+                  .returns("Adjusted net income")
 
               SmartAnswer::AgeRelatedAllowanceChooser.any_instance.
                 expects(:get_age_related_allowance).
@@ -464,11 +464,10 @@ class CalculateMarriedCouplesAllowanceTest < ActiveSupport::TestCase
       should "use the new rating values" do
         Timecop.travel("2014-04-13") do
           assert_state_variable :is_before_april_changes, false
-          assert_state_variable :personal_allowance, 10000
-          assert_state_variable :earner_limit, 27000.0
+          assert_state_variable :personal_allowance, 10_000
+          assert_state_variable :earner_limit, 27_000.0
         end
       end
     end
   end
-
 end

--- a/test/unit/calculators/married_couples_allowance_rate_query_test.rb
+++ b/test/unit/calculators/married_couples_allowance_rate_query_test.rb
@@ -16,11 +16,22 @@ module SmartAnswer::Calculators
       context "personal_allowance" do
         context "on 15th April 2116 (fallback)" do
           setup do
-            Timecop.travel("2116-04-05")
+            Timecop.travel("2116-04-15")
+            @query.stubs(:data).returns({ "personal_allowance" => { 2014 => 10000, 2015 => 99999 }})
           end
 
           should "be the latest known walue" do
-            assert_equal 10000, @query.personal_allowance
+            assert_equal 99999, @query.personal_allowance
+          end
+        end
+
+        context "on 5th April 2016" do
+          setup do
+            Timecop.travel("2016-04-05")
+          end
+
+          should "be 10600" do
+            assert_equal 10600, @query.personal_allowance
           end
         end
 

--- a/test/unit/calculators/married_couples_allowance_rate_query_test.rb
+++ b/test/unit/calculators/married_couples_allowance_rate_query_test.rb
@@ -1,0 +1,81 @@
+require_relative "../../test_helper"
+
+module SmartAnswer::Calculators
+  class MarriedCouplesAllowanceRateQueryTest < ActiveSupport::TestCase
+    context SmartAnswer::Calculators::MarriedCouplesAllowanceRateQuery do
+      setup do
+        @query = SmartAnswer::Calculators::MarriedCouplesAllowanceRateQuery.new
+      end
+
+      should "have all required rates defined for current_fiscal year" do
+        %w(personal_allowance over_65_allowance over_75_allowance income_limit_for_personal_allowances maximum_married_couple_allowance minimum_married_couple_allowance).each do |rate|
+          assert @query.send(rate).is_a?(Numeric)
+        end
+      end
+
+      context "personal_allowance" do
+        context "on 15th April 2116 (fallback)" do
+          setup do
+            Timecop.travel("2116-04-05")
+          end
+
+          should "be the latest known walue" do
+            assert_equal 10000, @query.personal_allowance
+          end
+        end
+
+        context "on 6th April 2013" do
+          setup do
+            Timecop.travel("2013-04-06")
+          end
+
+          should "be 9440" do
+            assert_equal 9440, @query.personal_allowance
+          end
+        end
+
+        context "on 6th April 2014" do
+          setup do
+            Timecop.travel("2014-04-06")
+          end
+
+          should "be 10000" do
+            assert_equal 10000, @query.personal_allowance
+          end
+        end
+      end
+
+      context "current_fiscal_year" do
+        context "on 5th April 2013" do
+          setup do
+            Timecop.travel("2013-04-05")
+          end
+
+          should "be 2012" do
+            assert_equal 2012, @query.current_fiscal_year
+          end
+        end
+
+        context "on 6th April 2013" do
+          setup do
+            Timecop.travel("2013-04-06")
+          end
+
+          should "be 2013" do
+            assert_equal 2013, @query.current_fiscal_year
+          end
+        end
+
+        context "on 6th April 2014" do
+          setup do
+            Timecop.travel("2014-04-06")
+          end
+
+          should "be 2014" do
+            assert_equal 2014, @query.current_fiscal_year
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/unit/married_couple_allowance_calculator_test.rb
+++ b/test/unit/married_couple_allowance_calculator_test.rb
@@ -3,32 +3,35 @@ require_relative '../test_helper'
 module SmartAnswer
   class MarriedCouplesAllowanceCalculatorTest < ActiveSupport::TestCase
 
-    def setup
-      @maximum_mca = 8020
-      @minimum_mca = 3010
-
+    setup do
       @income_limit = 27000
       @age_related_allowance = 12000
       @personal_allowance = 9000
-
-      @calculator = MarriedCouplesAllowanceCalculator.new(
-        maximum_mca: @maximum_mca,
-        minimum_mca: @minimum_mca,
-        income_limit: @income_limit,
-        personal_allowance: @personal_allowance)
-      @calculator_without_income_validation = MarriedCouplesAllowanceCalculator.new(
-        maximum_mca: @maximum_mca,
-        minimum_mca: @minimum_mca,
-        income_limit: @income_limit,
-        personal_allowance: @personal_allowance,
-        validate_income: false)
     end
 
+    def calculator(stubbed_values = {})
+      calculator = MarriedCouplesAllowanceCalculator.new
+      stubbed_values.each do |key, value|
+        calculator.stubs(key).returns(value)
+      end
+      calculator
+    end
+
+    def default_calculator
+      return @default_calculator if @default_calculator
+      @default_calculator = calculator(
+        maximum_mca: 8020,
+        minimum_mca: 3010,
+        income_limit_for_personal_allowances: @income_limit,
+        personal_allowance: @personal_allowance)
+    end
+
+
     test "worked example on directgov for 2011-12" do
-      hmrc_example_calculator = MarriedCouplesAllowanceCalculator.new(
+      hmrc_example_calculator = calculator(
           maximum_mca: 7295,
           minimum_mca: 2800,
-          income_limit: 24000,
+          income_limit_for_personal_allowances: 24000,
           personal_allowance: 7475)
 
       age_related_allowance_2011_12 = 10090
@@ -38,10 +41,10 @@ module SmartAnswer
 
     #add one for 2013-14 when the worked example is released
     test "worked example on HMRC site for 2012-13" do
-      hmrc_example_calculator = MarriedCouplesAllowanceCalculator.new(
+      hmrc_example_calculator = calculator(
           maximum_mca: 7705,
           minimum_mca: 2960,
-          income_limit: 25400,
+          income_limit_for_personal_allowances: 25400,
           personal_allowance: 8105)
       age_related_allowance_2012_13 = 10660
       result = hmrc_example_calculator.calculate_allowance(age_related_allowance_2012_13, 31500)
@@ -51,40 +54,41 @@ module SmartAnswer
     # backwards compatibility with version 1
     test "don't allow an income less than 1 by default" do
       assert_raises InvalidResponse do
-        @calculator.calculate_allowance(@age_related_allowance, 0)
+        default_calculator.calculate_allowance(@age_related_allowance, 0)
       end
     end
 
     test "allow an income less than 1 when income validation is false" do
-      result = @calculator_without_income_validation.calculate_allowance(@age_related_allowance, 0)
+      default_calculator.validate_income = false
+      result = default_calculator.calculate_allowance(@age_related_allowance, 0)
       assert_equal Money.new("802"), result
     end
 
     test "minimum allowance when annual income over income limit" do
-      result = @calculator.calculate_allowance(@age_related_allowance, 90000)
+      result = default_calculator.calculate_allowance(@age_related_allowance, 90000)
       assert_equal Money.new("301"), result
     end
 
     test "maximum allowance when low annual income" do
-      result = @calculator.calculate_allowance(@age_related_allowance, 100)
+      result = default_calculator.calculate_allowance(@age_related_allowance, 100)
       assert_equal Money.new("802"), result
     end
 
     test "maximum allowance when income is greater than income limit but not enough to reduce personal allowance" do
       maximum_reduction = @age_related_allowance - @personal_allowance
       test_income = @income_limit + (maximum_reduction - 100)
-      result = @calculator.calculate_allowance(@age_related_allowance, test_income)
+      result = default_calculator.calculate_allowance(@age_related_allowance, test_income)
       assert_equal Money.new("802"), result
     end
 
     test "maximum allowance when income is same as income limit" do
-      result = @calculator.calculate_allowance(@age_related_allowance, @income_limit)
+      result = default_calculator.calculate_allowance(@age_related_allowance, @income_limit)
       assert_equal Money.new("802"), result
     end
 
     test "maximum allowance when just over income limit" do
       test_income = @income_limit + 1
-      result = @calculator.calculate_allowance(@age_related_allowance, test_income)
+      result = default_calculator.calculate_allowance(@age_related_allowance, test_income)
       assert_equal Money.new("802"), result
     end
 
@@ -94,9 +98,8 @@ module SmartAnswer
       net_pension_contributions = 2000
       gift_aided_donations = 1000
 
-      result = @calculator.calculate_adjusted_net_income(income, gross_pension_contributions, net_pension_contributions, gift_aided_donations)
+      result = default_calculator.calculate_adjusted_net_income(income, gross_pension_contributions, net_pension_contributions, gift_aided_donations)
       assert_equal Money.new("28250"), result
     end
-
   end
 end


### PR DESCRIPTION
- whitespace fixes (wanted as a separate commit to reduce noise in the refactoring commit)
- refactors the way rates data is retrieved (see message https://github.com/alphagov/smart-answers/commit/59cd29fb51435bb53db2efa9a8a289f44185b380)
- updates values for the next fiscal year from [this table](https://www.gov.uk/government/publications/tax-and-tax-credit-rates-and-thresholds-for-2015-16/tax-and-tax-credit-rates-and-thresholds-for-2015-16#income-tax-allowances)

Since the refactoring is not very straightforward I'd like a careful review to make sure I didn't change anything I did not want to change /cc @jackscotti @BenJanecke @dsingleton 