### PR TITLE
Pass `response` into `calculate` blocks.

### DIFF
--- a/lib/smart_answer/question/base.rb
+++ b/lib/smart_answer/question/base.rb
@@ -59,7 +59,7 @@ module SmartAnswer
           state.save_input_as @save_input_as if @save_input_as
         end
         @calculations.each do |calculation|
-          new_state = calculation.evaluate(new_state)
+          new_state = calculation.evaluate(new_state, input)
         end
         new_state
       end

--- a/lib/smart_answer_flows/appeal-a-benefits-decision.rb
+++ b/lib/smart_answer_flows/appeal-a-benefits-decision.rb
@@ -76,8 +76,8 @@ end
 date_question :when_did_you_ask_for_it? do
   from { 5.years.ago }
   to { Date.today }
-  calculate :written_explanation_request_date do
-    Date.parse(responses.last).strftime("%e %B %Y")
+  calculate :written_explanation_request_date do |response|
+    Date.parse(response).strftime("%e %B %Y")
   end
   next_node :when_did_you_get_it?
 end
@@ -89,9 +89,9 @@ date_question :when_did_you_get_it? do
   from { 5.years.ago }
   to { Date.today }
 
-  calculate :appeal_expiry_date do
+  calculate :appeal_expiry_date do |response|
     decision_date = Date.parse(decision_letter_date)
-    received_date = Date.parse(responses.last)
+    received_date = Date.parse(response)
     request_date = Date.parse(written_explanation_request_date)
     raise InvalidResponse if received_date < request_date
     received_within_a_month = received_date < 1.month.since(request_date)

--- a/lib/smart_answer_flows/apply-for-probate.rb
+++ b/lib/smart_answer_flows/apply-for-probate.rb
@@ -17,8 +17,8 @@ multiple_choice :inheritance_tax? do
   option :yes
   option :no
 
-  calculate :inheritance_tax do
-    responses.last == "yes"
+  calculate :inheritance_tax do |response|
+    response == "yes"
   end
 
   next_node do
@@ -37,8 +37,8 @@ multiple_choice :amount_left_en_sco? do
 
   save_input_as :amount_left
 
-  calculate :fee_section do
-    if responses.last == "under_five_thousand"
+  calculate :fee_section do |response|
+    if response == "under_five_thousand"
       PhraseList.new(:no_fee)
     else
       PhraseList.new(:fee_info_eng_sco)
@@ -63,8 +63,8 @@ multiple_choice :which_ni_county? do
   option :fermanagh_londonderry_tyrone
   option :antrim_armagh_down
 
-  calculate :where_to_apply do
-    if responses.last == "fermanagh_londonderry_tyrone"
+  calculate :where_to_apply do |response|
+    if response == "fermanagh_londonderry_tyrone"
       PhraseList.new(:apply_in_fermanagh_londonderry_tyrone)
     else
       PhraseList.new(:apply_in_antrim_armagh_down)
@@ -79,8 +79,8 @@ multiple_choice :amount_left_ni? do
   option :under_ten_thousand
   option :ten_thousand_or_more
 
-  calculate :fee_section do
-    if responses.last == "under_ten_thousand"
+  calculate :fee_section do |response|
+    if response == "under_ten_thousand"
       PhraseList.new(:no_fee)
     else
       PhraseList.new(:fee_info_ni)

--- a/lib/smart_answer_flows/apply-tier-4-visa.rb
+++ b/lib/smart_answer_flows/apply-tier-4-visa.rb
@@ -38,14 +38,14 @@ value_question :sponsor_id? do
     Calculators::StaticDataQuery.new("apply_tier_4_visa_data").data
   end
 
-  calculate :sponsor_name do
-    name = data["post"].merge(data["online"])[responses.last]
+  calculate :sponsor_name do |response|
+    name = data["post"].merge(data["online"])[response]
     raise InvalidResponse, :error unless name
     name
   end
 
-  calculate :post_or_online do
-    if data["post"].keys.include?(responses.last)
+  calculate :post_or_online do |response|
+    if data["post"].keys.include?(response)
       "post"
     else
       "online"

--- a/lib/smart_answer_flows/benefit-cap-calculator.rb
+++ b/lib/smart_answer_flows/benefit-cap-calculator.rb
@@ -63,8 +63,8 @@ checkbox_question :receiving_non_exemption_benefits? do
   option :widow_pension
   option :widows_aged
 
-  calculate :benefit_related_questions do
-    questions = responses.last.split(",").map { |r| :"#{r}_amount?" }
+  calculate :benefit_related_questions do |response|
+    questions = response.split(",").map { |r| :"#{r}_amount?" }
     questions << :housing_benefit_amount? if housing_benefit == 'yes'
     questions << :single_couple_lone_parent?
     questions.shift
@@ -92,8 +92,8 @@ end
 #Q5a
 money_question :bereavement_amount? do
 
-  calculate :total_benefits do
-    total_benefits + responses.last.to_f
+  calculate :total_benefits do |response|
+    total_benefits + response.to_f
   end
 
   next_node do
@@ -104,8 +104,8 @@ end
 #Q5b
 money_question :carers_amount? do
 
-  calculate :total_benefits do
-    total_benefits + responses.last.to_f
+  calculate :total_benefits do |response|
+    total_benefits + response.to_f
   end
 
   next_node do
@@ -116,8 +116,8 @@ end
 #Q5c
 money_question :child_benefit_amount? do
 
-  calculate :total_benefits do
-    total_benefits + responses.last.to_f
+  calculate :total_benefits do |response|
+    total_benefits + response.to_f
   end
 
   next_node do
@@ -128,8 +128,8 @@ end
 #Q5d
 money_question :child_tax_amount? do
 
-  calculate :total_benefits do
-    total_benefits + responses.last.to_f
+  calculate :total_benefits do |response|
+    total_benefits + response.to_f
   end
 
   next_node do
@@ -140,8 +140,8 @@ end
 #Q5e
 money_question :esa_amount? do
 
-  calculate :total_benefits do
-    total_benefits + responses.last.to_f
+  calculate :total_benefits do |response|
+    total_benefits + response.to_f
   end
 
   next_node do
@@ -152,8 +152,8 @@ end
 #Q5f
 money_question :guardian_amount? do
 
-  calculate :total_benefits do
-    total_benefits + responses.last.to_f
+  calculate :total_benefits do |response|
+    total_benefits + response.to_f
   end
 
   next_node do
@@ -164,8 +164,8 @@ end
 #Q5g
 money_question :incapacity_amount? do
 
-  calculate :total_benefits do
-    total_benefits + responses.last.to_f
+  calculate :total_benefits do |response|
+    total_benefits + response.to_f
   end
 
   next_node do
@@ -176,8 +176,8 @@ end
 #Q5h
 money_question :income_support_amount? do
 
-  calculate :total_benefits do
-    total_benefits + responses.last.to_f
+  calculate :total_benefits do |response|
+    total_benefits + response.to_f
   end
 
   next_node do
@@ -188,8 +188,8 @@ end
 #Q5i
 money_question :jsa_amount? do
 
-  calculate :total_benefits do
-    total_benefits + responses.last.to_f
+  calculate :total_benefits do |response|
+    total_benefits + response.to_f
   end
 
   next_node do
@@ -200,8 +200,8 @@ end
 #Q5j
 money_question :maternity_amount? do
 
-  calculate :total_benefits do
-    total_benefits + responses.last.to_f
+  calculate :total_benefits do |response|
+    total_benefits + response.to_f
   end
 
   next_node do
@@ -212,8 +212,8 @@ end
 #Q5k
 money_question :sda_amount? do
 
-  calculate :total_benefits do
-    total_benefits + responses.last.to_f
+  calculate :total_benefits do |response|
+    total_benefits + response.to_f
   end
 
   next_node do
@@ -224,8 +224,8 @@ end
 #Q5l
 money_question :widowed_mother_amount? do
 
-  calculate :total_benefits do
-    total_benefits + responses.last.to_f
+  calculate :total_benefits do |response|
+    total_benefits + response.to_f
   end
 
   next_node do
@@ -236,8 +236,8 @@ end
 #Q5m
 money_question :widowed_parent_amount? do
 
-  calculate :total_benefits do
-    total_benefits + responses.last.to_f
+  calculate :total_benefits do |response|
+    total_benefits + response.to_f
   end
 
   next_node do
@@ -248,8 +248,8 @@ end
 #Q5n
 money_question :widow_pension_amount? do
 
-  calculate :total_benefits do
-    total_benefits + responses.last.to_f
+  calculate :total_benefits do |response|
+    total_benefits + response.to_f
   end
 
   next_node do
@@ -260,8 +260,8 @@ end
 #Q5o
 money_question :widows_aged_amount? do
 
-  calculate :total_benefits do
-    total_benefits + responses.last.to_f
+  calculate :total_benefits do |response|
+    total_benefits + response.to_f
   end
 
   next_node do
@@ -274,8 +274,8 @@ money_question :housing_benefit_amount? do
 
   save_input_as :housing_benefit_amount
 
-  calculate :total_benefits do
-    total_benefits + responses.last.to_f
+  calculate :total_benefits do |response|
+    total_benefits + response.to_f
   end
 
   next_node do
@@ -289,8 +289,8 @@ multiple_choice :single_couple_lone_parent? do
   option :couple
   option :parent
 
-  calculate :benefit_cap do
-    if responses.last == 'single'
+  calculate :benefit_cap do |response|
+    if response == 'single'
       benefit_cap = 350
     else
       benefit_cap = 500

--- a/lib/smart_answer_flows/calculate-agricultural-holiday-entitlement.rb
+++ b/lib/smart_answer_flows/calculate-agricultural-holiday-entitlement.rb
@@ -17,10 +17,10 @@ multiple_choice :how_many_days_per_week? do
   option "2-days"
   option "1-day"
 
-  calculate :days_worked_per_week do
+  calculate :days_worked_per_week do |response|
     # XXX: this is a bit nasty and takes advantage of the fact that
     # to_i only looks for the very first integer
-    responses.last.to_i
+    response.to_i
   end
 
   next_node :worked_for_same_employer?
@@ -31,8 +31,8 @@ date_question :what_date_does_holiday_start? do
   to { Date.civil(Date.today.year + 1, 12, 31) }
   save_input_as :holiday_start_date
 
-  calculate :weeks_from_october_1 do
-    calculator.weeks_worked(responses.last)
+  calculate :weeks_from_october_1 do |response|
+    calculator.weeks_worked(response)
   end
 
   next_node :how_many_total_days?
@@ -42,8 +42,8 @@ multiple_choice :worked_for_same_employer? do
   option "same-employer" => :done
   option "multiple-employers" => :how_many_weeks_at_current_employer?
 
-  calculate :holiday_entitlement_days do
-    if responses.last == 'same-employer'
+  calculate :holiday_entitlement_days do |response|
+    if response == 'same-employer'
       # This is calculated as a flat number based on the days you work
       # per week
       if !days_worked_per_week.nil?
@@ -63,11 +63,11 @@ value_question :how_many_total_days? do
     calculator.available_days
   end
 
-  calculate :total_days_worked do
-    if Integer(responses.last) > available_days
+  calculate :total_days_worked do |response|
+    if Integer(response) > available_days
       raise SmartAnswer::InvalidResponse
     end
-    responses.last
+    response
   end
 
   next_node :worked_for_same_employer?
@@ -76,9 +76,9 @@ end
 value_question :how_many_weeks_at_current_employer? do
   next_node :done
 
-  calculate :holiday_entitlement_days do
+  calculate :holiday_entitlement_days do |response|
     #Has to be less than a full year
-    if (Integer(responses.last) > 51)
+    if (Integer(response) > 51)
       raise SmartAnswer::InvalidResponse
     end
     if !days_worked_per_week.nil?
@@ -86,7 +86,7 @@ value_question :how_many_weeks_at_current_employer? do
     elsif !weeks_from_october_1.nil?
       days = calculator.holiday_days (total_days_worked.to_f / weeks_from_october_1.to_f).round(10)
     end
-    sprintf("%.1f", (days * (Integer(responses.last) / 52.0)).round(10))
+    sprintf("%.1f", (days * (Integer(response) / 52.0)).round(10))
   end
 end
 

--- a/lib/smart_answer_flows/calculate-married-couples-allowance.rb
+++ b/lib/smart_answer_flows/calculate-married-couples-allowance.rb
@@ -24,8 +24,8 @@ multiple_choice :did_you_marry_or_civil_partner_before_5_december_2005? do
   option yes: :whats_the_husbands_date_of_birth?
   option no: :whats_the_highest_earners_date_of_birth?
 
