### PR TITLE
Migrate "Inherits someone dies without will" from Ruby to Smartdown

### DIFF
--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/inherits-someone-dies-without-will-smartdown.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/inherits-someone-dies-without-will-smartdown.txt
@@ -1,0 +1,10 @@
+---
+satisfies_need: 100988
+status: draft
+---
+
+# Intestacy - who inherits if someone dies without a will?
+
+Find out who is entitled to a share of someone’s money, property and possessions if they die without making a will.
+
+[start: region]

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_1.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_1.txt
@@ -1,0 +1,1 @@
+# The husband, wife or civil partner gets all of the estate.

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_1.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_1.txt
@@ -1,1 +1,4 @@
 # The husband, wife or civil partner gets all of the estate.
+
+
+{{snippet: next_steps_wills_and_optional_inheritance_tax_links}}

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_1_scotland.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_1_scotland.txt
@@ -1,0 +1,4 @@
+# The husband, wife or civil partner gets all of the estate.
+
+
+{{snippet: next_steps_wills_and_inheritance_tax_links}}

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_2.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_2.txt
@@ -1,0 +1,3 @@
+# The estate is shared equally between the children or their descendants.
+
+If a son or daughter has already died, their children (the grandchildren of the deceased) inherit in their place.

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_2.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_2.txt
@@ -1,3 +1,6 @@
 # The estate is shared equally between the children or their descendants.
 
 If a son or daughter has already died, their children (the grandchildren of the deceased) inherit in their place.
+
+
+{{snippet: next_steps_wills_and_inheritance_tax_links}}

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_20.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_20.txt
@@ -1,0 +1,8 @@
+# The husband, wife or civil partner keeps all the assets (including property), up to £250,000, and all the personal possessions, whatever their value.
+
+The remainder of the estate will be shared as follows:
+
+* the husband, wife or civil partner gets an absolute interest in half of the remainder
+* the other half is then divided equally between the surviving children
+
+If a son or daughter (or other child where the deceased had a parental role) has already died, their children will inherit in their place.

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_20.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_20.txt
@@ -6,3 +6,6 @@ The remainder of the estate will be shared as follows:
 * the other half is then divided equally between the surviving children
 
 If a son or daughter (or other child where the deceased had a parental role) has already died, their children will inherit in their place.
+
+
+{{snippet: next_steps_wills_and_inheritance_tax_links}}

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_21.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_21.txt
@@ -5,3 +5,6 @@ They also get half of the amount left over.
 The remainder goes to the parent or parents.
 
 If a son or daughter has already died, their children will inherit in their place.
+
+
+{{snippet: next_steps_wills_and_inheritance_tax_links}}

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_21.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_21.txt
@@ -1,0 +1,7 @@
+# The husband, wife or civil partner keeps all the assets (including property) up to £450,000, and all the personal possessions, whatever their value.
+
+They also get half of the amount left over.
+
+The remainder goes to the parent or parents.
+
+If a son or daughter has already died, their children will inherit in their place.

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_22.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_22.txt
@@ -1,0 +1,7 @@
+# The husband, wife or civil partner keeps all the assets (including property) up to £450,000, and all the personal possessions, whatever their value.
+
+They also get half the amount left over.
+
+The remainder is divided between the surviving siblings.
+
+If a brother or sister has already died, their children (nieces and nephews of the deceased) inherit in their place.

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_22.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_22.txt
@@ -5,3 +5,6 @@ They also get half the amount left over.
 The remainder is divided between the surviving siblings.
 
 If a brother or sister has already died, their children (nieces and nephews of the deceased) inherit in their place.
+
+
+{{snippet: next_steps_wills_and_inheritance_tax_links}}

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_23.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_23.txt
@@ -1,0 +1,3 @@
+# The estate is shared equally between the half-brothers or half-sisters.
+
+If a half-brother or half-sister has already died, their children (nieces and nephews of the deceased) inherit in their place.

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_23.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_23.txt
@@ -1,3 +1,6 @@
 # The estate is shared equally between the half-brothers or half-sisters.
 
 If a half-brother or half-sister has already died, their children (nieces and nephews of the deceased) inherit in their place.
