### PR TITLE
Revert "Write should_eventually test for error messages"

### DIFF
--- a/test/unit/flow_test.rb
+++ b/test/unit/flow_test.rb
@@ -205,11 +205,6 @@ class FlowTest < ActiveSupport::TestCase
       should "truncate path after error" do
         assert_equal [:do_you_like_chocolate?], @flow.path(%w{no bad})
       end
-
-      should_eventually "permit custom error messages per question" do
-        assert_equal :do_you_like_this_custom_thing?, @flow.process(%w{no bad}).current_node
-        assert_equal "Custom error message", @flow.process(%w{no bad}).error
-      end
     end
 
     should "calculate the path traversed by a series of responses" do


### PR DESCRIPTION
This reverts commit 8affa3be8c2a08f5cc76e75e0737bd7df9d6b9e5.

This DEFERRED test was introduced over 3 years ago and it still doesn't pass.

I don't see the benefit of keeping it around, especially when it introduces
noise into the test output.