-  calculate :income_measure do
-    case responses.last
+  calculate :income_measure do |response|
+    case response
     when 'yes' then "husband"
     when 'no' then "highest earner"
     else
@@ -53,8 +53,8 @@ end
 money_question :whats_the_husbands_income? do
   save_input_as :income
 
-  calculate :income_greater_than_0 do
-    raise SmartAnswer::InvalidResponse if responses.last < 1
+  calculate :income_greater_than_0 do |response|
+    raise SmartAnswer::InvalidResponse if response < 1
   end
 
   next_node do |response|
@@ -70,8 +70,8 @@ end
 money_question :whats_the_highest_earners_income? do
   save_input_as :income
 
-  calculate :income_greater_than_0 do
-    raise SmartAnswer::InvalidResponse if responses.last < 1
+  calculate :income_greater_than_0 do |response|
+    raise SmartAnswer::InvalidResponse if response < 1
   end
 
   next_node do |response|
@@ -102,8 +102,8 @@ money_question :how_much_expected_contributions_with_tax_relief? do
 end
 
 money_question :how_much_expected_gift_aided_donations? do
-  calculate :income do
-    calculator.calculate_adjusted_net_income(income.to_f, (gross_pension_contributions.to_f || 0), (net_pension_contributions.to_f || 0), responses.last)
+  calculate :income do |response|
+    calculator.calculate_adjusted_net_income(income.to_f, (gross_pension_contributions.to_f || 0), (net_pension_contributions.to_f || 0), response)
   end
 
   next_node do |response|

--- a/lib/smart_answer_flows/calculate-state-pension.rb
+++ b/lib/smart_answer_flows/calculate-state-pension.rb
@@ -24,8 +24,8 @@ multiple_choice :gender? do
   option :female
 
   # optional text to include in a hint for a later question
-  calculate :if_married_woman do
-    if responses.last.eql? 'female'
+  calculate :if_married_woman do |response|
+    if response.eql? 'female'
       PhraseList.new(:married_woman_text)
     else
       ''
@@ -223,18 +223,18 @@ value_question :years_paid_ni? do
     end
   end
 
-  calculate :qualifying_years do
-    ni_years = Integer(responses.last)
+  calculate :qualifying_years do |response|
+    ni_years = Integer(response)
     raise InvalidResponse if ni_years < 0 or ni_years > ni_years_to_date_from_dob
     ni_years
   end
 
-  calculate :available_ni_years do
-    calculator.available_years_sum(Integer(responses.last))
+  calculate :available_ni_years do |response|
+    calculator.available_years_sum(Integer(response))
   end
 
-  calculate :ni_years_to_date_from_dob do
-    ni_years_to_date_from_dob - responses.last.to_i
+  calculate :ni_years_to_date_from_dob do |response|
+    ni_years_to_date_from_dob - response.to_i
   end
 
   define_predicate(:enough_years_credits_or_no_more_years?) do |response|
@@ -260,8 +260,8 @@ value_question :years_of_jsa? do
     end
   end
 
-  calculate :qualifying_years do
-    jsa_years = Integer(responses.last)
+  calculate :qualifying_years do |response|
+    jsa_years = Integer(response)
     qy = (qualifying_years + jsa_years)
     raise InvalidResponse if jsa_years < 0 or !(calculator.has_available_years?(qy)) #jsa_years > available_ni_years #70
     qy
@@ -271,8 +271,8 @@ value_question :years_of_jsa? do
     calculator.available_years_sum(qualifying_years)
   end
 
-  calculate :ni_years_to_date_from_dob do
-    ni_years_to_date_from_dob - responses.last.to_i
+  calculate :ni_years_to_date_from_dob do |response|
+    ni_years_to_date_from_dob - response.to_i
   end
 
   next_node_calculation :ni do |response|
@@ -327,12 +327,12 @@ value_question :years_of_benefit? do
     calculator.years_can_be_entered(available_ni_years, 22)
   end
 
-  calculate :ni_years_to_date_from_dob do
-    ni_years_to_date_from_dob - responses.last.to_i
+  calculate :ni_years_to_date_from_dob do |response|
+    ni_years_to_date_from_dob - response.to_i
   end
 
-  calculate :qualifying_years do
-    benefit_years = Integer(responses.last)
+  calculate :qualifying_years do |response|
+    benefit_years = Integer(response)
     qy = (benefit_years + qualifying_years)
     if benefit_years > 22 and calculator.has_available_years?(qy)
       raise InvalidResponse, :error_maximum_hrp_years
@@ -378,8 +378,8 @@ value_question :years_of_caring? do
     calculator.years_can_be_entered(available_ni_years, allowed_caring_years)
   end
 
-  calculate :qualifying_years do
-    caring_years = Integer(responses.last)
+  calculate :qualifying_years do |response|
+    caring_years = Integer(response)
     qy = (caring_years + qualifying_years)
     raise InvalidResponse if (caring_years < 0 or (caring_years > allowed_caring_years) or !(calculator.has_available_years?(qy)))
     qy
@@ -389,8 +389,8 @@ value_question :years_of_caring? do
     calculator.available_years_sum(qualifying_years)
   end
 
-  calculate :ni_years_to_date_from_dob do
-    ni_years_to_date_from_dob - responses.last.to_i
+  calculate :ni_years_to_date_from_dob do |response|
+    ni_years_to_date_from_dob - response.to_i
   end
 
   next_node_calculation :ni do |response|
@@ -413,15 +413,15 @@ end
 
 ## Q9
 value_question :years_of_carers_allowance? do
-  calculate :qualifying_years do
-    caring_years = Integer(responses.last)
+  calculate :qualifying_years do |response|
+    caring_years = Integer(response)
     qy = (caring_years + qualifying_years)
     raise InvalidResponse if caring_years < 0 or !(calculator.has_available_years?(qy))
     qy
   end
 
-  calculate :ni_years_to_date_from_dob do
-    ni_years_to_date_from_dob - responses.last.to_i
+  calculate :ni_years_to_date_from_dob do |response|
+    ni_years_to_date_from_dob - response.to_i
   end
 
   next_node_calculation :ni do |response|
@@ -449,12 +449,12 @@ end
 value_question :years_of_work? do
   save_input_as :years_of_work_entered
 
-  calculate :ni_years_to_date_from_dob do
-    calculator.ni_years_to_date_from_dob - Integer(responses.last)
+  calculate :ni_years_to_date_from_dob do |response|
+    calculator.ni_years_to_date_from_dob - Integer(response)
   end
 
-  calculate :qualifying_years do
-    work_years = Integer(responses.last)
+  calculate :qualifying_years do |response|
+    work_years = Integer(response)
     qy = (work_years + qualifying_years)
     raise InvalidResponse if (work_years < 0 or work_years > 3)
     qy

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -13,8 +13,8 @@ checkbox_question :is_your_employee_getting? do
     # this avoids lots of content duplication in the YML
     PhraseList.new(:ssp_link)
   end
-  calculate :paternity_maternity_warning do
-    (responses.last.split(",") & %w{ordinary_statutory_paternity_pay additional_statutory_paternity_pay statutory_adoption_pay}).any?
+  calculate :paternity_maternity_warning do |response|
+    (response.split(",") & %w{ordinary_statutory_paternity_pay additional_statutory_paternity_pay statutory_adoption_pay}).any?
   end
   next_node_if(:employee_tell_within_limit?,
     response_is_one_of(%w{ordinary_statutory_paternity_pay additional_statutory_paternity_pay statutory_adoption_pay none}))
@@ -26,8 +26,8 @@ multiple_choice :employee_tell_within_limit? do
   option :yes
   option :no
 
-  calculate :enough_notice_of_absence do
-    responses.last == 'yes'
+  calculate :enough_notice_of_absence do |response|
+    response == 'yes'
   end
 
   next_node(:employee_work_different_days?)
@@ -43,8 +43,8 @@ end
 date_question :first_sick_day? do
   from { Date.new(2011, 1, 1) }
   to { Date.today }
-  calculate :sick_start_date do
-    Date.parse(responses.last).strftime("%e %B %Y")
+  calculate :sick_start_date do |response|
+    Date.parse(response).strftime("%e %B %Y")
   end
 
   next_node :last_sick_day?
@@ -55,8 +55,8 @@ end
 date_question :last_sick_day? do
   from { Date.new(2011, 1, 1) }
   to { Date.today }
-  calculate :sick_end_date do
-    Date.parse(responses.last).strftime("%e %B %Y")
+  calculate :sick_end_date do |response|
+    Date.parse(response).strftime("%e %B %Y")
   end
 
   next_node_calculation(:days_sick) do |response|
@@ -97,8 +97,8 @@ date_question :last_payday_before_sickness? do
   from { Date.new(2010, 1, 1) }
   to { Date.today }
 
-  calculate :relevant_period_to do
-    Date.parse(responses.last).strftime("%e %B %Y")
+  calculate :relevant_period_to do |response|
+    Date.parse(response).strftime("%e %B %Y")
   end
 
   calculate :pay_day_offset do
@@ -124,8 +124,8 @@ date_question :last_payday_before_offset? do
   validate { |payday| Date.parse(payday) <= Date.parse(pay_day_offset) }
 
   # input plus 1 day = relevant_period_from
-  calculate :relevant_period_from do
-    (Date.parse(responses.last) + 1.day).strftime("%e %B %Y")
+  calculate :relevant_period_from do |response|
+    (Date.parse(response) + 1.day).strftime("%e %B %Y")
   end
 
   calculate :monthly_pattern_payments do
@@ -161,9 +161,9 @@ end
 value_question :contractual_days_covered_by_earnings? do
   save_input_as :contractual_earnings_days
 
-  calculate :employee_average_weekly_earnings do
+  calculate :employee_average_weekly_earnings do |response|
     pay = relevant_contractual_pay
-    days_worked = responses.last
+    days_worked = response
     Calculators::StatutorySickPayCalculator.contractual_earnings_awe(pay, days_worked)
   end
   next_node :off_sick_4_days?
@@ -179,9 +179,9 @@ end
 # Question 8.1
 value_question :days_covered_by_earnings? do
 
-  calculate :employee_average_weekly_earnings do
+  calculate :employee_average_weekly_earnings do |response|
     pay = earnings
-    days_worked = responses.last.to_i
+    days_worked = response.to_i
     Calculators::StatutorySickPayCalculator.total_earnings_awe(pay, days_worked)
   end
 
@@ -224,8 +224,8 @@ checkbox_question :usual_work_days? do
     Money.new(calculator.ssp_payment)
   end
 
-  calculate :formatted_sick_pay_weekly_amounts do
-    calculator = Calculators::StatutorySickPayCalculator.new(prior_sick_days.to_i, Date.parse(sick_start_date), Date.parse(sick_end_date), responses.last.split(","))
+  calculate :formatted_sick_pay_weekly_amounts do |response|
+    calculator = Calculators::StatutorySickPayCalculator.new(prior_sick_days.to_i, Date.parse(sick_start_date), Date.parse(sick_end_date), response.split(","))
 
     if calculator.ssp_payment > 0
       calculator.formatted_sick_pay_weekly_amounts

--- a/lib/smart_answer_flows/calculate-your-child-maintenance.rb
+++ b/lib/smart_answer_flows/calculate-your-child-maintenance.rb
@@ -16,8 +16,8 @@ multiple_choice :are_you_paying_or_receiving? do
       PhraseList.new(:"#{paying_or_receiving}_collect_and_pay_service")
     end
 
-  calculate :enforcement_charge do
-    if responses.last == "pay"
+  calculate :enforcement_charge do |response|
+    if response == "pay"
       PhraseList.new(:enforcement_charge)
     end
   end
@@ -39,9 +39,9 @@ multiple_choice :how_many_children_paid_for? do
     PhraseList.new(:"#{paying_or_receiving}_hint")
   end
 
-  calculate :number_of_children do
+  calculate :number_of_children do |response|
     ## to_i will look for the first integer in the string
-    responses.last.to_i
+    response.to_i
   end
 
   next_node :gets_benefits?
@@ -89,11 +89,11 @@ value_question :how_many_other_children_in_payees_household? do
     PhraseList.new(:"#{paying_or_receiving}_number_of_children")
   end
 
-  calculate :calculator do
+  calculate :calculator do |response|
     # if converting to int messes things up, raise invalid response
     # this deals with nil input through the API
-    raise SmartAnswer::InvalidResponse if responses.last.to_i.to_s != responses.last
-    calculator.number_of_other_children = responses.last.to_i
+    raise SmartAnswer::InvalidResponse if response.to_i.to_s != response
+    calculator.number_of_other_children = response.to_i
     calculator
   end
   next_node :how_many_nights_children_stay_with_payee?
