### PR TITLE
Add ability to run scenarios for single smartdown flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,21 @@ Run unit tests by executing the following:
 
 If you need to add a new worldwide organisations fixture find [it here](https://www.gov.uk/government/world/organisations) by the country name or its capital city, navigate to `<found_url>.json`, most likely it will be of the following format `https://www.gov.uk/api/world/organisations/british-[embassy|high-commission]-<capital city>`, copy over the JSON to `test/fixtures/worldwide/<country>_organisations.json` and change it to reflect the expected format based on other examples in the directory.
 
+### Testing Smartdown flows
+
+Smartdown flows are tested using [scenarios][smartdown-scenarios] in the flow directories.
+
+Test all Smartdown flows by running:
+
+    bundle exec ruby -Itest test/unit/smartdown_content/smartdown_scenarios_test.rb
+
+Test a single Smartdown flow by running:
+
+     SMARTDOWN_FLOW_TO_TEST=<name-of-smartdown-flow> \
+     bundle exec ruby -Itest test/unit/smartdown_content/smartdown_scenarios_test.rb
+
+[smartdown-scenarios]: https://github.com/alphagov/smartdown/blob/master/doc/scenarios.md
+
 Issues/todos
 ------------
 

--- a/test/unit/smartdown_content/smartdown_scenarios_test.rb
+++ b/test/unit/smartdown_content/smartdown_scenarios_test.rb
@@ -9,6 +9,9 @@ class SmartdownScenariosTest < ActiveSupport::TestCase
     imminence_has_areas_for_postcode("B1%201PW", [{ slug: "birmingham-city-council" }])
   end
 
+  smartdown_flow_to_test = ENV['SMARTDOWN_FLOW_TO_TEST']
+  run_all_tests = smartdown_flow_to_test.nil?
+
   flow_registry_options = {
     preload_flows: true,
     show_drafts: true,
@@ -17,6 +20,8 @@ class SmartdownScenariosTest < ActiveSupport::TestCase
   SmartdownAdapter::Registry.reset_instance
   smartdown_flows = SmartdownAdapter::Registry.instance(flow_registry_options).flows
   smartdown_flows.each do |smartdown_flow|
+    next unless run_all_tests || smartdown_flow.name == smartdown_flow_to_test
+
     smartdown_flow.scenario_sets.each do |scenario_set|
       scenario_set.scenarios.each_with_index do |scenario, scenario_index|
         description = scenario.description.empty? ? scenario_index+1 : scenario.description


### PR DESCRIPTION
Adding/amending Smartdown flows was painful as I had to run all scenarios for
all flows each time.

This change makes it possible to specify (by setting `SMARTDOWN_FLOW_TO_TEST`)
a single Smartdown flow to test.

Any objections to merging this to master?