### PR TITLE
Maternity paternity adoption calculator fixes

### DIFF
--- a/lib/smart_answer_flows/locales/en/maternity-paternity-calculator.yml
+++ b/lib/smart_answer_flows/locales/en/maternity-paternity-calculator.yml
@@ -29,8 +29,8 @@ en-GB:
 
         + the baby’s due date
         + date of birth - for paternity
-        + your employee’s salary details - eg weekly rates of pay
-        + the dates for adoption - eg match date or date of placement
+        + your employee’s salary details, eg weekly rates of pay
+        + the dates for adoption, eg match date and date of placement
 
 
         You can’t use the calculator for:
@@ -475,7 +475,7 @@ en-GB:
       ## QA6
       adoption_date_leave_starts?:
         title: When does the employee want to start their leave?
-        hint: Leave can't start before %{a_leave_earliest_start} or within 28 days of the child arriving in the UK (overseas adoptions only).
+        hint: Leave can’t start before %{a_leave_earliest_start}. For overseas adoptions your leave must start within 28 days of the child arriving in the UK.
         error_message: Please enter a valid date
       ## QA7
       last_normal_payday_adoption?:

--- a/lib/smart_answer_flows/shared_logic/adoption-calculator.rb
+++ b/lib/smart_answer_flows/shared_logic/adoption-calculator.rb
@@ -158,7 +158,7 @@ date_question :payday_eight_weeks_adoption? do
   end
 
   calculate :last_payday_eight_weeks do |response|
-    payday = Date.parse(response)
+    payday = Date.parse(response) + 1.day
     raise SmartAnswer::InvalidResponse if payday > Date.parse(payday_offset)
     calculator.pre_offset_payday = payday
     payday

--- a/lib/smart_answer_flows/shared_logic/maternity-calculator.rb
+++ b/lib/smart_answer_flows/shared_logic/maternity-calculator.rb
@@ -113,8 +113,7 @@ date_question :payday_eight_weeks? do
   end
 
   calculate :last_payday_eight_weeks do |response|
-    payday = Date.parse(response)
-    payday += 1 if leave_type == 'maternity'
+    payday = Date.parse(response) + 1.day
     raise SmartAnswer::InvalidResponse if payday > Date.parse(payday_offset)
     calculator.pre_offset_payday = payday
     payday

--- a/lib/smart_answer_flows/shared_logic/paternity-calculator.rb
+++ b/lib/smart_answer_flows/shared_logic/paternity-calculator.rb
@@ -276,7 +276,7 @@ date_question :payday_eight_weeks_paternity? do
   end
 
   calculate :pre_offset_payday do |response|
-    payday = Date.parse(response)
+    payday = Date.parse(response) + 1.day
     raise SmartAnswer::InvalidResponse if payday > calculator.payday_offset
     calculator.pre_offset_payday = payday
     payday

--- a/test/integration/smart_answer_flows/paternity_calculator_test.rb
+++ b/test/integration/smart_answer_flows/paternity_calculator_test.rb
@@ -410,7 +410,7 @@ class PaternityCalculatorTest < ActiveSupport::TestCase
           add_response "500"
           assert_current_node :paternity_leave_and_pay
           assert_phrase_list :paternity_info, [:paternity_entitled_to_leave, :paternity_not_entitled_to_pay_intro, :must_earn_over_threshold, :paternity_not_entitled_to_pay_outro]
-          assert_state_variable :relevant_period, 'Friday, 22 November 2013 and Friday, 17 January 2014'
+          assert_state_variable :relevant_period, 'Saturday, 23 November 2013 and Friday, 17 January 2014'
           assert_state_variable :to_saturday, "Saturday, 18 January 2014"
           assert_state_variable :lower_earning_limit, '109.00'
         end
@@ -434,7 +434,7 @@ class PaternityCalculatorTest < ActiveSupport::TestCase
           add_response "500"
           assert_current_node :paternity_leave_and_pay
           assert_phrase_list :paternity_info, [:paternity_entitled_to_leave, :paternity_not_entitled_to_pay_intro, :must_earn_over_threshold, :paternity_not_entitled_to_pay_outro]
-          assert_state_variable :relevant_period, "Tuesday, 02 April 2013 and Sunday, 06 April 2014"
+          assert_state_variable :relevant_period, "Wednesday, 03 April 2013 and Sunday, 06 April 2014"
           assert_state_variable :to_saturday, "Saturday, 12 April 2014"
           assert_state_variable :lower_earning_limit, '111.00'
         end


### PR DESCRIPTION
Change 1: 
pre_offset_payday is used to calculate the 8 week period a day needs to be added to fill the 8 week period as it was calculating it to be 8 weeks and 1 day

Change 2:
Need to amend fourth bullet in intro to: the dates for adoption, eg match date and date of placement

Change 3:
Need to amend third bullet in intro to: your employee’s salary details, eg weekly rates of pay

Change 4:
Need to reword hint text in Q8 adoption to: Leave can’t start before leave_earliest_start. For overseas adoptions your leave must start within 28 days of the child arriving in the UK.