+
+
+{{snippet: next_steps_wills_and_inheritance_tax_links}}

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_24.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_24.txt
@@ -1,0 +1,3 @@
+# The estate is shared equally between the half-aunts or half-uncles.
+
+If an aunt or uncle has already died, their children (the cousins of the deceased) inherit in their place.

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_24.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_24.txt
@@ -1,3 +1,6 @@
 # The estate is shared equally between the half-aunts or half-uncles.
 
 If an aunt or uncle has already died, their children (the cousins of the deceased) inherit in their place.
+
+
+{{snippet: next_steps_wills_and_inheritance_tax_links}}

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_25.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_25.txt
@@ -1,1 +1,4 @@
 # The whole estate goes to the Crown.
+
+
+{{snippet: next_steps_ownerless_link}}

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_25.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_25.txt
@@ -1,0 +1,1 @@
+# The whole estate goes to the Crown.

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_3.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_3.txt
@@ -1,3 +1,6 @@
 # The estate is shared equally between the parents.
 
 They may have to pay Inheritance Tax.
+
+
+{{snippet: next_steps_wills_and_inheritance_tax_links}}

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_3.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_3.txt
@@ -1,0 +1,3 @@
+# The estate is shared equally between the parents.
+
+They may have to pay Inheritance Tax.

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_4.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_4.txt
@@ -1,3 +1,6 @@
 # The estate is shared equally between the brothers or sisters.
 
 If a brother or sister has already died, their children (nieces and nephews of the deceased) inherit in their place.
+
+
+{{snippet: next_steps_wills_and_inheritance_tax_links}}

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_4.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_4.txt
@@ -1,0 +1,3 @@
+# The estate is shared equally between the brothers or sisters.
+
+If a brother or sister has already died, their children (nieces and nephews of the deceased) inherit in their place.

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_40.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_40.txt
@@ -9,3 +9,6 @@ They also get:
 The children will get two-thirds of the rest of the estate.
 
 If a son or daughter has already died, their children (the grandchildren of the deceased) will inherit in their place.
+
+
+{{snippet: next_steps_wills_and_inheritance_tax_links}}

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_40.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_40.txt
@@ -1,0 +1,11 @@
+# The husband, wife or civil partner gets the house up to a value of £473,000. They’ll get a lump sum of £473,000 if the house is worth more, and may have to sell off the property.
+
+They also get:
+
+- furniture and moveable household goods up to the value of £29,000
+- up to £50,000 in cash
+- a third of the rest of the estate
+
+The children will get two-thirds of the rest of the estate.
+
+If a son or daughter has already died, their children (the grandchildren of the deceased) will inherit in their place.

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_41.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_41.txt
@@ -1,0 +1,11 @@
+# The husband, wife or civil partner gets the house up to a value of £473,000. They’ll get a lump sum of £473,000 if the house is worth more, and may have to sell off the property.
+
+They also get:
+
+- furniture and moveable household goods up to the value of £29,000
+- up to £50,000 in cash
+- a third of the rest of the estate
+
+The rest of the estate goes to the brothers and sisters.
+
+If a brother or sister has already died, their children (nieces or nephews of the deceased) inherit in their place.

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_41.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_41.txt
@@ -9,3 +9,6 @@ They also get:
 The rest of the estate goes to the brothers and sisters.
 
 If a brother or sister has already died, their children (nieces or nephews of the deceased) inherit in their place.
+
+
+{{snippet: next_steps_wills_and_inheritance_tax_links}}

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_42.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_42.txt
@@ -9,3 +9,6 @@ They also get:
 (If the cash left is less than £50,000, they will get all of the money.)
 
 The rest of the estate goes to the parent or parents.
+
+
+{{snippet: next_steps_wills_and_inheritance_tax_links}}

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_42.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_42.txt
@@ -1,0 +1,11 @@
+# The husband, wife or civil partner gets the house up to a value of £473,000.
+
+They also get:
+
+- furniture and moveable household goods up to the value of £29,000
+- £50,000 in cash
+- a third of the rest of the estate
+
+(If the cash left is less than £50,000, they will get all of the money.)
+
+The rest of the estate goes to the parent or parents.

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_43.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_43.txt
@@ -11,3 +11,6 @@ The rest of the estate is divided in half between any surviving:
 - brothers or sisters
 
 If a brother or sister has already died, their children (nieces or nephews of the deceased) inherit in their place.
