### PR TITLE
No need to generate test coverage reports when running locally.

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -13,6 +13,6 @@ export GOVUK_APP_DOMAIN=dev.gov.uk
 export GOVUK_ASSET_HOST=http://static.dev.gov.uk
 
 export DISPLAY=:99
-RAILS_ENV=test SPEC_REPORTER=true bundle exec rake test
+RAILS_ENV=test SPEC_REPORTER=true TEST_COVERAGE=true bundle exec rake test
 
 bundle exec rake assets:precompile

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,10 +1,12 @@
 # encoding: UTF-8
 
-require 'simplecov'
-require 'simplecov-rcov'
+if ENV["TEST_COVERAGE"]
+  require 'simplecov'
+  require 'simplecov-rcov'
 
-SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
-SimpleCov.start 'rails'
+  SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
+  SimpleCov.start 'rails'
+end
 
 ENV["RAILS_ENV"] = "test"
 require File.expand_path('../../config/environment', __FILE__)


### PR DESCRIPTION
I based this on [how this was done in Whitehall](https://github.com/alphagov/whitehall/commit/59886b6aa9e11ce398fbf5d20f69ad58148eafd1).

I have verified that the test coverage report is still [generated as part of the Jenkins build](https://ci-new.alphagov.co.uk/job/govuk_smartanswers_branches/1925/console).