### PR TITLE
Publish UK visa checker changes

### DIFF
--- a/lib/data/ukba_additional_countries.yml
+++ b/lib/data/ukba_additional_countries.yml
@@ -1,4 +1,4 @@
---- 
+---
 - :name: British dependent territories citizen
   :slug: british-dependent-territories-citizen
 - :name: British national overseas
@@ -11,5 +11,9 @@
   :slug: cyprus-north
 - :name: Hong Kong (British national overseas)
   :slug: hong-kong-(british-national-overseas)
+- :name: Palestinian Territories
+  :slug: palestinian-territories
+- :name: Stateless or Refugee
+  :slug: stateless-or-refugee
 - :name: Vatican City
   :slug: vatican-city

--- a/lib/smart_answer_flows/locales/en/check-uk-visa.yml
+++ b/lib/smart_answer_flows/locales/en/check-uk-visa.yml
@@ -14,6 +14,9 @@ en-GB:
           You won't need a visa if your passport has a personal ID number on the bio data page.
 
       #phrases
+        apply_from_country_of_origin_or_residency: |
+          ^You must apply for your visa from the country you're originally from or currently living in.^
+
         b1_b2_visa_exception: |
           except if you have a B1 or B2 visit visa from the USA
 
@@ -45,7 +48,7 @@ en-GB:
         apply_for_visitor_visa: |
           ###Visitor visa
 
-          Apply for a [general visit visa](/general-visit-visa).
+          Apply for a [Standard Visitor visa](/standard-visitor-visa).
         epassport_general_visit_reason: |
           However, you should bring the [same documents](/government/publications/visitor-visa-guide-to-supporting-documents) you’d need to apply for a visa, to show to officers at the UK border.
           ^If you don’t have an ePassport, you must [apply for a short visit visa](/browse/visas-immigration/short-visit-visas).^
@@ -129,7 +132,8 @@ en-GB:
         You may need a visa to come to the UK to visit, study or work.
 
       what_passport_do_you_have?:
-        title: What passport do you have?
+        title: What passport or travel document do you have?
+        hint: If you're a refugee or don't have a passport or travel document, select stateless or refugee.
 
       purpose_of_visit?:
         title: What are you coming to the UK to do?
@@ -138,7 +142,7 @@ en-GB:
           work: "Work, academic visit or business"
           tourism: "Tourism, including visiting friends or family"
           school: "Visit your child at school"
-          marriage: "Get married"
+          marriage: "Get married or enter into a civil partnership"
           medical: "Get private medical treatment"
           transit: "Transit (on your way to somewhere else)"
           family: "Join partner or family for a long stay"
@@ -175,20 +179,23 @@ en-GB:
         body: |
           The visa you apply for depends on your circumstances.
 
-          Apply for a [study visa](/tier-4-general-visa) if you’re coming to the UK to study a degree or college course for longer than 6 months (or 11 months if it’s an English language course).
+          %{if_refugee}
 
-          Apply for a [child study visa](/child-study-visa) if you’re under 18.
+          Apply for a [study visa](/tier-4-general-visa) if you’re coming to the UK to study a university or college course for more than 6 months, or more than 11 months if it’s an English language course.
 
-          ^If you’re studying an English language course for less than 11 months, you can apply for a [study visit](/study-visit-visa) visa.^
+          You can apply for a [Short-term Study visa](/study-visit-visa) if you’re 18 or over and studying an English language course for 11 months or less.
+
+          You can also apply for a [child study visa](/child-study-visa) if you’re under 18.
 
       outcome_study_m:
         title: You’ll need a visa to study in the UK
 
         body: |
-          Apply for a [study visit](/study-visit-visa) visa if you’re studying for less than 6 months and you won’t work during your stay.
+          %{if_refugee}
+
+          Apply for a [Short-term Study visa](/study-visit-visa) if you are studying for 6 months or less.
 
           You should apply as a [child visitor](/child-visit-visa) if you’re under 18.
-
       outcome_work_y:
         title: You’ll need a visa to work or do business or academic research in the UK
         body: |
@@ -196,6 +203,7 @@ en-GB:
           The visa you apply for depends on your circumstances.
 
           %{if_turkey}
+          %{if_refugee}
 
           ###Skilled workers
 