+
+
+{{snippet: next_steps_wills_and_inheritance_tax_links}}

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_43.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_43.txt
@@ -1,0 +1,13 @@
+# The husband, wife or civil partner gets the house up to a value of £473,000. They’ll get a lump sum of £473,000 if the house is worth more, and may have to sell off the property.
+
+They also get:
+
+- up to £89,000 in cash
+- a third of the rest of the estate (or the entire estate if the cash sum was less than £89,000)
+
+The rest of the estate is divided in half between any surviving:
+
+- parents
+- brothers or sisters
+
+If a brother or sister has already died, their children (nieces or nephews of the deceased) inherit in their place.

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_44.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_44.txt
@@ -1,3 +1,6 @@
 # The estate is split in two, half goes to the parents and half to the brothers or sisters.
 
 If a brother or sister has already died, their children (nieces and nephews of the deceased) inherit in their place.
+
+
+{{snippet: next_steps_wills_and_inheritance_tax_links}}

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_44.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_44.txt
@@ -1,0 +1,3 @@
+# The estate is split in two, half goes to the parents and half to the brothers or sisters.
+
+If a brother or sister has already died, their children (nieces and nephews of the deceased) inherit in their place.

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_45.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_45.txt
@@ -1,3 +1,6 @@
 # The estate is shared equally between any great aunts or great uncles.
 
 They may have to pay Inheritance Tax.
+
+
+{{snippet: next_steps_wills_and_inheritance_tax_links}}

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_45.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_45.txt
@@ -1,0 +1,3 @@
+# The estate is shared equally between any great aunts or great uncles.
+
+They may have to pay Inheritance Tax.

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_46.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_46.txt
@@ -1,3 +1,6 @@
 # The whole estate goes to the Crown.
 
 However, before this can happen there would need to be proof that there are no surviving relatives in any generation.
+
+
+{{snippet: next_steps_ownerless_link}}

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_46.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_46.txt
@@ -1,0 +1,3 @@
+# The whole estate goes to the Crown.
+
+However, before this can happen there would need to be proof that there are no surviving relatives in any generation.

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_5.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_5.txt
@@ -1,3 +1,6 @@
 # The estate is shared equally between the grandparent(s).
 
 They may have to pay Inheritance Tax.
+
+
+{{snippet: next_steps_wills_and_inheritance_tax_links}}

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_5.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_5.txt
@@ -1,0 +1,3 @@
+# The estate is shared equally between the grandparent(s).
+
+They may have to pay Inheritance Tax.

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_6.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_6.txt
@@ -1,0 +1,3 @@
+# The estate is shared equally between the aunts or uncles.
+
+If an aunt or uncle has already died, their children (the cousins of the deceased) inherit in their place.

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_6.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_6.txt
@@ -1,3 +1,6 @@
 # The estate is shared equally between the aunts or uncles.
 
 If an aunt or uncle has already died, their children (the cousins of the deceased) inherit in their place.
+
+
+{{snippet: next_steps_wills_and_inheritance_tax_links}}

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_60.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_60.txt
@@ -1,1 +1,4 @@
 # The husband, wife or civil partner gets all of the estate but they must survive the deceased by at least 28 days.
+
+
+{{snippet: next_steps_wills_and_optional_inheritance_tax_links}}

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_60.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_60.txt
@@ -1,0 +1,1 @@
+# The husband, wife or civil partner gets all of the estate but they must survive the deceased by at least 28 days.

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_61.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_61.txt
@@ -1,0 +1,9 @@
+# The husband, wife or civil partner keeps all the assets (including property), up to £250,000, and all the personal possessions, whatever their value.
+
+The husband, wife or civil partner must survive the deceased by at least 28 days to inherit.
+
+They also get one third of the rest of the estate.
+
+The remaining two-thirds are shared between their children.
+
+If a son or daughter has already died, their children (the grandchildren of the deceased) will inherit in their place.

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_61.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_61.txt
@@ -7,3 +7,6 @@ They also get one third of the rest of the estate.
 The remaining two-thirds are shared between their children.
 
 If a son or daughter has already died, their children (the grandchildren of the deceased) will inherit in their place.
+
+
+{{snippet: next_steps_wills_and_inheritance_tax_links}}

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_62.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_62.txt
@@ -8,3 +8,6 @@ The remainder of the estate is divided in half between the:
 - son or daughter
 
 If the son or daughter has already died, their children (the grandchildren of the deceased) will inherit in their parent’s place.
