### PR TITLE
Remove maternity allowance from adoption flow

### DIFF
--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/outcomes/outcome_adoption_adopter_a.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/outcomes/outcome_adoption_adopter_a.txt
@@ -1,9 +1,3 @@
-$IF qualifies_for_maternity_allowance?(employment_status_1 earnings_employment_1 work_employment_1 job_before_x_1 job_after_y_1 lel_1)
-
-{{snippet: adoption-mat-allowance}}
-
-$ENDIF
-
 $IF qualifies_for_pay?(employment_status_1 job_before_x_1 job_after_y_1 lel_1)
 
 {{snippet: adoption-mat-pay}}
@@ -16,15 +10,11 @@ $IF qualifies_for_maternity_leave?(employment_status_1 job_after_y_1)
 
 $ENDIF
 
-$IF NOT qualifies_for_maternity_allowance?(employment_status_1 earnings_employment_1 work_employment_1 job_before_x_1 job_after_y_1 lel_1)
-
 $IF NOT qualifies_for_pay?(employment_status_1 job_before_x_1 job_after_y_1 lel_1)
 
 $IF NOT qualifies_for_leave?(employment_status_1 job_before_x_1 job_after_y_1)
 
 {{snippet: adoption-single-nothing}}
-
-$ENDIF
 
 $ENDIF
 

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/outcomes/outcome_adoption_post_april_5_2015_adopter_a_adopter_b.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/outcomes/outcome_adoption_post_april_5_2015_adopter_a_adopter_b.txt
@@ -1,17 +1,5 @@
 #Option A
 
-$IF qualifies_for_14_week_maternity_allowance?(employment_status_1 employment_status_2)
-
-{{snippet: adoption-mat-allowance-14-weeks}}
-
-$ENDIF
-
-$IF qualifies_for_maternity_allowance?(employment_status_1 earnings_employment_1 work_employment_1 job_before_x_1 job_after_y_1 lel_1)
-
-{{snippet: adoption-mat-allowance}}
-
-$ENDIF
-
 $IF qualifies_for_pay?(employment_status_1 job_before_x_1 job_after_y_1 lel_1)
 
 {{snippet: adoption-mat-pay}}
@@ -36,7 +24,7 @@ $ENDIF
 
 $IF NOT both_qualifies_for_shared_leave?(employment_status_1 job_before_x_1 job_after_y_1 lel_1 work_employment_1 earnings_employment_1 employment_status_2 job_before_x_2 job_after_y_2 lel_2 work_employment_2 earnings_employment_2)
 
-$IF qualifies_for_maternity_leave?(employment_status_1 job_after_y_1) OR qualifies_for_pay?(employment_status_1 job_before_x_1 job_after_y_1 lel_1) OR qualifies_for_maternity_allowance?(employment_status_1 earnings_employment_1 work_employment_1 job_before_x_1 job_after_y_1 lel_1)
+$IF qualifies_for_maternity_leave?(employment_status_1 job_after_y_1) OR qualifies_for_pay?(employment_status_1 job_before_x_1 job_after_y_1 lel_1)
 
 $IF qualifies_for_leave?(employment_status_1 job_before_x_1 job_after_y_1) AND earnings_employment(earnings_employment_2 work_employment_2)
 
@@ -53,7 +41,7 @@ $IF qualifies_for_pay?(employment_status_2 job_before_x_2 job_after_y_2 lel_2)
 
 {{snippet: adoption-pat-pay}}
 
-$IF qualifies_for_pay?(employment_status_1 job_before_x_1 job_after_y_1 lel_1) OR qualifies_for_maternity_allowance?(employment_status_1 earnings_employment_1 work_employment_1 job_before_x_1 job_after_y_1 lel_1)
+$IF qualifies_for_pay?(employment_status_1 job_before_x_1 job_after_y_1 lel_1)
 
 $IF NOT both_qualifies_for_shared_pay?(employment_status_1 job_before_x_1 job_after_y_1 lel_1 employment_status_2 job_before_x_2 job_after_y_2 lel_2)
 
@@ -73,7 +61,7 @@ $ENDIF
 
 $IF NOT both_qualifies_for_shared_leave?(employment_status_1 job_before_x_1 job_after_y_1 lel_1 work_employment_1 earnings_employment_1 employment_status_2 job_before_x_2 job_after_y_2 lel_2 work_employment_2 earnings_employment_2)
 
-$IF qualifies_for_maternity_leave?(employment_status_1 job_after_y_1) OR qualifies_for_pay?(employment_status_1 job_before_x_1 job_after_y_1 lel_1) OR qualifies_for_maternity_allowance?(employment_status_1 earnings_employment_1 work_employment_1 job_before_x_1 job_after_y_1 lel_1)
+$IF qualifies_for_maternity_leave?(employment_status_1 job_after_y_1) OR qualifies_for_pay?(employment_status_1 job_before_x_1 job_after_y_1 lel_1)
 
 $IF qualifies_for_leave?(employment_status_2 job_before_x_2 job_after_y_2) AND earnings_employment(earnings_employment_1 work_employment_1)
 