@@ -245,17 +253,16 @@ en-GB:
         title: |
           You'll need a visa to work, do business or academic research in the UK
         body: |
-          The visa you need to apply for depends on your circumstances
+          The visa you need to apply for depends on your circumstances.
+
+          %{if_refugee}
 
           ##Business visits
 
-          You can apply for a visa as:
+          You can apply:
 
-          - a [business or academic visitor](/business-visitor-visa) - eg if you’re coming to the UK for conferences, meetings, training or academic research
-          - a [sports visitor](/sports-visit-visa)
-          - an [entertainer](/entertainer-visitor-visa)
-          - a [prospective entrepreneur](/prospective-entrepreneur)
-          - a visitor doing a [‘permitted paid engagement’](http://www.ukba.homeoffice.gov.uk/visas-immigration/visiting/paid-engage/) (you must have been invited to the UK because of your expertise) - you can only stay for up to 1 month
+          - for a [Standard Visitor visa](/standard-visitor-visa) - eg if you’re coming to the UK for conferences, meetings, training, academic research or a sabbatical
+          - as a visitor doing a [‘permitted paid engagement’](/permitted-paid-engagement-visa) (you must have been invited to the UK because of your expertise) - you can only stay for up to 1 month
 
           ##Temporary workers
 
@@ -283,11 +290,8 @@ en-GB:
 
           You don't need a visa if you're coming to the UK for activities allowed under the following visas:
 
-          - a [business or academic visitor](/business-visitor-visa) - eg if you’re coming to the UK for conferences, meetings, training or academic research
-          - a [sports visitor](/sports-visit-visa)
-          - an [entertainer](/entertainer-visitor-visa)
-          - a [prospective entrepreneur](https://www.gov.uk/prospective-entrepreneur)
-          - a visitor doing a ['permitted paid engagement'](/permitted-paid-engagement-visa) (you must have been invited to the UK because of your expertise) - you can only stay for up to 1 month
+          - a [Standard Visitor visa](/standard-visitor-visa) - eg if you’re coming to the UK for conferences, meetings, training, academic research or a sabbatical
+          - a [‘permitted paid engagement’](/permitted-paid-engagement-visa) (you must have been invited to the UK because of your expertise) - you can only stay for up to 1 month
 
           However, you should bring [supporting documents](/government/publications/visitor-visa-guide-to-supporting-documents) to show at the border.
 
@@ -315,6 +319,8 @@ en-GB:
         title: You’ll need a visa to pass through the UK in transit
         body: |
           You should apply for a [Visitor in Transit visa](/transit-visa) if you arrive on a flight and will pass through immigration control before you leave the UK.
+
+          %{if_refugee}
 
           ##Transiting without a visa
           You might be eligible for ‘transit without visa’ if:
@@ -346,6 +352,7 @@ en-GB:
           All visas and residence permits must be valid.
 
           Australian paper confirmation slips are not accepted.
+
       outcome_transit_not_leaving_airport:
         title: You’ll need a visa to pass through the UK in transit (unless you’re exempt)
         body: |
@@ -371,6 +378,73 @@ en-GB:
           All visas and residence permits must be valid.
 
           %E-visas or e-residence permits are not acceptable unless your airline is able to verify it with the issuing country. Contact your airline for more information.%
+
+      outcome_transit_refugee_not_leaving_airport:
+        title: You may need a Direct Airside Transit Visa
+        body: |
+          You’ll need a [Direct Airside Transit visa](/transit-visa/direct-airside-transit-visa) if you’re a refugee and originally from one of these countries:
+
+          * Afghanistan
+          * Albania
+          * Algeria
+          * Angola
+          * Bangladesh
+          * Belarus
+          * Burma (Myanmar)
+          * Burundi
+          * Cameroon
+          * China - unless you have a diplomatic passport or you’re travelling with a Chinese government minister on an Official Visit to the UK and you have a service or public affairs passport
+          * Congo
+          * Democratic Republic of Congo or former Republic of Zaire
+          * Cyprus
+          * Egypt
+          * Eritrea
+          * Ethiopia
+          * Gambia
+          * Ghana
+          * Guinea
+          * Guinea-Bissau
+          * India  - unless you have a diplomatic or official passport
+          * Iran
+          * Iraq
+          * Ivory Coast
+          * Jamaica
+          * Kenya
+          * Kosovo
+          * Lebanon
+          * Lesotho
+          * Liberia
+          * Libya
+          * Macedonia
+          * Malawi
+          * Moldova
+          * Mongolia
+          * Nepal
+          * Nigeria
+          * Pakistan
+          * Palestinian Territories
+          * Rwanda
+          * Senegal
+          * Serbia
+          * Sierra Leone
+          * Somalia
+          * South Africa
+          * South Sudan
+          * Sri Lanka
+          * Sudan
+          * Swaziland
+          * Syria
+          * Tanzania
+          * Turkey - unless you have a diplomatic passport
+          * Uganda
+          * Venezuela - unless you have a biometric passport
+          * Vietnam  - unless you have a diplomatic passport
+          * Yemen
+          * Zimbabwe
+
+
+          Otherwise you don't need a visa.
+
       outcome_transit_leaving_airport_datv:
         title: You’ll need a visa to pass through the UK in transit
         body: |
@@ -414,6 +488,8 @@ en-GB:
 
           The visa you apply for depends on your family member’s situation.
 
+          %{if_refugee}
+
           ##They’re settled in the UK
 
           Apply for a [‘family of a settled person’ visa](/join-family-in-uk) if your family member or partner is either a British citizen or from outside the European Economic Area (EEA) and settled in the UK.
@@ -425,7 +501,6 @@ en-GB:
           ##They’re from the EEA
 
           Apply for a [family permit](/family-permit) to join your family or partner for a short or long stay if they’re living in the UK.
-
 
       outcome_joining_family_m:
         title: You may need a visa to join a member of your family or partner for a long stay
@@ -466,29 +541,21 @@ en-GB:
 
           Apply for a [family permit](/family-permit) to join your family or partner for a short or long stay if they’re living in the UK.
 
-      outcome_general_y:
+      outcome_standard_visit:
         title: You’ll need a visa to come to the UK
         body: |
-          The visa you need to apply for depends on your circumstances.
+
+          Apply for a [Standard Visitor visa](/standard-visitor-visa) if you’re visiting the UK for a holiday or to visit family or friends.
 
           %{if_china}
-
-          ##Tourism and visiting friends
-
-          Apply for a [general visit visa](https://www.gov.uk/general-visit-visa) if you’re visiting the UK for a holiday or to visit friends.
-
-          ##Visiting family
-
-          Apply for a [family visit visa](/family-visit-visa) if you plan to visit your family or partner (eg spouse) while you’re in the UK.
-
-          ##If you’re under 18
-
-          Apply for a [child visit visa](/child-visit-visa).
+          %{if_refugee}
 
       outcome_marriage:
         title: You’ll need a visa to come to the UK
         body: |
-          Apply for a [Marriage Visitor visa](/marriage-visa) if you and your partner don't plan to stay in the UK longer than 6 months.
+          %{if_refugee}
+
+          Apply for a [Marriage Visitor visa](/marriage-visa) if you and your partner want to get married or enter into a civil partnership in the UK.
 
           Apply for a [family of a settled person visa](/join-family-in-uk) if your partner is British or settled in the UK and you wish to join them to live in the UK permanently.
 
@@ -504,15 +571,17 @@ en-GB:
         body:
           You should apply for the [visa for parents](/parent-of-a-child-at-school-visa) visiting children at school.
 
+          %{if_refugee}
       outcome_medical_y:
         title: You’ll need a visa to visit the UK
         body:
-          You should apply for the [private medical treatment visa](/private-medical-treatment-visa).
+          You should apply for a [Standard Visitor visa](/standard-visitor-visa).
 
+          %{if_refugee}
       outcome_medical_n:
         title: You won’t need a visa to visit the UK
         body:
-          However, you should bring the [same documents](/government/publications/visitor-visa-guide-to-supporting-documents) you’d need to apply for a Private Medical Treatment Visitor visa, to show to officers at the UK border.
+          However, you should bring the [same documents](/government/publications/visitor-visa-guide-to-supporting-documents) you’d need to apply for a [Standard Visitor visa](/standard-visitor-visa), to show to officers at the UK border.
 
       outcome_visit_waiver:
         title: |
@@ -526,7 +595,7 @@ en-GB:
 
           However, you should bring the [same documents](https://www.gov.uk/government/publications/visitor-visa-guide-to-supporting-documents) you'd need to apply for a visa, to show to officers at the UK border. 
 
-          ^If the bio data page in your passport doesn't include a personal ID number, you must [apply for a short visit visa](/browse/visas-immigration/short-visit-visas).^
+          ^If the bio data page in your passport doesn't include a personal ID number, you must [apply for a Short-term Study visa](/study-visit-visa).^
 
       outcome_diplomatic_business:
         title: Diplomatic Business

--- a/test/integration/smart_answer_flows/check_uk_visa_test.rb
+++ b/test/integration/smart_answer_flows/check_uk_visa_test.rb
@@ -8,13 +8,96 @@ class CheckUkVisaTest < ActiveSupport::TestCase
   include GdsApi::TestHelpers::Worldwide
 
   setup do
-    @location_slugs = %w(andorra anguilla armenia bolivia canada china colombia croatia mexico south-africa syria turkey yemen oman united-arab-emirates qatar taiwan venezuela)
+    @location_slugs = %w(andorra anguilla armenia bolivia canada china colombia croatia mexico south-africa stateless-or-refugee syria turkey yemen oman united-arab-emirates qatar taiwan venezuela)
     worldwide_api_has_locations(@location_slugs)
     setup_for_testing_flow 'check-uk-visa'
   end
 
   should "ask what passport do you have" do
     assert_current_node :what_passport_do_you_have?
+  end
+
+  context "choose Stateless or Refugee" do
+    setup do
+      add_response "stateless-or-refugee"
+    end
+
+    should "suggest to apply in country of originallity or residence for outcome_marriage" do
+      add_response 'marriage'
+
+      assert_current_node :outcome_marriage
+      assert_phrase_list :if_refugee, [:apply_from_country_of_origin_or_residency]
+    end
+
+    should "suggest to apply in country of originallity or residence for outcome_study_m" do
+      add_response 'study'
+      add_response 'six_months_or_less'
+
+      assert_current_node :outcome_study_m
+      assert_phrase_list :if_refugee, [:apply_from_country_of_origin_or_residency]
+    end
+
+    should "suggest to apply in country of originallity or residence for outcome_study_y" do
+      add_response 'study'
+      add_response 'longer_than_six_months'
+
+      assert_current_node :outcome_study_y
+      assert_phrase_list :if_refugee, [:apply_from_country_of_origin_or_residency]
+    end
+
+    should "suggest to apply in country of originallity or residence for outcome_work_m" do
+      add_response 'work'
+      add_response 'six_months_or_less'
+      assert_current_node :outcome_work_m
+      assert_phrase_list :if_refugee, [:apply_from_country_of_origin_or_residency]
+    end
+
+    should "suggest to apply in country of originallity or residence for outcome_work_y" do
+      add_response 'work'
+      add_response 'longer_than_six_months'
+      assert_current_node :outcome_work_y
+      assert_phrase_list :if_refugee, [:apply_from_country_of_origin_or_residency]
+    end
+
+    should "suggest to apply in country of originallity or residence for outcome_transit_leaving_airport" do
+      add_response 'transit'
+      add_response 'yes'
+
+      assert_current_node :outcome_transit_leaving_airport
+      assert_phrase_list :if_refugee, [:apply_from_country_of_origin_or_residency]
+    end
+
+    should "suggests to get a Direct Airside Transit visa if not leaving the airport" do
+      add_response 'transit'
+      add_response 'no'
+
+      assert_current_node :outcome_transit_refugee_not_leaving_airport
+    end
+
+    should "suggest to apply in country of originallity or residence for outcome_standard_visit" do
+      add_response 'tourism'
+
+      assert_current_node :outcome_standard_visit
+      assert_phrase_list :if_refugee, [:apply_from_country_of_origin_or_residency]
+    end
+
+    should "suggest to apply in country of originallity or residence for outcome_school_y" do
+      add_response 'school'
+      assert_current_node :outcome_school_y
+      assert_phrase_list :if_refugee, [:apply_from_country_of_origin_or_residency]
+    end
+
+    should "suggest to apply in country of originallity or residence for outcome_medical_y" do
+      add_response 'medical'
+      assert_current_node :outcome_medical_y
+      assert_phrase_list :if_refugee, [:apply_from_country_of_origin_or_residency]
+    end
+
+    should "suggest to apply in country of originallity or residence for outcome_joining_family_y" do
+      add_response 'family'
+      assert_current_node :outcome_joining_family_y
+      assert_phrase_list :if_refugee, [:apply_from_country_of_origin_or_residency]
+    end
   end
 
   context "choose a UKOT country" do
@@ -149,82 +232,68 @@ class CheckUkVisaTest < ActiveSupport::TestCase
     end
   end
 
-  context "choose a Visa nationals country" do
-    setup do
-      add_response 'yemen'
-    end
-    should "ask what are you coming to the UK to do" do
-      assert_current_node :purpose_of_visit?
-    end
-    context "tourism, visiting friends or family" do
+  context "choose a visa national country or refugee" do
+    context "when chosen armenia" do
       setup do
-        add_response 'tourism'
+        add_response 'armenia'
       end
-      should "take you to general_y outcome" do
-        assert_current_node :outcome_general_y
+      should "ask what are you coming to the UK to do" do
+        assert_current_node :purpose_of_visit?
       end
-    end
-    context "visiting child at school" do
-      setup do
-        add_response 'school'
-      end
-      should "take you to school_y outcome" do
-        assert_current_node :outcome_school_y
-      end
-    end
-    context "getting married" do
-      setup do
-        add_response 'marriage'
-      end
-      should "take you to the marriage outcome" do
-        assert_current_node :outcome_marriage
-      end
-    end
-    context "get private medical treatment" do
-      setup do
-        add_response 'medical'
-      end
-      should "take you to the 'medical_y' outcome" do
-        assert_current_node :outcome_medical_y
-      end
-    end
-    context "coming to the UK on the way somewhere else" do
-      setup do
-        add_response 'transit'
-      end
-      should "ask you if you're planning to leave the airport?" do
-        assert_current_node :planning_to_leave_airport?
-      end
-      context "planning to leave airport" do
+
+      context "coming to the UK to study" do
         setup do
-          add_response 'yes'
+          add_response 'study'
+          add_response 'six_months_or_less'
         end
-        should "take you to 'transit_leaving_airport' outcome" do
-          assert_current_node :outcome_transit_leaving_airport_datv
+        should "take you to outcome study_m" do
+          assert_current_node :outcome_study_m
+          assert_phrase_blank :if_refugee
         end
       end
-      context "not planning to leave airport" do
+
+      context "coming to the UK to work" do
         setup do
-          add_response 'no'
+          add_response 'work'
+          add_response 'six_months_or_less'
         end
-        should "take you to outcome no visa needed" do
-          assert_current_node :outcome_transit_not_leaving_airport
+        should "take you to outcome work_m" do
+          assert_current_node :outcome_work_m
+          assert_phrase_blank :if_refugee
         end
       end
-    end
-    context "coming to join family" do
-      setup do
-        add_response 'family'
-      end
-      should "take you to outcome Family Y" do
-        assert_current_node :outcome_joining_family_y
+
+      context "coming to the UK on the way somewhere else" do
+        setup do
+          add_response 'transit'
+        end
+        should "ask you if you're planning to leave the airport" do
+          assert_current_node :planning_to_leave_airport?
+        end
+        context "planning to leave airport" do
+          setup do
+            add_response 'yes'
+          end
+          should "take you to transit_leaving_airport outcome" do
+            assert_current_node :outcome_transit_leaving_airport
+            assert_phrase_blank :if_refugee
+          end
+        end
+        context "not planning to leave airport" do
+          setup do
+            add_response 'no'
+          end
+          should "take you to transit_not_leaving_airport outcome" do
+            assert_current_node :outcome_no_visa_needed
+          end
+        end
       end
     end
   end
 
-   context "choose a DATV country" do
+  context "choose a DATV country" do
     setup do
-      add_response 'south-africa'
+      add_response 'yemen'
     end
     should "ask what are you coming to the UK to do" do
       assert_current_node :purpose_of_visit?
@@ -252,7 +321,7 @@ class CheckUkVisaTest < ActiveSupport::TestCase
         add_response 'tourism'
       end
       should "take you to general_y outcome" do
-        assert_current_node :outcome_general_y
+        assert_current_node :outcome_standard_visit
       end
       context "Chinese passport" do
         setup do
@@ -261,7 +330,7 @@ class CheckUkVisaTest < ActiveSupport::TestCase
           add_response "tourism"
         end
         should "take insert an additional phrase" do
-          assert_current_node :outcome_general_y
+          assert_current_node :outcome_standard_visit
           assert_phrase_list :if_china, [:china_tour_group]
         end
       end
@@ -300,7 +369,7 @@ class CheckUkVisaTest < ActiveSupport::TestCase
         assert_current_node :outcome_medical_y
       end
     end
-    context "coming to the on the way somewhere else" do
+    context "coming to the UK on the way somewhere else" do
       setup do
         add_response 'transit'
       end
@@ -374,17 +443,17 @@ class CheckUkVisaTest < ActiveSupport::TestCase
     end
   end
   context "testing turkey phrase list" do
-  setup do
-    add_response "turkey"
-    add_response "work"
-    add_response "longer_than_six_months"
+    setup do
+      add_response "turkey"
+      add_response "work"
+      add_response "longer_than_six_months"
+    end
+    should "takes you to outcome_work_y" do
+      assert_current_node :outcome_work_y
+      assert_phrase_list :if_turkey, [:turkey_business_person_visa]
+    end
   end
-  should "takes you to outcome_work_y" do
-    assert_current_node :outcome_work_y
-    assert_phrase_list :if_turkey, [:turkey_business_person_visa]
-  end
-end
-    context "testing outcome visit waiver" do
+  context "testing outcome visit waiver" do
     setup do
       add_response 'oman'
       add_response 'medical'
@@ -394,7 +463,6 @@ end
         assert_phrase_list :if_exception, [:electronic_visa_waiver, :apply_for_visitor_visa]
     end
   end
-
   context "testing croatia phrase list" do
     setup do
       add_response "croatia"
@@ -513,13 +581,13 @@ end
     end
   end
 
-  context "choose a Non-visa country and check for outcome_work_m" do
+  context "choose a Non-visa country and check for outcome_work_n" do
     setup do
       add_response 'mexico'
       add_response 'work'
       add_response 'six_months_or_less'
     end
-      should "take you to outcome work_m" do
+      should "take you to outcome work_n" do
       assert_current_node :outcome_work_n
     end
   end
@@ -621,7 +689,7 @@ end
         add_response 'tourism'
       end
       should "take you to tourism outcome without personalised phraselist" do
-        assert_current_node :outcome_general_y
+        assert_current_node :outcome_standard_visit
         assert_state_variable :if_exception, nil
       end
     end
@@ -645,15 +713,6 @@ end
       end
     end
   end
-  context "check for diplomatic and government business travellers" do
-    setup do
-      add_response 'bolivia'
-      add_response 'diplomatic'
-    end
-    should "go to diplomatic and government outcome" do
-      assert_current_node :outcome_diplomatic_business
-    end
-  end
 
   context "Syria transit B1 B2 visa exceptions" do
     setup do
@@ -671,6 +730,16 @@ end
       add_response 'no'
       assert_current_node :outcome_transit_not_leaving_airport
       assert_phrase_list :if_syria, [:b1_b2_visa_exception]
+    end
+  end
+
+  context "check for diplomatic and government business travellers" do
+    setup do
+      add_response 'bolivia'
+      add_response 'diplomatic'
+    end
+    should "go to diplomatic and government outcome" do
+      assert_current_node :outcome_diplomatic_business
     end
   end
 end


### PR DESCRIPTION
(V2 files are not deleted, because some more changes are pending)

Summary of changes:

- stateless or refugee shows a notification where to apply for a visa when its needed.
- Replace a lot of visa types with a standard visitor visa
- Mention civil partnership alongside marriage
- simplification of student visas

Affected path samples:
/check-uk-visa-v2/y/check-uk-visa-v2/y/stateless-or-refugee/tourism
/check-uk-visa-v2/y/check-uk-visa-v2/y/china/tourism
/check-uk-visa-v2/y/check-uk-visa-v2/y/stateless-or-refugee/study/longer_than_six_months
/check-uk-visa-v2/y/check-uk-visa-v2/y/stateless-or-refugee/study/six_months_or_less
/check-uk-visa-v2/y/check-uk-visa-v2/y/stateless-or-refugee/marriage