### PR TITLE
Allow parsing of date question responses into date objects instead of strings

### DIFF
--- a/app/presenters/date_question_presenter.rb
+++ b/app/presenters/date_question_presenter.rb
@@ -1,6 +1,6 @@
 class DateQuestionPresenter < QuestionPresenter
   def response_label(value)
-    I18n.localize(Date.parse(value), format: :long)
+    I18n.localize(value.to_date, format: :long)
   end
 
   def start_date

--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -60,8 +60,8 @@ module SmartAnswer
       add_node Question::CountrySelect.new(name, options, &block)
     end
 
-    def date_question(name, &block)
-      add_node Question::Date.new(name, &block)
+    def date_question(name, options = {}, &block)
+      add_node Question::Date.new(name, options, &block)
     end
 
     def optional_date(name, &block)

--- a/lib/smart_answer/question/date.rb
+++ b/lib/smart_answer/question/date.rb
@@ -3,7 +3,8 @@ require 'date'
 module SmartAnswer
   module Question
     class Date < Base
-      def initialize(name, &block)
+      def initialize(name, options = {}, &block)
+        @parse = options[:parse]
         super
       end
 
@@ -105,13 +106,14 @@ module SmartAnswer
           else
            raise InvalidResponse, "Bad date", caller
           end
-        date.strftime('%Y-%m-%d')
+        parse? ? date : date.strftime('%Y-%m-%d')
       rescue
         raise InvalidResponse, "Bad date: #{input.inspect}", caller
       end
 
       def to_response(input)
-        date = ::Date.parse(parse_input(input))
+        date = parse_input(input)
+        date = ::Date.parse(date) unless parse?
         {
           day: date.day,
           month: date.month,
@@ -119,6 +121,12 @@ module SmartAnswer
         }
       rescue
         nil
+      end
+
+      private
+
+      def parse?
+        @parse
       end
     end
   end

--- a/lib/smart_answer_flows/appeal-a-benefits-decision.rb
+++ b/lib/smart_answer_flows/appeal-a-benefits-decision.rb
@@ -17,13 +17,13 @@ multiple_choice :problem_with_tribunal_proceedure? do
 end
 
 # Q3
-date_question :date_of_decision_letter? do
+date_question :date_of_decision_letter?, parse: true do
   from { 5.years.ago }
   to { Date.today }
   save_input_as :decision_letter_date
 
   next_node do |response|
-    decision_date = Date.parse(response)
+    decision_date = response
     appeal_expiry_date = decision_appeal_limit_in_months.months.since(decision_date)
     if Date.today < appeal_expiry_date
       :had_written_explanation?
@@ -40,7 +40,7 @@ multiple_choice :had_written_explanation? do
   option :no
 
   calculate :appeal_expiry_date do
-    decision_date = Date.parse(decision_letter_date)
+    decision_date = decision_letter_date
     if (decision_date > 1.month.ago.to_date)
       1.month.since(decision_date)
     end
@@ -58,7 +58,7 @@ multiple_choice :had_written_explanation? do
     if response == 'written_explanation'
       :when_did_you_ask_for_it?
     else
-      a_month_has_passed = (Date.parse(decision_letter_date) < 1.month.ago.to_date)
+      a_month_has_passed = (decision_letter_date < 1.month.ago.to_date)
       if a_month_has_passed
         :special_circumstances?
       else
@@ -73,26 +73,26 @@ multiple_choice :had_written_explanation? do
 end
 
 # Q5
-date_question :when_did_you_ask_for_it? do
+date_question :when_did_you_ask_for_it?, parse: true do
   from { 5.years.ago }
   to { Date.today }
   calculate :written_explanation_request_date do |response|
-    Date.parse(response).strftime("%e %B %Y")
+    response
   end
   next_node :when_did_you_get_it?
 end
 
 # Q6
-date_question :when_did_you_get_it? do
+date_question :when_did_you_get_it?, parse: true do
 
   save_input_as :written_explanation_received_date
   from { 5.years.ago }
   to { Date.today }
 
   calculate :appeal_expiry_date do |response|
-    decision_date = Date.parse(decision_letter_date)
-    received_date = Date.parse(response)
-    request_date = Date.parse(written_explanation_request_date)
+    decision_date = decision_letter_date
+    received_date = response
+    request_date = written_explanation_request_date
     raise InvalidResponse if received_date < request_date
     received_within_a_month = received_date < 1.month.since(request_date)
 
@@ -115,10 +115,10 @@ date_question :when_did_you_get_it? do
   end
 
   next_node do |response|