+
+
+{{snippet: next_steps_wills_and_inheritance_tax_links}}

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_62.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_62.txt
@@ -1,0 +1,10 @@
+# The husband, wife or civil partner keeps all the assets (including property), up to £250,000, and all the personal possessions, whatever their value.
+
+The husband, wife or civil partner must survive the deceased by at least 28 days to inherit.
+
+The remainder of the estate is divided in half between the:
+
+- husband, wife or civil partner
+- son or daughter
+
+If the son or daughter has already died, their children (the grandchildren of the deceased) will inherit in their parent’s place.

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_63.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_63.txt
@@ -1,0 +1,7 @@
+# The husband, wife or civil partner keeps all the assets (including property) up to £450,000, and all the personal possessions, whatever their value.
+
+The husband, wife or civil partner must survive the deceased by at least 28 days to inherit.
+
+They also get half of the amount left over.
+
+The remainder goes to the parents.

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_63.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_63.txt
@@ -5,3 +5,6 @@ The husband, wife or civil partner must survive the deceased by at least 28 days
 They also get half of the amount left over.
 
 The remainder goes to the parents.
+
+
+{{snippet: next_steps_wills_and_inheritance_tax_links}}

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_64.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_64.txt
@@ -7,3 +7,6 @@ They also get half the amount left over.
 The remainder is divided between any brothers or sisters.
 
 If any brother or sister is dead, their children (the deceased’s nieces and nephews) inherit.
+
+
+{{snippet: next_steps_wills_and_inheritance_tax_links}}

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_64.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_64.txt
@@ -1,0 +1,9 @@
+# The husband, wife or civil partner keeps all the assets (including property) up to £450,000, and all the personal possessions, whatever their value.
+
+The husband, wife or civil partner must survive the deceased by at least 28 days to inherit.
+
+They also get half the amount left over.
+
+The remainder is divided between any brothers or sisters.
+
+If any brother or sister is dead, their children (the deceased’s nieces and nephews) inherit.

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_65.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_65.txt
@@ -1,1 +1,4 @@
 # The husband, wife or civil partner gets all of the estate but they must survive the deceased by at least 28 days.
+
+
+{{snippet: next_steps_wills_and_inheritance_tax_links}}

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_65.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_65.txt
@@ -1,0 +1,1 @@
+# The husband, wife or civil partner gets all of the estate but they must survive the deceased by at least 28 days.

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_66.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_66.txt
@@ -1,0 +1,5 @@
+# The estate is shared equally between the children.
+
+If a son or daughter has already died, their children (the grandchildren of the deceased) inherit in their place.
+
+They may have to pay Inheritance Tax.

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_66.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_66.txt
@@ -3,3 +3,6 @@
 If a son or daughter has already died, their children (the grandchildren of the deceased) inherit in their place.
 
 They may have to pay Inheritance Tax.
+
+
+{{snippet: next_steps_wills_and_inheritance_tax_links}}

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_67.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_67.txt
@@ -1,0 +1,3 @@
+# The estate goes to the next of kin - the person is closest in blood relationship to the deceased in the family tree.
+
+If nobody claims the estate, the whole estate goes to the Crown.

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_67.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/outcomes/outcome_67.txt
@@ -1,3 +1,6 @@
 # The estate goes to the next of kin - the person is closest in blood relationship to the deceased in the family tree.
 
 If nobody claims the estate, the whole estate goes to the Crown.
