### PR TITLE
Remove duplicated textfrom death registration in Kenya and Nigeria

### DIFF
--- a/lib/smart_answer_flows/locales/en/register-a-death-v2.yml
+++ b/lib/smart_answer_flows/locales/en/register-a-death-v2.yml
@@ -367,11 +367,17 @@ en-GB:
         oru_courier_text_cambodia: |
           Your documents will be returned to the British Embassy in Phnom Penh after the death has been registered.
         oru_courier_text_cameroon: |
-          Your documents will be returned to the British High Commission in Yaonde. You'll also be sent copies of the registration certificate if you've paid for them. The High Commission will contact you when your documents are ready for collection.
+          Your documents will be returned to the British High Commission in Yaonde.
+
+          You’ll also be sent copies of the registration certificate if you’ve paid for them. The High Commission will contact you when your documents are ready for collection.
         oru_courier_text_kenya: |
-          Your documents will be returned to the British High Commission in Nairobi after the death has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+          Your documents will be returned to the British High Commission in Nairobi after the death has been registered.
+
+          You’ll also be sent copies of the registration certificate if you’ve paid for them. The High Commission will contact you when your documents and certificates are ready for collection.
         oru_courier_text_nigeria: |
-          Your documents will be returned to the British High Commission in Lagos after the death has been registered. You’ll also be sent copies of the registration certificate if you’ve paid for them. The embassy will contact you when your documents and certificates are ready for collection.
+          Your documents will be returned to the British High Commission in Lagos after the death has been registered.
+
+          You’ll also be sent copies of the registration certificate if you’ve paid for them. The High Commission will contact you when your documents and certificates are ready for collection.
         oru_courier_text_north-korea: |
           Your documents will be returned to the British Embassy in Pyongyang after the death has been registered.
         oru_courier_text_papua-new-guinea: |

--- a/lib/smart_answer_flows/register-a-death-v2.rb
+++ b/lib/smart_answer_flows/register-a-death-v2.rb
@@ -162,10 +162,9 @@ outcome :oru_result do
   precalculate :oru_courier_text do
     phrases = PhraseList.new
     if reg_data_query.class::ORU_COURIER_VARIANTS.include?(current_location)
-      if current_location == 'cameroon'
-        phrases << :oru_courier_text_cameroon
-      else
-        phrases << :"oru_courier_text_#{current_location}" << :oru_courier_text_common
+      phrases << :"oru_courier_text_#{current_location}"
+      unless current_location.in?(%w(cameroon kenya nigeria)) # High Comission countries
+        phrases << :oru_courier_text_common
       end
     else
       phrases << :oru_courier_text_default

--- a/test/integration/smart_answer_flows/register_a_death_v2_test.rb
+++ b/test/integration/smart_answer_flows/register_a_death_v2_test.rb
@@ -480,9 +480,9 @@ class RegisterADeathV2Test < ActiveSupport::TestCase
         add_response 'in_the_uk'
       end
 
-      should "take you to the embassy outcome with custom courier message" do
+      should "take you to the ORU outcome with custom courier message without common text" do
         assert_current_node :oru_result
-        assert_phrase_list :oru_courier_text, [:oru_courier_text_kenya, :oru_courier_text_common]
+        assert_phrase_list :oru_courier_text, [:oru_courier_text_kenya]
       end
     end
 
@@ -493,9 +493,9 @@ class RegisterADeathV2Test < ActiveSupport::TestCase
         add_response 'in_the_uk'
       end
 
-      should "take you to the embassy outcome with custom courier message" do
+      should "take you to the ORU outcome with custom courier message without common text" do
         assert_current_node :oru_result
-        assert_phrase_list :oru_courier_text, [:oru_courier_text_nigeria, :oru_courier_text_common]
+        assert_phrase_list :oru_courier_text, [:oru_courier_text_nigeria]
       end
     end
 


### PR DESCRIPTION
As per FC feedback:
This text appears twice: "You’ll also be sent copies of the registration certificate if you’ve paid for them.
The embassy will contact you when your documents and certificates are ready for collection."
Also, it should be 'high commission' not 'embassy'.

`/register-a-death-v2/y/overseas/kenya/same_country`
`/register-a-death-v2/y/overseas/nigeria/same_country`