### PR TITLE
Allow parsing of value_question responses into Integers instead of Strings

### DIFF
--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -64,8 +64,8 @@ module SmartAnswer
       add_node Question::Date.new(name, &block)
     end
 
-    def value_question(name, &block)
-      add_node Question::Value.new(name, &block)
+    def value_question(name, options = {}, &block)
+      add_node Question::Value.new(name, options, &block)
     end
 
     def money_question(name, &block)

--- a/lib/smart_answer/question/value.rb
+++ b/lib/smart_answer/question/value.rb
@@ -1,6 +1,18 @@
 module SmartAnswer
   module Question
     class Value < Base
+      def initialize(name, options = {}, &block)
+        @parse = options[:parse]
+        super
+      end
+
+      def parse_input(raw_input)
+        if Integer == @parse
+          Integer(raw_input)
+        else
+          super
+        end
+      end
     end
   end
 end

--- a/lib/smart_answer_flows/calculate-agricultural-holiday-entitlement.rb
+++ b/lib/smart_answer_flows/calculate-agricultural-holiday-entitlement.rb
@@ -56,14 +56,14 @@ multiple_choice :worked_for_same_employer? do
   end
 end
 
-value_question :how_many_total_days? do
+value_question :how_many_total_days?, parse: Integer do
 
   precalculate :available_days do
     calculator.available_days
   end
 
   calculate :total_days_worked do |response|
-    if Integer(response) > available_days
+    if response > available_days
       raise SmartAnswer::InvalidResponse
     end
     response
@@ -72,12 +72,12 @@ value_question :how_many_total_days? do
   next_node :worked_for_same_employer?
 end
 
-value_question :how_many_weeks_at_current_employer? do
+value_question :how_many_weeks_at_current_employer?, parse: Integer do
   next_node :done
 
   calculate :holiday_entitlement_days do |response|
     #Has to be less than a full year
-    if (Integer(response) > 51)
+    if (response > 51)
       raise SmartAnswer::InvalidResponse
     end
     if !days_worked_per_week.nil?
@@ -85,7 +85,7 @@ value_question :how_many_weeks_at_current_employer? do
     elsif !weeks_from_october_1.nil?
       days = calculator.holiday_days (total_days_worked.to_f / weeks_from_october_1.to_f).round(10)
     end
-    sprintf("%.1f", (days * (Integer(response) / 52.0)).round(10))
+    sprintf("%.1f", (days * (response / 52.0)).round(10))
   end
 end
 

--- a/test/unit/flow_test.rb
+++ b/test/unit/flow_test.rb
@@ -62,14 +62,25 @@ class FlowTest < ActiveSupport::TestCase
 
   test "Can build value question nodes" do
     s = SmartAnswer::Flow.new do
-      value_question :how_many_green_bottles? do
+      value_question :what_colour_are_the_bottles? do
+        save_input_as :bottle_colour
+      end
+    end
+
+    assert_equal 1, s.nodes.size
+    assert_equal 1, s.questions.size
+    assert_equal :what_colour_are_the_bottles?, s.questions.first.name
+  end
+
+  test "Can build value question nodes with response parsed to Integer object" do
+    s = SmartAnswer::Flow.new do
+      value_question :how_many_green_bottles?, parse: Integer do
         save_input_as :num_bottles
       end
     end
 
     assert_equal 1, s.nodes.size
     assert_equal 1, s.questions.size
-    assert_equal :how_many_green_bottles?, s.questions.first.name
   end
 
   test "Can build money question nodes" do

--- a/test/unit/value_question_test.rb
+++ b/test/unit/value_question_test.rb
@@ -9,8 +9,28 @@ module SmartAnswer
       @initial_state = State.new(:example)
     end
 
-    test "Value can be saved" do
+    test "Value is saved as a String by default" do
       q = Question::Value.new(:example) do
+        save_input_as :myval
+        next_node :done
+      end
+
+      new_state = q.transition(@initial_state, "123")
+      assert_equal '123', new_state.myval
+    end
+
+    test "Value is saved as an Integer specified by parse option" do
+      q = Question::Value.new(:example, parse: Integer) do
+        save_input_as :myval
+        next_node :done
+      end
+
+      new_state = q.transition(@initial_state, "123")
+      assert_equal 123, new_state.myval
+    end
+
+    test "Value is saved as a String if parse option specifies unknown type" do
+      q = Question::Value.new(:example, parse: Float) do
         save_input_as :myval
         next_node :done
       end


### PR DESCRIPTION
This PR adds an _optional_ `parse` option to `value_question` which when set to
`Integer` causes the response to be an `Integer` object and not just a `String`.

There seems to be a lot of code in the Ruby DSL flows which has to parse the
response from a `value_question` into an `Integer`. It feels as if it would be
simpler if the Ruby DSL flows always dealt with richer non-string value types
and the parsing was dealt with in one place in
`SmartAnswer::Question::Value#parse_input`.

I've chosen to specify the `Integer` type as the `parse` option value, because it
looks as if we'll need the flexibility to handle genuine `String` or even `Float`
responses.

Making the option optional means that I'll be able incrementally convert one
question or smart answer flow at a time to use the new parsing mechanism.

This PR includes changing the `calculate-agricultural-holiday-entitlement`
smart answer to use the new option as an example of how it works. I plan
to introduce similar changes to other smart answers directly into `master` in
order to reduce the possibility of merge problems.

This is part of a plan to adopt this kind of mechanism for all question types.

c.f.  #1608 where we did a similar thing for `date_question`.
