### PR TITLE
Report a lost or stolen passport updates

### DIFF
--- a/lib/smart_answer_flows/locales/en/report-a-lost-or-stolen-passport-v2.yml
+++ b/lib/smart_answer_flows/locales/en/report-a-lost-or-stolen-passport-v2.yml
@@ -1,0 +1,72 @@
+en-GB:
+  flow:
+    report-a-lost-or-stolen-passport-v2:
+      meta:
+        description: What you need to do if your passport has been lost or stolen and you need to travel urgently - emergency travel document and replacement passport.
+      title: Cancel a lost or stolen passport
+      body: |
+        You must cancel a lost or stolen passport as soon as possible.
+
+        This will reduce the risk of anyone else using your passport or your identity.
+
+        You can report a lost or stolen passport for someone else if they can't do it themselves.
+
+      options:
+        in_the_uk: "In the UK"
+        abroad: "Abroad"
+
+      which_country?:
+        title: In which country?
+
+      ## A1
+      complete_LS01_form:
+        body: |
+          You must report your lost or stolen passport to Her Majesty's Passport Office.
+
+          To report your lost passport you can do any of:
+
+          - [download a copy of form LS01](/government/publications/report-a-lost-or-stolen-passport-form-ls01) and post the completed form to Her Majesty's Passport Office - the address is on the form
+          - get a copy of form LS01 from a Post Office that offers the [Check and Send service](/how-the-post-office-check-and-send-service-works)
+          - use the new [online service](https://www.loststolenpassport.service.gov.uk/report) - this service is [in beta](/help/beta)
+
+
+          ^You’ll need a daytime telephone number and either an email address or UK mobile number to use the online service.^
+
+
+          %Your signature will be compared to the signature on the original passport application form. If the original application was made by someone else, you’ll also need to send a signed letter from that person confirming that the passport has been lost or stolen. This is to help prevent child abduction.%
+
+          You can use the [online enquiry form](https://eforms.homeoffice.gov.uk/outreach/Passport_Enquiries.ofml) to contact Her Majesty’s Passport Office for general advice.
+
+          ##Replacing your passport
+
+          You can apply for a replacement at the same time if you’re a British national and in the UK.
+
+          Follow the same process as [renewing a passport](/renew-adult-passport) but you must send a completed form LS01 with your application (if you haven’t already reported it as lost)
+
+          ^Use the [online enquiry form](https://eforms.homeoffice.gov.uk/outreach/Passport_Enquiries.ofml) to contact Her Majesty’s Passport Office for general advice.
+
+          % You can’t use the [1-day Premium service](/get-a-passport-urgently) if you’re replacing a lost passport. %
+
+          ##If you find your passport
+
+          If you find your passport, don’t sign the form. Instead, return the form in the envelope provided with a signed note confirming that you have found your passport and don’t want to cancel it.
+
+      # A2
+      contact_the_embassy:
+        title: You must report your lost or stolen passport
+        body: |
+          [Download form LS01 - 'Lost or stolen passport notification'](/government/publications/report-a-lost-or-stolen-passport-form-ls01)
+
+          Fill in form LS01 and post, fax or take it to your nearest British embassy, high commission or consulate. Check if you need to make an appointment first if you’re taking it in.
+
+          You can use the [online enquiry form](https://eforms.homeoffice.gov.uk/outreach/Passport_Enquiries.ofml) to contact Her Majesty’s Passport Office for general advice.
+
+          +[data_partial:overseas_passports_embassies:overseas_passports_embassies]
+
+          ##Get a replacement passport
+
+          If you don’t need to travel urgently, you can [apply for a replacement passport from the country you’re in.](/apply-renew-passport-abroad)
+
+          ##Emergency travel documents
+
+          If you need to travel urgently, you may be able to get an [emergency travel document](/emergency-travel-document) from the Embassy, High Commission or Consulate. You will have to pay a fee.

--- a/lib/smart_answer_flows/locales/en/report-a-lost-or-stolen-passport-v2.yml
+++ b/lib/smart_answer_flows/locales/en/report-a-lost-or-stolen-passport-v2.yml
@@ -51,13 +51,33 @@ en-GB:
 
           If you find your passport, don’t sign the form. Instead, return the form in the envelope provided with a signed note confirming that you have found your passport and don’t want to cancel it.
 
-      # A2
+       # A2
       contact_the_embassy:
         title: You must report your lost or stolen passport
         body: |
           [Download form LS01 - 'Lost or stolen passport notification'](/government/publications/report-a-lost-or-stolen-passport-form-ls01)
 
           Fill in form LS01 and post, fax or take it to your nearest British embassy, high commission or consulate. Check if you need to make an appointment first if you’re taking it in.
+
+          You can use the [online enquiry form](https://eforms.homeoffice.gov.uk/outreach/Passport_Enquiries.ofml) to contact Her Majesty’s Passport Office for general advice.
+
+          +[data_partial:overseas_passports_embassies:overseas_passports_embassies]
+
+          ##Get a replacement passport
+
+          If you don’t need to travel urgently, you can [apply for a replacement passport from the country you’re in.](/apply-renew-passport-abroad)
+
+          ##Emergency travel documents
+
+          If you need to travel urgently, you may be able to get an [emergency travel document](/emergency-travel-document) from the Embassy, High Commission or Consulate. You will have to pay a fee.
+
+      # A3
+      contact_the_embassy_canada:
+        title: You must report your lost or stolen passport
+        body: |
+          [Download form LS01 - 'Lost or stolen passport notification'](/government/publications/report-a-lost-or-stolen-passport-form-ls01)
+
+          Fill in form LS01 and post it to your nearest British embassy, high commission or consulate.
 
           You can use the [online enquiry form](https://eforms.homeoffice.gov.uk/outreach/Passport_Enquiries.ofml) to contact Her Majesty’s Passport Office for general advice.
 

--- a/lib/smart_answer_flows/report-a-lost-or-stolen-passport-v2.rb
+++ b/lib/smart_answer_flows/report-a-lost-or-stolen-passport-v2.rb
@@ -1,4 +1,3 @@
-status :published
 status :draft
 satisfies_need "100221"
 
@@ -29,9 +28,13 @@ country_select :which_country?, exclude_countries: exclude_countries do
     else
       []
     end
+
   end
+
+  next_node_if(:contact_the_embassy_canada, responded_with('canada'))
   next_node :contact_the_embassy
 end
 
 outcome :contact_the_embassy
+outcome :contact_the_embassy_canada
 outcome :complete_LS01_form

--- a/lib/smart_answer_flows/report-a-lost-or-stolen-passport-v2.rb
+++ b/lib/smart_answer_flows/report-a-lost-or-stolen-passport-v2.rb
@@ -1,0 +1,37 @@
+status :published
+status :draft
+satisfies_need "100221"
+
+exclude_countries = %w(holy-see british-antarctic-territory)
+
+multiple_choice :where_was_the_passport_lost_or_stolen? do
+  option in_the_uk: :complete_LS01_form
+  option abroad: :which_country?
+
+  save_input_as :location
+
+  next_node do
+    case location
+    when 'in_the_uk' then :complete_LS01_form
+    when 'abroad' then :which_country?
+    end
+  end
+end
+
+country_select :which_country?, exclude_countries: exclude_countries do
+  save_input_as :country
+
+  calculate :overseas_passports_embassies do
+    location = WorldLocation.find(country)
+    raise InvalidResponse unless location
+    if location.fco_organisation
+      location.fco_organisation.offices_with_service 'Lost or Stolen Passports'
+    else
+      []
+    end
+  end
+  next_node :contact_the_embassy
+end
+
+outcome :contact_the_embassy
+outcome :complete_LS01_form

--- a/test/integration/smart_answer_flows/report_a_lost_or_stolen_passport_test_v2.rb
+++ b/test/integration/smart_answer_flows/report_a_lost_or_stolen_passport_test_v2.rb
@@ -7,10 +7,12 @@ class ReportALostOrStolenPassportV2Test < ActiveSupport::TestCase
   include GdsApi::TestHelpers::Worldwide
 
   setup do
-    @location_slugs = %w(azerbaijan)
+    @location_slugs = %w(azerbaijan canada)
     worldwide_api_has_locations(@location_slugs)
-    json = read_fixture_file('worldwide/azerbaijan_organisations.json')
-    worldwide_api_has_organisations_for_location('azerbaijan', json)
+    @location_slugs.each do |location|
+      json = read_fixture_file("worldwide/#{location}_organisations.json")
+      worldwide_api_has_organisations_for_location(location, json)
+    end
     setup_for_testing_flow "report-a-lost-or-stolen-passport-v2"
   end
 
@@ -45,6 +47,27 @@ class ReportALostOrStolenPassportV2Test < ActiveSupport::TestCase
       should "tell you to report it to the embassy" do
         assert_current_node :contact_the_embassy
         assert_match /British Embassy Baku/, outcome_body
+      end
+    end
+  end
+
+  context "abroad" do
+    setup do
+      add_response :abroad
+    end
+
+    should "ask in which country has been lost/stolen" do
+      assert_current_node :which_country?
+    end
+
+    context "in Canada" do
+      setup do
+        add_response "canada"
+      end
+
+      should "tell you to fill in a form and visit the embassy" do
+        assert_current_node :contact_the_embassy_canada
+        assert_match /Fill in form LS01 and post it to your nearest British embassy, high commission or consulate./, outcome_body
       end
     end
   end

--- a/test/integration/smart_answer_flows/report_a_lost_or_stolen_passport_test_v2.rb
+++ b/test/integration/smart_answer_flows/report_a_lost_or_stolen_passport_test_v2.rb
@@ -2,7 +2,7 @@ require_relative "../../test_helper"
 require_relative "flow_test_helper"
 require 'gds_api/test_helpers/worldwide'
 
-class ReportALostOrStolenPassportTest < ActiveSupport::TestCase
+class ReportALostOrStolenPassportV2Test < ActiveSupport::TestCase
   include FlowTestHelper
   include GdsApi::TestHelpers::Worldwide
 
@@ -11,7 +11,7 @@ class ReportALostOrStolenPassportTest < ActiveSupport::TestCase
     worldwide_api_has_locations(@location_slugs)
     json = read_fixture_file('worldwide/azerbaijan_organisations.json')
     worldwide_api_has_organisations_for_location('azerbaijan', json)
-    setup_for_testing_flow "report-a-lost-or-stolen-passport"
+    setup_for_testing_flow "report-a-lost-or-stolen-passport-v2"
   end
 
   should "ask where the passport was lost or stolen" do


### PR DESCRIPTION
For Canada route, abroad only. Change opening line to: Fill in form LS01 and post it to your nearest British embassy, high commission or consulate. 

https://www.gov.uk/report-a-lost-or-stolen-passport/y/abroad/canada