### PR TITLE
Replace SPL calculations with flat text

### DIFF
--- a/lib/smartdown_flows/pay-leave-for-parents-v2/snippets/additional-pat-leave.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-v2/snippets/additional-pat-leave.txt
@@ -1,8 +1,9 @@
 ##Additional paternity leave
 
-If the mother returns to work early, their partner may be able to take up to 26 weeks off as [additional paternity leave](/paternity-pay-leave/leave).
+If the mother returns to work early, her partner may be able to take up to 26 weeks off as [additional paternity leave](/paternity-pay-leave/leave).
 
  | Dates
 - | -
-Additional paternity leave must be used between | %{start_of_additional_paternity_leave(due_date)} to %{end_of_additional_paternity_leave(due_date)}
+Additional paternity leave can start | 20 weeks after the birth
+Additional paternity leave must finish | by the child's first birthday
 Tell the partner’s employer | 8 weeks before they want to start additional paternity leave

--- a/lib/smartdown_flows/pay-leave-for-parents-v2/snippets/additional-pat-pay.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-v2/snippets/additional-pat-pay.txt
@@ -6,26 +6,24 @@ The mother’s partner can get [additional paternity pay](/paternity-pay-leave/p
 
 $IF range_in_2013_2014_fin_year?(due_date)
 
-Weekly rate (between 6 April 2013 and 5 April 2014) | %{rate_of_paternity_pay_2013_2014(salary_2)}
+Weekly rate (between 6 April 2013 and 5 April 2014) | £136.78, or 90% of their average weekly earnings (whichever is lower).
 
 $ENDIF
 
 $IF range_in_2014_2015_fin_year?(due_date)
 
-Weekly rate (between 6 April 2014 and 5 April 2015) | %{rate_of_paternity_pay_2014_2015(salary_2)}
+Weekly rate (between 6 April 2014 and 5 April 2015) | £138.18, or 90% of their average weekly earnings (whichever is lower).
 
 $ENDIF
 
 $IF range_in_2015_2016_fin_year?(due_date)
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | %{rate_of_paternity_pay_2015_2016(salary_2)}
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
 
 $ENDIF
 
 $IF NOT range_in_2013_2014_fin_year?(due_date) AND NOT range_in_2014_2015_fin_year?(due_date) AND NOT range_in_2015_2016_fin_year?(due_date)
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | %{rate_of_paternity_pay_2015_2016(salary_2)}
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
 
 $ENDIF
-
-Total pay | %{total_aspp(salary_2 due_date)}

--- a/lib/smartdown_flows/pay-leave-for-parents-v2/snippets/both-shared-leave.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-v2/snippets/both-shared-leave.txt
@@ -1,10 +1,10 @@
 ##Shared parental leave
 
-The mother and her partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother. 
+The mother and her partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
 
-The parents can choose how to share this leave between them. They can each take SPL in up to 3 blocks, going back to work between the blocks. 
+The parents can choose how to share this leave between them. They can each take SPL in up to 3 blocks, going back to work between the blocks.
 
  | Dates
 - | -
-Shared parental leave must be used between | %{due_date} to %{end_of_shared_parental_leave(due_date)}
+Shared parental leave must be used | Within a year of the birth
 Tell the parent’s employer | 8 weeks before their first block of SPL

--- a/lib/smartdown_flows/pay-leave-for-parents-v2/snippets/both-shared-pay.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-v2/snippets/both-shared-pay.txt
@@ -6,48 +6,48 @@ The mother and her partner can both get [shared parental pay](/shared-parental-l
 
 $IF range_in_2013_2014_fin_year?(due_date)
 
-Mother’s shared parental pay (between 6 April 2013 and 5 April 2014) | %{rate_of_shpp_2013_2014(salary_1)}
+Mother’s shared parental pay (between 6 April 2013 and 5 April 2014) | £136.78 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 $ENDIF
 
 $IF range_in_2014_2015_fin_year?(due_date)
 
-Mother’s shared parental pay (between 6 April 2014 and 5 April 2015) | %{rate_of_shpp_2014_2015(salary_1)}
+Mother’s shared parental pay (between 6 April 2014 and 5 April 2015) | £138.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 $ENDIF
 
 $IF range_in_2015_2016_fin_year?(due_date)
 
-Mother’s shared parental pay (between 6 April 2015 and 5 April 2016) | %{rate_of_shpp_2015_2016(salary_1)}
+Mother’s shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 $ENDIF
 
 $IF NOT range_in_2013_2014_fin_year?(due_date) AND NOT range_in_2014_2015_fin_year?(due_date) AND NOT range_in_2015_2016_fin_year?(due_date)
 
-Mother’s shared parental pay (between 6 April 2015 and 5 April 2016) | %{rate_of_shpp_2015_2016(salary_1)}
+Mother’s shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 $ENDIF
 
 $IF range_in_2013_2014_fin_year?(due_date)
 
-Partner's shared parental pay (between 6 April 2013 and 5 April 2014) | %{rate_of_shpp_2013_2014(salary_1)}
+Partner's shared parental pay (between 6 April 2013 and 5 April 2014) | £136.78 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 $ENDIF
 
 $IF range_in_2014_2015_fin_year?(due_date)
 
-Partner's shared parental pay (between 6 April 2014 and 5 April 2015) | %{rate_of_shpp_2014_2015(salary_1)}
+Partner's shared parental pay (between 6 April 2014 and 5 April 2015) | £138.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 $ENDIF
 
 $IF range_in_2015_2016_fin_year?(due_date)
 
-Partner's shared parental pay (between 6 April 2015 and 5 April 2016) | %{rate_of_shpp_2015_2016(salary_1)}
+Partner's shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 $ENDIF
 
 $IF NOT range_in_2013_2014_fin_year?(due_date) AND NOT range_in_2014_2015_fin_year?(due_date) AND NOT range_in_2015_2016_fin_year?(due_date)
 
-Partner's shared parental pay (between 6 April 2015 and 5 April 2016) | %{rate_of_shpp_2015_2016(salary_1)}
+Partner's shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 $ENDIF

--- a/lib/smartdown_flows/pay-leave-for-parents-v2/snippets/mat-allowance.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-v2/snippets/mat-allowance.txt
@@ -8,28 +8,26 @@ Maternity allowance can start on | %{start_of_maternity_allowance(due_date)}
 
 $IF range_in_2013_2014_fin_year?(due_date)
 
-Weekly rate (between 6 April 2013 and 5 April 2014) | %{rate_of_maternity_allowance_2013_2014(salary_1_66_weeks)}
+Weekly rate (between 6 April 2013 and 5 April 2014) | £136.78, or 90% of her average weekly earnings (whichever is lower)
 
 $ENDIF
 
 $IF range_in_2014_2015_fin_year?(due_date)
 
-Weekly rate (between 6 April 2014 and 5 April 2015) | %{rate_of_maternity_allowance_2014_2015(salary_1_66_weeks)}
+Weekly rate (between 6 April 2014 and 5 April 2015) | £138.18, or 90% of her average weekly earnings (whichever is lower)
 
 $ENDIF
 
 $IF range_in_2015_2016_fin_year?(due_date)
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | %{rate_of_maternity_allowance_2015_2016(salary_1_66_weeks)}
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 $ENDIF
 
 $IF NOT range_in_2013_2014_fin_year?(due_date) AND NOT range_in_2014_2015_fin_year?(due_date) AND NOT range_in_2015_2016_fin_year?(due_date)
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | %{rate_of_maternity_allowance_2015_2016(salary_1_66_weeks)}
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 $ENDIF
-
-Total estimated allowance | %{total_maternity_allowance(salary_1_66_weeks due_date)}
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.

--- a/lib/smartdown_flows/pay-leave-for-parents-v2/snippets/mat-pay.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-v2/snippets/mat-pay.txt
@@ -4,34 +4,32 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 ###Dates and amounts
 
-First 6 weeks | %{rate_of_smp_6_weeks(salary_1)} per week
+First 6 weeks | 90% of her average weekly earnings (before tax)
 
 $IF range_in_2013_2014_fin_year?(due_date)
 
-Next 33 weeks (between 6 April 2013 and 5 April 2014) | %{rate_of_smp_33_weeks_2013_2014(salary_1)} per week
+Remaining weeks (between 6 April 2013 and 5 April 2014) | £136.78 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 $ENDIF
 
 $IF range_in_2014_2015_fin_year?(due_date)
 
-Next 33 weeks (between 6 April 2014 and 5 April 2015) | %{rate_of_smp_33_weeks_2014_2015(salary_1)} per week
+Remaining weeks (between 6 April 2014 and 5 April 2015) | £138.18 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 $ENDIF
 
 $IF range_in_2015_2016_fin_year?(due_date)
 
-Next 33 weeks (between 6 April 2015 and 5 April 2016) | %{rate_of_smp_33_weeks_2015_2016(salary_1)} per week
+Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 $ENDIF
 
 $IF NOT range_in_2013_2014_fin_year?(due_date) AND NOT range_in_2014_2015_fin_year?(due_date) AND NOT range_in_2015_2016_fin_year?(due_date)
 
-Next 33 weeks (between 6 April 2015 and 5 April 2016) | %{rate_of_smp_33_weeks_2015_2016(salary_1)} per week
+Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 $ENDIF
 
-Total estimated pay | %{total_smp(salary_1 due_date)}
-
-Tell the mother’s employer | 28 days before they want to start maternity pay
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/lib/smartdown_flows/pay-leave-for-parents-v2/snippets/mat-shared-leave.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-v2/snippets/mat-shared-leave.txt
@@ -1,6 +1,6 @@
 ##Shared parental leave (mother only)
 
-The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes. 
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
 
 She can take SPL in up to 3 blocks, going back to work between the blocks.
 
@@ -8,5 +8,5 @@ She can take SPL in up to 3 blocks, going back to work between the blocks.
 
  | Dates
 - | -
-Shared parental leave must be used between | %{due_date} to %{end_of_shared_parental_leave(due_date)}
+Shared parental leave must be used | Within a year of the birth
 Tell the mother’s employer | 8 weeks before the first block of SPL

--- a/lib/smartdown_flows/pay-leave-for-parents-v2/snippets/mat-shared-pay.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-v2/snippets/mat-shared-pay.txt
@@ -6,24 +6,24 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 $IF range_in_2013_2014_fin_year?(due_date)
 
-Shared Parental Pay (between 6 April 2013 and 5 April 2014) | %{rate_of_shpp_2013_2014(salary_1)}
+Shared Parental Pay (between 6 April 2013 and 5 April 2014) | £136.78 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 $ENDIF
 
 $IF range_in_2014_2015_fin_year?(due_date)
 
-Shared Parental Pay (between 6 April 2014 and 5 April 2015) | %{rate_of_shpp_2014_2015(salary_1)}
+Shared Parental Pay (between 6 April 2014 and 5 April 2015) | £138.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 $ENDIF
 
 $IF range_in_2015_2016_fin_year?(due_date)
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | %{rate_of_shpp_2015_2016(salary_1)}
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 $ENDIF
 
 $IF NOT range_in_2013_2014_fin_year?(due_date) AND NOT range_in_2014_2015_fin_year?(due_date) AND NOT range_in_2015_2016_fin_year?(due_date)
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | %{rate_of_shpp_2015_2016(salary_1)}
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 $ENDIF

--- a/lib/smartdown_flows/pay-leave-for-parents-v2/snippets/pat-leave.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-v2/snippets/pat-leave.txt
@@ -1,8 +1,8 @@
 ##Paternity leave
 
-The mother’s partner can take up to 2 weeks of [ordinary paternity leave](/paternity-pay-leave/leave). 
+The mother’s partner can take up to 2 weeks of [ordinary paternity leave](/paternity-pay-leave/leave).
 
  | Dates
 - | -
-Paternity leave must be used between | %{due_date} to %{latest_pat_leave(due_date)}
-Tell the partner’s employer | %{paternity_leave_notice_date(due_date)}
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | %{paternity_leave_notice_date(due_date)}

--- a/lib/smartdown_flows/pay-leave-for-parents-v2/snippets/pat-pay.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-v2/snippets/pat-pay.txt
@@ -6,25 +6,25 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 $IF range_in_2013_2014_fin_year?(due_date)
 
-Weekly rate (between 6 April 2013 and 5 April 2014) | %{rate_of_paternity_pay_2013_2014(salary_2)}
+Weekly rate (between 6 April 2013 and 5 April 2014) | £136.78 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 $ENDIF
 
 $IF range_in_2014_2015_fin_year?(due_date)
 
-Weekly rate (between 6 April 2014 and 5 April 2015) | %{rate_of_paternity_pay_2014_2015(salary_2)}
+Weekly rate (between 6 April 2014 and 5 April 2015) | £138.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 $ENDIF
 
 $IF range_in_2015_2016_fin_year?(due_date)
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | %{rate_of_paternity_pay_2015_2016(salary_2)}
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 $ENDIF
 
 $IF NOT range_in_2013_2014_fin_year?(due_date) AND NOT range_in_2014_2015_fin_year?(due_date) AND NOT range_in_2015_2016_fin_year?(due_date)
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | %{rate_of_paternity_pay_2015_2016(salary_2)}
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 $ENDIF
 

--- a/lib/smartdown_flows/pay-leave-for-parents-v2/snippets/pat-shared-leave.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-v2/snippets/pat-shared-leave.txt
@@ -1,6 +1,6 @@
 ##Shared parental leave (partner only)
 
-The mother’s partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother. 
+The mother’s partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
 
 The partner can take SPL in up to 3 blocks, going back to work between the blocks.
 
@@ -8,5 +8,5 @@ The partner can take SPL in up to 3 blocks, going back to work between the block
 
  | Dates
 - | -
-Shared parental leave must be used between | %{due_date} to %{end_of_shared_parental_leave(due_date)}
+Shared parental leave must be used | Within a year of the birth
 Tell the partner’s employer | 8 weeks before the first block of SPL

--- a/lib/smartdown_flows/pay-leave-for-parents-v2/snippets/pat-shared-pay.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-v2/snippets/pat-shared-pay.txt
@@ -6,24 +6,24 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 $IF range_in_2013_2014_fin_year?(due_date)
 
-Shared Parental Pay (between 6 April 2013 and 5 April 2014) | %{rate_of_shpp_2013_2014(salary_2)}
+Shared Parental Pay (between 6 April 2013 and 5 April 2014) | £136.78 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 $ENDIF
 
 $IF range_in_2014_2015_fin_year?(due_date)
 
-Shared Parental Pay (between 6 April 2014 and 5 April 2015) | %{rate_of_shpp_2014_2015(salary_2)}
+Shared Parental Pay (between 6 April 2014 and 5 April 2015) | £138.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 $ENDIF
 
 $IF range_in_2015_2016_fin_year?(due_date)
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | %{rate_of_shpp_2015_2016(salary_2)}
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 $ENDIF
 
 $IF NOT range_in_2013_2014_fin_year?(due_date) AND NOT range_in_2014_2015_fin_year?(due_date) AND NOT range_in_2015_2016_fin_year?(due_date)
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | %{rate_of_shpp_2015_2016(salary_2)}
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 $ENDIF


### PR DESCRIPTION
This had to be done because assumptions made about birth date were incorrect. As well as assumptions made about the current income of the person instead of the average income of the person.