@@ -111,8 +111,8 @@ multiple_choice :how_many_nights_children_stay_with_payee? do
     PhraseList.new(:"#{paying_or_receiving}_how_many_nights")
   end
 
-  calculate :child_maintenance_payment do
-    calculator.number_of_shared_care_nights = responses.last.to_i
+  calculate :child_maintenance_payment do |response|
+    calculator.number_of_shared_care_nights = response.to_i
     sprintf("%.0f", calculator.calculate_maintenance_payment)
   end
 

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
@@ -34,8 +34,8 @@ end
 
 # Q3
 value_question :how_many_days_per_week? do
-  calculate :days_per_week do
-    days_per_week = Float(responses.last)
+  calculate :days_per_week do |response|
+    days_per_week = Float(response)
     raise InvalidResponse if days_per_week <= 0 or days_per_week > 7
     days_per_week
   end
@@ -84,7 +84,7 @@ date_question :what_is_your_leaving_date? do
   to { Date.civil(1.year.since(Date.today).year, 12, 31) }
   save_input_as :leaving_date
 
-  next_node do |response|
+  next_node do
     if holiday_period == "starting-and-leaving"
       case calculation_basis
       when "days-worked-per-week"
@@ -105,7 +105,7 @@ date_question :when_does_your_leave_year_start? do
   from { Date.civil(1.year.ago.year, 1, 1) }
   to { Date.civil(1.year.since(Date.today).year, 12, 31) }
   save_input_as :leave_year_start_date
-  next_node do |response|
+  next_node do
     case calculation_basis
     when "days-worked-per-week"
       :how_many_days_per_week?
@@ -119,9 +119,9 @@ end
 
 # Q10
 value_question :how_many_hours_per_week? do
