### PR TITLE
Fix state pension calculator rounding error

### DIFF
--- a/lib/smart_answer/calculators/state_pension_amount_calculator.rb
+++ b/lib/smart_answer/calculators/state_pension_amount_calculator.rb
@@ -59,7 +59,7 @@ module SmartAnswer::Calculators
     end
 
     def what_you_get
-      what_you_get_raw.round(2)
+      BigDecimal(what_you_get_raw.to_s).round(2).to_f
     end
 
     def what_you_get_raw
@@ -72,7 +72,7 @@ module SmartAnswer::Calculators
 
     # what would you get if all remaining years to pension were qualifying years
     def what_you_would_get_if_not_full
-      what_you_would_get_if_not_full_raw.round(2)
+      BigDecimal(what_you_would_get_if_not_full_raw.to_s).round(2).to_f
     end
 
     def what_you_would_get_if_not_full_raw

--- a/test/unit/calculators/state_pension_amount_calculator_test.rb
+++ b/test/unit/calculators/state_pension_amount_calculator_test.rb
@@ -160,6 +160,8 @@ module SmartAnswer::Calculators
           assert_equal 57.98, @calculator.what_you_get
           @calculator.qualifying_years = 10
           assert_equal 38.65, @calculator.what_you_get
+          @calculator.qualifying_years = 9
+          assert_equal 34.79, @calculator.what_you_get
           @calculator.qualifying_years = 5
           assert_equal 19.33, @calculator.what_you_get
           @calculator.qualifying_years = 4


### PR DESCRIPTION
Floats where used when rounding, therefore in some edge cases the
returned pension weekly rate values were off by 1p.

e.g. /calculate-state-pension/y/amount/female/1977-06-29/0/6/no/no
was £34.78 instead of £34.79
```
>> 35.765.round(2)
=> 35.77
>> 35.775.round(2)
=> 35.78
>> 35.785.round(2)
=> 35.78
```
Using BigDecimals for rounding is more accurate