+
+
+{{snippet: next_steps_ownerless_link}}

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/questions/aunts_or_uncles.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/questions/aunts_or_uncles.txt
@@ -1,0 +1,15 @@
+# Did the deceased have any aunts or uncles?
+
+[choice: aunts_or_uncles]
+* yes: Yes
+* no: No
+
+* region is 'england-and-wales'
+  * aunts_or_uncles is 'yes' => outcome_6
+  * aunts_or_uncles is 'no' => half_aunts_or_uncles
+* region is 'scotland'
+  * aunts_or_uncles is 'yes' => outcome_6
+  * aunts_or_uncles is 'no' => grandparents
+* region is 'northern-ireland'
+  * aunts_or_uncles is 'yes' => outcome_6
+  * aunts_or_uncles is 'no' => outcome_67

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/questions/children.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/questions/children.txt
@@ -1,0 +1,29 @@
+# Are there any living children, grandchildren or other direct descendants (eg great-grandchildren)?
+
+Children include legally-adopted sons or daughters (but not stepchildren) and any children where the deceased had a parental role.
+
+[choice: children]
+* yes: Yes
+* no: No
+
+* region is 'england-and-wales'
+  * partner is 'yes'
+    * children is 'yes' => outcome_20
+    * children is 'no' => outcome_1
+  * partner is 'no'
+    * children is 'yes' => outcome_2
+    * children is 'no' => parents
+* region is 'scotland'
+  * partner is 'yes'
+    * children is 'yes' => outcome_40
+    * children is 'no' => parents
+  * partner is 'no'
+    * children is 'yes' => outcome_2
+    * children is 'no' => parents
+* region is 'northern-ireland'
+  * partner is 'yes'
+    * children is 'yes' => more_than_one_child
+    * children is 'no' => parents
+  * partner is 'no'
+    * children is 'yes' => outcome_66
+    * children is 'no' => parents

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/questions/estate_over_250000.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/questions/estate_over_250000.txt
@@ -1,0 +1,13 @@
+# Is the estate likely to be worth more than £250,000?
+
+[choice: estate_over_250000]
+* yes: Yes
+* no: No
+
+* region is 'england-and-wales'
+  * estate_over_250000 is 'yes' => children
+  * estate_over_250000 is 'no' => outcome_1
+* region is 'northern-ireland'
+  * estate_over_250000 is 'yes' => children
+  * estate_over_250000 is 'no' => outcome_60
+* region is 'scotland' => children

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/questions/grandparents.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/questions/grandparents.txt
@@ -1,0 +1,15 @@
+# Are there any living grandparents?
+
+[choice: grandparents]
+* yes: Yes
+* no: No
+
+* region is 'england-and-wales'
+  * grandparents is 'yes' => outcome_5
+  * grandparents is 'no' => aunts_or_uncles
+* region is 'scotland'
+  * grandparents is 'yes' => outcome_5
+  * grandparents is 'no' => great_aunts_or_uncles
+* region is 'northern-ireland'
+  * grandparents is 'yes' => outcome_5
+  * grandparents is 'no' => aunts_or_uncles

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/questions/great_aunts_or_uncles.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/questions/great_aunts_or_uncles.txt
@@ -1,0 +1,10 @@
+# Are there any living great aunts or great uncles?
+
+Great aunts and great uncles are brothers or sisters of the grandparents of the deceased.
+
+[choice: great_aunts_or_uncles]
+* yes: Yes
+* no: No
+
+* great_aunts_or_uncles is 'yes' => outcome_45
+* great_aunts_or_uncles is 'no' => outcome_46

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/questions/half_aunts_or_uncles.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/questions/half_aunts_or_uncles.txt
@@ -1,0 +1,8 @@
+# Did the deceased have any half-aunts or half-uncles?
+
+[choice: half_aunts_or_uncles]
+* yes: Yes
+* no: No
+
+* half_aunts_or_uncles is 'yes' => outcome_24
+* half_aunts_or_uncles is 'no' => outcome_25

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/questions/half_siblings.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/questions/half_siblings.txt
@@ -1,0 +1,8 @@
+# Did the deceased have any half-brothers or half-sisters?
+
+[choice: half_siblings]
+* yes: Yes
+* no: No
+
+* half_siblings is 'yes' => outcome_23
+* half_siblings is 'no' => grandparents

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/questions/more_than_one_child.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/questions/more_than_one_child.txt
@@ -1,0 +1,8 @@
+# Did they have more than one child?
+
+[choice: more_than_one_child]
+* yes: Yes
+* no: No
+
+* more_than_one_child is 'yes' => outcome_61
+* more_than_one_child is 'no' => outcome_62

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/questions/parents.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/questions/parents.txt
@@ -1,0 +1,21 @@
+# Are there any living parents?
+
+[choice: parents]
+* yes: Yes
+* no: No
+
+* region is 'england-and-wales'
+  * partner is 'yes'
+    * parents is 'yes' => outcome_21
+    * parents is 'no' => siblings
+  * partner is 'no'
+    * parents is 'yes' => outcome_3
+    * parents is 'no' => siblings
+* region is 'scotland' => siblings
+* region is 'northern-ireland'
+  * partner is 'yes'
+    * parents is 'yes' => outcome_63
+    * parents is 'no' => siblings_including_mixed_parents
+  * partner is 'no'
+    * parents is 'yes' => outcome_3
+    * parents is 'no' => siblings

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/questions/partner.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/questions/partner.txt
@@ -1,0 +1,15 @@
+# Is there a living husband, wife or civil partner?
+
+A surviving partner who wasn't married or in a civil partnership with the deceased has no automatic right to inherit.
+
+[choice: partner]
+* yes: Yes
+* no: No
+
+* region is 'england-and-wales'
+  * partner is 'yes' => estate_over_250000
+  * partner is 'no' => children
+* region is 'northern-ireland'
+  * partner is 'yes' => estate_over_250000
+  * partner is 'no' => children
+* region is 'scotland' => children

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/questions/region.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/questions/region.txt
@@ -1,0 +1,10 @@
+# Where did the deceased live?
+
+[choice: region]
+* england-and-wales: England and Wales
+* scotland: Scotland
+* northern-ireland: Northern Ireland
+
+* region is 'england-and-wales' => partner
+* region is 'scotland' => partner
+* region is 'northern-ireland' => partner

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/questions/siblings.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/questions/siblings.txt
@@ -18,7 +18,7 @@
       * siblings is 'no' => outcome_42
     * parents is 'no'
       * siblings is 'yes' => outcome_41
