### PR TITLE
Bring back the notice in the pension calculator

### DIFF
--- a/lib/smart_answer_flows/locales/en/calculate-state-pension.yml
+++ b/lib/smart_answer_flows/locales/en/calculate-state-pension.yml
@@ -6,6 +6,9 @@ en-GB:
         description: Work out your State Pension age and Pension Credit qualifying age or estimate how much basic State Pension you may get
       body: |
         Calculate when you’ll reach State Pension age or Pension Credit qualifying age and how much you may get in today’s money for your basic State Pension.
+
+        %Get a [State Pension Statement](/state-pension-statement) instead of using this calculator if you're 55 or over and making a financial decision based on [the new pension options](https://www.pensionwise.gov.uk/).%
+
       post_body: |
         ##What you need to know:
 


### PR DESCRIPTION
Was first added in 0ae859c89e021912005a9da55041f9008b8f51f1 and then
accidentally overwritten by a V2 merge.