### PR TITLE
Allow deploying to Heroku

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby '2.1.5'
+
 gem 'unicorn', '4.8.3'
 
 gem 'rails', '4.2.1'

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ To help developers track changes in files easily, it is best if you commit V2 fi
 
 ## Deploying to Heroku
 
-    heroku apps:create
+    heroku apps:create --region eu
 
     heroku config:set GOVUK_APP_DOMAIN=preview.alphagov.co.uk
     heroku config:set PLEK_SERVICE_CONTENTAPI_URI=https://www.gov.uk/api

--- a/README.md
+++ b/README.md
@@ -98,14 +98,8 @@ To help developers track changes in files easily, it is best if you commit V2 fi
 
 ## Deploying to Heroku
 
-    heroku apps:create --region eu
+The 'startup_heroku.sh' shell script will create and configure an app on Heroku, push the __current branch___ and open the marriage-abroad Smart Answer in the browser.
 
-    heroku config:set GOVUK_APP_DOMAIN=preview.alphagov.co.uk
-    heroku config:set PLEK_SERVICE_CONTENTAPI_URI=https://www.gov.uk/api
-    heroku config:set PLEK_SERVICE_STATIC_URI=https://assets-origin.preview.alphagov.co.uk
-    heroku config:set RUNNING_ON_HEROKU=true
+Once deployed you'll need to use the standard `git push` mechanism to deploy your changes.
 
-    git push heroku <your-local-branch>:master
-
-    # *NOTE.* You'll need to add the path to a Smart Answer, e.g. /marriage-abroad
-    heroku apps:open
+    ./startup_heroku.sh

--- a/README.md
+++ b/README.md
@@ -95,3 +95,17 @@ To help developers track changes in files easily, it is best if you commit V2 fi
 ## Detailed documentation
 
 - [How to archive a Smart Answer](doc/archiving.md)
+
+## Deploying to Heroku
+
+    heroku apps:create
+
+    heroku config:set GOVUK_APP_DOMAIN=preview.alphagov.co.uk
+    heroku config:set PLEK_SERVICE_CONTENTAPI_URI=https://www.gov.uk/api
+    heroku config:set PLEK_SERVICE_STATIC_URI=https://assets-origin.preview.alphagov.co.uk
+    heroku config:set RUNNING_ON_HEROKU=true
+
+    git push heroku <your-local-branch>:master
+
+    # *NOTE.* You'll need to add the path to a Smart Answer, e.g. /marriage-abroad
+    heroku apps:open

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -65,8 +65,10 @@ SmartAnswers::Application.configure do
   config.action_mailer.default_url_options = { host: Plek.current.find('smartanswers') }
   config.action_mailer.delivery_method = :ses
 
-  # Enable JSON-style logging
-  config.logstasher.enabled = true
-  config.logstasher.logger = Logger.new("#{Rails.root}/log/#{Rails.env}.json.log")
-  config.logstasher.supress_app_log = true
+  unless ENV['RUNNING_ON_HEROKU']
+    # Enable JSON-style logging
+    config.logstasher.enabled = true
+    config.logstasher.logger = Logger.new("#{Rails.root}/log/#{Rails.env}.json.log")
+    config.logstasher.supress_app_log = true
+  end
 end

--- a/startup_heroku.sh
+++ b/startup_heroku.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+echo
+echo "# Creating a new Heroku App"
+echo
+heroku apps:create --region eu
+
+echo
+echo "# Configuring Heroku ready for Smart Answers"
+echo
+heroku config:set \
+GOVUK_APP_DOMAIN=preview.alphagov.co.uk \
+PLEK_SERVICE_CONTENTAPI_URI=https://www.gov.uk/api \
+PLEK_SERVICE_STATIC_URI=https://assets-origin.preview.alphagov.co.uk \
+RUNNING_ON_HEROKU=true
+
+echo
+echo "# Pushing the current branch to Heroku's master"
+echo
+export CURRENT_BRANCH_NAME=`git branch | grep "^\*" | cut -d" " -f2`
+git push heroku $CURRENT_BRANCH_NAME:master
+
+echo
+echo "# Opening Smart Answers"
+echo "*NOTE.* You may have to refresh as the app can be slow to start"
+echo
+export HEROKU_URL=`heroku apps:info | grep "Web URL" | cut -c16-`
+export SMART_ANSWER_TO_OPEN="marriage-abroad"
+open $HEROKU_URL$SMART_ANSWER_TO_OPEN
+
+echo
+echo "All done"
+echo


### PR DESCRIPTION
The current mechanism for making changes to Smart Answers isn't ideal: We have to duplicate everything about the Smart Answer, make the changes and then deploy to preview for someone to view and test. See "[Making bigger changes](https://github.com/alphagov/smart-answers#making-bigger-changes)" for more information.

We think that using git branches, instead of manually branching in the filesystem, will make our lives easier in this situation. Although we can deploy branches to Preview, the auto-deployment functionality means that we can't guarantee how long they'll live. Allowing us to deploy to Heroku should solve this particular problem.
