### PR TITLE
Pt students 2015 2016

### DIFF
--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_eu_pt_1516_continuing.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_eu_pt_1516_continuing.txt
@@ -1,0 +1,26 @@
+# EU part-time student
+
+To apply for a Tuition Fee Loan use form EUPTLC.
+
+Academic year | Form
+- | -
+2015 to 2016 | [EUPTLC - form (PDF, 613KB)](http://www.sfengland.slc.co.uk/media/888368/eu_ptlc_form_1516_d.pdf)
+2015 to 2016 | [EUPTLC - guidance notes (PDF, 96KB)](http://www.sfengland.slc.co.uk/media/888372/eu_ptlc_notes_1516_d.pdf)
+
+If you started your course before 1 September 2012 you may be eligible for a Tuition Fee Grant. These forms will be available in summer 2015.
+
+##Additional information
+
+You may need to include additional information on the following forms.
+
+Form | When to use the form
+- | -
+[EUTFLR - form (PDF, 441KB)](http://www.sfengland.slc.co.uk/media/873481/eu_tuition_fee_loan_request_form_1516_d.pdf) | To change the amount of loan you want to apply for
+[Evidence factsheet (PDF, 82KB)](http://www.sfengland.slc.co.uk/media/873356/eu_evidence_fact_sheet_1516_d.pdf) | List of evidence to send with your application, eg proof of identity or income
+[Certifier checklist (PDF, 60KB)](http://www.sfengland.slc.co.uk/media/873116/eu_certifier_checklist_1516_d.pdf) | Get the person who verifies your evidence to sign this form
+[EUCO1 - form (PDF, 116KB)](http://www.sfengland.slc.co.uk/media/873352/eu_euco1_form_1516_d.pdf) | To update your course, name and other details
+
+
+^You can apply up to 9 months after the start of your course.^
+
+{{snippet: where-to-send-your-forms-non-uk}}

--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_eu_pt_1516_new.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_eu_pt_1516_new.txt
@@ -1,0 +1,23 @@
+# EU part-time student
+
+To apply for a Tuition Fee Loan use form EUPTL1.
+
+Academic year | Form
+- | -
+2015 to 2016 | [EUPTL1 - form (PDF, ???KB)](http://www.sfengland.slc.co.uk/media/888360/eu_ptl1_form_1516_d.pdf)
+2015 to 2016 | [EUPTL1 - guidance notes (PDF, 590KB)](http://www.sfengland.slc.co.uk/media/888364/eu_ptl1_notes_1516_d.pdf)
+
+If you started your course before 1 September 2012 and you haven’t applied for student finance before, you may be eligible for a Tuition Fee Grant. These forms will be available summer 2015
+
+##Additional information
+
+Form | When to use the form
+- | -
+[EUTFLR - form (PDF, 441KB)](http://www.sfengland.slc.co.uk/media/873481/eu_tuition_fee_loan_request_form_1516_d.pdf) | To change the amount of loan you want to apply for
+[Evidence factsheet (PDF, 82KB)](http://www.sfengland.slc.co.uk/media/873356/eu_evidence_fact_sheet_1516_d.pdf) | List of evidence to send with your application, eg proof of identity or income
+[Certifier checklist (PDF, 60KB)](http://www.sfengland.slc.co.uk/media/873116/eu_certifier_checklist_1516_d.pdf) | Get the person who verifies your evidence to sign this form
+[EUCO1 - form (PDF, 116KB)](http://www.sfengland.slc.co.uk/media/873352/eu_euco1_form_1516_d.pdf) | To update your course, name and other details
+
+^You can apply up to 9 months after the start of your course.^
+
+{{snippet: where-to-send-your-forms-non-uk}}

--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_continuing.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_continuing.txt
@@ -1,0 +1,26 @@
+# EU part-time student
+
+To apply for a Tuition Fee Loan use form EUPTLC.
+
+Academic year | Form
+- | -
+2015 to 2016 | [EUPTLC - form (PDF, 613KB)](http://www.sfengland.slc.co.uk/media/888368/eu_ptlc_form_1516_d.pdf)
+2015 to 2016 | [EUPTLC - guidance notes (PDF, 96KB)](http://www.sfengland.slc.co.uk/media/888372/eu_ptlc_notes_1516_d.pdf)
+
+If you started your course before 1 September 2012 you may be eligible for a Tuition Fee Grant. These forms will be available in summer 2015.
+
+##Additional information
+
+You may need to include additional information on the following forms.
+
+Form | When to use the form
+- | -
+[EUTFLR - form (PDF, 441KB)](http://www.sfengland.slc.co.uk/media/873481/eu_tuition_fee_loan_request_form_1516_d.pdf) | To change the amount of loan you want to apply for
+[Evidence factsheet (PDF, 82KB)](http://www.sfengland.slc.co.uk/media/873356/eu_evidence_fact_sheet_1516_d.pdf) | List of evidence to send with your application, eg proof of identity or income
+[Certifier checklist (PDF, 60KB)](http://www.sfengland.slc.co.uk/media/873116/eu_certifier_checklist_1516_d.pdf) | Get the person who verifies your evidence to sign this form
+[EUCO1 - form (PDF, 116KB)](http://www.sfengland.slc.co.uk/media/873352/eu_euco1_form_1516_d.pdf) | To update your course, name and other details
+
+
+^You can apply up to 9 months after the start of your course.^
+
+{{snippet: where-to-send-your-forms-non-uk}}

--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_continuing.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_continuing.txt
@@ -1,26 +1,13 @@
-# EU part-time student
+# Student finance - application form
 
-To apply for a Tuition Fee Loan use form EUPTLC.
+You should [apply online](/apply-online-for-student-finance) for a Tuition Fee Loan. If you can't apply online, use form PTLC.
 
-Academic year | Form
+Academic Year | Form
 - | -
-2015 to 2016 | [EUPTLC - form (PDF, 613KB)](http://www.sfengland.slc.co.uk/media/888368/eu_ptlc_form_1516_d.pdf)
-2015 to 2016 | [EUPTLC - guidance notes (PDF, 96KB)](http://www.sfengland.slc.co.uk/media/888372/eu_ptlc_notes_1516_d.pdf)
-
-If you started your course before 1 September 2012 you may be eligible for a Tuition Fee Grant. These forms will be available in summer 2015.
-
-##Additional information
-
-You may need to include additional information on the following forms.
-
-Form | When to use the form
-- | -
-[EUTFLR - form (PDF, 441KB)](http://www.sfengland.slc.co.uk/media/873481/eu_tuition_fee_loan_request_form_1516_d.pdf) | To change the amount of loan you want to apply for
-[Evidence factsheet (PDF, 82KB)](http://www.sfengland.slc.co.uk/media/873356/eu_evidence_fact_sheet_1516_d.pdf) | List of evidence to send with your application, eg proof of identity or income
-[Certifier checklist (PDF, 60KB)](http://www.sfengland.slc.co.uk/media/873116/eu_certifier_checklist_1516_d.pdf) | Get the person who verifies your evidence to sign this form
-[EUCO1 - form (PDF, 116KB)](http://www.sfengland.slc.co.uk/media/873352/eu_euco1_form_1516_d.pdf) | To update your course, name and other details
-
+2014 to 2015 | [Apply online](/apply-online-for-student-finance)
+2014 to 2015 | [PTLC - form (PDF, ???KB)](http://www.sfengland.slc.co.uk/media/887066_ptlc_form_1516_d.pdf)
+2014 to 2015 | [PTLC - guidance notes (PDF, ???KB)](http://www.sfengland.slc.co.uk/media/887070_ptlc_notes_1516_d.pdf)
 
 ^You can apply up to 9 months after the start of your course.^
 
-{{snippet: where-to-send-your-forms-non-uk}}
+{{snippet: where-to-send-your-forms-uk}}

--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_grant.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_grant.txt
@@ -1,0 +1,3 @@
+# Student finance - application form
+
+Application forms for Fee Grants and Course Grants for the 2015 to 2016 academic year will be available from summer 2015.

--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_new.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_new.txt
@@ -1,23 +1,13 @@
-# EU part-time student
+# Student finance - application form
 
-To apply for a Tuition Fee Loan use form EUPTL1.
+You should [apply online](/apply-online-for-student-finance) for a Tuition Fee Loan. If you can't apply online, use form PTL1.
 
-Academic year | Form
+Academic Year | Form
 - | -
-2015 to 2016 | [EUPTL1 - form (PDF, ???KB)](http://www.sfengland.slc.co.uk/media/888360/eu_ptl1_form_1516_d.pdf)
-2015 to 2016 | [EUPTL1 - guidance notes (PDF, 590KB)](http://www.sfengland.slc.co.uk/media/888364/eu_ptl1_notes_1516_d.pdf)
-
-If you started your course before 1 September 2012 and you haven’t applied for student finance before, you may be eligible for a Tuition Fee Grant. These forms will be available summer 2015
-
-##Additional information
-
-Form | When to use the form
-- | -
-[EUTFLR - form (PDF, 441KB)](http://www.sfengland.slc.co.uk/media/873481/eu_tuition_fee_loan_request_form_1516_d.pdf) | To change the amount of loan you want to apply for
-[Evidence factsheet (PDF, 82KB)](http://www.sfengland.slc.co.uk/media/873356/eu_evidence_fact_sheet_1516_d.pdf) | List of evidence to send with your application, eg proof of identity or income
-[Certifier checklist (PDF, 60KB)](http://www.sfengland.slc.co.uk/media/873116/eu_certifier_checklist_1516_d.pdf) | Get the person who verifies your evidence to sign this form
-[EUCO1 - form (PDF, 116KB)](http://www.sfengland.slc.co.uk/media/873352/eu_euco1_form_1516_d.pdf) | To update your course, name and other details
+2014 to 2015 | [Apply online](/apply-online-for-student-finance)
+2014 to 2015 | [PTL1 - form (PDF, ???KB)](http://www.sfengland.slc.co.uk/media/887058_ptl1_form_1516_d.pdf)
+2014 to 2015 | [PTL1 - guidance notes (PDF, ???KB)](http://www.sfengland.slc.co.uk/media/887062_ptl1_notes_1516_d.pdf)
 
 ^You can apply up to 9 months after the start of your course.^
 
-{{snippet: where-to-send-your-forms-non-uk}}
+{{snippet: where-to-send-your-forms-uk}}

--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_new.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_new.txt
@@ -1,0 +1,23 @@
+# EU part-time student
+
+To apply for a Tuition Fee Loan use form EUPTL1.
+
+Academic year | Form
+- | -
+2015 to 2016 | [EUPTL1 - form (PDF, ???KB)](http://www.sfengland.slc.co.uk/media/888360/eu_ptl1_form_1516_d.pdf)
+2015 to 2016 | [EUPTL1 - guidance notes (PDF, 590KB)](http://www.sfengland.slc.co.uk/media/888364/eu_ptl1_notes_1516_d.pdf)
+
+If you started your course before 1 September 2012 and you haven’t applied for student finance before, you may be eligible for a Tuition Fee Grant. These forms will be available summer 2015
+
+##Additional information
+
+Form | When to use the form
+- | -
+[EUTFLR - form (PDF, 441KB)](http://www.sfengland.slc.co.uk/media/873481/eu_tuition_fee_loan_request_form_1516_d.pdf) | To change the amount of loan you want to apply for
+[Evidence factsheet (PDF, 82KB)](http://www.sfengland.slc.co.uk/media/873356/eu_evidence_fact_sheet_1516_d.pdf) | List of evidence to send with your application, eg proof of identity or income
+[Certifier checklist (PDF, 60KB)](http://www.sfengland.slc.co.uk/media/873116/eu_certifier_checklist_1516_d.pdf) | Get the person who verifies your evidence to sign this form
+[EUCO1 - form (PDF, 116KB)](http://www.sfengland.slc.co.uk/media/873352/eu_euco1_form_1516_d.pdf) | To update your course, name and other details
+
+^You can apply up to 9 months after the start of your course.^
+
+{{snippet: where-to-send-your-forms-non-uk}}

--- a/lib/smartdown_flows/student-finance-forms/questions/continuing_student.txt
+++ b/lib/smartdown_flows/student-finance-forms/questions/continuing_student.txt
@@ -29,4 +29,6 @@ You’re usually a continuing student if you got student finance last year.
     * form_needed_for_1 is 'apply-loans-grants'
       * continuing_student is 'continuing-student' => outcome_uk_ft_1516_continuing
       * continuing_student is 'new-student' => outcome_uk_ft_1516_new
-* type_of_student is 'uk-part-time' => pt_course_start
+* type_of_student is 'uk-part-time' 
+ * continuing_student is 'continuing-student' => pt_course_start
+ * continuing_student is 'new-student' => outcome_uk_pt_1516_new.txt

--- a/lib/smartdown_flows/student-finance-forms/questions/continuing_student.txt
+++ b/lib/smartdown_flows/student-finance-forms/questions/continuing_student.txt
@@ -30,5 +30,13 @@ You’re usually a continuing student if you got student finance last year.
       * continuing_student is 'continuing-student' => outcome_uk_ft_1516_continuing
       * continuing_student is 'new-student' => outcome_uk_ft_1516_new
 * type_of_student is 'uk-part-time' 
- * continuing_student is 'continuing-student' => pt_course_start
- * continuing_student is 'new-student' => outcome_uk_pt_1516_new.txt
+  * what_year is 'year-1415'
+    * form_needed_for_2 is 'apply-loans-grants'
+      * continuing_student is 'continuing-student' => pt_course_start
+      * continuing_student is 'new-student' => outcome_uk_pt_1415_new.txt
+  * what_year is 'year-1516'
+    * form_needed_for_2 is 'apply-loans-grants'
+      * continuing_student is 'continuing-student' => pt_course_start
+      * continuing_student is 'new-student' => outcome_uk_pt_1516_new.txt
+ 
+

--- a/lib/smartdown_flows/student-finance-forms/questions/continuing_student.txt
+++ b/lib/smartdown_flows/student-finance-forms/questions/continuing_student.txt
@@ -14,12 +14,12 @@ You’re usually a continuing student if you got student finance last year.
     * continuing_student is 'continuing-student' => outcome_eu_ft_1516_continuing
     * continuing_student is 'new-student' => outcome_eu_ft_1516_new
 * type_of_student is 'eu-part-time'
-  * what_year is 'year-1314'
-    * continuing_student is 'continuing-student' => outcome_eu_pt_1314_continuing
-    * continuing_student is 'new-student' => outcome_eu_pt_1314_new
   * what_year is 'year-1415'
     * continuing_student is 'continuing-student' => outcome_eu_pt_1415_continuing
     * continuing_student is 'new-student' => outcome_eu_pt_1415_new
+  * what_year is 'year-1516'
+    * continuing_student is 'continuing-student' => outcome_eu_pt_1516_continuing
+    * continuing_student is 'new-student' => outcome_eu_pt_1516_new
 * type_of_student is 'uk-full-time'
   * what_year is 'year-1415'
     * form_needed_for_1 is 'apply-loans-grants'

--- a/lib/smartdown_flows/student-finance-forms/questions/form_needed_for_1.txt
+++ b/lib/smartdown_flows/student-finance-forms/questions/form_needed_for_1.txt
@@ -13,4 +13,4 @@
 * form_needed_for_1 is 'dsa-expenses' => outcome_dsa_expenses
 * form_needed_for_1 is 'ccg-expenses' => outcome_ccg_expenses
 * form_needed_for_1 is 'travel-grant' => outcome_travel
-* otherwise => what_year_uk_fulltime
+* otherwise => what_year

--- a/lib/smartdown_flows/student-finance-forms/questions/form_needed_for_2.txt
+++ b/lib/smartdown_flows/student-finance-forms/questions/form_needed_for_2.txt
@@ -7,4 +7,4 @@
 * dsa-expenses: Claim Disabled Students’ Allowances expenses
 
 * form_needed_for_2 is 'dsa-expenses' => outcome_dsa_expenses
-* otherwise => what_year_uk_fulltime.txt
+* otherwise => what_year

--- a/lib/smartdown_flows/student-finance-forms/questions/form_needed_for_2.txt
+++ b/lib/smartdown_flows/student-finance-forms/questions/form_needed_for_2.txt
@@ -7,4 +7,4 @@
 * dsa-expenses: Claim Disabled Students’ Allowances expenses
 
 * form_needed_for_2 is 'dsa-expenses' => outcome_dsa_expenses
-* otherwise => what_year
+* otherwise => what_year_uk_fulltime.txt

--- a/lib/smartdown_flows/student-finance-forms/questions/pt_course_start.txt
+++ b/lib/smartdown_flows/student-finance-forms/questions/pt_course_start.txt
@@ -4,13 +4,11 @@
 * course-start-before-01092012: Yes
 * course-start-after-01092012: No
 
-* what_year is 'year-1314'
-  * pt_course_start is 'course-start-before-01092012' => outcome_uk_pt_1314_grant
-  * pt_course_start is 'course-start-after-01092012'
-    * continuing_student is 'continuing-student' => outcome_uk_pt_1314_continuing
-    * continuing_student is 'new-student' => outcome_uk_pt_1314_new
 * what_year is 'year-1415'
   * pt_course_start is 'course-start-before-01092012' => outcome_uk_pt_1415_grant
   * pt_course_start is 'course-start-after-01092012'
     * continuing_student is 'continuing-student' => outcome_uk_pt_1415_continuing
-    * continuing_student is 'new-student' => outcome_uk_pt_1415_new
+* what_year is 'year-1516'
+  * pt_course_start is 'course-start-before-01092012' => outcome_uk_pt_1516_grant
+  * pt_course_start is 'course-start-after-01092012'
+    * continuing_student is 'continuing-student' => outcome_uk_pt_1516_continuing

--- a/lib/smartdown_flows/student-finance-forms/questions/type_of_student.txt
+++ b/lib/smartdown_flows/student-finance-forms/questions/type_of_student.txt
@@ -8,5 +8,5 @@
 
 * type_of_student is 'uk-full-time' => form_needed_for_1
 * type_of_student is 'uk-part-time' => form_needed_for_2
-* type_of_student is 'eu-full-time' => what_year_eu_fulltime
+* type_of_student is 'eu-full-time' => what_year
 * type_of_student is 'eu-part-time' => what_year

--- a/lib/smartdown_flows/student-finance-forms/questions/what_year.txt
+++ b/lib/smartdown_flows/student-finance-forms/questions/what_year.txt
@@ -1,30 +1,30 @@
 # What academic year do you want funding for?
 
 [choice: what_year]
-* year-1314: 2013 to 2014
+* year-1516: 2015 to 2016
 * year-1415: 2014 to 2015
 
-* type_of_student is 'eu-full-time' => continuing_student
-* type_of_student is 'eu-part-time' => continuing_student
 * type_of_student is 'uk-full-time'
   * form_needed_for_1 is 'proof-identity'
-    * what_year is 'year-1314' => outcome_proof_identity_1314
-    * what_year is 'year-1415' => outcome_proof_identity_1415
+   * what_year is 'year-1415' => outcome_proof_identity_1415
+   * what_year is 'year-1516' => outcome_proof_identity_1516
   * form_needed_for_1 is 'income-details'
-    * what_year is 'year-1314' => outcome_parent_partner_1314
-    * what_year is 'year-1415' => outcome_parent_partner_1415
+   * what_year is 'year-1415' => outcome_parent_partner_1415
+   * what_year is 'year-1516' => outcome_parent_partner_1516
   * form_needed_for_1 is 'apply-dsa'
-    * what_year is 'year-1314' => outcome_dsa_1314
-    * what_year is 'year-1415' => outcome_dsa_1415
+   * what_year is 'year-1415' => outcome_dsa_1415
+   * what_year is 'year-1516' => outcome_dsa_1516
   * form_needed_for_1 is 'apply-ccg'
-      * what_year is 'year-1314' => outcome_ccg_1314
-      * what_year is 'year-1415' => outcome_ccg_1415
+   * what_year is 'year-1415' => outcome_ccg_1415
+   * what_year is 'year-1516' => outcome_ccg_1516
   * form_needed_for_1 is 'apply-loans-grants' => continuing_student
 * type_of_student is 'uk-part-time'
   * form_needed_for_2 is 'proof-identity'
-    * what_year is 'year-1314' => outcome_proof_identity_1314
     * what_year is 'year-1415' => outcome_proof_identity_1415
+    * what_year is 'year-1516' => outcome_proof_identity_1516
   * form_needed_for_2 is 'apply-dsa'
-    * what_year is 'year-1314' => outcome_dsa_1314_pt
     * what_year is 'year-1415' => outcome_dsa_1415_pt
+    * what_year is 'year-1516' => outcome_dsa_1516_pt
   * form_needed_for_2 is 'apply-loans-grants' => continuing_student
+* type_of_student is 'eu-full-time' => continuing_student
+* type_of_student is 'eu-part-time' => continuing_student

--- a/lib/smartdown_flows/student-finance-forms/questions/what_year.txt
+++ b/lib/smartdown_flows/student-finance-forms/questions/what_year.txt
@@ -23,8 +23,8 @@
     * what_year is 'year-1415' => outcome_proof_identity_1415
     * what_year is 'year-1516' => outcome_proof_identity_1516
   * form_needed_for_2 is 'apply-dsa'
-    * what_year is 'year-1415' => outcome_dsa_1415_pt
-    * what_year is 'year-1516' => outcome_dsa_1516_pt
+    * what_year is 'year-1415' => outcome_dsa_1415
+    * what_year is 'year-1516' => outcome_dsa_1516
   * form_needed_for_2 is 'apply-loans-grants' => continuing_student
 * type_of_student is 'eu-full-time' => continuing_student
 * type_of_student is 'eu-part-time' => continuing_student

--- a/lib/smartdown_flows/student-finance-forms/questions/what_year_uk_fulltime.txt
+++ b/lib/smartdown_flows/student-finance-forms/questions/what_year_uk_fulltime.txt
@@ -17,3 +17,13 @@
   * what_year is 'year-1415' => outcome_ccg_1415
   * what_year is 'year-1516' => outcome_ccg_1516
 * form_needed_for_1 is 'apply-loans-grants' => continuing_student
+* type_of_student is 'uk-part-time'
+  * form_needed_for_2 is 'proof-identity'
+    * what_year is 'year-1415' => outcome_proof_identity_1415
+    * what_year is 'year-1516' => outcome_proof_identity_1516
+  * form_needed_for_2 is 'apply-dsa'
+    * what_year is 'year-1415' => outcome_dsa_1415_pt
+    * what_year is 'year-1516' => outcome_dsa_1516_pt
+  * form_needed_for_2 is 'apply-loans-grants' => continuing_student
+* type_of_student is 'eu-full-time' => continuing_student
+* type_of_student is 'eu-part-time' => continuing_student


### PR DESCRIPTION
I'd like a V2 preview version of this, please.

---------------------------------

Changes made to include new forms for UK and EU part time students in 2015-16.

Also amended logic to streamline the journey (eg all users can now use the same what_year file)

We can now delete the 2013-14 files:

Questions

what_year_eu_fulltime.txt
what_year_uk_fulltime.txt

Outcomes

outcome_ccg_1314.txt
outcome_dsa_1314.txt
outcome_dsa_1314_pt.txt
outcome_eu_ft_1314_continuing.txt
outcome_eu_ft_1314_new.txt
outcome_eu_pt_1314_continuing.txt
outcome_eu_pt_1314_new.txt
outcome_parent_partner_1314.txt
outcome_proof_identity_1314.txt
outcome_uk_pt_1314_continuing.txt
outcome_uk_pt_1314_grant.txt
outcome_uk_pt_1314_new.txt