-      * siblings is 'no' => outcome_1
+      * siblings is 'no' => outcome_1_scotland
   * partner is 'no'
     * parents is 'yes'
       * siblings is 'yes' => outcome_44

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/questions/siblings.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/questions/siblings.txt
@@ -1,0 +1,35 @@
+# Did the deceased have any brothers or sisters?
+
+[choice: siblings]
+* yes: Yes
+* no: No
+
+* region is 'england-and-wales'
+  * partner is 'yes'
+    * siblings is 'yes' => outcome_22
+    * siblings is 'no' => outcome_1
+  * partner is 'no'
+    * siblings is 'yes' => outcome_4
+    * siblings is 'no' => half_siblings
+* region is 'scotland'
+  * partner is 'yes'
+    * parents is 'yes'
+      * siblings is 'yes' => outcome_43
+      * siblings is 'no' => outcome_42
+    * parents is 'no'
+      * siblings is 'yes' => outcome_41
+      * siblings is 'no' => outcome_1
+  * partner is 'no'
+    * parents is 'yes'
+      * siblings is 'yes' => outcome_44
+      * siblings is 'no' => outcome_3
+    * parents is 'no'
+      * siblings is 'yes' => outcome_4
+      * siblings is 'no' => aunts_or_uncles
+* region is 'northern-ireland'
+  * partner is 'yes'
+    * siblings is 'yes' => outcome_64
+    * siblings is 'no' => outcome_65
+  * partner is 'no'
+    * siblings is 'yes' => outcome_4
+    * siblings is 'no' => grandparents

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/questions/siblings_including_mixed_parents.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/questions/siblings_including_mixed_parents.txt
@@ -1,0 +1,8 @@
+# Did the deceased have any brothers or sisters?
+
+[choice: siblings_including_mixed_parents]
+* yes: Yes
+* no: No
+
+* siblings_including_mixed_parents is 'yes' => outcome_64
+* siblings_including_mixed_parents is 'no' => outcome_65

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/scenarios/england-and-wales.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/scenarios/england-and-wales.txt
@@ -1,0 +1,94 @@
+# Partner, Estate under 250000
+- region: england-and-wales
+- partner: yes
+- estate_over_250000: no
+outcome_1
+
+# Partner, Estate over 250000, Children
+- region: england-and-wales
+- partner: yes
+- estate_over_250000: yes
+- children: yes
+outcome_20
+
+# Partner, Estate over 250000, No children
+- region: england-and-wales
+- partner: yes
+- estate_over_250000: yes
+- children: no
+outcome_1
+
+# No partner, Children
+- region: england-and-wales
+- partner: no
+- children: yes
+outcome_2
+
+# No partner, No children, Parents
+- region: england-and-wales
+- partner: no
+- children: no
+- parents: yes
+outcome_3
+
+# No partner, No children, No parents, Siblings
+- region: england-and-wales
+- partner: no
+- children: no
+- parents: no
+- siblings: yes
+outcome_4
+
+# No partner, No children, No parents, No siblings, Half siblings
+- region: england-and-wales
+- partner: no
+- children: no
+- parents: no
+- siblings: no
+- half_siblings: yes
+outcome_23
+
+# No partner, No children, No parents, No siblings, No half siblings, Grandparents
+- region: england-and-wales
+- partner: no
+- children: no
+- parents: no
+- siblings: no
+- half_siblings: no
+- grandparents: yes
+outcome_5
+
+# No partner, No children, No parents, No siblings, No half siblings, No grandparents, Aunts and Uncles
+- region: england-and-wales
+- partner: no
+- children: no
+- parents: no
+- siblings: no
+- half_siblings: no
+- grandparents: no
+- aunts_or_uncles: yes
+outcome_6
+
+# No partner, No children, No parents, No siblings, No half siblings, No grandparents, No Aunts and Uncles, Half Aunts or Uncles
+- region: england-and-wales
+- partner: no
+- children: no
+- parents: no
+- siblings: no
+- half_siblings: no
+- grandparents: no
+- aunts_or_uncles: no
+- half_aunts_or_uncles: yes
+outcome_24
+
+# No partner, No children, No parents, No siblings, No half siblings, No grandparents, No Aunts and Uncles, No Half Aunts or Uncles
+- region: england-and-wales
+- partner: no
+- children: no
+- parents: no
+- siblings: no
+- half_siblings: no
+- grandparents: no
+- aunts_or_uncles: no
+- half_aunts_or_uncles: no
+outcome_25

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/scenarios/northern-ireland.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/scenarios/northern-ireland.txt
@@ -1,0 +1,97 @@
+# Partner, Estate under 250,000
+- region: northern-ireland
+- partner: yes
+- estate_over_250000: no
+outcome_60
+
+# Partner, Estate over 250,000, More than 1 Child
+- region: northern-ireland
+- partner: yes
+- estate_over_250000: yes
+- children: yes
+- more_than_one_child: yes
+outcome_61
+
+# Partner, Estate over 250,000, 1 Child
+- region: northern-ireland
+- partner: yes
+- estate_over_250000: yes
+- children: yes
+- more_than_one_child: no
+outcome_62
+
+# Partner, Estate over 250,000, No Children, Parents
+- region: northern-ireland
+- partner: yes
+- estate_over_250000: yes
+- children: no
+- parents: yes
+outcome_63
+
+# Partner, Estate over 250,000, No Children, No Parents, Siblings
+- region: northern-ireland
+- partner: yes
+- estate_over_250000: yes
+- children: no
+- parents: no
+- siblings_including_mixed_parents: yes
+outcome_64
+
+# Partner, Estate over 250,000, No Children, No Parents, No Siblings
+- region: northern-ireland
+- partner: yes
+- estate_over_250000: yes
+- children: no
+- parents: no
+- siblings_including_mixed_parents: no
+outcome_65
+
+# No Partner, Children
+- region: northern-ireland
+- partner: no
+- children: yes
+outcome_66
+
+# No Partner, No Children, Parents
+- region: northern-ireland
+- partner: no
+- children: no
+- parents: yes
+outcome_3
+
+# No Partner, No Children, No Parents, Siblings
+- region: northern-ireland
+- partner: no
+- children: no
+- parents: no
+- siblings: yes
+outcome_4
+
+# No Partner, No Children, No Parents, No Siblings, Grandparents
+- region: northern-ireland
+- partner: no
+- children: no
+- parents: no
+- siblings: no
+- grandparents: yes
+outcome_5
+
+# No Partner, No Children, No Parents, No Siblings, No Grandparents, Aunts or Uncles
+- region: northern-ireland
+- partner: no
+- children: no
+- parents: no
+- siblings: no
+- grandparents: no
+- aunts_or_uncles: yes
+outcome_6
+
+# No Partner, No Children, No Parents, No Siblings, No Grandparents, No Aunts or Uncles
+- region: northern-ireland
+- partner: no
+- children: no
+- parents: no
+- siblings: no
+- grandparents: no
+- aunts_or_uncles: no
+outcome_67

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/scenarios/scotland.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/scenarios/scotland.txt
@@ -1,0 +1,108 @@
+# Partner, Children
+- region: scotland
+- partner: yes
+- children: yes
+outcome_40
+
+# Partner, No Children, No Parents, No Siblings
+- region: scotland
+- partner: yes
+- children: no
+- parents: no
+- siblings: no
+outcome_1
+
+# Partner, No Children, No Parents, Siblings
+- region: scotland
+- partner: yes
+- children: no
+- parents: no
+- siblings: yes
+outcome_41
+
+# Partner, No Children, Parents, No Siblings
+- region: scotland
+- partner: yes
+- children: no
+- parents: yes
+- siblings: no
+outcome_42
+
+# Partner, No Children, Parents, Siblings
+- region: scotland
+- partner: yes
+- children: no
+- parents: yes
+- siblings: yes
+outcome_43
+
+# No Partner, Children
+- region: scotland
+- partner: no
+- children: yes
+outcome_2
+
+# No Partner, No Children, Parents, Siblings
+- region: scotland
+- partner: no
+- children: no
+- parents: yes
+- siblings: yes
+outcome_44
+
+# No Partner, No Children, Parents, No Siblings
+- region: scotland
+- partner: no
+- children: no
+- parents: yes
+- siblings: no
+outcome_3
+
+# No Partner, No Children, No Parents, Siblings
+- region: scotland
+- partner: no
+- children: no
+- parents: no
+- siblings: yes
+outcome_4
+
+# No Partner, No Children, No Parents, No Siblings
+- region: scotland
+- partner: no
+- children: no
+- parents: no
+- siblings: no
+- aunts_or_uncles: yes
+outcome_6
+
+# No Partner, No Children, No Parents, No Siblings, No Aunts or Uncles, Grandparents
+- region: scotland
+- partner: no
+- children: no
+- parents: no
+- siblings: no
+- aunts_or_uncles: no
+- grandparents: yes
+outcome_5
+
+# No Partner, No Children, No Parents, No Siblings, No Aunts or Uncles, No Grandparents, Great Aunts or Uncles
+- region: scotland
+- partner: no
+- children: no
+- parents: no
+- siblings: no
+- aunts_or_uncles: no
+- grandparents: no
+- great_aunts_or_uncles: yes
+outcome_45
+
+# No Partner, No Children, No Parents, No Siblings, No Aunts or Uncles, No Grandparents, No Great Aunts or Uncles
+- region: scotland
+- partner: no
+- children: no
+- parents: no
+- siblings: no
+- aunts_or_uncles: no
+- grandparents: no
+- great_aunts_or_uncles: no
+outcome_46

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/scenarios/scotland.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/scenarios/scotland.txt
@@ -10,7 +10,7 @@ outcome_40
 - children: no
 - parents: no
 - siblings: no