-    received_date = Date.parse(response)
-    received_within_a_month = received_date < 1.month.since(Date.parse(written_explanation_request_date))
+    received_date = response
+    received_within_a_month = received_date < 1.month.since(written_explanation_request_date)
     a_fortnight_has_passed = Date.today > 1.fortnight.since(received_date)
-    decision_date = Date.parse(decision_letter_date)
+    decision_date = decision_letter_date
     a_month_and_a_fortnight_since_decision = Date.today > 1.fortnight.since(1.month.since(decision_date))
 
     if (!received_within_a_month and a_fortnight_has_passed) or

--- a/test/integration/smart_answer_flows/appeal_a_benefits_decision_test.rb
+++ b/test/integration/smart_answer_flows/appeal_a_benefits_decision_test.rb
@@ -281,7 +281,7 @@ class AppealABenefitsDecisionTest < ActiveSupport::TestCase
 
             should "show an error" do
               assert_current_node_is_error
-              assert_state_variable "written_explanation_request_date", @request_date.strftime("%e %B %Y")
+              assert_state_variable "written_explanation_request_date", @request_date
             end
           end
 

--- a/test/unit/date_question_test.rb
+++ b/test/unit/date_question_test.rb
@@ -9,7 +9,7 @@ module SmartAnswer
       @initial_state = State.new(:example)
     end
 
-    test "dates are parsed from hash form before being saved" do
+    test "dates are parsed from Hash into String before being saved" do
       q = Question::Date.new(:example) do
         save_input_as :date
         next_node :done
@@ -17,6 +17,16 @@ module SmartAnswer
 
       new_state = q.transition(@initial_state, {year: "2011", month: '2', day: '1'})
       assert_equal '2011-02-01', new_state.date
+    end
+
+    test "dates are parsed from Hash into Date before being saved" do
+      q = Question::Date.new(:example, parse: true) do
+        save_input_as :date
+        next_node :done
+      end
+
+      new_state = q.transition(@initial_state, {year: "2011", month: '2', day: '1'})
+      assert_equal Date.parse('2011-02-01'), new_state.date
     end
 
     test "incomplete dates raise an error" do

--- a/test/unit/flow_test.rb
+++ b/test/unit/flow_test.rb
@@ -60,6 +60,16 @@ class FlowTest < ActiveSupport::TestCase
     assert_equal Date.parse('2011-01-01')..Date.parse('2014-01-01'), s.questions.first.range
   end
 
+  test "Can build date question nodes with response parsed to Date object" do
+    s = SmartAnswer::Flow.new do
+      date_question :when_is_your_birthday?, parse: true do
+      end
+    end
+
+    assert_equal 1, s.nodes.size
+    assert_equal 1, s.questions.size
+  end
+
   test "Can build value question nodes" do
     s = SmartAnswer::Flow.new do
       value_question :how_many_green_bottles? do

--- a/test/unit/node_presenter_test.rb
+++ b/test/unit/node_presenter_test.rb
@@ -154,6 +154,13 @@ module SmartAnswer
       assert_equal " 1 March 2011", presenter.response_label("2011-03-01")
     end
 
+    test "Can lookup a response label for a date question with date object response" do
+      question = Question::Date.new(:example_question?)
+      presenter = DateQuestionPresenter.new("flow.test", question)
+
+      assert_equal " 1 March 2011", presenter.response_label(Date.parse("2011-03-01"))
+    end
+
     test "Outcome has a title if using the NodePresenter" do
       outcome = Outcome.new(:outcome_with_no_title)
       presenter = NodePresenter.new("flow.test", outcome)


### PR DESCRIPTION
This PR add an optional `parse` option to `date_question` which when `true`
causes the response to be a `Date` object and not just a date `String`.

Having parsed the response into a `Date` object it makes no sense to me to then
convert it back into a `String`. There seems to be a lot of code in the Ruby DSL
flows (and their calculators) which has to re-parse the date
strings. Also some date "variables" are `Date` objects and some are date strings
in these smart answers which is really confusing.

The plan is ultimately to **always** supply the response to a
`SmartAnswer::Question::Date` as a Date object and to only use `Date` objects
within the Ruby DSL flows and associated calculators. However, to get there
incrementally I'm introducing this option so we can convert one question or
smart answer flow at a time.

This PR includes changing the `appeal-a-benefits-decision` smart answer to use
the new option as an example of how it works. We plan to introduce similar
changes to other smart answers directly into `master` in order to reduce the
possibility of merge problems.

We think that it will be worth adopting this pattern for all question types,
but we have to start somewhere. The thinking is that the Ruby DSL flows
and their associated calculators should operate on richer Ruby objects where
possible rather than just strings.
