### PR TITLE
Do not set HTTP Cache-Control expiry time header by default in test environment

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,15 +23,4 @@ protected
   def set_analytics_headers
     set_slimmer_headers(format: "smart_answer")
   end
-
-  def set_expiry(duration = 30.minutes)
-    # if the artefact returned from the Content API is blank, or if
-    # the request to the Content API fails, set a very short cache so
-    # we don't cache an incomplete page for a while
-    duration = 5.seconds if @presenter.present? and @presenter.artefact.blank?
-
-    unless Rails.env.development?
-      expires_in(duration, public: true)
-    end
-  end
 end

--- a/app/controllers/smart_answers_controller.rb
+++ b/app/controllers/smart_answers_controller.rb
@@ -123,4 +123,14 @@ private
     smartdown_registry.find(name.to_s)
   end
 
+  def set_expiry(duration = 30.minutes)
+    # if the artefact returned from the Content API is blank, or if
+    # the request to the Content API fails, set a very short cache so
+    # we don't cache an incomplete page for a while
+    duration = 5.seconds if @presenter.present? and @presenter.artefact.blank?
+
+    unless Rails.env.development?
+      expires_in(duration, public: true)
+    end
+  end
 end

--- a/app/controllers/smart_answers_controller.rb
+++ b/app/controllers/smart_answers_controller.rb
@@ -129,7 +129,7 @@ private
     # we don't cache an incomplete page for a while
     duration = 5.seconds if @presenter.present? and @presenter.artefact.blank?
 
-    unless Rails.env.development?
+    if Rails.configuration.set_http_cache_control_expiry_time
       expires_in(duration, public: true)
     end
   end

--- a/config/initializers/http_cache_control.rb
+++ b/config/initializers/http_cache_control.rb
@@ -1,0 +1,7 @@
+SmartAnswers::Application.configure do
+  if Rails.env.development?
+    config.set_http_cache_control_expiry_time = false
+  else
+    config.set_http_cache_control_expiry_time = true
+  end
+end

--- a/config/initializers/http_cache_control.rb
+++ b/config/initializers/http_cache_control.rb
@@ -1,5 +1,5 @@
 SmartAnswers::Application.configure do
-  if Rails.env.development?
+  if Rails.env.development? || Rails.env.test?
     config.set_http_cache_control_expiry_time = false
   else
     config.set_http_cache_control_expiry_time = true


### PR DESCRIPTION
It feels safer/less surprising to disable any caching mechanisms by default
in the `test` environment and just enable them for the tests that need them.

I've checked and the tests now pass with the seed mentioned in #1612 for
both `phantomjs` v1.9.8 and v2.0.0. Fixes #1612