-outcome_1
+outcome_1_scotland
 
 # Partner, No Children, No Parents, Siblings
 - region: scotland

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/snippets/next_steps_ownerless_link.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/snippets/next_steps_ownerless_link.txt
@@ -1,0 +1,3 @@
+[next_steps]
+Find out what happens to [ownerless property](/unclaimed-estates-bona-vacantia "Ownerless property (bona vacantia)")
+[end_next_steps]

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/snippets/next_steps_wills_and_inheritance_tax_links.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/snippets/next_steps_wills_and_inheritance_tax_links.txt
@@ -1,0 +1,5 @@
+[next_steps]
+Read the guide to [wills, probate and inheritance.](/wills-probate-inheritance "Wills, probate and inheritance")
+
+Find out how to pay [Inheritance Tax.](https://www.gov.uk/inheritance-tax "Inheritance Tax")
+[end_next_steps]

--- a/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/snippets/next_steps_wills_and_optional_inheritance_tax_links.txt
+++ b/lib/smartdown_flows/inherits-someone-dies-without-will-smartdown/snippets/next_steps_wills_and_optional_inheritance_tax_links.txt
@@ -1,0 +1,19 @@
+$IF estate_over_250000 is 'yes'
+
+[next_steps]
+
+Read the guide to [wills, probate and inheritance.](/wills-probate-inheritance "Wills, probate and inheritance")
+
+Find out how to pay [Inheritance Tax.](https://www.gov.uk/inheritance-tax "Inheritance Tax")
+
+[end_next_steps]
+
+$ELSE
+
+[next_steps]
+
+Read the guide to [wills, probate and inheritance.](/wills-probate-inheritance "Wills, probate and inheritance")
+
+[end_next_steps]
+
+$ENDIF


### PR DESCRIPTION
__NOTE.__ Not to be merged to master!

I converted this Smart Answer from Ruby to Smartdown to see:

* How hard it is to convert between the formats.
* How useful the resulting Smartdown is.

It took a few hours to convert this relatively simple Smart Answer. The main complexity was in trying to conditionally show links in a `[next_steps]` block, which I ultimately solved by introducing the 'outcome_1_scotland' outcome.

Who should I ask/has opinions about whether the resulting Smartdown is better than the original Ruby?
