### PR TITLE
Marriage abroad: Removal of "Irish partner" response

### DIFF
--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -635,21 +635,6 @@ en-GB:
           You’ll need to get your statutory declaration and CNI '[legalised](/get-document-legalised)' (certified as genuine) by the Foreign & Commonwealth Office (FCO).
 
           You’ll also need to get your CNI [translated](/government/publications/italy-list-of-lawyers) and sworn before the Italian courts or an Italian Justice of the Peace.
-        consular_cni_os_england_or_wales_resident_not_italy: |
-          You need to get a CNI from the Foreign & Commonwealth Office (FCO) in London if your partner is Irish and you live in England or Wales.
-
-          Your partner should contact the Irish authorities to obtain their CNI.
-
-          ###Applying for a CNI from the FCO
-
-          s1. [Download ‘Certificate of no impediment application form’ (DOT, 60KB)](/government/uploads/system/uploads/attachment_data/file/136828/nulla-osta-form.doc).
-          s2. Place a public announcement of your marriage in your local newspaper for at least 1 week, as described on the form.
-          s3. Swear an affidavit (written statement of facts) in front of a [solicitor](http://www.lawsociety.org.uk/find-a-solicitor/) - there’s an example on the form.
-          s4. Make sure you’ve got all of the supporting documents you need - there’s a checklist on the form.
-          s5. You’ll also need to include a pre-paid, self-addressed special delivery envelope, or a £10 postage fee, so the FCO can return your documents.
-          s6. Send your completed form to the FCO with your supporting documents and payment. [You can pay by credit card online](/pay-foreign-marriage-certificates), or send a postal order or bank draft for £65 (or £75 if you’re paying the postage) made payable to ‘FCO’. Personal cheques aren’t accepted. The address is on the form.
-          s7. The FCO will forward your application to the local British embassy or consulate where you’re getting married, usually within 20 days - they’ll let you know when it’s ready to collect.
-          s8. The embassy or consulate will charge you an additional fee when you pick it up. It’s normally valid for 3 months, but you should check this with the local authorities.
         consular_cni_os_uk_resident_montenegro: |
           ###Getting a Montenegrin version of your CNI
 

--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -1338,14 +1338,7 @@ en-GB:
 
           The British Embassy in Saudi Arabia may also be able to give you advice.
           +[data_partial:overseas_passports_embassies:overseas_passports_embassies]
-        other_countries_os_saudi_arabia_local_resident_partner_irish: |
-          ^One of you must be a Muslim to get married under local laws in Saudi Arabia. You can’t get married at the British Embassy in Saudi Arabia if one of you is an Irish national, as the Irish authorities do not recognise consular marriages.^
-
-          Contact the [Embassy of Saudi Arabia](http://www.saudiembassy.org.uk/) to find out about local marriage laws.
-
-          The British Embassy in Saudi Arabia may also be able to give you advice.
-          +[data_partial:overseas_passports_embassies:overseas_passports_embassies]
-        other_countries_os_saudi_arabia_local_resident_partner_not_irish: |
+        other_countries_os_saudi_arabia_local_resident: |
           One of you must be a Muslim to get married under local laws in Saudi Arabia. Contact the [Embassy of Saudi Arabia](http://www.saudiembassy.org.uk/) to find out about local marriage laws.
 
           ##Getting married at the British Embassy
@@ -1371,11 +1364,11 @@ en-GB:
           As long as nobody has registered an objection after this time, the consular officer can then perform the marriage ceremony any time until 3 months after the date you gave notice.
 
           You’ll need to pay additional fees for the marriage ceremony and to get your marriage certificate (see below).
-        other_countries_os_saudi_arabia_local_resident_partner_not_irish_or_british: |
+        other_countries_os_saudi_arabia_local_resident_partner_not_british: |
           ##Naturalisation of your partner if they move to the UK
 
           Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they've lived in the UK for 3 years.
-        other_countries_os_saudi_arabia_local_resident_partner_not_irish_two: |
+        other_countries_os_saudi_arabia_local_resident_two: |
           ##Fees
 
           Service | Fee

--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -937,7 +937,7 @@ en-GB:
           - your [full birth certificate](/order-copy-birth-death-marriage-certificate/) or [naturalisation certificate](/get-replacement-citizenship-certificate)
           - a copy of your partner’s ID card and Certificato di Stato Libero from the comune
           - a copy of your partner’s Nulla Osta, if possible
-        italy_consular_cni_os_partner_other_or_irish: |
+        italy_consular_cni_os_partner_other: |
           You’ll need to provide supporting documents, including:
 
           - your passport

--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -620,7 +620,7 @@ en-GB:
           ^A CNI issued in England, Wales or Northern Ireland is valid for 6 months. A CNI issued in Scotland is valid for 3 months.^
 
           They’ll post your notice, and as long as nobody has registered an objection after 7 days, they’ll issue your CNI.
-        consular_cni_os_scotland_or_ni_partner_irish_or_partner_not_irish_three: |
+        consular_cni_os_resident_in_uk_ceremony_in_italy: |
           ###Getting a statutory declaration
 
           While you’re waiting for your CNI, you and your partner will need to make a statutory declaration before a [solicitor or public notary](http://www.lawsociety.org.uk/find-a-solicitor/). The Italian authorities will need this in addition to your CNI. There’s a standard template in English and Italian that you can download and use.
@@ -635,21 +635,6 @@ en-GB:
           You’ll need to get your statutory declaration and CNI '[legalised](/get-document-legalised)' (certified as genuine) by the Foreign & Commonwealth Office (FCO).
 
           You’ll also need to get your CNI [translated](/government/publications/italy-list-of-lawyers) and sworn before the Italian courts or an Italian Justice of the Peace.
-        consular_cni_os_england_or_wales_partner_irish_three: |
-          You need to get a Nulla Osta by applying to the Foreign & Commonwealth Office (FCO) in London if your partner is Irish and you live in England or Wales.
-
-          Your partner should contact the Irish authorities to get their Nulla Osta.
-
-          ###Applying for a Nulla Osta from the FCO
-
-          s1. [Download ‘Nulla Osta application form’ (DOT, 61KB)](/government/uploads/system/uploads/attachment_data/file/136828/nulla-osta-form.doc).
-          s2. Place a public announcement of your marriage in your local newspaper for at least 1 week, as described on the form.
-          s3. Swear an affidavit (written statement of facts) in front of a [solicitor](http://www.lawsociety.org.uk/find-a-solicitor/) - there’s an example on the form.
-          s4. Make sure you’ve got all of the supporting documents you need - there’s a checklist on the form.
-          s5. You’ll also need to include a pre-paid, self-addressed special delivery envelope, or a £10 postage fee, so the FCO can return your documents.
-          s6. Send your completed form to the FCO with your supporting documents and payment. [You can pay by credit card online](/pay-foreign-marriage-certificates), or send a postal order or bank draft for £65 (or £75 if you’re paying the postage) made payable to ‘FCO’. Personal cheques aren’t accepted. The address is on the form.
-          s7. FCO will forward your Nulla Osta application to the British Embassy in Rome. They'll aim to issue the Nulla Osta within 20 days, and contact you to arrange payment (see fees below).
-          s8. They’ll then send it to the town hall (‘comune’) in Italy where you’re getting married - or another address (such as your wedding planner) if you ask them to. It’s normally valid for 6 months, but you should check this with the comune.
         consular_cni_os_england_or_wales_resident_not_italy: |
           You need to get a CNI from the Foreign & Commonwealth Office (FCO) in London if your partner is Irish and you live in England or Wales.
 

--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -574,7 +574,7 @@ en-GB:
           If the Standesamt does ask you for a CNI (‘Ehefähigkeitszeugnis’), refer them to the relevant part of the [German Civil Code](http://www.gesetze-im-internet.de/bgb/__1309.html) (‘Bürgerliches Gesetzbuch’). This is published on the Stuttgart Higher Regional Court (‘Oberlandesgericht’) website, but it applies to the whole of Germany.
 
           Check with the Higher Regional Court where you're getting married if they don't accept this.
-        uk_resident_partner_not_irish_os_consular_cni_three: |
+        uk_resident_os_consular_cni_three: |
           You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf) or [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm).
 
           ^A CNI issued in England, Wales or Northern Ireland is valid for 6 months. A CNI issued in Scotland is valid for 3 months.^

--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -540,7 +540,7 @@ en-GB:
           You should also check the [travel advice for %{country_name_lowercase_prefix}](/foreign-travel-advice/%{ceremony_country}) before making any plans.
         gulf_states_os_consular_cni: |
           ^There are no civil marriages in %{country_name_lowercase_prefix}, but you can get married through a religious ceremony at a church or Sharia court.^
-        gulf_states_os_consular_cni_local_resident_partner_not_irish: |
+        gulf_states_os_consular_cni_local_resident: |
           You may be able to get married at the British Embassy if you're both resident in %{country_name_lowercase_prefix} and can prove that there are no other suitable facilities.
 
           Contact the British Embassy in %{country_name_lowercase_prefix} for more information.

--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -240,8 +240,6 @@ en-GB:
           ^Your partner will need to get an affidavit as well.^
         affirmation_os_translation_in_local_language_text: |
           You might need to get your affirmation [translated](/government/organisations/foreign-commonwealth-office/series/list-of-lawyers) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
-        affidavit_os_translation_in_local_language_text: |
-          You might need to get your affidavit [translated](/government/organisations/foreign-commonwealth-office/series/list-of-lawyers) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
 
 # fee tables
         fee_table_45_70_55: |

--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -181,10 +181,6 @@ en-GB:
           ##What you need to do
 
           You may be asked to provide an ‘affirmation for marriage’ document to prove you’re allowed to marry.
-        what_you_need_to_do_affidavit: |
-          ##What you need to do
-
-          You may be asked to provide an ‘affidavit for marriage’ document to prove you’re allowed to marry.
         what_you_need_to_do_affirmation_21_days: |
           ##What you need to do
 

--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -620,11 +620,6 @@ en-GB:
           ^A CNI issued in England, Wales or Northern Ireland is valid for 6 months. A CNI issued in Scotland is valid for 3 months.^
 
           They’ll post your notice, and as long as nobody has registered an objection after 7 days, they’ll issue your CNI.
-        scotland_ni_resident_partner_irish_os_consular_cni_three: |
-          You can normally get a CNI by giving a notice of marriage at local registrar if you live in [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf) or [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm).
-
-          ^A CNI issued in Northern Ireland is valid for 6 months. A CNI issued in Scotland is valid for 3 months.^
-
         consular_cni_os_scotland_or_ni_partner_irish_or_partner_not_irish_three: |
           ###Getting a statutory declaration
 

--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -269,12 +269,6 @@ en-GB:
           Service | Fee
           -|-
           Affidavit for marriage | £55
-        fee_table_affidavit_65: |
-          ##Fees
-
-          Service | Fee
-          -|-
-          Affidavit for marriage | £65
         fee_table_affirmation_55: |
           ##Fees
 

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -607,14 +607,12 @@ outcome :outcome_os_consular_cni do
       phrases << :spain_os_consular_cni_two
     elsif ceremony_country == 'italy'
       if resident_of == 'uk'
-        if (partner_nationality != partner_irish) or (%w(uk_scotland uk_ni).include?(residency_uk_region) and partner_nationality == 'partner_irish')
-          phrases << :italy_os_consular_cni_uk_resident
-        end
+        phrases << :italy_os_consular_cni_uk_resident
       end
       if resident_of == 'uk' and partner_nationality == 'partner_british'
         phrases << :italy_os_consular_cni_uk_resident_two
       end
-      if resident_of != 'uk' or (resident_of == 'uk' and partner_nationality == 'partner_irish' and %w(uk_scotland uk_ni).exclude?(residency_uk_region))
+      if resident_of != 'uk'
         phrases << :italy_os_consular_cni_uk_resident_three
       end
     end

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -635,14 +635,12 @@ outcome :outcome_os_consular_cni do
         else
           phrases << :cni_posted_if_no_objection_14_days
         end
-      elsif cni_posted_after_7_days_countries.include?(ceremony_country) or partner_nationality != 'partner_irish'
+      else
         if cni_notary_public_countries.include?(ceremony_country) or %w(italy japan macedonia spain).include?(ceremony_country)
           phrases << :cni_at_local_register_office_notary_public
         else
           phrases << :cni_at_local_register_office
         end
-      elsif partner_nationality == 'partner_irish' and %w(uk_scotland uk_ni).include?(residency_uk_region)
-        phrases << :scotland_ni_resident_partner_irish_os_consular_cni_three
       end
 
       if ceremony_country == 'italy'

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -1215,17 +1215,11 @@ outcome :outcome_os_other_countries do
       if ceremony_country != residency_country
         phrases << :other_countries_os_ceremony_saudia_arabia_not_local_resident
       else
-        if partner_nationality == 'partner_irish'
-          phrases << :other_countries_os_saudi_arabia_local_resident_partner_irish
-        else
-          phrases << :other_countries_os_saudi_arabia_local_resident_partner_not_irish
+        phrases << :other_countries_os_saudi_arabia_local_resident
+        if partner_nationality != 'partner_british'
+          phrases << :other_countries_os_saudi_arabia_local_resident_partner_not_british
         end
-        if %w(partner_irish partner_british).exclude?(partner_nationality)
-          phrases << :other_countries_os_saudi_arabia_local_resident_partner_not_irish_or_british
-        end
-        if partner_nationality != 'partner_irish'
-          phrases << :other_countries_os_saudi_arabia_local_resident_partner_not_irish_two
-        end
+        phrases << :other_countries_os_saudi_arabia_local_resident_two
       end
     end
     phrases

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -570,8 +570,8 @@ outcome :outcome_os_consular_cni do
 
     if %w(jordan oman qatar).include?(ceremony_country)
       phrases << :gulf_states_os_consular_cni
-      if residency_country == ceremony_country and partner_nationality != 'partner_irish'
-        phrases << :gulf_states_os_consular_cni_local_resident_partner_not_irish
+      if residency_country == ceremony_country
+        phrases << :gulf_states_os_consular_cni_local_resident
       end
     end
 
@@ -1015,7 +1015,7 @@ outcome :outcome_os_affirmation do
       elsif (ceremony_country == residency_country) or ceremony_country == 'qatar'
         phrases << :affirmation_os_local_resident
         if ceremony_country == 'qatar'
-          phrases << :gulf_states_os_consular_cni << :gulf_states_os_consular_cni_local_resident_partner_not_irish
+          phrases << :gulf_states_os_consular_cni << :gulf_states_os_consular_cni_local_resident
         end
       elsif ceremony_country != residency_country and resident_of != 'uk'
         if ceremony_country == 'morocco'

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -1114,11 +1114,7 @@ outcome :outcome_os_affirmation do
     elsif %w(cambodia ecuador morocco).include? ceremony_country
       phrases << :fee_table_affirmation_55
     elsif ceremony_country == 'finland'
-      if partner_nationality == 'partner_irish' and resident_of == 'uk'
-        phrases << :fee_table_affidavit_65
-      else
-        phrases << :fee_table_affirmation_65
-      end
+      phrases << :fee_table_affirmation_65
     elsif ceremony_country == 'philippines'
       phrases << :fee_table_55_70
     elsif ceremony_country == 'qatar'

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -1033,9 +1033,7 @@ outcome :outcome_os_affirmation do
 
     unless (ceremony_country == 'turkey' or residency_country == 'portugal')
       phrases << :embassies_data
-      if ceremony_country == 'finland' and partner_nationality == 'partner_irish' and resident_of == 'uk'
-        phrases << :affidavit_os_translation_in_local_language_text
-      elsif ceremony_country == 'cambodia'
+      if ceremony_country == 'cambodia'
         phrases << :cni_os_partner_local_legislation_documents_for_appointment
         phrases << :affirmation_os_translation_in_local_language_text
       elsif ceremony_country != 'china' and ceremony_country != 'egypt'

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -219,8 +219,8 @@ multiple_choice :partner_opposite_or_same_sex? do
   define_predicate(:ceremony_in_colombia_partner_not_local) {
     (ceremony_country == "colombia") & (partner_nationality != "partner_local")
   }
-  define_predicate(:ceremony_in_finland_uk_resident_partner_not_irish) {
-    (ceremony_country == "finland") & (resident_of == "uk") & %w(partner_british partner_other partner_local).include?(partner_nationality)
+  define_predicate(:ceremony_in_finland_uk_resident) {
+    (ceremony_country == "finland") & (resident_of == "uk")
   }
   define_predicate(:ceremony_in_mexico_partner_british) {
     (ceremony_country == "mexico") & (partner_nationality == "partner_british")
@@ -245,7 +245,7 @@ multiple_choice :partner_opposite_or_same_sex? do
       data_query.os_consular_cni_countries?(ceremony_country) or (resident_of == 'uk' and data_query.os_no_marriage_related_consular_services?(ceremony_country))
     })
     next_node_if(:outcome_os_consular_cni, ceremony_in_colombia_partner_not_local)
-    next_node_if(:outcome_os_consular_cni, ceremony_in_finland_uk_resident_partner_not_irish)
+    next_node_if(:outcome_os_consular_cni, ceremony_in_finland_uk_resident)
     next_node_if(:outcome_os_consular_cni, ceremony_in_mexico_partner_british)
     next_node_if(:outcome_os_affirmation, -> { data_query.os_affirmation_countries?(ceremony_country) })
     next_node_if(:outcome_os_commonwealth, -> { data_query.commonwealth_country?(ceremony_country) or ceremony_country == 'zimbabwe' })

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -275,13 +275,7 @@ multiple_choice :partner_opposite_or_same_sex? do
     data_query.ss_marriage_not_possible?(ceremony_country, partner_nationality)
   }
 
-  define_predicate(:uk_resident_irish_partner_finland_ss_ceremony) {
-    (ceremony_country == 'finland') & (resident_of == 'uk') & (partner_nationality == 'partner_irish')
-  }
-
   next_node_if(:outcome_ss_marriage_malta, -> {ceremony_country == "malta"})
-
-  next_node_if(:outcome_os_affirmation, uk_resident_irish_partner_finland_ss_ceremony)
 
   next_node_if(:outcome_ss_marriage_not_possible, ss_marriage_not_possible?)
 

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -1012,8 +1012,6 @@ outcome :outcome_os_affirmation do
     #What you need to do section
     if %w(turkey egypt china).include?(ceremony_country)
       phrases << :what_you_need_to_do
-    elsif ceremony_country == 'finland' and partner_nationality == 'partner_irish' and resident_of == 'uk'
-      phrases << :what_you_need_to_do_affidavit
     elsif data_query.os_21_days_residency_required_countries?(ceremony_country)
       phrases << :what_you_need_to_do_affirmation_21_days
     else

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -648,12 +648,6 @@ outcome :outcome_os_consular_cni do
       end
     end
 
-    if ceremony_country != 'italy' and partner_nationality == 'partner_irish'
-      if %w(uk_england uk_wales).include?(residency_uk_region)
-        phrases << :consular_cni_os_england_or_wales_resident_not_italy
-      end
-    end
-
     if resident_of == 'uk'
       if ceremony_country == 'tunisia'
         phrases << :tunisia_legalisation_and_translation

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -786,8 +786,8 @@ outcome :outcome_os_consular_cni do
       if ceremony_country == 'italy'
         if partner_nationality == 'partner_local'
           phrases << :italy_consular_cni_os_partner_local
-        elsif %w(partner_irish partner_other).include?(partner_nationality)
-          phrases << :italy_consular_cni_os_partner_other_or_irish
+        elsif partner_nationality == 'partner_other'
+          phrases << :italy_consular_cni_os_partner_other
         elsif partner_nationality == 'partner_british'
           phrases << :italy_consular_cni_os_partner_british
         end

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -644,15 +644,7 @@ outcome :outcome_os_consular_cni do
       end
 
       if ceremony_country == 'italy'
-        if %w(uk_england uk_wales).include?(residency_uk_region)
-          if partner_nationality == 'partner_irish'
-            phrases << :consular_cni_os_england_or_wales_partner_irish_three
-          else
-            phrases << :consular_cni_os_scotland_or_ni_partner_irish_or_partner_not_irish_three
-          end
-        else
-          phrases << :consular_cni_os_scotland_or_ni_partner_irish_or_partner_not_irish_three
-        end
+        phrases << :consular_cni_os_resident_in_uk_ceremony_in_italy
       end
     end
 

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -182,7 +182,6 @@ end
 # Q4
 multiple_choice :what_is_your_partners_nationality? do
   option :partner_british
-  option :partner_irish
   option :partner_local
   option :partner_other
 

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -1247,7 +1247,7 @@ outcome :outcome_cp_cp_or_equivalent do
     end
     unless ceremony_country == 'czech-republic' and sex_of_your_partner == 'same_sex'
       if ceremony_country == 'brazil' and sex_of_your_partner == 'same_sex' and resident_of == 'uk'
-        phrases << :what_you_need_to_do_cni << :uk_resident_partner_not_irish_os_consular_cni_three << :consular_cni_os_uk_resident_legalisation << :consular_cni_os_uk_resident_not_italy_or_portugal << :consular_cni_os_all_names_but_germany
+        phrases << :what_you_need_to_do_cni << :uk_resident_os_consular_cni_three << :consular_cni_os_uk_resident_legalisation << :consular_cni_os_uk_resident_not_italy_or_portugal << :consular_cni_os_all_names_but_germany
       else
         phrases << :cp_or_equivalent_cp_all_what_you_need_to_do
       end

--- a/test/integration/smart_answer_flows/marriage_abroad_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_test.rb
@@ -414,14 +414,14 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
   end
   #variants for denmark
-  context "ceremony in denmark, resident in canada, partner irish" do
+  context "ceremony in denmark, resident in canada, partner other" do
     setup do
       worldwide_api_has_organisations_for_location('denmark', read_fixture_file('worldwide/denmark_organisations.json'))
       worldwide_api_has_organisations_for_location('canada', read_fixture_file('worldwide/canada_organisations.json'))
       add_response 'denmark'
       add_response 'other'
       add_response 'canada'
-      add_response 'partner_irish'
+      add_response 'partner_other'
       add_response 'opposite_sex'
     end
     should "go to consular cni os outcome" do
@@ -431,13 +431,13 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
   end
   #variants for germany
-  context "ceremony in germany, resident in germany, partner irish" do
+  context "ceremony in germany, resident in germany, partner other" do
     setup do
       worldwide_api_has_organisations_for_location('germany', read_fixture_file('worldwide/germany_organisations.json'))
       add_response 'germany'
       add_response 'other'
       add_response 'germany'
-      add_response 'partner_irish'
+      add_response 'partner_other'
       add_response 'opposite_sex'
     end
     should "go to consular cni os outcome" do
@@ -490,34 +490,18 @@ class MarriageAbroadTest < ActiveSupport::TestCase
       assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :consular_cni_os_naturalisation, :consular_cni_os_fees_not_italy_not_uk, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
     end
   end
-  context "ceremony in azerbaijan, resident in northern ireland, partner irish" do
+  context "ceremony in azerbaijan, resident in northern ireland, partner other" do
     setup do
       worldwide_api_has_organisations_for_location('azerbaijan', read_fixture_file('worldwide/azerbaijan_organisations.json'))
       add_response 'azerbaijan'
       add_response 'uk'
       add_response 'uk_ni'
-      add_response 'partner_irish'
+      add_response 'partner_other'
       add_response 'opposite_sex'
     end
     should "go to consular cni os outcome" do
       assert_current_node :outcome_os_consular_cni
       assert_phrase_list :consular_cni_os_start, [:uk_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :cni_at_local_register_office_notary_public, :consular_cni_os_uk_resident_legalisation, :consular_cni_os_uk_resident_not_italy_or_portugal]
-      assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :consular_cni_os_naturalisation, :consular_cni_os_fees_not_italy_not_uk, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
-    end
-  end
-  #variant for england and wales, irish partner - ceremony not italy
-  context "ceremony in guatemala, resident in wales, partner irish" do
-    setup do
-      worldwide_api_has_organisations_for_location('guatemala', read_fixture_file('worldwide/guatemala_organisations.json'))
-      add_response 'guatemala'
-      add_response 'uk'
-      add_response 'uk_wales'
-      add_response 'partner_irish'
-      add_response 'opposite_sex'
-    end
-    should "go to consular cni os outcome" do
-      assert_current_node :outcome_os_consular_cni
-      assert_phrase_list :consular_cni_os_start, [:uk_resident_os_consular_cni, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_not_spain_or_italy, :consular_cni_os_england_or_wales_resident_not_italy, :consular_cni_os_uk_resident_legalisation, :consular_cni_os_uk_resident_not_italy_or_portugal]
       assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :consular_cni_os_naturalisation, :consular_cni_os_fees_not_italy_not_uk, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
     end
   end
@@ -990,15 +974,15 @@ class MarriageAbroadTest < ActiveSupport::TestCase
       assert_phrase_list :affirmation_os_outcome, [:affirmation_os_local_resident, :affirmation_os_all_what_you_need_to_do, :what_you_need_to_do, :make_an_appointment, :embassies_data, :docs_decree_and_death_certificate, :change_of_name_evidence, :partner_declaration, :fee_table_45_55, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
     end
   end
-  #testing for ceremony in lebanon, other resident, partner irish
-  context "ceremony in lebanon, resident in poland, partner irish" do
+  #testing for ceremony in lebanon, other resident, partner other
+  context "ceremony in lebanon, resident in poland, partner other" do
     setup do
       worldwide_api_has_organisations_for_location('lebanon', read_fixture_file('worldwide/lebanon_organisations.json'))
       worldwide_api_has_organisations_for_location('poland', read_fixture_file('worldwide/poland_organisations.json'))
       add_response 'lebanon'
       add_response 'other'
       add_response 'poland'
-      add_response 'partner_irish'
+      add_response 'partner_other'
       add_response 'opposite_sex'
     end
     should "go to os affirmation outcome" do
@@ -1149,15 +1133,15 @@ class MarriageAbroadTest < ActiveSupport::TestCase
       assert_phrase_list :no_cni_os_outcome, [:no_cni_os_dutch_caribbean_islands, :no_cni_os_dutch_caribbean_islands_local_resident, :get_legal_advice, :cni_os_consular_facilities_unavailable]
     end
   end
-  #testing for ceremony in aruba, other resident, partner irish
-  context "ceremony in aruba, resident in poland, partner irish" do
+  #testing for ceremony in aruba, other resident, partner other
+  context "ceremony in aruba, resident in poland, partner other" do
     setup do
       worldwide_api_has_organisations_for_location('aruba', read_fixture_file('worldwide/aruba_organisations.json'))
       worldwide_api_has_organisations_for_location('poland', read_fixture_file('worldwide/poland_organisations.json'))
       add_response 'aruba'
       add_response 'other'
       add_response 'poland'
-      add_response 'partner_irish'
+      add_response 'partner_other'
       add_response 'opposite_sex'
     end
     should "go to consular cni os outcome" do
@@ -1259,14 +1243,14 @@ class MarriageAbroadTest < ActiveSupport::TestCase
   end
 
   #testing for ceremony in usa
-  context "ceremony in usa, resident in poland, partner irish" do
+  context "ceremony in usa, resident in poland, partner other" do
     setup do
       worldwide_api_has_organisations_for_location('usa', read_fixture_file('worldwide/usa_organisations.json'))
       worldwide_api_has_organisations_for_location('poland', read_fixture_file('worldwide/poland_organisations.json'))
       add_response 'usa'
       add_response 'other'
       add_response 'poland'
-      add_response 'partner_irish'
+      add_response 'partner_other'
       add_response 'opposite_sex'
     end
     should "go to consular cni os outcome" do
@@ -1276,14 +1260,14 @@ class MarriageAbroadTest < ActiveSupport::TestCase
   end
 
   #testing for ceremony in argentina
-  context "ceremony in argentina, resident in poland, partner irish" do
+  context "ceremony in argentina, resident in poland, partner other" do
     setup do
       worldwide_api_has_organisations_for_location('argentina', read_fixture_file('worldwide/argentina_organisations.json'))
       worldwide_api_has_organisations_for_location('poland', read_fixture_file('worldwide/poland_organisations.json'))
       add_response 'argentina'
       add_response 'other'
       add_response 'poland'
-      add_response 'partner_irish'
+      add_response 'partner_other'
       add_response 'opposite_sex'
     end
     should "go to consular cni os outcome" do
@@ -1380,21 +1364,6 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     should "go to consular cni os outcome" do
       assert_current_node :outcome_os_other_countries
       assert_phrase_list :other_countries_os_outcome, [:other_countries_os_ceremony_saudia_arabia_not_local_resident]
-    end
-  end
-  #testing for saudi arabia, local resident, partner irish
-  context "ceremony in saudi arabia, resident in saudi arabia, partner irish" do
-    setup do
-      worldwide_api_has_organisations_for_location('saudi-arabia', read_fixture_file('worldwide/saudi-arabia_organisations.json'))
-      add_response 'saudi-arabia'
-      add_response 'other'
-      add_response 'saudi-arabia'
-      add_response 'partner_irish'
-      add_response 'opposite_sex'
-    end
-    should "go to consular cni os outcome" do
-      assert_current_node :outcome_os_other_countries
-      assert_phrase_list :other_countries_os_outcome, [:other_countries_os_saudi_arabia_local_resident_partner_irish]
     end
   end
   #testing for saudi arabia, local resident, partner british
@@ -1495,14 +1464,14 @@ class MarriageAbroadTest < ActiveSupport::TestCase
       assert_state_variable :pay_by_cash_or_credit_card_no_cheque, nil
     end
   end
-  #testing for ceremony in sweden, sweden resident, irish partner
-  context "ceremony in sweden, resident in sweden, partner irish" do
+  #testing for ceremony in sweden, sweden resident, partner other
+  context "ceremony in sweden, resident in sweden, partner other" do
     setup do
       worldwide_api_has_organisations_for_location('sweden', read_fixture_file('worldwide/sweden_organisations.json'))
       add_response 'sweden'
       add_response 'other'
       add_response 'sweden'
-      add_response 'partner_irish'
+      add_response 'partner_other'
       add_response 'same_sex'
     end
     should "go to cp or equivalent os outcome" do
@@ -1695,14 +1664,14 @@ class MarriageAbroadTest < ActiveSupport::TestCase
   end
 
   #testing for nicaragua
-  context "ceremony in nicaragua, resident in poland, partner irish" do
+  context "ceremony in nicaragua, resident in poland, partner other" do
     setup do
       worldwide_api_has_organisations_for_location('nicaragua', read_fixture_file('worldwide/nicaragua_organisations.json'))
       worldwide_api_has_organisations_for_location('poland', read_fixture_file('worldwide/poland_organisations.json'))
       add_response 'nicaragua'
       add_response 'other'
       add_response 'poland'
-      add_response 'partner_irish'
+      add_response 'partner_other'
       add_response 'opposite_sex'
     end
     should "go to consular cni os outcome" do
@@ -1978,35 +1947,19 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
   end
 
-  context "ceremony in finland, resident in the UK, partner Irish OS" do
+  context "ceremony in finland, resident in the UK, partner other, SS" do
     setup do
       worldwide_api_has_organisations_for_location('finland', read_fixture_file('worldwide/finland_organisations.json'))
       worldwide_api_has_organisations_for_location('australia', read_fixture_file('worldwide/australia_organisations.json'))
       add_response 'finland'
       add_response 'uk'
       add_response 'uk_england'
-      add_response 'partner_irish'
-      add_response 'opposite_sex'
-    end
-    should "go to affirmation outcome with specific fee table" do
-      assert_current_node :outcome_os_affirmation
-      assert_phrase_list :affirmation_os_outcome, [:affirmation_os_uk_resident, :affirmation_os_all_what_you_need_to_do, :what_you_need_to_do_affidavit, :appointment_for_affidavit, :embassies_data, :affidavit_os_translation_in_local_language_text, :docs_decree_and_death_certificate, :divorced_or_widowed_evidences, :change_of_name_evidence, :partner_equivalent_document_warning, :affirmation_os_partner_not_british, :fee_table_affidavit_65, :list_of_consular_fees, :pay_in_euros_or_visa_electron]
-    end
-  end
-
-  context "ceremony in finland, resident in the UK, partner Irish SS" do
-    setup do
-      worldwide_api_has_organisations_for_location('finland', read_fixture_file('worldwide/finland_organisations.json'))
-      worldwide_api_has_organisations_for_location('australia', read_fixture_file('worldwide/australia_organisations.json'))
-      add_response 'finland'
-      add_response 'uk'
-      add_response 'uk_england'
-      add_response 'partner_irish'
+      add_response 'partner_other'
       add_response 'same_sex'
     end
     should "go to affirmation outcome with specific fee table" do
-      assert_current_node :outcome_os_affirmation
-      assert_phrase_list :affirmation_os_outcome, [:affirmation_os_uk_resident, :affirmation_os_all_what_you_need_to_do, :what_you_need_to_do_affidavit, :appointment_for_affidavit, :embassies_data, :affidavit_os_translation_in_local_language_text, :docs_decree_and_death_certificate, :divorced_or_widowed_evidences, :change_of_name_evidence, :partner_equivalent_document_warning, :affirmation_os_partner_not_british, :fee_table_affidavit_65, :list_of_consular_fees, :pay_in_euros_or_visa_electron]
+      assert_current_node :outcome_cp_cp_or_equivalent
+      assert_phrase_list :cp_or_equivalent_cp_outcome, [:"cp_or_equivalent_cp_finland", :cp_or_equivalent_cp_uk_resident, :cp_or_equivalent_cp_all_what_you_need_to_do, :cp_or_equivalent_cp_naturalisation, :cp_or_equivalent_cp_all_fees, :list_of_consular_fees , :pay_by_cash_or_credit_card_no_cheque]
     end
   end
 
@@ -2088,13 +2041,13 @@ class MarriageAbroadTest < ActiveSupport::TestCase
       assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_local_resident_ceremony_not_italy_not_germany_partner_british, :consular_cni_os_all_names_but_germany, :consular_cni_os_fees_not_italy_not_uk]
     end
   end
-  context "ceremony in azerbaijan, resident in northern ireland, partner irish" do
+  context "ceremony in azerbaijan, resident in northern ireland, partner other" do
     setup do
       worldwide_api_has_organisations_for_location('azerbaijan', read_fixture_file('worldwide/azerbaijan_organisations.json'))
       add_response 'azerbaijan'
       add_response 'uk'
       add_response 'uk_ni'
-      add_response 'partner_irish'
+      add_response 'partner_other'
       add_response 'same_sex'
     end
     should "go to outcome_ss_marriage" do

--- a/test/integration/smart_answer_flows/marriage_abroad_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_test.rb
@@ -378,7 +378,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "go to consular cni os outcome" do
       assert_current_node :outcome_os_consular_cni
-      assert_phrase_list :consular_cni_os_start, [:italy_os_consular_cni_ceremony_italy, :consular_cni_all_what_you_need_to_do, :italy_os_consular_cni_uk_resident, :italy_os_consular_cni_uk_resident_two, :cni_at_local_register_office_notary_public, :consular_cni_os_scotland_or_ni_partner_irish_or_partner_not_irish_three]
+      assert_phrase_list :consular_cni_os_start, [:italy_os_consular_cni_ceremony_italy, :consular_cni_all_what_you_need_to_do, :italy_os_consular_cni_uk_resident, :italy_os_consular_cni_uk_resident_two, :cni_at_local_register_office_notary_public, :consular_cni_os_resident_in_uk_ceremony_in_italy]
       assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_all_names_but_germany, :pay_by_cash_or_credit_card_no_cheque]
     end
   end

--- a/test/integration/smart_answer_flows/marriage_abroad_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_test.rb
@@ -1378,7 +1378,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "go to consular cni os outcome" do
       assert_current_node :outcome_os_other_countries
-      assert_phrase_list :other_countries_os_outcome, [:other_countries_os_saudi_arabia_local_resident_partner_not_irish, :other_countries_os_saudi_arabia_local_resident_partner_not_irish_two]
+      assert_phrase_list :other_countries_os_outcome, [:other_countries_os_saudi_arabia_local_resident, :other_countries_os_saudi_arabia_local_resident_two]
     end
   end
   #testing for saudi arabia, local resident, partner other
@@ -1393,7 +1393,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "go to consular cni os outcome" do
       assert_current_node :outcome_os_other_countries
-      assert_phrase_list :other_countries_os_outcome, [:other_countries_os_saudi_arabia_local_resident_partner_not_irish, :other_countries_os_saudi_arabia_local_resident_partner_not_irish_or_british, :other_countries_os_saudi_arabia_local_resident_partner_not_irish_two]
+      assert_phrase_list :other_countries_os_outcome, [:other_countries_os_saudi_arabia_local_resident, :other_countries_os_saudi_arabia_local_resident_partner_not_british, :other_countries_os_saudi_arabia_local_resident_two]
     end
   end
 

--- a/test/integration/smart_answer_flows/marriage_abroad_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_test.rb
@@ -253,7 +253,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
       add_response 'cyprus'
       add_response 'other'
       add_response 'cyprus'
-      add_response 'partner_irish'
+      add_response 'partner_other'
       add_response 'opposite_sex'
     end
     should "go to commonwealth os outcome" do
@@ -296,7 +296,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
       add_response 'anguilla'
       add_response 'other'
       add_response 'anguilla'
-      add_response 'partner_irish'
+      add_response 'partner_other'
       add_response 'opposite_sex'
     end
     should "go to bos os outcome" do
@@ -1582,7 +1582,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
       assert_phrase_list :no_cni_required_cp_outcome, [:"no_cni_required_cp_bonaire-st-eustatius-saba", :no_cni_required_all_legal_advice, :no_cni_required_all_what_you_need_to_do, :no_cni_required_cp_dutch_islands, :no_cni_required_cp_dutch_islands_local_resident, :no_cni_required_cp_all_consular_facilities]
     end
   end
-  #testing for ceremony in bonaire, other resident, irish partner
+  #testing for ceremony in bonaire, other resident, other partner
   context "ceremony in bonaire, resident in mexico, partner other" do
     setup do
       worldwide_api_has_organisations_for_location('bonaire-st-eustatius-saba', read_fixture_file('worldwide/bonaire-st-eustatius-saba_organisations.json'))
@@ -1590,7 +1590,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
       add_response 'bonaire-st-eustatius-saba'
       add_response 'other'
       add_response 'mexico'
-      add_response 'partner_irish'
+      add_response 'partner_other'
       add_response 'same_sex'
     end
     should "go to cp no cni required outcome" do
@@ -1759,7 +1759,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
       add_response 'china'
       add_response 'uk'
       add_response 'uk_england'
-      add_response 'partner_irish'
+      add_response 'partner_other'
       add_response 'opposite_sex'
       assert_current_node :outcome_os_affirmation
       assert_phrase_list :affirmation_os_outcome, [:affirmation_os_uk_resident, :affirmation_os_all_what_you_need_to_do, :what_you_need_to_do, :book_online_china_non_local_prelude, :book_online_china_affirmation_affidavit, :embassies_data, :documents_for_divorced_or_widowed_china_colombia, :change_of_name_evidence, :affirmation_affidavit_os_partner, :affirmation_os_all_fees_45_70, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
@@ -1771,7 +1771,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
       add_response 'china'
       add_response 'uk'
       add_response 'uk_england'
-      add_response 'partner_irish'
+      add_response 'partner_other'
       add_response 'same_sex'
       assert_current_node :outcome_ss_marriage
       assert_phrase_list :ss_ceremony_body, [:able_to_ss_marriage, :contact_embassy_or_consulate, :embassies_data, :documents_needed_21_days_residency, :documents_needed_ss_not_british, :what_to_do_ss_marriage, :will_display_in_14_days, :no_objection_in_14_days_ss_marriage, :provide_two_witnesses_ss_marriage, :ss_marriage_footnote_21_days_residency, :partner_naturalisation_in_uk, :fees_table_ss_marriage_alt, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]

--- a/test/integration/smart_answer_flows/marriage_abroad_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_test.rb
@@ -362,7 +362,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "go to consular cni os outcome" do
       assert_current_node :outcome_os_consular_cni
-      assert_phrase_list :consular_cni_os_start, [:local_resident_os_consular_cni, :gulf_states_os_consular_cni, :gulf_states_os_consular_cni_local_resident_partner_not_irish, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_foreign_resident_21_days_jordan, :consular_cni_os_foreign_resident_ceremony_not_germany_italy, :check_with_embassy_or_consulate, :embassies_data, :consular_cni_variant_local_resident_jordan, :consular_cni_os_not_uk_resident_ceremony_jordan, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :consular_cni_os_local_resident_not_germany_or_spain_or_foreign_resident_not_germany, :display_notice_of_marriage_7_days]
+      assert_phrase_list :consular_cni_os_start, [:local_resident_os_consular_cni, :gulf_states_os_consular_cni, :gulf_states_os_consular_cni_local_resident, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_foreign_resident_21_days_jordan, :consular_cni_os_foreign_resident_ceremony_not_germany_italy, :check_with_embassy_or_consulate, :embassies_data, :consular_cni_variant_local_resident_jordan, :consular_cni_os_not_uk_resident_ceremony_jordan, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :consular_cni_os_local_resident_not_germany_or_spain_or_foreign_resident_not_germany, :display_notice_of_marriage_7_days]
       assert_phrase_list :consular_cni_os_remainder, [:consular_cni_os_local_resident_ceremony_not_italy_not_germany_partner_british, :consular_cni_os_all_names_but_germany, :consular_cni_os_other_resident_ceremony_not_italy, :consular_cni_os_fees_not_italy_not_uk, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
     end
   end
@@ -1017,7 +1017,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "go to os affirmation outcome" do
       assert_current_node :outcome_os_consular_cni
-      assert_phrase_list :consular_cni_os_start, [:local_resident_os_consular_cni, :gulf_states_os_consular_cni, :gulf_states_os_consular_cni_local_resident_partner_not_irish, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_21_day_requirement, :consular_cni_os_foreign_resident_ceremony_not_germany_italy, :check_with_embassy_or_consulate, :embassies_data, :consular_cni_variant_local_resident_not_germany_or_spain_or_foreign_resident, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :consular_cni_os_local_resident_not_germany_or_spain_or_foreign_resident_not_germany, :display_notice_of_marriage_7_days]
+      assert_phrase_list :consular_cni_os_start, [:local_resident_os_consular_cni, :gulf_states_os_consular_cni, :gulf_states_os_consular_cni_local_resident, :italy_os_consular_cni_ceremony_not_italy_or_spain, :consular_cni_all_what_you_need_to_do, :consular_cni_os_ceremony_21_day_requirement, :consular_cni_os_foreign_resident_ceremony_not_germany_italy, :check_with_embassy_or_consulate, :embassies_data, :consular_cni_variant_local_resident_not_germany_or_spain_or_foreign_resident, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :consular_cni_os_local_resident_not_germany_or_spain_or_foreign_resident_not_germany, :display_notice_of_marriage_7_days]
     end
   end
   #testing for ceremony in Turkey, uk resident, partner british
@@ -2169,7 +2169,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "go to outcome_os_consular_cni and show specific phraselist" do
       assert_current_node :outcome_os_affirmation
-      assert_phrase_list :affirmation_os_outcome, [:affirmation_os_local_resident, :gulf_states_os_consular_cni, :gulf_states_os_consular_cni_local_resident_partner_not_irish, :affirmation_os_all_what_you_need_to_do, :what_you_need_to_do_affirmation_21_days, :appointment_for_affidavit, :embassies_data, :affirmation_os_translation_in_local_language_text, :docs_decree_and_death_certificate, :divorced_or_widowed_evidences, :change_of_name_evidence, :partner_equivalent_document_warning, :affirmation_os_partner_not_british, :fee_table_45_70_55, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+      assert_phrase_list :affirmation_os_outcome, [:affirmation_os_local_resident, :gulf_states_os_consular_cni, :gulf_states_os_consular_cni_local_resident, :affirmation_os_all_what_you_need_to_do, :what_you_need_to_do_affirmation_21_days, :appointment_for_affidavit, :embassies_data, :affirmation_os_translation_in_local_language_text, :docs_decree_and_death_certificate, :divorced_or_widowed_evidences, :change_of_name_evidence, :partner_equivalent_document_warning, :affirmation_os_partner_not_british, :fee_table_45_70_55, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
     end
   end
   context "Marrying in Qatar > Resident of anywhere in the world > Partner is of any nationality in the world > Partner is opposite sex" do
@@ -2184,7 +2184,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "go to outcome_os_consular_cni and show specific phraselist" do
       assert_current_node :outcome_os_affirmation
-      assert_phrase_list :affirmation_os_outcome, [:affirmation_os_local_resident, :gulf_states_os_consular_cni, :gulf_states_os_consular_cni_local_resident_partner_not_irish, :affirmation_os_all_what_you_need_to_do, :what_you_need_to_do_affirmation_21_days, :appointment_for_affidavit, :embassies_data, :affirmation_os_translation_in_local_language_text, :docs_decree_and_death_certificate, :divorced_or_widowed_evidences, :change_of_name_evidence, :partner_equivalent_document_warning, :affirmation_os_partner_not_british, :fee_table_45_70_55, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+      assert_phrase_list :affirmation_os_outcome, [:affirmation_os_local_resident, :gulf_states_os_consular_cni, :gulf_states_os_consular_cni_local_resident, :affirmation_os_all_what_you_need_to_do, :what_you_need_to_do_affirmation_21_days, :appointment_for_affidavit, :embassies_data, :affirmation_os_translation_in_local_language_text, :docs_decree_and_death_certificate, :divorced_or_widowed_evidences, :change_of_name_evidence, :partner_equivalent_document_warning, :affirmation_os_partner_not_british, :fee_table_45_70_55, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
     end
   end
   context "ceremony in Lithuania, partner same sex, partner british" do


### PR DESCRIPTION
PT: https://www.pivotaltracker.com/story/show/91098778

@floehopper and I are fairly confident that we've removed the 'Irish partner' response in this pull request.

One thing we're unsure about is whether we should also be making these changes to marriage-abroad-v2 as well?
