### PR TITLE
Log missing phrase keys

### DIFF
--- a/app/presenters/node_presenter.rb
+++ b/app/presenters/node_presenter.rb
@@ -32,10 +32,11 @@ class NodePresenter
     when ::SmartAnswer::PhraseList then
       if nested == false
         value.phrase_keys.map do |phrase_key|
+          full_phrase_key = "#{@i18n_prefix}.phrases.#{phrase_key}"
           begin
-            I18n.translate!("#{@i18n_prefix}.phrases.#{phrase_key}", state_for_interpolation(true))
+            I18n.translate!(full_phrase_key, state_for_interpolation(true))
           rescue => e
-            Airbrake.notify_or_ignore(e)
+            Rails.logger.warn("[Missing phrase] The phrase being rendered is not present: #{full_phrase_key}. Responses: #{@state.responses.join('/')}")
             phrase_key
           end
         end.join("\n\n")

--- a/test/unit/node_presenter_test.rb
+++ b/test/unit/node_presenter_test.rb
@@ -74,7 +74,7 @@ module SmartAnswer
       state.phrases = PhraseList.new(:four, :one, :two, :three)
       presenter = NodePresenter.new("flow.test", outcome, state)
 
-      Airbrake.expects(:notify_or_ignore).once
+      Rails.logger.expects(:warn).with("[Missing phrase] The phrase being rendered is not present: flow.test.phrases.four. Responses: ").once
 
       assert_match Regexp.new("<p>Here are the phrases:</p>
 


### PR DESCRIPTION
in 3e9c290 a change was introduced
to silently fall back to a phrase key if the phrase is not defined
in the YML file. I think developers should know about cases like
this. Hence I'm logging it, but leaving the UX as it was at least
initially. Perhaps later we can just raise the exception so we know
about it in dev/test environments as well as staging/production.

This overwrites the changes in https://github.com/alphagov/smart-answers/pull/1614 because they generated too much noise in staging and messed up metrics and alerts

/cc @jennyd @floehopper 