### PR TITLE
Uprate redundancy pay calculator for 2015/16

### DIFF
--- a/lib/smart_answer/calculators/redundancy_calculator.rb
+++ b/lib/smart_answer/calculators/redundancy_calculator.rb
@@ -7,7 +7,8 @@ module SmartAnswer::Calculators
     AMOUNTS = [
       OpenStruct.new(start_date: Date.new(2012, 01, 01), end_date: Date.new(2013, 01, 31), max: "12,900", rate: 430),
       OpenStruct.new(start_date: Date.new(2013, 02, 01), end_date: Date.new(2014, 04, 05), max: "13,500", rate: 450),
-      OpenStruct.new(start_date: Date.new(2014, 04, 06), end_date: Date.new(2030, 12, 31), max: "13,920", rate: 464)
+      OpenStruct.new(start_date: Date.new(2014, 04, 06), end_date: Date.new(2015, 04, 05), max: "13,920", rate: 464),
+      OpenStruct.new(start_date: Date.new(2015, 04, 06), end_date: Date.new(2130, 12, 31), max: "13,920", rate: 475)
     ]
 
     attr_reader :pay, :number_of_weeks_entitlement

--- a/test/unit/calculators/redundancy_calculator_test.rb
+++ b/test/unit/calculators/redundancy_calculator_test.rb
@@ -22,19 +22,27 @@ module SmartAnswer::Calculators
     context "amounts for the redundancy date" do
       should "vary the rate per year" do
         assert_equal 430, RedundancyCalculator.redundancy_rates(Date.new(2013, 01, 01)).rate
- assert_equal 430, RedundancyCalculator.redundancy_rates(Date.new(2013, 01, 31)).rate
- assert_equal 450, RedundancyCalculator.redundancy_rates(Date.new(2013, 02, 01)).rate
- assert_equal 450, RedundancyCalculator.redundancy_rates(Date.new(2014, 04, 05)).rate
- assert_equal 464, RedundancyCalculator.redundancy_rates(Date.new(2014, 04, 06)).rate
- assert_equal 464, RedundancyCalculator.redundancy_rates(Date.new(Date.today.year, 12, 31)).rate
+        assert_equal 430, RedundancyCalculator.redundancy_rates(Date.new(2013, 01, 31)).rate
+        assert_equal 450, RedundancyCalculator.redundancy_rates(Date.new(2013, 02, 01)).rate
+        assert_equal 450, RedundancyCalculator.redundancy_rates(Date.new(2014, 04, 05)).rate
+        assert_equal 464, RedundancyCalculator.redundancy_rates(Date.new(2014, 04, 06)).rate
+        assert_equal 475, RedundancyCalculator.redundancy_rates(Date.new(2015, 04, 06)).rate
       end
+
       should "vary the max amount per year" do
         assert_equal "12,900", RedundancyCalculator.redundancy_rates(Date.new(2013, 01, 01)).max
- assert_equal "12,900", RedundancyCalculator.redundancy_rates(Date.new(2013, 01, 31)).max
- assert_equal "13,500", RedundancyCalculator.redundancy_rates(Date.new(2013, 02, 01)).max
- assert_equal "13,500", RedundancyCalculator.redundancy_rates(Date.new(2014, 04, 05)).max
- assert_equal "13,920", RedundancyCalculator.redundancy_rates(Date.new(2014, 04, 06)).max
- assert_equal "13,920", RedundancyCalculator.redundancy_rates(Date.new(Date.today.year, 12, 31)).max
+        assert_equal "12,900", RedundancyCalculator.redundancy_rates(Date.new(2013, 01, 31)).max
+        assert_equal "13,500", RedundancyCalculator.redundancy_rates(Date.new(2013, 02, 01)).max
+        assert_equal "13,500", RedundancyCalculator.redundancy_rates(Date.new(2014, 04, 05)).max
+        assert_equal "13,920", RedundancyCalculator.redundancy_rates(Date.new(2014, 04, 06)).max
+        assert_equal "13,920", RedundancyCalculator.redundancy_rates(Date.new(Date.today.year, 12, 31)).max
+      end
+
+      should "use the most recent rate for far future dates" do
+        latest_amount = RedundancyCalculator::AMOUNTS.sort_by(&:end_date).last
+        future_calculator = RedundancyCalculator.redundancy_rates(5.years.from_now.to_date)
+        assert_equal latest_amount.rate, future_calculator.rate
+        assert_equal latest_amount.max, future_calculator.max
       end
     end
     context "use correct weekly pay and number of years limits" do


### PR DESCRIPTION
Maximum weekly rate is now £475  (from 6 April)