### PR TITLE
Update poltergeist to work with latest version of phantomjs.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ group :test do
   gem 'webmock', '1.20.4', :require => false
   gem 'simplecov', '~> 0.6.4', :require => false
   gem 'simplecov-rcov', '~> 0.2.3', :require => false
-  gem 'poltergeist', '1.5.1'
+  gem 'poltergeist', '1.6.0'
   gem 'timecop'
   gem 'minitest-reporters', '~> 1.0.11'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,7 +146,7 @@ GEM
     parslet (1.6.2)
       blankslate (>= 2.0, <= 4.0)
     plek (1.7.0)
-    poltergeist (1.5.1)
+    poltergeist (1.6.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
       multi_json (~> 1.0)
@@ -273,7 +273,7 @@ GEM
     webmock (1.20.4)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
-    websocket-driver (0.5.3)
+    websocket-driver (0.5.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
     xpath (2.0.0)
@@ -305,7 +305,7 @@ DEPENDENCIES
   nokogiri
   parser
   plek (= 1.7.0)
-  poltergeist (= 1.5.1)
+  poltergeist (= 1.6.0)
   pry
   rack_strip_client_ip (= 0.0.1)
   rails (= 4.2.1)


### PR DESCRIPTION
I was seeing test failures like this one:

    Cliver::Dependency::VersionMismatch: Could not find an executable 'phantomjs' that matched the requirements '~> 1.8', '>= 1.8.1'. Found versions were {"/usr/local/bin/phantomjs"=>"2.0.0"}.
        test/integration/engine/report_a_problem_test.rb:8:in `block (3 levels) in <class:ReportAProblemTest>'

This incompatibility was [fixed in poltergeist v1.6.0][1].

@chrisroos has confirmed that this change is backwardly compatible with
phantomjs v1.9.8, so I'm hopeful it should work with other older versions.
The Continuous Integration build for this branch should tell us if it isn't.

[1]: https://github.com/teampoltergeist/poltergeist/blob/master/CHANGELOG.md#160