### PR TITLE
WIP: Use ERB templates for Ruby/YAML Smart Answer outcomes

### DIFF
--- a/app/presenters/outcome_presenter.rb
+++ b/app/presenters/outcome_presenter.rb
@@ -1,6 +1,7 @@
 require 'erubis'
 
 class OutcomePresenter < NodePresenter
+  include ActionView::Helpers::NumberHelper
 
   def title
     translate!('title')
@@ -25,7 +26,28 @@ class OutcomePresenter < NodePresenter
     calendar.present?
   end
 
+  def has_body?
+    use_template? || super()
+  end
+
+  def body
+    if use_template?
+      erb_template_path = Rails.root.join("lib/smart_answer_flows/#{@node.flow_name}/#{name}.txt.erb")
+      template = File.read(erb_template_path)
+      govspeak = ERB.new(template).result(binding)
+      GovspeakPresenter.new(govspeak).html
+    else
+      super()
+    end
+  end
+
   private
+
+  attr_reader :state
+
+  def use_template?
+    @node.use_template?
+  end
 
   def render_data_partial(partial, variable_name)
     data = @state.send(variable_name.to_sym)

--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -84,8 +84,16 @@ module SmartAnswer
       add_node Question::Checkbox.new(name, &block)
     end
 
+    def use_outcome_templates
+      @use_outcome_templates = true
+    end
+
     def outcome(name, options = {}, &block)
-      add_node Outcome.new(name, options, &block)
+      modified_options = options.merge(
+        use_outcome_templates: @use_outcome_templates,
+        flow_name: self.name
+      )
+      add_node Outcome.new(name, modified_options, &block)
     end
 
     def outcomes

--- a/lib/smart_answer/flow_registry.rb
+++ b/lib/smart_answer/flow_registry.rb
@@ -53,8 +53,8 @@ module SmartAnswer
     def build_flow(name)
       absolute_path = @load_path.join("#{name}.rb").to_s
       Flow.new do
-        eval(File.read(absolute_path), binding, absolute_path)
         name(name)
+        eval(File.read(absolute_path), binding, absolute_path)
       end
     end
 

--- a/lib/smart_answer/outcome.rb
+++ b/lib/smart_answer/outcome.rb
@@ -1,5 +1,10 @@
 module SmartAnswer
   class Outcome < Node
+    def initialize(name, options = {}, &block)
+      @options = options
+      super
+    end
+
     def outcome?
       true
     end
@@ -14,6 +19,14 @@ module SmartAnswer
 
     def evaluate_calendar(state)
       @calendar.evaluate(state) if @calendar
+    end
+
+    def use_template?
+      @options[:use_outcome_templates]
+    end
+
+    def flow_name
+      @options[:flow_name]
     end
   end
 end

--- a/lib/smart_answer_flows/student-finance-calculator.rb
+++ b/lib/smart_answer_flows/student-finance-calculator.rb
@@ -181,6 +181,8 @@ multiple_choice :what_course_are_you_studying? do
 
 end
 
+use_outcome_templates
+
 outcome :outcome_uk_full_time_students do
   precalculate :students_body_text do
     PhraseList.new(:uk_students_body_text_start)

