### PR TITLE
Notify about missing phrases via Airbrake

### DIFF
--- a/app/presenters/node_presenter.rb
+++ b/app/presenters/node_presenter.rb
@@ -32,7 +32,12 @@ class NodePresenter
     when ::SmartAnswer::PhraseList then
       if nested == false
         value.phrase_keys.map do |phrase_key|
-          I18n.translate!("#{@i18n_prefix}.phrases.#{phrase_key}", state_for_interpolation(true)) rescue phrase_key
+          begin
+            I18n.translate!("#{@i18n_prefix}.phrases.#{phrase_key}", state_for_interpolation(true))
+          rescue => e
+            Airbrake.notify_or_ignore(e)
+            phrase_key
+          end
         end.join("\n\n")
       else
         false

--- a/test/unit/node_presenter_test.rb
+++ b/test/unit/node_presenter_test.rb
@@ -68,11 +68,13 @@ module SmartAnswer
       ".gsub /^      /, ''), presenter.body
     end
 
-    test "Phrase lists fallback gracefully when no translation can be found" do
+    test "Phrase lists notify developers and fallback gracefully when no translation can be found" do
       outcome = Outcome.new(:outcome_with_interpolated_phrase_list)
       state = State.new(outcome.name)
       state.phrases = PhraseList.new(:four, :one, :two, :three)
       presenter = NodePresenter.new("flow.test", outcome, state)
+
+      Airbrake.expects(:notify_or_ignore).once
 
       assert_match Regexp.new("<p>Here are the phrases:</p>
 


### PR DESCRIPTION
In https://github.com/alphagov/smart-answers/commit/3e9c2909758c480bfb4fd2897f20748d051739e6 a change was introduced to silently fall back to a phrase key if the phrase is not defined in the YML file. 

I think developers should know about cases like this. Hence I'm adding an airbrake notification, but leaving the UX as it was at least initially. Perhaps later we can just raise those exceptions so we know about it in dev/test environments as well as staging/production.

Thoughts?