### PR TITLE
Remove old copy from all Laos outcomes

### DIFF
--- a/lib/smart_answer_flows/locales/en/overseas-passports-v2.yml
+++ b/lib/smart_answer_flows/locales/en/overseas-passports-v2.yml
@@ -778,6 +778,15 @@ en-GB:
 
           You’ll need to book an appointment by email. Include your first name and last name and 3 alternative dates and times. You will receive an email confirming your appointment.
 
+        send_application_uk_visa_apply_renew_old_replace_colour_laos: |
+          ## Making your application
+          You must apply in person. If you’re unable to, someone else can go on your behalf.
+          You must bring photo ID with you.
+
+          Bring original supporting documents and a colour photocopy of each one. The original documents will be returned to you.
+
+          You’ll need to book an appointment by email. Include your first name and last name. You will receive an email confirming your appointment.
+
         send_application_address_algeria: |
           $A
           UK Visa Application Centre

--- a/lib/smart_answer_flows/overseas-passports-v2.rb
+++ b/lib/smart_answer_flows/overseas-passports-v2.rb
@@ -292,6 +292,8 @@ outcome :ips_application_result do
         if passport_data['application_office']
           if %w(western-sahara).include?(current_location)
             phrases << :send_application_uk_visa_renew_old_replace_colour_western_sahara
+          elsif %w(laos).include?(current_location)
+            phrases << :send_application_uk_visa_apply_renew_old_replace_colour_laos
           elsif uk_visa_application_with_colour_pictures.include?(current_location)
             phrases << :send_application_uk_visa_apply_renew_old_replace_colour
           else

--- a/test/integration/smart_answer_flows/overseas_passports_v2_test.rb
+++ b/test/integration/smart_answer_flows/overseas_passports_v2_test.rb
@@ -1270,12 +1270,44 @@ class OverseasPassportsV2Test < ActiveSupport::TestCase
       worldwide_api_has_organisations_for_location('laos', read_fixture_file('worldwide/laos_organisations.json'))
       add_response 'laos'
     end
+
     context "renewing_new adult" do
       should "have custom phrase for send_application_uk_visa_renew_new_colour_laos" do
         add_response 'renewing_new'
         add_response 'adult'
         assert_current_node :ips_application_result
         assert_phrase_list :send_your_application, [:send_application_uk_visa_renew_new_colour_laos, :send_application_address_laos]
+      end
+    end
+
+    context "replacing adult" do
+      should "have custom phrase for send_application_uk_visa_renew_new_colour_laos" do
+        add_response 'replacing'
+        add_response 'adult'
+        assert_current_node :ips_application_result
+        assert_phrase_list :send_your_application, [:send_application_uk_visa_apply_renew_old_replace_colour_laos, :send_application_address_laos]
+      end
+    end
+
+    context "renewing_old adult" do
+      should "have custom phrase for send_application_uk_visa_renew_new_colour_laos" do
+        add_response 'renewing_old'
+        add_response 'adult'
+        add_response 'laos'
+
+        assert_current_node :ips_application_result
+        assert_phrase_list :send_your_application, [:send_application_uk_visa_apply_renew_old_replace_colour_laos, :send_application_address_laos]
+      end
+    end
+
+    context "applying adult" do
+      should "have custom phrase for send_application_uk_visa_renew_new_colour_laos" do
+        add_response 'applying'
+        add_response 'adult'
+        add_response 'laos'
+
+        assert_current_node :ips_application_result
+        assert_phrase_list :send_your_application, [:send_application_uk_visa_apply_renew_old_replace_colour_laos, :send_application_address_laos]
       end
     end
   end


### PR DESCRIPTION
Laos has a new process. Delete “and 3 alternative dates and times” from all outcomes.

Current text:
You’ll need to book an appointment by email. Include your first name and last name and 3 alternative dates and times. You will receive an email confirming your appointment.

New text:
You’ll need to book an appointment by email. Include your first name and last name. You will receive an email confirming your appointment.