### PR TITLE
Register a death fixes

### DIFF
--- a/lib/smart_answer_flows/locales/en/register-a-death-v2.yml
+++ b/lib/smart_answer_flows/locales/en/register-a-death-v2.yml
@@ -321,7 +321,7 @@ en-GB:
         footnote: |
           ^It takes about 3 working days for the death to be officially registered.^
         footnote_oru_variants_intro: |
-          ^Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.^
+          ^Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where the death happened to be registered there.^
         footnote_oru_variants_out: |
           You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
         footnote_oru_variants_cambodia: |
@@ -380,7 +380,7 @@ en-GB:
           Your documents will be returned to the British High Commission in Kampala after the death has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
 
         registration_can_take_3_months: |
-          Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+          Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where the death happened to be registered there.
 
         registration_takes_3_days: |
           It usually takes 3 working days for the death to be registered in the UK once the Overseas Registration Unit has received your form and the right documents.

--- a/lib/smart_answer_flows/locales/en/register-a-death-v2.yml
+++ b/lib/smart_answer_flows/locales/en/register-a-death-v2.yml
@@ -468,7 +468,7 @@ en-GB:
 
           s1. Check that you have the right documents.
           s2. Print out and fill in the forms.
-          s3. Pay online.
+          s3. Pay.
           s4. Post your documents and the forms.
 
 

--- a/lib/smart_answer_flows/locales/en/register-a-death.yml
+++ b/lib/smart_answer_flows/locales/en/register-a-death.yml
@@ -321,7 +321,7 @@ en-GB:
         footnote: |
           ^It takes about 3 working days for the death to be officially registered.^
         footnote_oru_variants_intro: |
-          ^Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.^
+          ^Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where the death happened to be registered there.^
         footnote_oru_variants_out: |
           You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
         footnote_oru_variants_cambodia: |
@@ -373,7 +373,7 @@ en-GB:
         oru_courier_text_papua-new-guinea: |
           Your documents will be returned to the British Embassy in Port Moresby after the death has been registered.
         registration_can_take_3_months: |
-          Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where your child was born to be registered there.
+          Registration can take up to 3 months - your application will be sent to the local British embassy, consulate or high commission where the death happened to be registered there.
 
         registration_takes_3_days: |
           It usually takes 3 working days for the death to be registered in the UK once the Overseas Registration Unit has received your form and the right documents.

--- a/lib/smart_answer_flows/register-a-death-v2.rb
+++ b/lib/smart_answer_flows/register-a-death-v2.rb
@@ -174,7 +174,7 @@ outcome :oru_result do
   end
 
   precalculate :payment_method do
-    if country_of_death == 'algeria'
+    if !in_the_uk && current_location == 'algeria'
       PhraseList.new(:payment_method_in_algeria)
     else
       PhraseList.new(:standard_payment_method)

--- a/test/integration/smart_answer_flows/register_a_death_v2_test.rb
+++ b/test/integration/smart_answer_flows/register_a_death_v2_test.rb
@@ -298,11 +298,24 @@ class RegisterADeathV2Test < ActiveSupport::TestCase
       end
 
       context "now back in the UK" do
-        should "give the ORU result with a translator link and a custom payment method" do
+        should "give the ORU result with a translator link and a standard payment method" do
           add_response 'in_the_uk'
           assert_current_node :oru_result
           assert_state_variable :button_data, {text: "Pay now", url: "https://pay-register-death-abroad.service.gov.uk/start"}
           assert_phrase_list :oru_address, [:oru_address_uk]
+          assert_phrase_list :translator_link, [:approved_translator_link]
+          assert_phrase_list :payment_method, [:standard_payment_method]
+          assert_state_variable :translator_link_url, "/government/publications/algeria-list-of-lawyers"
+        end
+      end
+
+      context "now in Algeria" do
+        should "give the ORU result with a translator link and a custom payment method" do
+          add_response 'another_country'
+          add_response 'algeria'
+          assert_current_node :oru_result
+          assert_state_variable :button_data, {text: "Pay now", url: "https://pay-register-death-abroad.service.gov.uk/start"}
+          assert_phrase_list :oru_address, [:oru_address_abroad]
           assert_phrase_list :translator_link, [:approved_translator_link]
           assert_phrase_list :payment_method, [:payment_method_in_algeria]
           assert_state_variable :translator_link_url, "/government/publications/algeria-list-of-lawyers"
@@ -320,13 +333,15 @@ class RegisterADeathV2Test < ActiveSupport::TestCase
         expected_location = WorldLocation.find('iran')
       end
     end # Iran
+
     context "answer Libya" do
       setup do
         worldwide_api_has_organisations_for_location('libya', read_fixture_file('worldwide/libya_organisations.json'))
         add_response 'libya'
-        add_response 'same_country'
       end
-      should "give the oru result and a custom translators link" do
+
+      should "give the oru result and a custom translators link if currently in Libya" do
+        add_response 'same_country'
         assert_current_node :oru_result
         assert_state_variable :translator_link_url, "/government/publications/libya-list-of-translators"
         assert_phrase_list :translator_link, [:approved_translator_link]
@@ -335,6 +350,14 @@ class RegisterADeathV2Test < ActiveSupport::TestCase
         assert_phrase_list :oru_address, [:oru_address_abroad]
         assert_phrase_list :oru_courier_text, [:oru_courier_text_default]
         assert_phrase_list :payment_method, [:standard_payment_method]
+      end
+
+      should "give a custom algerian payment method if currently in Algeria " do
+        worldwide_api_has_organisations_for_location('algeria', read_fixture_file('worldwide/algeria_organisations.json'))
+        add_response 'another_country'
+        add_response 'algeria'
+        assert_current_node :oru_result
+        assert_phrase_list :payment_method, [:payment_method_in_algeria]
       end
     end # Answer Libya
 


### PR DESCRIPTION
- Algeria-specific payment option applies only if you are currently there.
- Fixes a typo (V1 and V2) where something birth-related was copied to the deaths registration document
- Resolve the contradictionary 'You will need to' bulletpoint

All V2 + a typo fix for V1.