-  calculate :calculator do
+  calculate :calculator do |response|
     Calculators::HolidayEntitlement.new(
-      hours_per_week: Float(responses.last),
+      hours_per_week: Float(response),
       start_date: start_date,
       leaving_date: leaving_date,
       leave_year_start_date: leave_year_start_date
@@ -143,8 +143,8 @@ value_question :how_many_hours_per_week? do
 end
 
 value_question :casual_or_irregular_hours? do
-  calculate :total_hours do
-    hours = Float(responses.last)
+  calculate :total_hours do |response|
+    hours = Float(response)
     raise InvalidResponse if hours <= 0
     hours
   end
@@ -164,8 +164,8 @@ value_question :casual_or_irregular_hours? do
 end
 
 value_question :annualised_hours? do
-  calculate :total_hours do
-    hours = Float(responses.last)
+  calculate :total_hours do |response|
+    hours = Float(response)
     raise InvalidResponse if hours <= 0
     hours
   end
@@ -188,8 +188,8 @@ value_question :annualised_hours? do
 end
 
 value_question :compressed_hours_how_many_hours_per_week? do
-  calculate :hours_per_week do
-    hours = Float(responses.last)
+  calculate :hours_per_week do |response|
+    hours = Float(response)
     raise InvalidResponse if hours <= 0 or hours > 168
     hours
   end
@@ -197,8 +197,8 @@ value_question :compressed_hours_how_many_hours_per_week? do
 end
 
 value_question :compressed_hours_how_many_days_per_week? do
-  calculate :days_per_week do
-    days = Float(responses.last)
+  calculate :days_per_week do |response|
+    days = Float(response)
     raise InvalidResponse if days <= 0 or days > 7
     days
   end
@@ -235,8 +235,8 @@ multiple_choice :shift_worker_basis? do
 end
 
 value_question :shift_worker_hours_per_shift? do
-  calculate :hours_per_shift do
-    hours_per_shift = Float(responses.last)
+  calculate :hours_per_shift do |response|
+    hours_per_shift = Float(response)
     raise InvalidResponse if hours_per_shift <= 0
     hours_per_shift
   end
@@ -244,8 +244,8 @@ value_question :shift_worker_hours_per_shift? do
 end
 
 value_question :shift_worker_shifts_per_shift_pattern? do
-  calculate :shifts_per_shift_pattern do
-    shifts = Integer(responses.last)
+  calculate :shifts_per_shift_pattern do |response|
+    shifts = Integer(response)
     raise InvalidResponse if shifts <= 0
     shifts
   end
@@ -253,8 +253,8 @@ value_question :shift_worker_shifts_per_shift_pattern? do
 end
 
 value_question :shift_worker_days_per_shift_pattern? do
-  calculate :days_per_shift_pattern do
-    days = Float(responses.last)
+  calculate :days_per_shift_pattern do |response|
+    days = Float(response)
     raise InvalidResponse if days < shifts_per_shift_pattern
     days
   end

--- a/lib/smart_answer_flows/check-uk-visa-v2.rb
+++ b/lib/smart_answer_flows/check-uk-visa-v2.rb
@@ -42,10 +42,10 @@ multiple_choice :purpose_of_visit? do
   option diplomatic: :outcome_diplomatic_business
   save_input_as :purpose_of_visit_answer
 
-  calculate :reason_of_staying do
-    if responses.last == 'study'
+  calculate :reason_of_staying do |response|
+    if response == 'study'
       PhraseList.new(:study_reason)
-    elsif responses.last == 'work'
+    elsif response == 'work'
       PhraseList.new(:work_reason)
     end
   end

--- a/lib/smart_answer_flows/check-uk-visa.rb
+++ b/lib/smart_answer_flows/check-uk-visa.rb
@@ -42,10 +42,10 @@ multiple_choice :purpose_of_visit? do
   option diplomatic: :outcome_diplomatic_business
   save_input_as :purpose_of_visit_answer
 
-  calculate :reason_of_staying do
-    if responses.last == 'study'
+  calculate :reason_of_staying do |response|
+    if response == 'study'
       PhraseList.new(:study_reason)
-    elsif responses.last == 'work'
+    elsif response == 'work'
       PhraseList.new(:work_reason)
     end
   end

--- a/lib/smart_answer_flows/childcare-costs-for-tax-credits.rb
+++ b/lib/smart_answer_flows/childcare-costs-for-tax-credits.rb
@@ -41,24 +41,24 @@ end
 
 #Q6
 money_question :how_much_12_months_1? do
-  calculate :weekly_cost do
-    SmartAnswer::Calculators::ChildcareCostCalculator.weekly_cost(responses.last)
+  calculate :weekly_cost do |response|
+    SmartAnswer::Calculators::ChildcareCostCalculator.weekly_cost(response)
   end
   next_node :weekly_costs_are_x #O4
 end
 
 #Q7
 money_question :how_much_52_weeks_1? do
-  calculate :weekly_cost do
-    SmartAnswer::Calculators::ChildcareCostCalculator.weekly_cost(responses.last)
+  calculate :weekly_cost do |response|
+    SmartAnswer::Calculators::ChildcareCostCalculator.weekly_cost(response)
   end
   next_node :weekly_costs_are_x #O4
 end
 
 #Q8
 money_question :how_much_52_weeks_2? do
-  calculate :weekly_cost do
-    SmartAnswer::Calculators::ChildcareCostCalculator.weekly_cost(responses.last)
+  calculate :weekly_cost do |response|
+    SmartAnswer::Calculators::ChildcareCostCalculator.weekly_cost(response)
   end
 
   next_node do |response|
@@ -69,8 +69,8 @@ end
 
 #Q9
 money_question :how_much_12_months_2? do
-  calculate :weekly_cost do
-    SmartAnswer::Calculators::ChildcareCostCalculator.weekly_cost(responses.last)
+  calculate :weekly_cost do |response|
+    SmartAnswer::Calculators::ChildcareCostCalculator.weekly_cost(response)
   end
   next_node do |response|
     amount = Money.new(response)
@@ -80,8 +80,8 @@ end
 
 #Q10
 money_question :how_much_each_month? do
-  calculate :weekly_cost do
-    SmartAnswer::Calculators::ChildcareCostCalculator.weekly_cost_from_monthly(responses.last)
+  calculate :weekly_cost do |response|
+    SmartAnswer::Calculators::ChildcareCostCalculator.weekly_cost_from_monthly(response)
   end
   next_node :weekly_costs_are_x #O4
 end
@@ -105,8 +105,8 @@ end
 
 #Q13
 money_question :how_much_fortnightly? do
-  calculate :weekly_cost do
-    SmartAnswer::Calculators::ChildcareCostCalculator.weekly_cost_from_fortnightly(responses.last)
+  calculate :weekly_cost do |response|
+    SmartAnswer::Calculators::ChildcareCostCalculator.weekly_cost_from_fortnightly(response)
   end
 
   next_node :weekly_costs_are_x #O4
@@ -114,32 +114,32 @@ end
 
 #Q14
 money_question :how_much_4_weeks? do
-  calculate :weekly_cost do
-    SmartAnswer::Calculators::ChildcareCostCalculator.weekly_cost_from_four_weekly(responses.last)
+  calculate :weekly_cost do |response|
+    SmartAnswer::Calculators::ChildcareCostCalculator.weekly_cost_from_four_weekly(response)
   end
   next_node :weekly_costs_are_x #04
 end
 
 #Q15
 money_question :how_much_yearly? do
-  calculate :weekly_cost do
-    SmartAnswer::Calculators::ChildcareCostCalculator.weekly_cost(responses.last)
+  calculate :weekly_cost do |response|
+    SmartAnswer::Calculators::ChildcareCostCalculator.weekly_cost(response)
   end
   next_node :weekly_costs_are_x #O4
 end
 
 #Q16
 money_question :how_much_spent_last_12_months? do
-  calculate :weekly_cost do
-    SmartAnswer::Calculators::ChildcareCostCalculator.weekly_cost(responses.last)
+  calculate :weekly_cost do |response|
+    SmartAnswer::Calculators::ChildcareCostCalculator.weekly_cost(response)
   end
   next_node :weekly_costs_are_x #O4
 end
 
 #Q17
 money_question :new_weekly_costs? do
-  calculate :new_weekly_costs do
-    Float(responses.last).ceil
+  calculate :new_weekly_costs do |response|
+    Float(response).ceil
   end
   next_node do |response|
     amount = Money.new(response)
@@ -151,8 +151,8 @@ end
 money_question :old_weekly_amount_1? do
   # get weekly amount from Q8 or Q9 (whichever the user answered)
   # calculate different using input from Q18
-  calculate :old_weekly_cost do
-    Float(responses.last).ceil
+  calculate :old_weekly_cost do |response|
+    Float(response).ceil
   end
 
   calculate :weekly_difference do
@@ -168,8 +168,8 @@ end
 
 #Q19
 money_question :new_monthly_cost? do
-  calculate :new_weekly_costs do
-    SmartAnswer::Calculators::ChildcareCostCalculator.weekly_cost_from_monthly(responses.last)
+  calculate :new_weekly_costs do |response|
+    SmartAnswer::Calculators::ChildcareCostCalculator.weekly_cost_from_monthly(response)
   end
 
   next_node do |response|
@@ -180,8 +180,8 @@ end
 
 #Q20
 money_question :old_weekly_amount_2? do
-  calculate :old_weekly_costs do
-    Float(responses.last).ceil
+  calculate :old_weekly_costs do |response|
+    Float(response).ceil
   end
 
   calculate :weekly_difference do
@@ -199,8 +199,8 @@ end
 
 #Q21
 money_question :old_weekly_amount_3? do
-  calculate :old_weekly_costs do
-    Float(responses.last).ceil
+  calculate :old_weekly_costs do |response|
+    Float(response).ceil
   end
 
   calculate :weekly_difference do

--- a/lib/smart_answer_flows/energy-grants-calculator.rb
+++ b/lib/smart_answer_flows/energy-grants-calculator.rb
@@ -9,14 +9,14 @@ multiple_choice :what_are_you_looking_for? do
   option :all_help
   save_input_as :which_help
 
-  calculate :bills_help do
-    %w(help_with_fuel_bill).include?(responses.last) ? :bills_help : nil
+  calculate :bills_help do |response|
+    %w(help_with_fuel_bill).include?(response) ? :bills_help : nil
   end
-  calculate :measure_help do
-    %w(help_energy_efficiency help_boiler_measure).include?(responses.last) ? :measure_help : nil
+  calculate :measure_help do |response|
+    %w(help_energy_efficiency help_boiler_measure).include?(response) ? :measure_help : nil
   end
-  calculate :both_help do
-    %w(all_help).include?(responses.last) ? :both_help : nil
+  calculate :both_help do |response|
+    %w(all_help).include?(response) ? :both_help : nil
   end
 
   calculate :warm_home_discount_amount do
@@ -38,8 +38,8 @@ checkbox_question :what_are_your_circumstances? do
   option :permission
   option :social_housing
 
-  calculate :circumstances do
-    responses.last.split(",")
+  calculate :circumstances do |response|
+    response.split(",")
   end
 
   calculate :benefits_claimed do
@@ -68,8 +68,8 @@ checkbox_question :what_are_your_circumstances_without_bills_help? do
   option :property
   option :permission
 
-  calculate :circumstances do
-    responses.last.split(",")
+  calculate :circumstances do |response|
+    response.split(",")
   end
 
   calculate :benefits_claimed do
@@ -94,8 +94,8 @@ date_question :date_of_birth? do
   from { 100.years.ago }
   to { Date.today }
 
-  calculate :age_variant do
-    dob = Date.parse(responses.last)
+  calculate :age_variant do |response|
+    dob = Date.parse(response)
     if dob < Date.new(1951, 7, 5)
       :winter_fuel_payment
     elsif dob < 60.years.ago(Date.today + 1)
@@ -117,11 +117,11 @@ checkbox_question :which_benefits? do
   option :child_tax_credit
   option :working_tax_credit
 
-  calculate :benefits_claimed do
-    responses.last.split(",")
+  calculate :benefits_claimed do |response|
+    response.split(",")
   end
-  calculate :incomesupp_jobseekers_2 do
-    if %w(working_tax_credit).include?(responses.last)
+  calculate :incomesupp_jobseekers_2 do |response|
+    if %w(working_tax_credit).include?(response)
       if age_variant == :over_60
         :incomesupp_jobseekers_2
       end
@@ -156,14 +156,14 @@ checkbox_question :disabled_or_have_children? do
   option :pensioner_premium
   option :work_support_esa
 
-  calculate :incomesupp_jobseekers_1 do
-    case responses.last
+  calculate :incomesupp_jobseekers_1 do |response|
+    case response
     when 'disabled', 'disabled_child', 'child_under_5', 'pensioner_premium'
       :incomesupp_jobseekers_1
     end
   end
-  calculate :incomesupp_jobseekers_2 do
-    case responses.last
+  calculate :incomesupp_jobseekers_2 do |response|
+    case response
     when 'child_under_16', 'work_support_esa'
       if circumstances.include?('social_housing') || (benefits_claimed.include?('working_tax_credit') && age_variant != :over_60)
         nil
@@ -184,14 +184,14 @@ multiple_choice :when_property_built? do
   option :"before-1940"
   save_input_as :property_age
 
-  calculate :modern do
-    %w(on-or-after-1995).include?(responses.last)
+  calculate :modern do |response|
+    %w(on-or-after-1995).include?(response)
   end
-  calculate :older do
-    %w(1940s-1984).include?(responses.last)
+  calculate :older do |response|
+    %w(1940s-1984).include?(response)
   end
-  calculate :historic do
-    %w(before-1940).include?(responses.last)
+  calculate :historic do |response|
+    %w(before-1940).include?(response)
   end
 
   next_node :type_of_property?
@@ -229,8 +229,8 @@ checkbox_question :home_features_modern? do
   option :loft_attic_conversion
   option :draught_proofing
 
-  calculate :features do
-    responses.last.split(",")
+  calculate :features do |response|
+    response.split(",")
   end
 
   define_predicate(:modern_and_gas_and_electric_heating?) do |response|
@@ -272,8 +272,8 @@ checkbox_question :home_features_historic? do
   option :modern_boiler
   option :draught_proofing
 
-  calculate :features do
-    responses.last.split(",")
+  calculate :features do |response|
+    response.split(",")
   end
 
   define_predicate(:measure_help_and_property_permission_circumstance?) do
@@ -311,8 +311,8 @@ checkbox_question :home_features_older? do
   option :modern_boiler
   option :draught_proofing
 
-  calculate :features do
-    responses.last.split(",")
+  calculate :features do |response|
+    response.split(",")
   end
 
   define_predicate(:measure_help_and_property_permission_circumstance?) do

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
@@ -26,10 +26,10 @@ multiple_choice :which_year? do
 
   save_input_as :tax_year
 
-  calculate :start_of_next_tax_year do
-    if responses.last == '2011-12'
+  calculate :start_of_next_tax_year do |response|
+    if response == '2011-12'
       Date.new(2012, 4, 6)
-    elsif responses.last == '2012-13'
+    elsif response == '2012-13'
       Date.new(2013, 4, 6)
     else
       Date.new(2014, 4, 6)
@@ -39,10 +39,10 @@ multiple_choice :which_year? do
     start_of_next_tax_year.strftime("%e %B %Y")
   end
 
-  calculate :one_year_after_start_date_for_penalties do
-    if responses.last == '2011-12'
+  calculate :one_year_after_start_date_for_penalties do |response|
+    if response == '2011-12'
       Date.new(2014, 2, 01)
-    elsif responses.last == '2012-13'
+    elsif response == '2012-13'
       Date.new(2015, 2, 01)
     else
       Date.new(2016, 2, 01)
@@ -106,12 +106,12 @@ end
 money_question :how_much_tax? do
   save_input_as :estimated_bill
 
-  calculate :calculator do
+  calculate :calculator do |response|
     Calculators::SelfAssessmentPenalties.new(
       submission_method: submission_method,
       filing_date: filing_date,
       payment_date: payment_date,
-      estimated_bill: responses.last,
+      estimated_bill: response,
       dates: calculator_dates,
       tax_year: tax_year
     )

--- a/lib/smart_answer_flows/legalisation-document-checker.rb
+++ b/lib/smart_answer_flows/legalisation-document-checker.rb
@@ -68,9 +68,9 @@ checkbox_question :which_documents_do_you_want_legalised? do
   option "translation"
   option "utility-bill"
 
-  calculate :choices do
-    raise InvalidResponse if responses.last == 'none'
-    responses.last.split(',')
+  calculate :choices do |response|
+    raise InvalidResponse if response == 'none'
+    response.split(',')
   end
 
   next_node :outcome_results

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -204,16 +204,16 @@ multiple_choice :partner_opposite_or_same_sex? do
 
   save_input_as :sex_of_your_partner
 
-  calculate :ceremony_type do
-    if responses.last == 'opposite_sex'
+  calculate :ceremony_type do |response|
+    if response == 'opposite_sex'
       PhraseList.new(:ceremony_type_marriage)
     else
       PhraseList.new(:ceremony_type_civil_partnership)
     end
   end
 
-  calculate :ceremony_type_lowercase do
-    if responses.last == 'opposite_sex'
+  calculate :ceremony_type_lowercase do |response|
+    if response == 'opposite_sex'
       "marriage"
     else
       "civil partnership"

--- a/lib/smart_answer_flows/overseas-passports.rb
+++ b/lib/smart_answer_flows/overseas-passports.rb
@@ -54,8 +54,8 @@ multiple_choice :renewing_replacing_applying? do
     end
   end
 
-  calculate :general_action do
-    responses.last =~ /^renewing_/ ? 'renewing' : responses.last
+  calculate :general_action do |response|
+    response =~ /^renewing_/ ? 'renewing' : response
   end
 
   calculate :passport_data do
@@ -120,11 +120,11 @@ multiple_choice :child_or_adult_passport? do
 
   save_input_as :child_or_adult
 
-  calculate :fco_forms do
+  calculate :fco_forms do |response|
     if %w(nigeria).include?(current_location)
-      PhraseList.new(:"#{responses.last}_fco_forms_nigeria")
+      PhraseList.new(:"#{response}_fco_forms_nigeria")
     else
-      PhraseList.new(:"#{responses.last}_fco_forms")
+      PhraseList.new(:"#{response}_fco_forms")
     end
   end
 
@@ -141,12 +141,12 @@ end
 country_select :country_of_birth?, include_uk: true, exclude_countries: exclude_countries do
   save_input_as :birth_location
 
-  calculate :application_group do
-    data_query.find_passport_data(responses.last)['group']
+  calculate :application_group do |response|
+    data_query.find_passport_data(response)['group']
   end
 
-  calculate :supporting_documents do
-    responses.last == 'united-kingdom' ? supporting_documents : application_group
+  calculate :supporting_documents do |response|
+    response == 'united-kingdom' ? supporting_documents : application_group
   end
 
   calculate :ips_docs_number do

--- a/lib/smart_answer_flows/pip-checker.rb
+++ b/lib/smart_answer_flows/pip-checker.rb
@@ -11,8 +11,8 @@ multiple_choice :are_you_getting_dla? do
     Calculators::PIPDates.new
   end
 
-  calculate :getting_dla do
-    responses.last == 'yes'
+  calculate :getting_dla do |response|
+    response == 'yes'
   end
 
   calculate :postcodes do

--- a/lib/smart_answer_flows/plan-adoption-leave.rb
+++ b/lib/smart_answer_flows/plan-adoption-leave.rb
@@ -8,19 +8,19 @@ date_question :child_match_date? do
 end
 
 date_question :child_arrival_date? do
-  calculate :arrival_date do
-    raise InvalidResponse if Date.parse(responses.last) <= Date.parse(match_date)
-    responses.last
+  calculate :arrival_date do |response|
+    raise InvalidResponse if Date.parse(response) <= Date.parse(match_date)
+    response
   end
 
   next_node :leave_start?
 end
 
 date_question :leave_start? do
-  calculate :start_date do
-    dist = (Date.parse(arrival_date) - Date.parse(responses.last)).to_i
+  calculate :start_date do |response|
+    dist = (Date.parse(arrival_date) - Date.parse(response)).to_i
     raise InvalidResponse unless (1..14).include? dist
-    responses.last
+    response
   end
 
   calculate :calculator do

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -11,8 +11,8 @@ exclude_countries = %w(holy-see british-antarctic-territory)
 country_select :country_of_birth?, exclude_countries: exclude_countries do
   save_input_as :country_of_birth
 
-  calculate :registration_country do
-    reg_data_query.registration_country_slug(responses.last)
+  calculate :registration_country do |response|
+    reg_data_query.registration_country_slug(response)
   end
 
   calculate :registration_country_name_lowercase_prefix do
@@ -47,8 +47,8 @@ multiple_choice :married_couple_or_civil_partnership? do
   option :yes
   option :no
 
-  calculate :paternity_declaration do
-    responses.last == 'no'
+  calculate :paternity_declaration do |response|
+    response == 'no'
   end
 
   next_node_if(:childs_date_of_birth?, responded_with('no'), variable_matches(:british_national_parent, 'father'))
@@ -75,16 +75,16 @@ multiple_choice :where_are_you_now? do
   option :another_country
   option :in_the_uk
 
-  calculate :same_country do
-    responses.last == 'same_country'
+  calculate :same_country do |response|
+    response == 'same_country'
   end
 
-  calculate :another_country do
-    responses.last == 'another_country'
+  calculate :another_country do |response|
+    response == 'another_country'
   end
 
-  calculate :in_the_uk do
-    responses.last == 'in_the_uk'
+  calculate :in_the_uk do |response|
+    response == 'in_the_uk'
   end
 
   define_predicate(:no_birth_certificate_exception) {
@@ -103,8 +103,8 @@ end
 
 # Q6
 country_select :which_country?, exclude_countries: exclude_countries do
-  calculate :registration_country do
-    reg_data_query.registration_country_slug(responses.last)
+  calculate :registration_country do |response|
+    reg_data_query.registration_country_slug(response)
   end
 
   calculate :registration_country_name_lowercase_prefix do

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -21,8 +21,8 @@ end
 multiple_choice :did_the_person_die_at_home_hospital? do
   option :at_home_hospital
   option :elsewhere
-  calculate :died_at_home_hospital do
-    responses.last == 'at_home_hospital'
+  calculate :died_at_home_hospital do |response|
+    response == 'at_home_hospital'
   end
   next_node :was_death_expected?
 end
@@ -32,8 +32,8 @@ multiple_choice :was_death_expected? do
   option :yes
   option :no
 
-  calculate :death_expected do
-    responses.last == 'yes'
+  calculate :death_expected do |response|
+    response == 'yes'
   end
 
   next_node :uk_result
@@ -43,8 +43,8 @@ end
 country_select :which_country?, exclude_countries: exclude_countries do
   save_input_as :country_of_death
 
-  calculate :current_location do
-    reg_data_query.registration_country_slug(responses.last) || responses.last
+  calculate :current_location do |response|
+    reg_data_query.registration_country_slug(response) || response
   end
 
   calculate :current_location_name_lowercase_prefix do
@@ -66,12 +66,12 @@ multiple_choice :where_are_you_now? do
   option another_country: :which_country_are_you_in_now?
   option :in_the_uk
 
-  calculate :another_country do
-    responses.last == 'another_country'
+  calculate :another_country do |response|
+    response == 'another_country'
   end
 
-  calculate :in_the_uk do
-    responses.last == 'in_the_uk'
+  calculate :in_the_uk do |response|
+    response == 'in_the_uk'
   end
 
   on_condition(->(_) { reg_data_query.class::ORU_TRANSITION_EXCEPTIONS.include?(country_of_death) }) do
@@ -85,8 +85,8 @@ end
 
 # Q6
 country_select :which_country_are_you_in_now?, exclude_countries: exclude_countries do
-  calculate :current_location do
-    reg_data_query.registration_country_slug(responses.last) || responses.last
+  calculate :current_location do |response|
+    reg_data_query.registration_country_slug(response) || response
   end
 
   calculate :current_location_name_lowercase_prefix do

--- a/lib/smart_answer_flows/shared_logic/adoption-calculator.rb
+++ b/lib/smart_answer_flows/shared_logic/adoption-calculator.rb
@@ -6,8 +6,8 @@ end
 
 ## QA1
 date_question :date_of_adoption_match? do
-  calculate :match_date do
-    Date.parse(responses.last)
+  calculate :match_date do |response|
+    Date.parse(response)
   end
   calculate :calculator do
     Calculators::MaternityPaternityCalculator.new(match_date, "adoption")
@@ -18,8 +18,8 @@ end
 
 ## QA2
 date_question :date_of_adoption_placement? do
-  calculate :adoption_placement_date do
-    placement_date = Date.parse(responses.last)
+  calculate :adoption_placement_date do |response|
+    placement_date = Date.parse(response)
     raise SmartAnswer::InvalidResponse if placement_date < match_date
     calculator.adoption_placement_date = placement_date
     placement_date
@@ -53,8 +53,8 @@ multiple_choice :adoption_employment_contract? do
   save_input_as :employee_has_contract_adoption
 
   #not entitled to leave if no contract; keep asking questions to check eligibility
-  calculate :adoption_leave_info do
-    if responses.last == 'no'
+  calculate :adoption_leave_info do |response|
+    if response == 'no'
       PhraseList.new(:adoption_not_entitled_to_leave)
     end
   end
@@ -69,8 +69,8 @@ multiple_choice :adoption_is_the_employee_on_your_payroll? do
 
   save_input_as :on_payroll
 
-  calculate :adoption_pay_info do
-    if responses.last == 'no'
+  calculate :adoption_pay_info do |response|
+    if response == 'no'
       PhraseList.new(
         :adoption_not_entitled_to_pay_intro,
         :must_be_on_payroll,
@@ -93,8 +93,8 @@ end
 
 ## QA6
 date_question :adoption_date_leave_starts? do
-  calculate :adoption_date_leave_starts do
-    ald_start = Date.parse(responses.last)
+  calculate :adoption_date_leave_starts do |response|
+    ald_start = Date.parse(response)
     raise SmartAnswer::InvalidResponse if ald_start < Date.parse(a_leave_earliest_start)
     calculator.leave_start_date = ald_start
   end
@@ -140,8 +140,8 @@ date_question :last_normal_payday_adoption? do
   from { 2.years.ago(Date.today) }
   to { 2.years.since(Date.today) }
 
-  calculate :last_payday do
-    calculator.last_payday = Date.parse(responses.last)
+  calculate :last_payday do |response|
+    calculator.last_payday = Date.parse(response)
     raise SmartAnswer::InvalidResponse if calculator.last_payday > Date.parse(to_saturday)
     calculator.last_payday
   end
@@ -157,8 +157,8 @@ date_question :payday_eight_weeks_adoption? do
     calculator.format_date_day calculator.payday_offset
   end
 
-  calculate :last_payday_eight_weeks do
-    payday = Date.parse(responses.last)
+  calculate :last_payday_eight_weeks do |response|
+    payday = Date.parse(response)
     raise SmartAnswer::InvalidResponse if payday > Date.parse(payday_offset)
     calculator.pre_offset_payday = payday
     payday
@@ -179,8 +179,8 @@ multiple_choice :pay_frequency_adoption? do
   option monthly: :earnings_for_pay_period_adoption?
   save_input_as :pay_pattern
 
-  calculate :calculator do
-    calculator.pay_method = responses.last
+  calculate :calculator do |response|
+    calculator.pay_method = response
     calculator
   end
 end

--- a/lib/smart_answer_flows/shared_logic/maternity-calculator.rb
+++ b/lib/smart_answer_flows/shared_logic/maternity-calculator.rb
@@ -6,8 +6,8 @@ date_question :baby_due_date_maternity? do
   from { 1.year.ago(Date.today) }
   to { 2.years.since(Date.today) }
 
-  calculate :calculator do
-    Calculators::MaternityPaternityCalculator.new(Date.parse(responses.last))
+  calculate :calculator do |response|
+    Calculators::MaternityPaternityCalculator.new(Date.parse(response))
   end
   next_node :employment_contract?
 end
@@ -16,8 +16,8 @@ end
 multiple_choice :employment_contract? do
   option :yes
   option :no
-  calculate :maternity_leave_info do
-    if responses.last == 'yes'
+  calculate :maternity_leave_info do |response|
+    if response == 'yes'
       PhraseList.new(:maternity_leave_table)
     else
       PhraseList.new(:not_entitled_to_statutory_maternity_leave)
@@ -35,8 +35,8 @@ date_question :date_leave_starts? do
     calculator.leave_earliest_start_date
   end
 
-  calculate :leave_start_date do
-    ls_date = Date.parse(responses.last)
+  calculate :leave_start_date do |response|
+    ls_date = Date.parse(response)
     raise SmartAnswer::InvalidResponse if ls_date < leave_earliest_start_date
     calculator.leave_start_date = ls_date
     calculator.leave_start_date
@@ -71,8 +71,8 @@ end
 multiple_choice :did_the_employee_work_for_you? do
   option yes: :is_the_employee_on_your_payroll?
   option no: :maternity_leave_and_pay_result
-  calculate :not_entitled_to_pay_reason do
-    responses.last == 'no' ? :not_worked_long_enough : nil
+  calculate :not_entitled_to_pay_reason do |response|
+    response == 'no' ? :not_worked_long_enough : nil
   end
 end
 
@@ -81,8 +81,8 @@ multiple_choice :is_the_employee_on_your_payroll? do
   option yes: :last_normal_payday? # NOTE: goes to shared questions
   option no: :maternity_leave_and_pay_result
 
-  calculate :not_entitled_to_pay_reason do
-    responses.last == 'no' ? :must_be_on_payroll : nil
+  calculate :not_entitled_to_pay_reason do |response|
+    response == 'no' ? :must_be_on_payroll : nil
   end
 
   calculate :to_saturday do
@@ -95,8 +95,8 @@ date_question :last_normal_payday? do
   from { 2.years.ago(Date.today) }
   to { 2.years.since(Date.today) }
 
-  calculate :last_payday do
-    calculator.last_payday = Date.parse(responses.last)
+  calculate :last_payday do |response|
+    calculator.last_payday = Date.parse(response)
     raise SmartAnswer::InvalidResponse if calculator.last_payday > Date.parse(to_saturday)
     calculator.last_payday
   end
@@ -112,8 +112,8 @@ date_question :payday_eight_weeks? do
     calculator.format_date_day calculator.payday_offset
   end
 
-  calculate :last_payday_eight_weeks do
-    payday = Date.parse(responses.last)
+  calculate :last_payday_eight_weeks do |response|
+    payday = Date.parse(response)
     payday += 1 if leave_type == 'maternity'
     raise SmartAnswer::InvalidResponse if payday > Date.parse(payday_offset)
     calculator.pre_offset_payday = payday
@@ -140,8 +140,8 @@ end
 
 ## QM9 Maternity only onwards
 money_question :earnings_for_pay_period? do
-  calculate :calculator do
-    calculator.calculate_average_weekly_pay(pay_pattern, responses.last)
+  calculate :calculator do |response|
+    calculator.calculate_average_weekly_pay(pay_pattern, response)
     calculator
   end
   calculate :average_weekly_earnings do
@@ -166,8 +166,8 @@ end
 
 ## QM11
 date_question :when_is_your_employees_next_pay_day? do
-  calculate :next_pay_day do
-    calculator.pay_date = Date.parse(responses.last)
+  calculate :next_pay_day do |response|
+    calculator.pay_date = Date.parse(response)
     calculator.pay_date
   end
 
@@ -187,8 +187,8 @@ end
 
 ## QM13
 value_question :what_specific_date_each_month_is_the_employee_paid? do
-  calculate :pay_day_in_month do
-    day = responses.last.to_i
+  calculate :pay_day_in_month do |response|
+    day = response.to_i
     raise InvalidResponse unless day > 0 and day < 32
     calculator.pay_day_in_month = day
   end
@@ -200,9 +200,9 @@ end
 checkbox_question :what_days_does_the_employee_work? do
   (0...days_of_the_week.size).each { |i| option i.to_s.to_sym }
 
-  calculate :last_day_in_week_worked do
-    calculator.work_days = responses.last.split(",").map(&:to_i)
-    calculator.pay_day_in_week = responses.last.split(",").sort.last.to_i
+  calculate :last_day_in_week_worked do |response|
+    calculator.work_days = response.split(",").map(&:to_i)
+    calculator.pay_day_in_week = response.split(",").sort.last.to_i
   end
   next_node :maternity_leave_and_pay_result
 end
@@ -211,9 +211,9 @@ end
 multiple_choice :what_particular_day_of_the_month_is_the_employee_paid? do
   days_of_the_week.each { |d| option d.to_sym }
 
-  calculate :pay_day_in_week do
-    calculator.pay_day_in_week = days_of_the_week.index(responses.last)
-    responses.last
+  calculate :pay_day_in_week do |response|
+    calculator.pay_day_in_week = days_of_the_week.index(response)
+    response
   end
   next_node :which_week_in_month_is_the_employee_paid?
 end
@@ -226,8 +226,8 @@ multiple_choice :which_week_in_month_is_the_employee_paid? do
   option :"fourth"
   option :"last"
 
-  calculate :pay_week_in_month do
-    calculator.pay_week_in_month = responses.last
+  calculate :pay_week_in_month do |response|
+    calculator.pay_week_in_month = response
   end
   next_node :maternity_leave_and_pay_result
 end

--- a/lib/smart_answer_flows/shared_logic/minimum_wage.rb
+++ b/lib/smart_answer_flows/shared_logic/minimum_wage.rb
@@ -51,10 +51,10 @@ end
 
 # Q3
 value_question :how_old_are_you? do
-  calculate :age do
+  calculate :age do |response|
     # Fail-hard cast to Integer here will raise
     # an exception and show the appropriate error.
-    age = Integer(responses.last)
+    age = Integer(response)
     if age <= 0 || age > 200
       raise SmartAnswer::InvalidResponse
     end
@@ -71,10 +71,10 @@ end
 
 # Q3 Past
 value_question :how_old_were_you? do
-  calculate :age do
+  calculate :age do |response|
     # Fail-hard cast to Integer here will raise
     # an exception and show the appropriate error.
-    age = Integer(responses.last)
+    age = Integer(response)
     if age <= 0
       raise SmartAnswer::InvalidResponse
     end
@@ -92,8 +92,8 @@ end
 
 # Q4
 value_question :how_often_do_you_get_paid? do
-  calculate :pay_frequency do
-    pay_frequency = responses.last.to_i
+  calculate :pay_frequency do |response|
+    pay_frequency = response.to_i
     if pay_frequency < 1 or pay_frequency > 31
       raise SmartAnswer::InvalidResponse
     end
@@ -104,8 +104,8 @@ end
 
 # Q4 Past
 value_question :how_often_did_you_get_paid? do
-  calculate :pay_frequency do
-    pay_frequency = responses.last.to_i
+  calculate :pay_frequency do |response|
+    pay_frequency = response.to_i
     if pay_frequency < 1 or pay_frequency > 31
       raise SmartAnswer::InvalidResponse
     end
@@ -116,8 +116,8 @@ end
 
 # Q5
 value_question :how_many_hours_do_you_work? do
-  calculate :basic_hours do
-    basic_hours = Float(responses.last)
+  calculate :basic_hours do |response|
+    basic_hours = Float(response)
     if basic_hours < 0 or basic_hours > (pay_frequency * 16)
       raise SmartAnswer::InvalidResponse, :error_hours
     end
@@ -128,8 +128,8 @@ end
 
 # Q5 Past
 value_question :how_many_hours_did_you_work? do
-  calculate :basic_hours do
-    basic_hours = Float(responses.last)
+  calculate :basic_hours do |response|
+    basic_hours = Float(response)
     if basic_hours < 0 or basic_hours > (pay_frequency * 16)
       raise SmartAnswer::InvalidResponse, :error_hours
     end
@@ -141,8 +141,8 @@ end
 # Q6
 money_question :how_much_are_you_paid_during_pay_period? do
 
-  calculate :calculator do
-    amount_paid = Float(responses.last)
+  calculate :calculator do |response|
+    amount_paid = Float(response)
     if amount_paid < 0
       raise SmartAnswer::InvalidResponse
     end
@@ -161,8 +161,8 @@ end
 # Q6 Past
 money_question :how_much_were_you_paid_during_pay_period? do
 
-  calculate :calculator do
-    amount_paid = Float(responses.last)
+  calculate :calculator do |response|
+    amount_paid = Float(response)
     if amount_paid < 0
       raise SmartAnswer::InvalidResponse
     end
@@ -182,8 +182,8 @@ end
 # Q7
 value_question :how_many_hours_overtime_do_you_work? do
 
-  calculate :overtime_hours do
-    overtime_hours = Float(responses.last)
+  calculate :overtime_hours do |response|
+    overtime_hours = Float(response)
     if overtime_hours < 0
       raise SmartAnswer::InvalidResponse
     end
@@ -203,8 +203,8 @@ end
 value_question :how_many_hours_overtime_did_you_work? do
   save_input_as :overtime_hours
 
-  calculate :overtime_hours do
-    overtime_hours = Float(responses.last)
+  calculate :overtime_hours do |response|
+    overtime_hours = Float(response)
     if overtime_hours < 0
       raise SmartAnswer::InvalidResponse
     end
@@ -224,8 +224,8 @@ end
 money_question :what_is_overtime_pay_per_hour? do
   save_input_as :overtime_rate
 
-  calculate :overtime_rate do
-    overtime_hourly_rate = Float(responses.last)
+  calculate :overtime_rate do |response|
+    overtime_hourly_rate = Float(response)
     if overtime_hourly_rate < 0
       raise SmartAnswer::InvalidResponse
     end
@@ -239,8 +239,8 @@ end
 money_question :what_was_overtime_pay_per_hour? do
   save_input_as :overtime_rate
 
-  calculate :overtime_rate do
-    overtime_hourly_rate = Float(responses.last)
+  calculate :overtime_rate do |response|
+    overtime_hourly_rate = Float(response)
     if overtime_hourly_rate < 0
       raise SmartAnswer::InvalidResponse
     end
@@ -257,8 +257,8 @@ multiple_choice :is_provided_with_accommodation? do
   option "yes_free"
   option "yes_charged"
 
-  calculate :accommodation_provided do
-    responses.last != 'no'
+  calculate :accommodation_provided do |response|
+    response != 'no'
   end
 
   calculate :total_hours do
@@ -300,8 +300,8 @@ multiple_choice :was_provided_with_accommodation? do
   option "yes_free"
   option "yes_charged"
 
-  calculate :accommodation_provided do
-    responses.last != 'no'
+  calculate :accommodation_provided do |response|
+    response != 'no'
   end
 
   calculate :total_hours do
@@ -339,8 +339,8 @@ end
 
 # Q10
 money_question :current_accommodation_charge? do
-  calculate :accommodation_charge do
-    accommodation_charge = Float(responses.last)
+  calculate :accommodation_charge do |response|
+    accommodation_charge = Float(response)
     if accommodation_charge <= 0
       raise SmartAnswer::InvalidResponse
     end
@@ -351,8 +351,8 @@ end
 
 # Q10 Past
 money_question :past_accommodation_charge? do
-  calculate :accommodation_charge do
-    accommodation_charge = Float(responses.last)
+  calculate :accommodation_charge do |response|
+    accommodation_charge = Float(response)
     if accommodation_charge <= 0
       raise SmartAnswer::InvalidResponse
     end
@@ -366,8 +366,8 @@ value_question :current_accommodation_usage? do
 
   save_input_as :accommodation_usage
 
-  calculate :calculator do
-    days_per_week = Integer(responses.last)
+  calculate :calculator do |response|
+    days_per_week = Integer(response)
     if days_per_week < 0 or days_per_week > 7
       raise SmartAnswer::InvalidResponse
     end
@@ -408,8 +408,8 @@ value_question :past_accommodation_usage? do
 
   save_input_as :accommodation_usage
 
-  calculate :calculator do
-    days_per_week = Integer(responses.last)
+  calculate :calculator do |response|
+    days_per_week = Integer(response)
     if days_per_week < 0 or days_per_week > 7
       raise SmartAnswer::InvalidResponse
     end

--- a/lib/smart_answer_flows/shared_logic/minimum_wage_v2.rb
+++ b/lib/smart_answer_flows/shared_logic/minimum_wage_v2.rb
@@ -52,10 +52,10 @@ end
 
 # Q3
 value_question :how_old_are_you? do
-  calculate :age do
+  calculate :age do |response|
     # Fail-hard cast to Integer here will raise
     # an exception and show the appropriate error.
-    age = Integer(responses.last)
+    age = Integer(response)
     if age <= 0 || age > 200
       raise SmartAnswer::InvalidResponse
     end
@@ -72,10 +72,10 @@ end
 
 # Q3 Past
 value_question :how_old_were_you? do
-  calculate :age do
+  calculate :age do |response|
     # Fail-hard cast to Integer here will raise
     # an exception and show the appropriate error.
-    age = Integer(responses.last)
+    age = Integer(response)
     if age <= 0
       raise SmartAnswer::InvalidResponse
     end
@@ -93,8 +93,8 @@ end
 
 # Q4
 value_question :how_often_do_you_get_paid? do
-  calculate :pay_frequency do
-    pay_frequency = responses.last.to_i
+  calculate :pay_frequency do |response|
+    pay_frequency = response.to_i
     if pay_frequency < 1 or pay_frequency > 31
       raise SmartAnswer::InvalidResponse
     end
@@ -105,8 +105,8 @@ end
 
 # Q4 Past
 value_question :how_often_did_you_get_paid? do
-  calculate :pay_frequency do
-    pay_frequency = responses.last.to_i
+  calculate :pay_frequency do |response|
+    pay_frequency = response.to_i
     if pay_frequency < 1 or pay_frequency > 31
       raise SmartAnswer::InvalidResponse
     end
@@ -117,8 +117,8 @@ end
 
 # Q5
 value_question :how_many_hours_do_you_work? do
-  calculate :basic_hours do
-    basic_hours = Float(responses.last)
+  calculate :basic_hours do |response|
+    basic_hours = Float(response)
     if basic_hours < 0 or basic_hours > (pay_frequency * 16)
       raise SmartAnswer::InvalidResponse, :error_hours
     end
@@ -129,8 +129,8 @@ end
 
 # Q5 Past
 value_question :how_many_hours_did_you_work? do
-  calculate :basic_hours do
-    basic_hours = Float(responses.last)
+  calculate :basic_hours do |response|
+    basic_hours = Float(response)
     if basic_hours < 0 or basic_hours > (pay_frequency * 16)
       raise SmartAnswer::InvalidResponse, :error_hours
     end
@@ -142,8 +142,8 @@ end
 # Q6
 money_question :how_much_are_you_paid_during_pay_period? do
 
-  calculate :calculator do
-    amount_paid = Float(responses.last)
+  calculate :calculator do |response|
+    amount_paid = Float(response)
     if amount_paid < 0
       raise SmartAnswer::InvalidResponse
     end
@@ -163,8 +163,8 @@ end
 # Q6 Past
 money_question :how_much_were_you_paid_during_pay_period? do
 
-  calculate :calculator do
-    amount_paid = Float(responses.last)
+  calculate :calculator do |response|
+    amount_paid = Float(response)
     if amount_paid < 0
       raise SmartAnswer::InvalidResponse
     end
@@ -184,8 +184,8 @@ end
 # Q7
 value_question :how_many_hours_overtime_do_you_work? do
 
-  calculate :overtime_hours do
-    overtime_hours = Float(responses.last)
+  calculate :overtime_hours do |response|
+    overtime_hours = Float(response)
     if overtime_hours < 0
       raise SmartAnswer::InvalidResponse
     end
@@ -205,8 +205,8 @@ end
 value_question :how_many_hours_overtime_did_you_work? do
   save_input_as :overtime_hours
 
-  calculate :overtime_hours do
-    overtime_hours = Float(responses.last)
+  calculate :overtime_hours do |response|
+    overtime_hours = Float(response)
     if overtime_hours < 0
       raise SmartAnswer::InvalidResponse
     end
@@ -226,8 +226,8 @@ end
 money_question :what_is_overtime_pay_per_hour? do
   save_input_as :overtime_rate
 
-  calculate :overtime_rate do
-    overtime_hourly_rate = Float(responses.last)
+  calculate :overtime_rate do |response|
+    overtime_hourly_rate = Float(response)
     if overtime_hourly_rate < 0
       raise SmartAnswer::InvalidResponse
     end
@@ -241,8 +241,8 @@ end
 money_question :what_was_overtime_pay_per_hour? do
   save_input_as :overtime_rate
 
-  calculate :overtime_rate do
-    overtime_hourly_rate = Float(responses.last)
+  calculate :overtime_rate do |response|
+    overtime_hourly_rate = Float(response)
     if overtime_hourly_rate < 0
       raise SmartAnswer::InvalidResponse
     end
@@ -259,8 +259,8 @@ multiple_choice :is_provided_with_accommodation? do
   option "yes_free"
   option "yes_charged"
 
-  calculate :accommodation_provided do
-    responses.last != 'no'
+  calculate :accommodation_provided do |response|
+    response != 'no'
   end
 
   calculate :total_hours do
@@ -302,8 +302,8 @@ multiple_choice :was_provided_with_accommodation? do
   option "yes_free"
   option "yes_charged"
 
-  calculate :accommodation_provided do
-    responses.last != 'no'
+  calculate :accommodation_provided do |response|
+    response != 'no'
   end
 
   calculate :total_hours do
@@ -341,8 +341,8 @@ end
 
 # Q10
 money_question :current_accommodation_charge? do
-  calculate :accommodation_charge do
-    accommodation_charge = Float(responses.last)
+  calculate :accommodation_charge do |response|
+    accommodation_charge = Float(response)
     if accommodation_charge <= 0
       raise SmartAnswer::InvalidResponse
     end
@@ -353,8 +353,8 @@ end
 
 # Q10 Past
 money_question :past_accommodation_charge? do
-  calculate :accommodation_charge do
-    accommodation_charge = Float(responses.last)
+  calculate :accommodation_charge do |response|
+    accommodation_charge = Float(response)
     if accommodation_charge <= 0
       raise SmartAnswer::InvalidResponse
     end
@@ -368,8 +368,8 @@ value_question :current_accommodation_usage? do
 
   save_input_as :accommodation_usage
 
-  calculate :calculator do
-    days_per_week = Integer(responses.last)
+  calculate :calculator do |response|
+    days_per_week = Integer(response)
     if days_per_week < 0 or days_per_week > 7
       raise SmartAnswer::InvalidResponse
     end
@@ -410,8 +410,8 @@ value_question :past_accommodation_usage? do
 
   save_input_as :accommodation_usage
 
-  calculate :calculator do
-    days_per_week = Integer(responses.last)
+  calculate :calculator do |response|
+    days_per_week = Integer(response)
     if days_per_week < 0 or days_per_week > 7
       raise SmartAnswer::InvalidResponse
     end

--- a/lib/smart_answer_flows/shared_logic/paternity-calculator.rb
+++ b/lib/smart_answer_flows/shared_logic/paternity-calculator.rb
@@ -8,8 +8,8 @@ end
 
 ## QP1
 date_question :baby_due_date_paternity? do
-  calculate :due_date do
-    Date.parse(responses.last)
+  calculate :due_date do |response|
+    Date.parse(response)
   end
 
   calculate :calculator do
@@ -21,8 +21,8 @@ end
 
 ## QAP1 - Paternity Adoption
 date_question :employee_date_matched_paternity_adoption? do
-  calculate :matched_date do
-    Date.parse(responses.last)
+  calculate :matched_date do |response|
+    Date.parse(response)
   end
 
   calculate :calculator do
@@ -42,8 +42,8 @@ end
 
 ## QP2
 date_question :baby_birth_date_paternity? do
-  calculate :date_of_birth do
-    Date.parse(responses.last)
+  calculate :date_of_birth do |response|
+    Date.parse(response)
   end
 
   calculate :calculator do
@@ -57,8 +57,8 @@ end
 ## QAP2 - Paternity Adoption
 date_question :padoption_date_of_adoption_placement? do
 
-  calculate :ap_adoption_date do
-    placement_date = Date.parse(responses.last)
+  calculate :ap_adoption_date do |response|
+    placement_date = Date.parse(response)
     raise SmartAnswer::InvalidResponse if placement_date < matched_date
     calculator.adoption_placement_date = placement_date
     placement_date
@@ -135,8 +135,8 @@ multiple_choice :employee_on_payroll_paternity? do
     paternity_adoption? ? 'adoption' : 'notice-period'
   end
 
-  calculate :not_entitled_reason do
-    if responses.last == 'no' && has_contract == 'no'
+  calculate :not_entitled_reason do |response|
+    if response == 'no' && has_contract == 'no'
       PhraseList.new(
         :paternity_not_entitled_to_leave,
         :paternity_not_entitled_to_pay_intro,
@@ -172,8 +172,8 @@ multiple_choice :employee_still_employed_on_birth_date? do
   option :no
   save_input_as :employed_dob
 
-  calculate :not_entitled_reason do
-    if responses.last == 'no' and has_contract == 'no'
+  calculate :not_entitled_reason do |response|
+    if response == 'no' and has_contract == 'no'
       PhraseList.new(
         :paternity_not_entitled_to_leave,
         :paternity_not_entitled_to_pay_intro,
@@ -194,8 +194,8 @@ date_question :employee_start_paternity? do
 
   save_input_as :employee_leave_start
 
-  calculate :leave_start_date do
-    calculator.leave_start_date = Date.parse(responses.last)
+  calculate :leave_start_date do |response|
+    calculator.leave_start_date = Date.parse(response)
     if paternity_adoption?
       raise SmartAnswer::InvalidResponse if calculator.leave_start_date < ap_adoption_date
     else
@@ -217,9 +217,9 @@ multiple_choice :employee_paternity_length? do
   option :two_weeks
   save_input_as :leave_amount
 
-  calculate :leave_end_date do
+  calculate :leave_end_date do |response|
     unless leave_start_date.nil?
-      if responses.last == 'one_week'
+      if response == 'one_week'
         1.week.since(leave_start_date)
       else
         2.weeks.since(leave_start_date)
@@ -257,8 +257,8 @@ date_question :last_normal_payday_paternity? do
   from { 2.years.ago(Date.today) }
   to { 2.years.since(Date.today) }
 
-  calculate :calculator do
-    calculator.last_payday = Date.parse(responses.last)
+  calculate :calculator do |response|
+    calculator.last_payday = Date.parse(response)
     raise SmartAnswer::InvalidResponse if calculator.last_payday > Date.parse(to_saturday)
     calculator
   end
@@ -275,8 +275,8 @@ date_question :payday_eight_weeks_paternity? do
     calculator.payday_offset
   end
 
-  calculate :pre_offset_payday do
-    payday = Date.parse(responses.last)
+  calculate :pre_offset_payday do |response|
+    payday = Date.parse(response)
     raise SmartAnswer::InvalidResponse if payday > calculator.payday_offset
     calculator.pre_offset_payday = payday
     payday
@@ -297,8 +297,8 @@ multiple_choice :pay_frequency_paternity? do
   option monthly: :earnings_for_pay_period_paternity?
   save_input_as :pay_pattern
 
-  calculate :calculator do
-    calculator.pay_method = responses.last
+  calculate :calculator do |response|
+    calculator.pay_method = response
     calculator
   end
 
@@ -339,8 +339,8 @@ date_question :next_pay_day_paternity? do
   to { 2.years.since(Date.today) }
   save_input_as :next_pay_day
 
-  calculate :calculator do
-    calculator.pay_date = Date.parse(responses.last)
+  calculate :calculator do |response|
+    calculator.pay_date = Date.parse(response)
     calculator
   end
   next_node :paternity_leave_and_pay
@@ -363,8 +363,8 @@ end
 ## QP17
 value_question :specific_date_each_month_paternity? do
 
-  calculate :pay_day_in_month do
-    day = responses.last.to_i
+  calculate :pay_day_in_month do |response|
+    day = response.to_i
     raise InvalidResponse unless day > 0 and day < 32
     calculator.pay_day_in_month = day
   end
@@ -377,9 +377,9 @@ end
 checkbox_question :days_of_the_week_paternity? do
   (0...days_of_the_week.size).each { |i| option i.to_s.to_sym }
 
-  calculate :last_day_in_week_worked do
-    calculator.work_days = responses.last.split(",").map(&:to_i)
-    calculator.pay_day_in_week = responses.last.split(",").sort.last.to_i
+  calculate :last_day_in_week_worked do |response|
+    calculator.work_days = response.split(",").map(&:to_i)
+    calculator.pay_day_in_week = response.split(",").sort.last.to_i
   end
 
   next_node_if(:adoption_leave_and_pay, variable_matches(:leave_type, 'adoption'))
@@ -396,9 +396,9 @@ multiple_choice :day_of_the_month_paternity? do
   option :"5"
   option :"6"
 
-  calculate :pay_day_in_week do
-    calculator.pay_day_in_week = responses.last.to_i
-    days_of_the_week[responses.last.to_i]
+  calculate :pay_day_in_week do |response|
+    calculator.pay_day_in_week = response.to_i
+    days_of_the_week[response.to_i]
   end
 
   next_node :pay_date_options_paternity?
@@ -412,8 +412,8 @@ multiple_choice :pay_date_options_paternity? do
   option :"fourth"
   option :"last"
 
-  calculate :pay_week_in_month do
-    calculator.pay_week_in_month = responses.last
+  calculate :pay_week_in_month do |response|
+    calculator.pay_week_in_month = response
   end
 
   next_node_if(:adoption_leave_and_pay, variable_matches(:leave_type, 'adoption'))

--- a/lib/smart_answer_flows/shared_logic/redundancy_pay.rb
+++ b/lib/smart_answer_flows/shared_logic/redundancy_pay.rb
@@ -1,8 +1,8 @@
 date_question :date_of_redundancy? do
   from { Date.civil(2012, 1, 1) }
   to { Date.today }
-  calculate :rates do
-    Calculators::RedundancyCalculator.redundancy_rates(Date.parse(responses.last))
+  calculate :rates do |response|
+    Calculators::RedundancyCalculator.redundancy_rates(Date.parse(response))
   end
   calculate :rate do
     rates.rate
@@ -15,8 +15,8 @@ date_question :date_of_redundancy? do
 end
 
 value_question :age_of_employee? do
-  calculate :employee_age do
-    age = responses.last.to_i
+  calculate :employee_age do |response|
+    age = response.to_i
     raise InvalidResponse if age < 16 or age > 100
     age
   end
@@ -30,8 +30,8 @@ end
 # Using Float(response) instead will fail with an ArgumentError that will be handled by the flow controller
 value_question :years_employed? do
   save_input_as :years_employed
-  calculate :years_employed do
-    ye = Float(responses.last).floor
+  calculate :years_employed do |response|
+    ye = Float(response).floor
     raise InvalidResponse if ye.to_i > years_available
     ye
   end
@@ -45,8 +45,8 @@ value_question :years_employed? do
 end
 
 money_question :weekly_pay_before_tax? do
-  calculate :calculator do
-    Calculators::RedundancyCalculator.new(rate, employee_age, years_employed, responses.last)
+  calculate :calculator do |response|
+    Calculators::RedundancyCalculator.new(rate, employee_age, years_employed, response)
   end
   calculate :statutory_redundancy_pay do
     calculator.format_money(calculator.pay.to_f)

--- a/lib/smart_answer_flows/simplified-expenses-checker-v2.rb
+++ b/lib/smart_answer_flows/simplified-expenses-checker-v2.rb
@@ -26,8 +26,8 @@ checkbox_question :type_of_expense? do
   option :using_home_for_business
   option :live_on_business_premises
 
-  calculate :list_of_expenses do
-    responses.last == "none" ? [] : responses.last.split(",")
+  calculate :list_of_expenses do |response|
+    response == "none" ? [] : response.split(",")
   end
 
   next_node do |response|
@@ -77,8 +77,8 @@ multiple_choice :capital_allowances? do
   option :yes
   option :no
 
-  calculate :capital_allowance_claimed do
-    responses.last == "yes" and (list_of_expenses & %w(using_home_for_business live_on_business_premises)).any?
+  calculate :capital_allowance_claimed do |response|
+    response == "yes" and (list_of_expenses & %w(using_home_for_business live_on_business_premises)).any?
   end
 
   next_node do |response|
@@ -119,8 +119,8 @@ multiple_choice :is_vehicle_green? do
   option :yes
   option :no
 
-  calculate :vehicle_is_green do
-    responses.last == "yes"
+  calculate :vehicle_is_green do |response|
+    response == "yes"
   end
 
   next_node :price_of_vehicle?
@@ -151,8 +151,8 @@ end
 #Q8 - vehicle private use time
 value_question :vehicle_business_use_time? do
   # deduct percentage amount from [green_cost] or [dirty_cost] and store as [green_write_off] or [dirty_write_off]
-  calculate :business_use_percent do
-    responses.last.to_f
+  calculate :business_use_percent do |response|
+    response.to_f
   end
   calculate :green_vehicle_write_off do
     vehicle_is_green ? Money.new(green_vehicle_price * ( business_use_percent / 100)) : nil
@@ -174,8 +174,8 @@ value_question :drive_business_miles_car_van? do
   # Calculation:
   # [user input 1-10,000] x 0.45
   # [user input > 10,001]  x 0.25
-  calculate :simple_vehicle_costs do
-    answer = responses.last.gsub(",", "").to_f
+  calculate :simple_vehicle_costs do |response|
+    answer = response.gsub(",", "").to_f
     if answer <= 10000
       Money.new(answer * 0.45)
     else
@@ -198,8 +198,8 @@ end
 
 #Q10 - miles to drive for business motorcycle
 value_question :drive_business_miles_motorcycle? do
-  calculate :simple_motorcycle_costs do
-    Money.new(responses.last.gsub(",", "").to_f * 0.24)
+  calculate :simple_motorcycle_costs do |response|
+    Money.new(response.gsub(",", "").to_f * 0.24)
   end
   next_node do
     if list_of_expenses.include?("using_home_for_business")
@@ -215,8 +215,8 @@ end
 #Q11 - hours for home work
 value_question :hours_work_home? do
 
-  calculate :hours_worked_home do
-    responses.last.gsub(",", "").to_f
+  calculate :hours_worked_home do |response|
+    response.gsub(",", "").to_f
   end
 
   calculate :simple_home_costs do
@@ -260,8 +260,8 @@ end
 
 #Q14 - people who live on business premises?
 value_question :people_live_on_premises? do
-  calculate :live_on_premises do
-    responses.last.to_i
+  calculate :live_on_premises do |response|
+    response.to_i
   end
 
   calculate :simple_business_costs do

--- a/lib/smart_answer_flows/simplified-expenses-checker.rb
+++ b/lib/smart_answer_flows/simplified-expenses-checker.rb
@@ -26,8 +26,8 @@ checkbox_question :type_of_expense? do
   option :using_home_for_business
   option :live_on_business_premises
 
-  calculate :list_of_expenses do
-    responses.last == "none" ? [] : responses.last.split(",")
+  calculate :list_of_expenses do |response|
+    response == "none" ? [] : response.split(",")
   end
 
   next_node do |response|
@@ -77,8 +77,8 @@ multiple_choice :capital_allowances? do
   option :yes
   option :no
 
-  calculate :capital_allowance_claimed do
-    responses.last == "yes" and (list_of_expenses & %w(using_home_for_business live_on_business_premises)).any?
+  calculate :capital_allowance_claimed do |response|
+    response == "yes" and (list_of_expenses & %w(using_home_for_business live_on_business_premises)).any?
   end
 
   next_node do |response|
@@ -119,8 +119,8 @@ multiple_choice :is_vehicle_green? do
   option :yes
   option :no
 
-  calculate :vehicle_is_green do
-    responses.last == "yes"
+  calculate :vehicle_is_green do |response|
+    response == "yes"
   end
 
   next_node :price_of_vehicle?
@@ -151,8 +151,8 @@ end
 #Q8 - vehicle private use time
 value_question :vehicle_business_use_time? do
   # deduct percentage amount from [green_cost] or [dirty_cost] and store as [green_write_off] or [dirty_write_off]
-  calculate :business_use_percent do
-    responses.last.to_f
+  calculate :business_use_percent do |response|
+    response.to_f
   end
   calculate :green_vehicle_write_off do
     vehicle_is_green ? Money.new(green_vehicle_price * ( business_use_percent / 100)) : nil
@@ -174,8 +174,8 @@ value_question :drive_business_miles_car_van? do
   # Calculation:
   # [user input 1-10,000] x 0.45
   # [user input > 10,001]  x 0.25
-  calculate :simple_vehicle_costs do
-    answer = responses.last.gsub(",", "").to_f
+  calculate :simple_vehicle_costs do |response|
+    answer = response.gsub(",", "").to_f
     if answer <= 10000
       Money.new(answer * 0.45)
     else
@@ -198,8 +198,8 @@ end
 
 #Q10 - miles to drive for business motorcycle
 value_question :drive_business_miles_motorcycle? do
-  calculate :simple_motorcycle_costs do
-    Money.new(responses.last.gsub(",", "").to_f * 0.24)
+  calculate :simple_motorcycle_costs do |response|
+    Money.new(response.gsub(",", "").to_f * 0.24)
   end
   next_node do
     if list_of_expenses.include?("using_home_for_business")
@@ -215,8 +215,8 @@ end
 #Q11 - hours for home work
 value_question :hours_work_home? do
 
-  calculate :hours_worked_home do
-    responses.last.gsub(",", "").to_f
+  calculate :hours_worked_home do |response|
+    response.gsub(",", "").to_f
   end
 
   calculate :simple_home_costs do
@@ -260,8 +260,8 @@ end
 
 #Q14 - people who live on business premises?
 value_question :people_live_on_premises? do
-  calculate :live_on_premises do
-    responses.last.to_i
+  calculate :live_on_premises do |response|
+    response.to_i
   end
 
   calculate :simple_business_costs do

--- a/lib/smart_answer_flows/state-pension-through-partner.rb
+++ b/lib/smart_answer_flows/state-pension-through-partner.rb
@@ -10,13 +10,13 @@ multiple_choice :what_is_your_marital_status? do
   option :widowed
   option :divorced
 
-  calculate :answers do
+  calculate :answers do |response|
     answers = []
-    if responses.last == "married" or responses.last == "will_marry_before_specific_date"
+    if response == "married" or response == "will_marry_before_specific_date"
       answers << :old1
-    elsif responses.last == "will_marry_on_or_after_specific_date"
+    elsif response == "will_marry_on_or_after_specific_date"
       answers << :new1
-    elsif responses.last == "widowed"
+    elsif response == "widowed"
       answers << :widow
     end
     answers
@@ -40,18 +40,18 @@ multiple_choice :when_will_you_reach_pension_age? do
   option :your_pension_age_before_specific_date
   option :your_pension_age_after_specific_date
 
-  calculate :answers do
-    if responses.last == "your_pension_age_before_specific_date"
+  calculate :answers do |response|
+    if response == "your_pension_age_before_specific_date"
       answers << :old2
-    elsif responses.last == "your_pension_age_after_specific_date"
+    elsif response == "your_pension_age_after_specific_date"
       answers << :new2
     end
     answers << :old3 if responses.first == "widowed"
     answers
   end
 
-  calculate :result_phrase do
-    if responses.first == "widowed" and responses.last == "your_pension_age_before_specific_date"
+  calculate :result_phrase do |response|
+    if responses.first == "widowed" and response == "your_pension_age_before_specific_date"
       PhraseList.new(
         :current_rules_and_additional_pension,
         :increase_retirement_income #outcome 2
@@ -77,10 +77,10 @@ multiple_choice :when_will_your_partner_reach_pension_age? do
   option :partner_pension_age_before_specific_date
   option :partner_pension_age_after_specific_date
 
-  calculate :answers do
-    if responses.last == "partner_pension_age_before_specific_date"
+  calculate :answers do |response|
+    if response == "partner_pension_age_before_specific_date"
       answers << :old3
-    elsif responses.last == "partner_pension_age_after_specific_date"
+    elsif response == "partner_pension_age_after_specific_date"
       answers << :new3
     end
     answers
@@ -110,9 +110,9 @@ multiple_choice :what_is_your_gender? do
   option :male_gender
   option :female_gender
 
-  calculate :result_phrase do
+  calculate :result_phrase do |response|
     phrases = PhraseList.new
-    if responses.last == "male_gender"
+    if response == "male_gender"
       if responses.first == "divorced"
         phrases << :impossibility_due_to_divorce #outcome 9
       else

--- a/lib/smart_answer_flows/state-pension-topup.rb
+++ b/lib/smart_answer_flows/state-pension-topup.rb
@@ -43,8 +43,8 @@ end
 money_question :how_much_extra_per_week? do
   save_input_as :weekly_amount
 
-  calculate :integer_value do
-    money = responses.last.to_f
+  calculate :integer_value do |response|
+    money = response.to_f
     if (money % 1 != 0) or (money > 25 or money < 1)
       raise SmartAnswer::InvalidResponse
     end

--- a/lib/smart_answer_flows/student-finance-calculator.rb
+++ b/lib/smart_answer_flows/student-finance-calculator.rb
@@ -37,13 +37,13 @@ end
 #Q3
 money_question :how_much_are_your_tuition_fees_per_year? do
 
-  calculate :tuition_fee_amount do
+  calculate :tuition_fee_amount do |response|
     if course_type == "uk-full-time" or course_type == 'eu-full-time'
-      raise SmartAnswer::InvalidResponse if responses.last > 9000
+      raise SmartAnswer::InvalidResponse if response > 9000
     else
-      raise SmartAnswer::InvalidResponse if responses.last > 6750
+      raise SmartAnswer::InvalidResponse if response > 6750
     end
-    Money.new(responses.last)
+    Money.new(response)
   end
 
   calculate :eligible_finance do
@@ -68,9 +68,9 @@ multiple_choice :where_will_you_live_while_studying? do
   option :'away-outside-london'
   option :'away-in-london'
 
-  calculate :max_maintenance_loan_amount do
+  calculate :max_maintenance_loan_amount do |response|
     begin
-      Money.new(max_maintainence_loan_amounts[start_date][responses.last].to_s)
+      Money.new(max_maintainence_loan_amounts[start_date][response].to_s)
     rescue
       raise SmartAnswer::InvalidResponse
     end
@@ -83,8 +83,8 @@ end
 #Q5
 money_question :whats_your_household_income? do
 
-  calculate :maintenance_grant_amount do
-    household_income = responses.last
+  calculate :maintenance_grant_amount do |response|
+    household_income = response
     # 2015-16 rates are the same as 2014-15:
     # max of £3,387 for income up to £25,000 then,
     # £1 less than max for each whole £5.28 above £25000 up to £42,611
@@ -102,14 +102,14 @@ money_question :whats_your_household_income? do
   end
 
   # loan amount depends on maintenance grant amount and household income
-  calculate :maintenance_loan_amount do
-    if responses.last <= 42875
+  calculate :maintenance_loan_amount do |response|
+    if response <= 42875
       # reduce maintenance loan by £0.5 for each £1 of maintenance grant
       Money.new ( max_maintenance_loan_amount - (maintenance_grant_amount.value / 2.0).floor)
     else
       # reduce maintenance loan by £1 for each full £9.90 of income above £42875 until loan reaches 65% of max, when no further reduction applies
       min_loan_amount = (0.65 * max_maintenance_loan_amount.value).floor # to match the reference table
-      reduced_loan_amount = max_maintenance_loan_amount - ((responses.last - 42875) / 9.59).floor
+      reduced_loan_amount = max_maintenance_loan_amount - ((response - 42875) / 9.59).floor
       if reduced_loan_amount > min_loan_amount
         Money.new (reduced_loan_amount)
       else
@@ -139,8 +139,8 @@ checkbox_question :do_any_of_the_following_apply_uk_full_time_students_only? do
   option :"low-income"
   option :"no"
 
-  calculate :uk_ft_circumstances do
-    responses.last.split(',')
+  calculate :uk_ft_circumstances do |response|
+    response.split(',')
   end
 
   next_node :what_course_are_you_studying?
@@ -152,8 +152,8 @@ checkbox_question :do_any_of_the_following_apply_all_uk_students? do
   option :"low-income"
   option :"no"
 
-  calculate :all_uk_students_circumstances do
-    responses.last.split(',')
+  calculate :all_uk_students_circumstances do |response|
+    response.split(',')
   end
 
   next_node :what_course_are_you_studying?

--- a/lib/smart_answer_flows/uk-benefits-abroad-v2.rb
+++ b/lib/smart_answer_flows/uk-benefits-abroad-v2.rb
@@ -36,20 +36,20 @@ multiple_choice :going_or_already_abroad? do
   end
 
 
-  calculate :already_abroad_text do
-    if responses.last == 'already_abroad'
+  calculate :already_abroad_text do |response|
+    if response == 'already_abroad'
       PhraseList.new(:already_abroad_text)
       end
   end
 
-  calculate :already_abroad_text_two do
-    if responses.last == 'already_abroad'
+  calculate :already_abroad_text_two do |response|
+    if response == 'already_abroad'
       PhraseList.new(:already_abroad_text_two)
     end
   end
 
-  calculate :iidb_maybe do
-    if responses.last == 'already_abroad'
+  calculate :iidb_maybe do |response|
+    if response == 'already_abroad'
       PhraseList.new(:iidb_maybe_text)
     end
   end

--- a/lib/smart_answer_flows/uk-benefits-abroad.rb
+++ b/lib/smart_answer_flows/uk-benefits-abroad.rb
@@ -36,20 +36,20 @@ multiple_choice :going_or_already_abroad? do
   end
 
 
-  calculate :already_abroad_text do
-    if responses.last == 'already_abroad'
+  calculate :already_abroad_text do |response|
+    if response == 'already_abroad'
       PhraseList.new(:already_abroad_text)
       end
   end
 
-  calculate :already_abroad_text_two do
-    if responses.last == 'already_abroad'
+  calculate :already_abroad_text_two do |response|
+    if response == 'already_abroad'
       PhraseList.new(:already_abroad_text_two)
     end
   end
 
-  calculate :iidb_maybe do
-    if responses.last == 'already_abroad'
+  calculate :iidb_maybe do |response|
+    if response == 'already_abroad'
       PhraseList.new(:iidb_maybe_text)
     end
   end

--- a/lib/smart_answer_flows/vat-payment-deadlines.rb
+++ b/lib/smart_answer_flows/vat-payment-deadlines.rb
@@ -5,8 +5,8 @@ date_question :when_does_your_vat_accounting_period_end? do
   default_day -1
   next_node :how_do_you_want_to_pay?
 
-  calculate :period_end_date do
-    date = Date.parse(responses.last)
+  calculate :period_end_date do |response|
+    date = Date.parse(response)
     raise InvalidResponse unless date == date.end_of_month
     date
   end
@@ -21,8 +21,8 @@ multiple_choice :how_do_you_want_to_pay? do
   option :'chaps' => :result_chaps
   option :'cheque' => :result_cheque
 
-  calculate :calculator do
-    Calculators::VatPaymentDeadlines.new(period_end_date, responses.last)
+  calculate :calculator do |response|
+    Calculators::VatPaymentDeadlines.new(period_end_date, response)
   end
 
   calculate :last_payment_date do

--- a/test/fixtures/smart_answer_flows/money-and-salary-sample.rb
+++ b/test/fixtures/smart_answer_flows/money-and-salary-sample.rb
@@ -9,8 +9,8 @@ salary_question :how_much_do_you_earn? do
 end
 
 money_question :what_size_bonus_do_you_want? do
-  calculate :requested_bonus do
-    value = Money.new(responses.last)
+  calculate :requested_bonus do |response|
+    value = Money.new(response)
     if value < annual_salary
       raise InvalidResponse, "You can't request a bonus less than your annual salary.", caller
     end

--- a/test/unit/question_base_test.rb
+++ b/test/unit/question_base_test.rb
@@ -100,6 +100,19 @@ class QuestionBaseTest < ActiveSupport::TestCase
 
   test "Can calculate other variables based on input" do
     q = SmartAnswer::Question::Base.new(:favourite_colour?) do
+      calculate :complementary_colour do |response|
+        response == :red ? :green : :red
+      end
+      next_node :done
+    end
+    initial_state = SmartAnswer::State.new(q.name)
+    new_state = q.transition(initial_state, :red)
+    assert_equal :green, new_state.complementary_colour
+    assert new_state.frozen?
+  end
+
+  test "Can calculate other variables based on saved input" do
+    q = SmartAnswer::Question::Base.new(:favourite_colour?) do
       save_input_as :colour_preference
       calculate :complementary_colour do
         colour_preference == :red ? :green : :red


### PR DESCRIPTION
* Brings such blocks into line with other types of blocks e.g. `validate`,
`define_predicate`, `next_node`.

* Reduces duplication and makes code slightly terser.

* I've only declared the block argument where it is actually needed i.e. there
are still many `calculate` blocks which do not have a `response` argument
declared.

* This may seem like a small change, but I think it will make some other
refactoring easier.