### PR TITLE
Fix a randomly failing test

### DIFF
--- a/test/unit/smartdown_content/smartdown_scenarios_test.rb
+++ b/test/unit/smartdown_content/smartdown_scenarios_test.rb
@@ -38,6 +38,7 @@ class SmartdownScenariosTest < ActiveSupport::TestCase
       end
     end
   end
+  SmartdownAdapter::Registry.reset_instance
 
   def questions_are_asked(flow, answers, question_names)
     assert_nothing_raised("Exception was thrown when running flow #{flow.name} with answers #{answers}") do


### PR DESCRIPTION
To reproduce run `rake test TESTOPTS="--seed=56021"`.

smartdown_scenarios_test.rb was modifying registry options that
got cached in a class variable and errored next time it was
being accessed with different options.

It may have some performance degradation, but we must choose 2 out of 3:
1) Being able to run tests in random order
2) Having fast tests
3) Living with intermittent test failures
:)