--- a/lib/smart_answer_flows/student-finance-calculator/outcome_eu_students.txt.erb
+++ b/lib/smart_answer_flows/student-finance-calculator/outcome_eu_students.txt.erb
@@ -1,0 +1,32 @@
+$!
+This is an estimate of your student finance. You must apply to find out exactly what you'll get.
+$!
+
+##Tuition costs
+
+You could get a Tuition Fee Loan - <%= number_to_currency(state.tuition_fee_amount, precision: 0) %> per year.
+
+The loan pays for the cost of your course and must be paid back.
+
+<% if state.course_type == 'eu-full-time' %>
+##Living costs
+
+Most EU full-time students don't [qualify](/student-finance/who-qualifies) for help with living costs (known as 'maintenance').
+<% else %>
+##Living costs
+
+EU part-time students don't qualify for help with living costs (known as 'maintenance').
+<% end %>
+
+##Extra help
+
+You could get a [bursary or scholarship](/extra-money-pay-university) from your university or college. Usually, this doesn't have to be paid back.
+
+Use the [Family Action grant search](http://www.family-action.org.uk/section.aspx?id=21211) to check whether you qualify for funding from a charitable trust.
+
+##Your next steps
+
+s1. Find out how to [apply](/apply-for-student-finance) for student finance
+s2. Check if you [qualify](/student-finance/who-qualifies) for student finance
+
+^Usually, you’ll only get student finance if you’re doing your first higher education qualification.^

--- a/lib/smart_answer_flows/student-finance-calculator/outcome_uk_all_students.txt.erb
+++ b/lib/smart_answer_flows/student-finance-calculator/outcome_uk_all_students.txt.erb
@@ -1,0 +1,52 @@
+$!
+This is an estimate of your student finance. You must apply to find out exactly what you'll get.
+$!
+
+##Student finance
+
+You could get per year:
+
+- <%= number_to_currency(state.tuition_fee_amount, precision: 0) %> Tuition Fee Loan
+
+###Extra student funding
+
+<% if state.all_uk_students_circumstances.include?('no') and state.course_studied == 'none-of-the-above' %>
+You don’t qualify for extra grants and allowances.
+<% else %>
+You could get:
+
+  <% if state.all_uk_students_circumstances.include?('has-disability') %>
+- [Disabled Students' Allowances](/disabled-students-allowances-dsas)
+  <% end %>
+
+  <% if state.all_uk_students_circumstances.include?('low-income') %>
+- [University and college hardship funds](/extra-money-pay-university/university-and-college-hardship-funds) (extra help with costs while studying)
+  <% end %>
+
+  <% if state.course_studied == 'teacher-training' %>
+- [Funding for teacher training](/teacher-training-funding)
+  <% elsif state.course_studied == 'dental-medical-healthcare' %>
+- [NHS Bursary](/nhs-bursaries) (NHS funding towards your fees and living costs)
+  <% elsif state.course_studied == 'social-work' %>
+- [Social Work Bursary](/social-work-bursaries) (NHS funding towards your fees and living costs)
+  <% end %>
+
+<% end %>
+
+^Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you [qualify](/student-finance/who-qualifies).^
+
+##Extra help
+
+You could get a [bursary or scholarship](/extra-money-pay-university) from your university or college.
+
+You might be able to get [help with the costs of travel for study or work placements](/travel-grants-medical-dental-students-england) as part of your course.
+
+Use the [Family Action grant search](http://www.family-action.org.uk/section.aspx?id=21211) to check whether you qualify for funding from a charitable trust.
+
+^Student loans have to be paid back - grants, bursaries and allowances don’t.^
+
+##Your next steps
+
+s1. Find out how to [apply](/apply-for-student-finance) for student finance
+s2. Check if you [qualify](/student-finance/who-qualifies) for student finance
+

--- a/lib/smart_answer_flows/student-finance-calculator/outcome_uk_full_time_students.txt.erb
+++ b/lib/smart_answer_flows/student-finance-calculator/outcome_uk_full_time_students.txt.erb
@@ -1,0 +1,76 @@
+$!
+This is an estimate of your student finance. You must apply to find out exactly what you'll get.
+$!
+
+##Student finance
+
+You could get per year:
+
+- <%= number_to_currency(state.tuition_fee_amount, precision: 0) %> Tuition Fee Loan
+- <%= number_to_currency(state.maintenance_loan_amount, precision: 0) %> Maintenance Loan (for living costs)
+<% if state.maintenance_grant_amount > 0 %>
+- <%= number_to_currency(state.maintenance_grant_amount, precision: 0) %> Maintenance Grant (for living costs)
+<% end %>
+
+###Extra student funding
+
+<% if state.uk_ft_circumstances.include?('no') and state.course_studied == 'none-of-the-above' %>
+You don’t qualify for extra grants and allowances.
+<% else %>
+You could get:
+
+  <% if state.uk_ft_circumstances.include?('children-under-17') %>
+    <% if state.start_date == '2014-2015' %>
+- up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) [Childcare Grant](/childcare-grant)
+- up to £1,523 per year [Parents’ Learning Allowance](/parents-learning-allowance)
+- [Child Tax Credit](/child-tax-credit)
+    <% elsif state.start_date == '2015-2016' %>
+- up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) [Childcare Grant](/childcare-grant)
+- up to £1,573 per year [Parents’ Learning Allowance](/parents-learning-allowance)
+- [Child Tax Credit](/child-tax-credit)
+    <% end %>
+  <% end %>
+
+  <% if state.uk_ft_circumstances.include?('dependant-adult') %>
+    <% if state.start_date == '2014-2015' %>
+- up to £2,668 per year [Adult Dependant’s Grant](/adult-dependants-grant)
+    <% elsif state.start_date == '2015-2016' %>
+- up to £2,757 per year [Adult Dependant’s Grant](/adult-dependants-grant)
+    <% end %>
+  <% end %>
+
+  <% if state.uk_ft_circumstances.include?('has-disability') %>
+- [Disabled Students' Allowances](/disabled-students-allowances-dsas)
+  <% end %>
+
+  <% if state.uk_ft_circumstances.include?('low-income') %>
+- [University and college hardship funds](/extra-money-pay-university/university-and-college-hardship-funds) (extra help with costs while studying)
+  <% end %>
+
+  <% if state.course_studied == 'teacher-training' %>
+- [Funding for teacher training](/teacher-training-funding)
+  <% elsif state.course_studied == 'dental-medical-healthcare' %>
+- [NHS Bursary](/nhs-bursaries) (NHS funding towards your fees and living costs)
+  <% elsif state.course_studied == 'social-work' %>
+- [Social Work Bursary](/social-work-bursaries) (NHS funding towards your fees and living costs)
+  <% end %>
+
+<% end %>
+
+^Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you [qualify](/student-finance/who-qualifies).^
+
+##Extra help
+
+You could get a [bursary or scholarship](/extra-money-pay-university) from your university or college.
+
+You might be able to get [help with the costs of travel for study or work placements](/travel-grants-medical-dental-students-england) as part of your course.
+
+Use the [Family Action grant search](http://www.family-action.org.uk/section.aspx?id=21211) to check whether you qualify for funding from a charitable trust.
+
+^Student loans have to be paid back - grants, bursaries and allowances don’t.^
+
+##Your next steps
+
+s1. Find out how to [apply](/apply-for-student-finance) for student finance
+s2. Check if you [qualify](/student-finance/who-qualifies) for student finance
+


### PR DESCRIPTION
**DO NOT MERGE - FOR DISCUSSION ONLY**

@chrisroos & I think that using ERB templates for outcomes might make the code/content easier to follow as opposed to the current implementation which uses Ruby phrase keys and YAML locale files. 

We think doing something like this might give us many of the benefits of using Smartdown without incurring all the cost of actually converting the Smart Answers into Smartdown.

This branch is a bit of a spike to see (a) how hard it would be to implement this kind of idea and (b) whether the result is indeed any easier to follow.

So far we've only converted the Student Finance Calculator. You can see the resultant outcome templates here:-

* [outcome_uk_full_time_students.txt.erb](https://github.com/alphagov/smart-answers/blob/use-outcome-templates-for-student-finance-calculator/lib/smart_answer_flows/student-finance-calculator/outcome_uk_full_time_students.txt.erb)
* [outcome_uk_all_students.txt.erb](https://github.com/alphagov/smart-answers/blob/use-outcome-templates-for-student-finance-calculator/lib/smart_answer_flows/student-finance-calculator/outcome_uk_all_students.txt.erb)
* [outcome_eu_students.txt.erb](https://github.com/alphagov/smart-answers/blob/use-outcome-templates-for-student-finance-calculator/lib/smart_answer_flows/student-finance-calculator/outcome_eu_students.txt.erb)

One problem with this approach is that (like when using conditional logic `$IF`/`$ENDIF`/etc in Smartdown outcomes), it becomes more awkward to test that various bits of content have been included or not included. This is why the `{{marker: pet-is-a-cat}}` syntax was introduced into Smartdown and we could do something along those lines here, although we're not convinced that's the right approach.

We haven't attempted to address the testing issue in this branch yet, but we thought we'd see what people thought before going any further.