@@ -102,10 +90,6 @@ $IF NOT both_qualifies_for_shared_pay?(employment_status_1 job_before_x_1 job_af
 
 $IF NOT both_qualifies_for_shared_leave?(employment_status_1 job_before_x_1 job_after_y_1 lel_1 work_employment_1 earnings_employment_1 employment_status_2 job_before_x_2 job_after_y_2 lel_2 work_employment_2 earnings_employment_2)
 
-$IF NOT qualifies_for_14_week_maternity_allowance?(employment_status_1 employment_status_2)
-
-$IF NOT qualifies_for_maternity_allowance?(employment_status_1 earnings_employment_1 work_employment_1 job_before_x_1 job_after_y_1 lel_1)
-
 $IF NOT qualifies_for_pay?(employment_status_1 job_before_x_1 job_after_y_1 lel_1)
 
 $IF NOT qualifies_for_pay?(employment_status_2 job_before_x_2 job_after_y_2 lel_2)
@@ -128,25 +112,9 @@ $ENDIF
 
 $ENDIF
 
-$ENDIF
-
-$ENDIF
-
 {{snippet: extra-help}}
 
 #Option B
-
-$IF qualifies_for_14_week_maternity_allowance?(employment_status_2 employment_status_1)
-
-{{snippet: adoption-mat-allowance-14-weeks-perm2}}
-
-$ENDIF
-
-$IF qualifies_for_maternity_allowance?(employment_status_2 earnings_employment_2 work_employment_2 job_before_x_2 job_after_y_2 lel_2)
-
-{{snippet: adoption-mat-allowance-perm2}}
-
-$ENDIF
 
 $IF qualifies_for_pay?(employment_status_2 job_before_x_2 job_after_y_2 lel_2)
 
@@ -172,7 +140,7 @@ $ENDIF
 
 $IF NOT both_qualifies_for_shared_leave?(employment_status_2 job_before_x_2 job_after_y_2 lel_2 work_employment_2 earnings_employment_2 employment_status_1 job_before_x_1 job_after_y_1 lel_1 work_employment_1 earnings_employment_1)
 
-$IF qualifies_for_maternity_leave?(employment_status_2 job_after_y_2) OR qualifies_for_pay?(employment_status_2 job_before_x_2 job_after_y_2 lel_2) OR qualifies_for_maternity_allowance?(employment_status_2 earnings_employment_2 work_employment_2 job_before_x_2 job_after_y_2 lel_2)
+$IF qualifies_for_maternity_leave?(employment_status_2 job_after_y_2) OR qualifies_for_pay?(employment_status_2 job_before_x_2 job_after_y_2 lel_2)
 
 $IF qualifies_for_leave?(employment_status_2 job_before_x_2 job_after_y_2) AND earnings_employment(earnings_employment_1 work_employment_1)
 
@@ -189,7 +157,7 @@ $IF qualifies_for_pay?(employment_status_1 job_before_x_1 job_after_y_1 lel_1)
 
 {{snippet: adoption-pat-pay-perm2}}
 
-$IF qualifies_for_pay?(employment_status_2 job_before_x_2 job_after_y_2 lel_2) OR qualifies_for_maternity_allowance?(employment_status_2 earnings_employment_2 work_employment_2 job_before_x_2 job_after_y_2 lel_2)
+$IF qualifies_for_pay?(employment_status_2 job_before_x_2 job_after_y_2 lel_2)
 
 $IF NOT both_qualifies_for_shared_pay?(employment_status_2 job_before_x_2 job_after_y_2 lel_2 employment_status_1 job_before_x_1 job_after_y_1 lel_1)
 
@@ -209,7 +177,7 @@ $ENDIF
 
 $IF NOT both_qualifies_for_shared_leave?(employment_status_2 job_before_x_2 job_after_y_2 lel_2 work_employment_2 earnings_employment_2 employment_status_1 job_before_x_1 job_after_y_1 lel_1 work_employment_1 earnings_employment_1)
 
-$IF qualifies_for_maternity_leave?(employment_status_2 job_after_y_2) OR qualifies_for_pay?(employment_status_2 job_before_x_2 job_after_y_2 lel_2) OR qualifies_for_maternity_allowance?(employment_status_2 earnings_employment_2 work_employment_2 job_before_x_2 job_after_y_2 lel_2)
+$IF qualifies_for_maternity_leave?(employment_status_2 job_after_y_2) OR qualifies_for_pay?(employment_status_2 job_before_x_2 job_after_y_2 lel_2)
 
 $IF qualifies_for_leave?(employment_status_1 job_before_x_1 job_after_y_1) AND earnings_employment(earnings_employment_2 work_employment_2)
 
@@ -238,10 +206,6 @@ $IF NOT both_qualifies_for_shared_pay?(employment_status_2 job_before_x_2 job_af
 
 $IF NOT both_qualifies_for_shared_leave?(employment_status_2 job_before_x_2 job_after_y_2 lel_2 work_employment_2 earnings_employment_2 employment_status_1 job_before_x_1 job_after_y_1 lel_1 work_employment_1 earnings_employment_1)
 
-$IF NOT qualifies_for_14_week_maternity_allowance?(employment_status_2 employment_status_1)
-
-$IF NOT qualifies_for_maternity_allowance?(employment_status_2 earnings_employment_2 work_employment_2 job_before_x_2 job_after_y_2 lel_2)
-
 $IF NOT qualifies_for_pay?(employment_status_2 job_before_x_2 job_after_y_2 lel_2)
 
 $IF NOT qualifies_for_pay?(employment_status_1 job_before_x_1 job_after_y_1 lel_1)
@@ -251,10 +215,6 @@ $IF NOT qualifies_for_maternity_leave?(employment_status_2 job_after_y_2)
 $IF NOT qualifies_for_leave?(employment_status_1 job_before_x_1 job_after_y_1)
 
 {{snippet: adoption-nothing}}
-
-$ENDIF
-
-$ENDIF
 
 $ENDIF
 

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/outcomes/outcome_adoption_pre_april_5_2015_adopter_a_adopter_b.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/outcomes/outcome_adoption_pre_april_5_2015_adopter_a_adopter_b.txt
@@ -1,17 +1,5 @@
 #Option A
 
-$IF qualifies_for_14_week_maternity_allowance?(employment_status_1 employment_status_2)
-
-{{snippet: adoption-mat-allowance-14-weeks}}
-
-$ENDIF
-
-$IF qualifies_for_maternity_allowance?(employment_status_1 earnings_employment_1 work_employment_1 job_before_x_1 job_after_y_1 lel_1)
-
-{{snippet: adoption-mat-allowance}}
-
-$ENDIF
-
 $IF qualifies_for_pay?(employment_status_1 job_before_x_1 job_after_y_1 lel_1)
 
 {{snippet: adoption-mat-pay}}
@@ -28,7 +16,7 @@ $IF qualifies_for_pay?(employment_status_2 job_before_x_2 job_after_y_2 lel_2)
 
 {{snippet: adoption-pat-pay}}
 
-$IF qualifies_for_pay?(employment_status_1 job_before_x_1 job_after_y_1 lel_1) OR qualifies_for_maternity_allowance?(employment_status_1 earnings_employment_1 work_employment_1 job_before_x_1 job_after_y_1 lel_1)
+$IF qualifies_for_pay?(employment_status_1 job_before_x_1 job_after_y_1 lel_1)
 
 {{snippet: adoption-additional-pat-pay}}
 
@@ -40,17 +28,13 @@ $IF qualifies_for_leave?(employment_status_2 job_before_x_2 job_after_y_2)
 
 {{snippet: adoption-pat-leave}}
 
-$IF qualifies_for_maternity_leave?(employment_status_1 job_after_y_1) OR qualifies_for_pay?(employment_status_1 job_before_x_1 job_after_y_1 lel_1) OR qualifies_for_maternity_allowance?(employment_status_1 earnings_employment_1 work_employment_1 job_before_x_1 job_after_y_1 lel_1)
+$IF qualifies_for_maternity_leave?(employment_status_1 job_after_y_1) OR qualifies_for_pay?(employment_status_1 job_before_x_1 job_after_y_1 lel_1)
 
 {{snippet: adoption-additional-pat-leave}}
 
 $ENDIF
 
 $ENDIF
-
-$IF NOT qualifies_for_14_week_maternity_allowance?(employment_status_1 employment_status_2)
-
-$IF NOT qualifies_for_maternity_allowance?(employment_status_1 earnings_employment_1 work_employment_1 job_before_x_1 job_after_y_1 lel_1)
 
 $IF NOT qualifies_for_pay?(employment_status_1 job_before_x_1 job_after_y_1 lel_1)
 
@@ -70,25 +54,9 @@ $ENDIF
 
 $ENDIF
 
-$ENDIF
-
-$ENDIF
-
 {{snippet: extra-help}}
 
 #Option B
-
-$IF qualifies_for_14_week_maternity_allowance?(employment_status_2 employment_status_1)
-
-{{snippet: adoption-mat-allowance-14-weeks-perm2}}
-
-$ENDIF
-
-$IF qualifies_for_maternity_allowance?(employment_status_2 earnings_employment_2 work_employment_2 job_before_x_2 job_after_y_2 lel_2)
-
-{{snippet: adoption-mat-allowance-perm2}}
-
-$ENDIF
 
 $IF qualifies_for_pay?(employment_status_2 job_before_x_2 job_after_y_2 lel_2)
 
@@ -106,7 +74,7 @@ $IF qualifies_for_pay?(employment_status_1 job_before_x_1 job_after_y_1 lel_1)
 
 {{snippet: adoption-pat-pay-perm2}}
 
-$IF qualifies_for_pay?(employment_status_2 job_before_x_2 job_after_y_2 lel_2) OR qualifies_for_maternity_allowance?(employment_status_2 earnings_employment_2 work_employment_2 job_before_x_2 job_after_y_2 lel_2)
+$IF qualifies_for_pay?(employment_status_2 job_before_x_2 job_after_y_2 lel_2)
 
 {{snippet: adoption-additional-pat-pay-perm2}}
 
@@ -126,10 +94,6 @@ $ENDIF
 
 $ENDIF
 
-$IF NOT qualifies_for_14_week_maternity_allowance?(employment_status_2 employment_status_1)
-
-$IF NOT qualifies_for_maternity_allowance?(employment_status_2 earnings_employment_2 work_employment_2 job_before_x_2 job_after_y_2 lel_2)
-
 $IF NOT qualifies_for_pay?(employment_status_2 job_before_x_2 job_after_y_2 lel_2)
 
 $IF NOT qualifies_for_pay?(employment_status_1 job_before_x_1 job_after_y_1 lel_1)
@@ -139,10 +103,6 @@ $IF NOT qualifies_for_maternity_leave?(employment_status_2 job_after_y_2)
 $IF NOT qualifies_for_leave?(employment_status_1 job_before_x_1 job_after_y_1)
 
 {{snippet: adoption-nothing}}
-
-$ENDIF
-
-$ENDIF
 
 $ENDIF
 

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/scenarios/adoption-singleparent.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/scenarios/adoption-singleparent.txt
@@ -28,7 +28,7 @@ has markers: adoption-single-nothing, extra-help
   earnings_employment_1: yes
 - salary_1_66_weeks: 400-week
 outcome_adoption_adopter_a
-has markers: adoption-mat-allowance, extra-help
+has markers: adoption-single-nothing, extra-help
 
 #Adopter A worker, does not pass earnings and employment test
 - two_carers: no
@@ -60,7 +60,7 @@ has markers: adoption-single-nothing, extra-help
   earnings_employment_1: yes
 - salary_1_66_weeks: 400-week
 outcome_adoption_adopter_a
-has markers: adoption-mat-allowance, extra-help
+has markers: adoption-single-nothing, extra-help
 
 #Adopter A employee, soon to leave job, passes earnings and employment test
 - two_carers: no
@@ -76,7 +76,7 @@ has markers: adoption-mat-allowance, extra-help
   earnings_employment_1: yes
 - salary_1_66_weeks: 400-week
 outcome_adoption_adopter_a
-has markers: adoption-mat-allowance, extra-help
+has markers: adoption-single-nothing, extra-help
 
 #Adopter A employee, passes continuity test, does not pass lower earnings test, passes earnings and employment test
 - two_carers: no
@@ -92,7 +92,7 @@ has markers: adoption-mat-allowance, extra-help
   earnings_employment_1: yes
 - salary_1_66_weeks: 400-week
 outcome_adoption_adopter_a
-has markers: adoption-mat-allowance, adoption-mat-leave, extra-help
+has markers: adoption-mat-leave, extra-help
 
 #Adopter A employee, passes continuity test, does not pass lower earnings test, does not pass earnings and employment test
 - two_carers: no

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/scenarios/adoption-twoparents-2014.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/scenarios/adoption-twoparents-2014.txt
@@ -46,7 +46,7 @@ has markers: adoption-nothing, extra-help
   earnings_employment_2: no
 - salary_2_66_weeks: 400-week
 outcome_adoption_pre_april_5_2015_adopter_a_adopter_b
-has markers: adoption-mat-allowance, extra-help, adoption-nothing, extra-help
+has markers: adoption-nothing, extra-help, adoption-nothing, extra-help
 
 #Mother self-employed, passes earnings and employment test
 #Partner self-employed
@@ -71,7 +71,7 @@ has markers: adoption-mat-allowance, extra-help, adoption-nothing, extra-help
   earnings_employment_2: yes
 - salary_2_66_weeks: 400-week
 outcome_adoption_pre_april_5_2015_adopter_a_adopter_b
-has markers: adoption-mat-allowance, extra-help, adoption-mat-allowance-perm2, extra-help
+has markers: adoption-nothing, extra-help, adoption-nothing, extra-help
 
 #Mother employee, does not pass continuity test, passes lower earnings test
 #Partner employee, does not pass continuity test, does not pass lower earnings test
@@ -96,7 +96,7 @@ has markers: adoption-mat-allowance, extra-help, adoption-mat-allowance-perm2, e
   earnings_employment_2: yes
 - salary_2_66_weeks: 400-week
 outcome_adoption_pre_april_5_2015_adopter_a_adopter_b
-has markers: adoption-mat-allowance, extra-help, adoption-mat-allowance-perm2, adoption-mat-leave-perm2, extra-help
+has markers: adoption-nothing, extra-help, adoption-mat-leave-perm2, extra-help
 
 #Mother unemployed, does not pass earnings and employment test
 #Partner self-employed
@@ -121,7 +121,7 @@ has markers: adoption-mat-allowance, extra-help, adoption-mat-allowance-perm2, a
   earnings_employment_2: yes
 - salary_2_66_weeks: 400-week
 outcome_adoption_pre_april_5_2015_adopter_a_adopter_b
-has markers: adoption-mat-allowance-14-weeks, extra-help, adoption-mat-allowance-perm2, extra-help
+has markers: adoption-nothing, extra-help, adoption-nothing, extra-help
 
 #Mother employee, passes continuity test, does not pass lower earnings test, passes earnings and employment test
 #Partner self-employed
@@ -146,7 +146,7 @@ has markers: adoption-mat-allowance-14-weeks, extra-help, adoption-mat-allowance
   earnings_employment_2: yes
 - salary_2_66_weeks: 400-week
 outcome_adoption_pre_april_5_2015_adopter_a_adopter_b
-has markers: adoption-mat-allowance, adoption-mat-leave, extra-help, adoption-mat-allowance-perm2, adoption-pat-leave-perm2, adoption-additional-pat-leave-perm2, extra-help
+has markers: adoption-mat-leave, extra-help, adoption-pat-leave-perm2, adoption-additional-pat-leave-perm2, extra-help
 
 #Mother employee, passes continuity test, does not pass lower earnings test, passes earnings and employment test
 #Partner employee, passes continuity test, passes lower earnings test
@@ -171,7 +171,7 @@ has markers: adoption-mat-allowance, adoption-mat-leave, extra-help, adoption-ma
   earnings_employment_2: yes
 - salary_2_66_weeks: 400-week
 outcome_adoption_pre_april_5_2015_adopter_a_adopter_b
-has markers: adoption-mat-allowance, adoption-mat-leave, adoption-pat-pay, adoption-additional-pat-pay, adoption-pat-leave, adoption-additional-pat-leave, extra-help, adoption-mat-pay-perm2, adoption-mat-leave-perm2, adoption-pat-leave-perm2, adoption-additional-pat-leave-perm2, extra-help
+has markers: adoption-mat-leave, adoption-pat-pay, adoption-pat-leave, adoption-additional-pat-leave, extra-help, adoption-mat-pay-perm2, adoption-mat-leave-perm2, adoption-pat-leave-perm2, adoption-additional-pat-leave-perm2, extra-help
 
 #Mother employee, passes continuity test, does not pass lower earnings test, passes earnings and employment test
 #Partner worker, passes continuity test, passes lower earnings test
@@ -196,7 +196,7 @@ has markers: adoption-mat-allowance, adoption-mat-leave, adoption-pat-pay, adopt
   earnings_employment_2: yes
 - salary_2_66_weeks: 400-week
 outcome_adoption_pre_april_5_2015_adopter_a_adopter_b
-has markers: adoption-mat-allowance, adoption-mat-leave, adoption-pat-pay, adoption-additional-pat-pay, extra-help, adoption-mat-pay-perm2, adoption-pat-leave-perm2, adoption-additional-pat-leave-perm2, extra-help
+has markers: adoption-mat-leave, adoption-pat-pay, extra-help, adoption-mat-pay-perm2, adoption-pat-leave-perm2, adoption-additional-pat-leave-perm2, extra-help
 
 #Mother self-employed, passes earnings and employment test
 #Partner employee, passes continuity test, passes lower earnings test
@@ -221,7 +221,7 @@ has markers: adoption-mat-allowance, adoption-mat-leave, adoption-pat-pay, adopt
   earnings_employment_2: yes
 - salary_2_66_weeks: 400-week
 outcome_adoption_pre_april_5_2015_adopter_a_adopter_b
-has markers: adoption-mat-allowance, adoption-pat-pay, adoption-additional-pat-pay, adoption-pat-leave, adoption-additional-pat-leave, extra-help, adoption-mat-pay-perm2, adoption-mat-leave-perm2, extra-help
+has markers: adoption-pat-pay, adoption-pat-leave, extra-help, adoption-mat-pay-perm2, adoption-mat-leave-perm2, extra-help
 
 #Mother worker, does not pass continuity test, does not pass lower earnings test, passes earnings and employment test
 #Partner employee, passes continuity test, passes lower earnings test
@@ -246,7 +246,7 @@ has markers: adoption-mat-allowance, adoption-pat-pay, adoption-additional-pat-p
   earnings_employment_2: yes
 - salary_2_66_weeks: 400-week
 outcome_adoption_pre_april_5_2015_adopter_a_adopter_b
-has markers: adoption-mat-allowance, adoption-pat-pay, adoption-additional-pat-pay, adoption-pat-leave, adoption-additional-pat-leave, extra-help, adoption-mat-pay-perm2, adoption-mat-leave-perm2, extra-help
+has markers: adoption-pat-pay, adoption-pat-leave, extra-help, adoption-mat-pay-perm2, adoption-mat-leave-perm2, extra-help
 
 #Mother self-employed, passes earnings and employment test
 #Partner worker, passes continuity test, passes lower earnings test
@@ -271,7 +271,7 @@ has markers: adoption-mat-allowance, adoption-pat-pay, adoption-additional-pat-p
   earnings_employment_2: yes
 - salary_2_66_weeks: 400-week
 outcome_adoption_pre_april_5_2015_adopter_a_adopter_b
-has markers: adoption-mat-allowance, adoption-pat-pay, adoption-additional-pat-pay, extra-help, adoption-mat-pay-perm2, extra-help
+has markers: adoption-pat-pay, extra-help, adoption-mat-pay-perm2, extra-help
 
 #Mother worker, does not pass continuity test, does not pass lower earnings test, passes earnings and employment test
 #Partner worker, passes continuity test, passes lower earnings test
@@ -296,7 +296,7 @@ has markers: adoption-mat-allowance, adoption-pat-pay, adoption-additional-pat-p
   earnings_employment_2: yes
 - salary_2_66_weeks: 400-week
 outcome_adoption_pre_april_5_2015_adopter_a_adopter_b
-has markers: adoption-mat-allowance, adoption-pat-pay, adoption-additional-pat-pay, extra-help, adoption-mat-pay-perm2, extra-help
+has markers: adoption-pat-pay, extra-help, adoption-mat-pay-perm2, extra-help
 
 #Mother employee, passes continuity test, does not pass lower earnings test, does not pass earnings and employment test
 #Partner self-employed
@@ -346,7 +346,7 @@ has markers: adoption-mat-leave, extra-help, adoption-pat-leave-perm2, extra-hel
   earnings_employment_2: yes
 - salary_2_66_weeks: 400-week
 outcome_adoption_pre_april_5_2015_adopter_a_adopter_b
-has markers: adoption-mat-allowance, adoption-mat-leave, extra-help, adoption-mat-allowance-perm2, extra-help
+has markers: adoption-mat-leave, extra-help, adoption-nothing, extra-help
 
 #Mother employee, passes continuity test, passes lower earnings test
 #Partner self-employed
@@ -371,7 +371,7 @@ has markers: adoption-mat-allowance, adoption-mat-leave, extra-help, adoption-ma
   earnings_employment_2: yes
 - salary_2_66_weeks: 400-week
 outcome_adoption_pre_april_5_2015_adopter_a_adopter_b
-has markers: adoption-mat-pay, adoption-mat-leave, extra-help, adoption-mat-allowance-perm2, adoption-pat-pay-perm2, adoption-additional-pat-pay-perm2, adoption-pat-leave-perm2, adoption-additional-pat-leave-perm2, extra-help
+has markers: adoption-mat-pay, adoption-mat-leave, extra-help, adoption-pat-pay-perm2, adoption-pat-leave-perm2, adoption-additional-pat-leave-perm2, extra-help
 
 #Mother employee, passes continuity test, passes lower earnings test
 #Partner employee, passes continuity test, does not pass lower earnings test
@@ -396,7 +396,7 @@ has markers: adoption-mat-pay, adoption-mat-leave, extra-help, adoption-mat-allo
   earnings_employment_2: yes
 - salary_2_66_weeks: 400-week
 outcome_adoption_pre_april_5_2015_adopter_a_adopter_b
-has markers: adoption-mat-pay, adoption-mat-leave, adoption-pat-leave, adoption-additional-pat-leave, extra-help, adoption-mat-allowance-perm2, adoption-mat-leave-perm2, adoption-pat-pay-perm2, adoption-additional-pat-pay-perm2, adoption-pat-leave-perm2, adoption-additional-pat-leave-perm2, extra-help
+has markers: adoption-mat-pay, adoption-mat-leave, adoption-pat-leave, adoption-additional-pat-leave, extra-help, adoption-mat-leave-perm2, adoption-pat-pay-perm2, adoption-pat-leave-perm2, adoption-additional-pat-leave-perm2, extra-help
 
 #Mother employee, passes continuity test, passes lower earnings test
 #Partner employee, passes continuity test, passes lower earnings test
@@ -546,7 +546,7 @@ has markers: adoption-mat-leave, adoption-pat-pay, extra-help, adoption-mat-pay-
   earnings_employment_2: yes
 - salary_2_66_weeks: 400-week
 outcome_adoption_pre_april_5_2015_adopter_a_adopter_b
-has markers: adoption-mat-pay, extra-help, adoption-mat-allowance-perm2, adoption-pat-pay-perm2, adoption-additional-pat-pay-perm2, extra-help
+has markers: adoption-mat-pay, extra-help, adoption-pat-pay-perm2, extra-help
 
 #Mother worker, passes continuity test, passes lower earnings test
 #Partner worker, does not pass continuity test
@@ -771,7 +771,7 @@ has markers: adoption-pat-pay, extra-help, adoption-mat-pay-perm2, extra-help
   earnings_employment_2: yes
 - salary_2_66_weeks: 400-week
 outcome_adoption_pre_april_5_2015_adopter_a_adopter_b
-has markers: adoption-mat-allowance, adoption-mat-leave, adoption-pat-pay, adoption-additional-pat-pay, adoption-pat-leave, adoption-additional-pat-leave, extra-help, adoption-mat-pay-perm2, adoption-mat-leave-perm2, extra-help
+has markers: adoption-mat-leave, adoption-pat-pay, adoption-pat-leave, adoption-additional-pat-leave, extra-help, adoption-mat-pay-perm2, adoption-mat-leave-perm2, extra-help
 
 #Mother employee, does not pass continuity test, does not pass lower earnings test, does not pass earnings and employment test, still working
 #Partner employee, passes continuity test, passes lower earnings test

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/scenarios/adoption-twoparents-2016.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/scenarios/adoption-twoparents-2016.txt
@@ -21,7 +21,7 @@
   earnings_employment_2: yes
 - salary_2_66_weeks: 400-week
 outcome_adoption_post_april_5_2015_adopter_a_adopter_b
-has markers: adoption-nothing, extra-help, adoption-mat-allowance-perm2, extra-help
+has markers: adoption-nothing, extra-help, adoption-nothing, extra-help
 
 #Mother employee, does not pass continuity test, passes lower earnings test
 #Partner self-employed
@@ -46,7 +46,7 @@ has markers: adoption-nothing, extra-help, adoption-mat-allowance-perm2, extra-h
   earnings_employment_2: yes
 - salary_2_66_weeks: 400-week
 outcome_adoption_post_april_5_2015_adopter_a_adopter_b
-has markers: adoption-mat-allowance, extra-help, adoption-mat-allowance-perm2, extra-help
+has markers: adoption-nothing, extra-help, adoption-nothing, extra-help
 
 #Mother worker, passes continuity test, does not pass lower earnings test, does not pass earnings and employment test
 #Partner worker, does not pass continuity test
@@ -96,7 +96,7 @@ has markers: adoption-nothing, extra-help
   earnings_employment_2: yes
 - salary_2_66_weeks: 400-week
 outcome_adoption_post_april_5_2015_adopter_a_adopter_b
-has markers: adoption-mat-allowance, extra-help, adoption-mat-allowance-perm2, extra-help
+has markers: adoption-nothing, extra-help, adoption-nothing, extra-help
 
 #Mother unemployed, passes earnings and employment test
 #Partner unemployed
@@ -121,7 +121,7 @@ has markers: adoption-mat-allowance, extra-help, adoption-mat-allowance-perm2, e
   earnings_employment_2: no
 - salary_2_66_weeks: 400-week
 outcome_adoption_post_april_5_2015_adopter_a_adopter_b
-has markers: adoption-mat-allowance, extra-help, adoption-nothing, extra-help
+has markers: adoption-nothing, extra-help, adoption-nothing, extra-help
 
 #Mother employee, does not pass continuity test, passes earnings and employment test
 #Partner self-employed
@@ -146,7 +146,7 @@ has markers: adoption-mat-allowance, extra-help, adoption-nothing, extra-help
   earnings_employment_2: yes
 - salary_2_66_weeks: 400-week
 outcome_adoption_post_april_5_2015_adopter_a_adopter_b
-has markers: adoption-mat-allowance, extra-help, adoption-mat-allowance-perm2, extra-help
+has markers: adoption-nothing, extra-help, adoption-nothing, extra-help
 
 #Mother employee, does not pass continuity test, passes lower earnings test
 #Partner worker, does not pass continuity test
@@ -171,7 +171,7 @@ has markers: adoption-mat-allowance, extra-help, adoption-mat-allowance-perm2, e
   earnings_employment_2: yes
 - salary_2_66_weeks: 400-week
 outcome_adoption_post_april_5_2015_adopter_a_adopter_b
-has markers: adoption-mat-allowance, extra-help, adoption-mat-allowance-perm2, extra-help
+has markers: adoption-nothing, extra-help, adoption-nothing, extra-help
 
 #Mother unemployed, passes earnings and employment test
 #Partner self-employed
@@ -196,7 +196,7 @@ has markers: adoption-mat-allowance, extra-help, adoption-mat-allowance-perm2, e
   earnings_employment_2: yes
 - salary_2_66_weeks: 400-week
 outcome_adoption_post_april_5_2015_adopter_a_adopter_b
-has markers: adoption-mat-allowance-14-weeks, extra-help, adoption-mat-allowance-perm2, extra-help
+has markers: adoption-nothing, extra-help, adoption-nothing, extra-help
 
 #Mother employee, passes continuity test, does not pass lower earnings test, passes earnings and employment test
 #Partner self-employed, passes earnings and employment test
@@ -221,7 +221,7 @@ has markers: adoption-mat-allowance-14-weeks, extra-help, adoption-mat-allowance
   earnings_employment_2: yes
 - salary_2_66_weeks: 400-week
 outcome_adoption_post_april_5_2015_adopter_a_adopter_b
-has markers: adoption-mat-allowance, adoption-mat-leave, adoption-mat-shared-leave, extra-help, adoption-mat-allowance-perm2, adoption-pat-leave-perm2, adoption-pat-shared-leave-perm2, extra-help
+has markers: adoption-mat-leave, adoption-mat-shared-leave, extra-help, adoption-pat-leave-perm2, extra-help
 
 #Mother employee, passes continuity test, does not pass lower earnings test, passes earnings and employment test
 #Partner self-employed, does not pass earnings and employment test
@@ -246,7 +246,7 @@ has markers: adoption-mat-allowance, adoption-mat-leave, adoption-mat-shared-lea
   earnings_employment_2: no
 - salary_2_66_weeks: 400-week
 outcome_adoption_post_april_5_2015_adopter_a_adopter_b
-has markers: adoption-mat-allowance, adoption-mat-leave, extra-help, adoption-pat-leave-perm2, extra-help
+has markers: adoption-mat-leave, extra-help, adoption-pat-leave-perm2, extra-help
 
 #Mother employee, passes continuity test, does not pass lower earnings test, does not pass earnings and employment test
 #Partner self-employed, passes earnings and employment test
@@ -271,7 +271,7 @@ has markers: adoption-mat-allowance, adoption-mat-leave, extra-help, adoption-pa
   earnings_employment_2: yes
 - salary_2_66_weeks: 400-week
 outcome_adoption_post_april_5_2015_adopter_a_adopter_b
-has markers: adoption-mat-leave, adoption-mat-shared-leave, extra-help, adoption-mat-allowance-perm2, adoption-pat-leave-perm2, adoption-pat-shared-leave-perm2, extra-help
+has markers: adoption-mat-leave, adoption-mat-shared-leave, extra-help, adoption-pat-leave-perm2, extra-help
 
 #Mother employee, passes continuity test, does not pass lower earnings test, does not pass earnings and employment test
 #Partner self-employed, does not pass earnings and employment test
@@ -321,7 +321,7 @@ has markers: adoption-mat-leave, extra-help, adoption-pat-leave-perm2, extra-hel
   earnings_employment_2: no
 - salary_2_66_weeks: 400-week
 outcome_adoption_post_april_5_2015_adopter_a_adopter_b
-has markers: adoption-mat-allowance, adoption-mat-leave, extra-help, adoption-nothing, extra-help
+has markers: adoption-mat-leave, extra-help, adoption-nothing, extra-help
 
 #Mother employee, passes continuity test, does not pass lower earnings test, passes earnings and employment test
 #Partner employee, passes continuity test, passes lower earnings test
@@ -346,7 +346,7 @@ has markers: adoption-mat-allowance, adoption-mat-leave, extra-help, adoption-no
   earnings_employment_2: yes
 - salary_2_66_weeks: 400-week
 outcome_adoption_post_april_5_2015_adopter_a_adopter_b
-has markers: adoption-mat-allowance, adoption-mat-leave, adoption-pat-pay, adoption-pat-shared-pay, adoption-pat-leave, adoption-both-shared-leave, extra-help, adoption-mat-pay-perm2, adoption-mat-shared-pay-perm2, adoption-mat-leave-perm2, adoption-pat-leave-perm2, adoption-both-shared-leave-perm2, extra-help
+has markers: adoption-mat-leave, adoption-pat-pay, adoption-pat-leave, adoption-both-shared-leave, extra-help, adoption-mat-pay-perm2, adoption-mat-shared-pay-perm2, adoption-mat-leave-perm2, adoption-pat-leave-perm2, adoption-both-shared-leave-perm2, extra-help
 
 #Mother employee, passes continuity test, does not pass lower earnings test, passes earnings and employment test
 #Partner worker, passes continuity test, passes lower earnings test
@@ -371,7 +371,7 @@ has markers: adoption-mat-allowance, adoption-mat-leave, adoption-pat-pay, adopt
   earnings_employment_2: yes
 - salary_2_66_weeks: 400-week
 outcome_adoption_post_april_5_2015_adopter_a_adopter_b
-has markers: adoption-mat-allowance, adoption-mat-leave, adoption-mat-shared-leave, adoption-pat-pay, adoption-pat-shared-pay, extra-help, adoption-mat-pay-perm2, adoption-mat-shared-pay-perm2, adoption-pat-leave-perm2, adoption-pat-shared-leave-perm2, extra-help
+has markers: adoption-mat-leave, adoption-mat-shared-leave, adoption-pat-pay, extra-help, adoption-mat-pay-perm2, adoption-mat-shared-pay-perm2, adoption-pat-leave-perm2, adoption-pat-shared-leave-perm2, extra-help
 
 #Mother self-employed, passes earnings and employment test
 #Partner employee, passes continuity test, passes lower earnings test
@@ -396,7 +396,7 @@ has markers: adoption-mat-allowance, adoption-mat-leave, adoption-mat-shared-lea
   earnings_employment_2: yes
 - salary_2_66_weeks: 400-week
 outcome_adoption_post_april_5_2015_adopter_a_adopter_b
-has markers: adoption-mat-allowance, adoption-pat-pay, adoption-pat-shared-pay, adoption-pat-leave, adoption-pat-shared-leave, extra-help, adoption-mat-pay-perm2, adoption-mat-shared-pay-perm2, adoption-mat-leave-perm2, adoption-mat-shared-leave-perm2, extra-help
+has markers: adoption-pat-pay, adoption-pat-leave, extra-help, adoption-mat-pay-perm2, adoption-mat-shared-pay-perm2, adoption-mat-leave-perm2, adoption-mat-shared-leave-perm2, extra-help
 
 #Mother self-employed, passes earnings and employment test
 #Partner worker, passes continuity test, passes lower earnings test
@@ -421,7 +421,7 @@ has markers: adoption-mat-allowance, adoption-pat-pay, adoption-pat-shared-pay, 
   earnings_employment_2: yes
 - salary_2_66_weeks: 400-week
 outcome_adoption_post_april_5_2015_adopter_a_adopter_b
-has markers: adoption-mat-allowance, adoption-pat-pay, adoption-pat-shared-pay, extra-help, adoption-mat-pay-perm2, adoption-mat-shared-pay-perm2, extra-help
+has markers: adoption-pat-pay, extra-help, adoption-mat-pay-perm2, adoption-mat-shared-pay-perm2, extra-help
 
 #Mother worker, does not pass continuity test, passes earnings and employment test
 #Partner worker, passes continuity test, passes lower earnings test
@@ -446,7 +446,7 @@ has markers: adoption-mat-allowance, adoption-pat-pay, adoption-pat-shared-pay, 
   earnings_employment_2: yes
 - salary_2_66_weeks: 400-week
 outcome_adoption_post_april_5_2015_adopter_a_adopter_b
-has markers: adoption-mat-allowance, adoption-pat-pay, adoption-pat-shared-pay, extra-help, adoption-mat-pay-perm2, adoption-mat-shared-pay-perm2, extra-help
+has markers: adoption-pat-pay, extra-help, adoption-mat-pay-perm2, adoption-mat-shared-pay-perm2, extra-help
 
 #Mother employee, does not pass continuity test, passes lower earnings test
 #Partner employee, passes continuity test, does not pass lower earnings test
@@ -471,7 +471,7 @@ has markers: adoption-mat-allowance, adoption-pat-pay, adoption-pat-shared-pay, 
   earnings_employment_2: yes
 - salary_2_66_weeks: 400-week
 outcome_adoption_post_april_5_2015_adopter_a_adopter_b
-has markers: adoption-mat-allowance, adoption-mat-leave, adoption-pat-leave, adoption-pat-shared-leave, extra-help, adoption-mat-allowance-perm2, adoption-mat-leave-perm2, adoption-mat-shared-leave-perm2, extra-help
+has markers: adoption-mat-leave, adoption-pat-leave, adoption-pat-shared-leave, extra-help, adoption-mat-leave-perm2, adoption-mat-shared-leave-perm2, extra-help
 
 #Mother employee, passes continuity test, passes lower earnings test
 #Partner self-employed, does not pass earnings and employment test
@@ -521,7 +521,7 @@ has markers: adoption-mat-pay, adoption-mat-leave, extra-help, adoption-pat-pay-
   earnings_employment_2: yes
 - salary_2_66_weeks: 400-week
 outcome_adoption_post_april_5_2015_adopter_a_adopter_b
-has markers: adoption-mat-pay, adoption-mat-shared-pay, adoption-mat-leave, adoption-mat-shared-leave, extra-help, adoption-mat-allowance-perm2, adoption-pat-pay-perm2, adoption-pat-shared-pay-perm2, adoption-pat-leave-perm2, adoption-pat-shared-leave-perm2, extra-help
+has markers: adoption-mat-pay, adoption-mat-shared-pay, adoption-mat-leave, adoption-mat-shared-leave, extra-help, adoption-pat-pay-perm2, adoption-pat-leave-perm2, extra-help
 
 #Mother employee, passes continuity test, passes lower earnings test
 #Partner employee, does not pass continuity test, passes lower earnings test, passes earnings and employment test
@@ -546,7 +546,7 @@ has markers: adoption-mat-pay, adoption-mat-shared-pay, adoption-mat-leave, adop
   earnings_employment_2: yes
 - salary_2_66_weeks: 400-week
 outcome_adoption_post_april_5_2015_adopter_a_adopter_b
-has markers: adoption-mat-pay, adoption-mat-shared-pay, adoption-mat-leave, adoption-mat-shared-leave, extra-help, adoption-mat-allowance-perm2, adoption-mat-leave-perm2, adoption-pat-pay-perm2, adoption-pat-shared-pay-perm2, adoption-pat-leave-perm2, adoption-pat-shared-leave-perm2, extra-help
+has markers: adoption-mat-pay, adoption-mat-shared-pay, adoption-mat-leave, adoption-mat-shared-leave, extra-help, adoption-mat-leave-perm2, adoption-pat-pay-perm2, adoption-pat-leave-perm2, adoption-pat-shared-leave-perm2, extra-help
 
 #Mother employee, passes continuity test, passes lower earnings test
 #Partner employee, passes continuity test, passes lower earnings test
@@ -696,7 +696,7 @@ has markers: adoption-mat-pay, extra-help, adoption-pat-pay-perm2, extra-help
   earnings_employment_2: yes
 - salary_2_66_weeks: 400-week
 outcome_adoption_post_april_5_2015_adopter_a_adopter_b
-has markers: adoption-mat-pay, adoption-mat-shared-pay, extra-help, adoption-mat-allowance-perm2, adoption-pat-pay-perm2, adoption-pat-shared-pay-perm2, extra-help
+has markers: adoption-mat-pay, adoption-mat-shared-pay, extra-help, adoption-pat-pay-perm2, extra-help
 
 #Mother worker, passes continuity test, passes lower earnings test
 #Partner employee, does not pass continuity test, does not pass lower earnings test, passes earnings and employment test
@@ -721,7 +721,7 @@ has markers: adoption-mat-pay, adoption-mat-shared-pay, extra-help, adoption-mat
   earnings_employment_2: yes
 - salary_2_66_weeks: 400-week
 outcome_adoption_post_april_5_2015_adopter_a_adopter_b
-has markers: adoption-mat-pay, adoption-mat-shared-pay, extra-help, adoption-mat-allowance-perm2, adoption-pat-pay-perm2, adoption-pat-shared-pay-perm2, extra-help
+has markers: adoption-mat-pay, adoption-mat-shared-pay, extra-help, adoption-pat-pay-perm2, extra-help
 
 #Mother worker, passes continuity test, passes lower earnings test
 #Partner employee, passes continuity test, passes lower earnings test
@@ -871,7 +871,7 @@ has markers: adoption-mat-pay, adoption-mat-leave, adoption-pat-leave, adoption-
   earnings_employment_2: yes
 - salary_2_66_weeks: 400-week
 outcome_adoption_post_april_5_2015_adopter_a_adopter_b
-has markers: adoption-mat-leave, adoption-mat-shared-leave, extra-help, adoption-mat-allowance-perm2, adoption-pat-leave-perm2, adoption-pat-shared-leave-perm2, extra-help
+has markers: adoption-mat-leave, adoption-mat-shared-leave, extra-help, adoption-pat-leave-perm2, extra-help
 
 #Mother employee, passes continuity test, does not pass lower earnings test, does not pass earnings and employment test
 #Partner worker, does not pass continuity test, does not pass lower earnings test, passes earnings and employment test
@@ -896,7 +896,7 @@ has markers: adoption-mat-leave, adoption-mat-shared-leave, extra-help, adoption
   earnings_employment_2: yes
 - salary_2_66_weeks: 400-week
 outcome_adoption_post_april_5_2015_adopter_a_adopter_b
-has markers: adoption-mat-leave, adoption-mat-shared-leave, extra-help, adoption-mat-allowance-perm2, adoption-pat-leave-perm2, adoption-pat-shared-leave-perm2, extra-help
+has markers: adoption-mat-leave, adoption-mat-shared-leave, extra-help, adoption-pat-leave-perm2, extra-help
 
 #Mother worker, does not pass continuity test, does not pass lower earnings test, does not pass earnings and employment test
 #Partner worker, passes continuity test, does not pass lower earnings test
@@ -921,4 +921,4 @@ has markers: adoption-mat-leave, adoption-mat-shared-leave, extra-help, adoption
   earnings_employment_2: yes
 - salary_2_66_weeks: 400-week
 outcome_adoption_post_april_5_2015_adopter_a_adopter_b
-has markers: adoption-nothing, extra-help, adoption-mat-allowance-perm2, extra-help
+has markers: adoption-nothing, extra-help, adoption-nothing, extra-help

--- a/lib/smartdown_plugins/pay-leave-for-parents-adoption/render_time.rb
+++ b/lib/smartdown_plugins/pay-leave-for-parents-adoption/render_time.rb
@@ -38,8 +38,7 @@ module SmartdownPlugins
       (qualifies_for_maternity_leave?(employment_status_1, job_after_1) ||
       qualifies_for_leave?(employment_status_1, job_before_1, job_after_1) ||
       qualifies_for_pay?(employment_status_1, job_before_1, job_after_1, lel_1) ||
-      qualifies_for_pay?(employment_status_2, job_before_2, job_after_2, lel_2) ||
-      qualifies_for_maternity_allowance?(employment_status_1, earnings_employment_1, work_employment_1, job_before_1, job_after_1, lel_1)) &&
+      qualifies_for_pay?(employment_status_2, job_before_2, job_after_2, lel_2)) &&
       employment_status_1 == 'employee' &&
       continuity(job_before_1, job_after_1) &&
       earnings_employment(earnings_employment_1, work_employment_1) &&


### PR DESCRIPTION
Removed all occurrences of maternity allowance for the single parent adoption flow.
Removed all occurrences of maternity allowance for the two pre April 5 2015 parent adoption flow.
Removed all occurrences of maternity allowance for the two post April 5 2015 parent adoption flow.