### PR TITLE
Bust helper state cache

### DIFF
--- a/lib/smart_answer_flows/README.md
+++ b/lib/smart_answer_flows/README.md
@@ -169,7 +169,7 @@ next_node_if(:something, can_has_cheesburger?)
 
 ## Testing Smart Answers
 
-You need to use nested contexts/tests in order to test Ruby/YAML Smart Answers.
+You used to need to use nested contexts/tests in order to test Ruby/YAML Smart Answers. This is no longer needed, feel free to flatten tests that are too deeply nested.
 
 ### Example Smart Answer Flow
 
@@ -199,9 +199,9 @@ You need to use nested contexts/tests in order to test Ruby/YAML Smart Answers.
     outcome :outcome_1 do
     end
 
-### Valid test using nested contexts
+### A test using nested contexts
 
-This test passes using the example flow above.
+This test passes using the example flow above. 
 
     setup do
       setup_for_testing_flow 'example-flow'
@@ -241,9 +241,9 @@ This test passes using the example flow above.
       end
     end
 
-### Invalid test - Not using nested contexts
+### Flattened test
 
-This test will fail at `assert_current_node :question_2`.
+The same test as above in a flattened form. It passes using the example flow above.
 
     should "exercise the example flow" do
       setup_for_testing_flow 'example-flow'

--- a/test/integration/smart_answer_flows/flow_test_helper.rb
+++ b/test/integration/smart_answer_flows/flow_test_helper.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 module FlowTestHelper
   def setup_for_testing_flow(flow_slug)
     @flow = SmartAnswer::FlowRegistry.instance.find(flow_slug)
@@ -11,7 +9,11 @@ module FlowTestHelper
   end
 
   def current_state
+    if @cached_responses && @cached_responses != @responses
+      @cached_responses, @state = nil, nil
+    end
     @state ||= begin
+      @cached_responses = @responses.dup
       @flow.process(@responses)
     end
   end

--- a/test/unit/test_helpers/flow_test_helper_test.rb
+++ b/test/unit/test_helpers/flow_test_helper_test.rb
@@ -1,0 +1,34 @@
+require_relative '../../test_helper'
+require_relative '../../integration/smart_answer_flows/flow_test_helper'
+
+class FlowTestHelperTest < ActiveSupport::TestCase
+
+  class FlowTestHelperIncluder
+    include FlowTestHelper
+    attr_accessor :responses
+
+    def initialize(flow, responses)
+      @flow = flow
+      @responses = responses
+    end
+  end
+
+
+  test "caches current_state" do
+    flow = Object.new
+    flow.expects(:process).once.returns(:state)
+    includer = FlowTestHelperIncluder.new(flow, [:yes, :no])
+    includer.current_state
+    includer.current_state
+  end
+
+  test "busts current_state cache when responses change" do
+    flow = Object.new
+    flow.expects(:process).twice.returns(:state)
+    responses = [:yes, :no]
+    includer = FlowTestHelperIncluder.new(flow, responses)
+    includer.current_state
+    responses << :maybe
+    includer.current_state
+  end
+end


### PR DESCRIPTION
The #current_state was cached regardless of the current state of @responses.
As a side effect this forced developers to write tests within nested contexts, as explained [here](https://gist.github.com/chrisroos/bbd450c6a13d64faf66f). This is no longer required.

The test suite duration has not changed:
```
# This branch
1.59s user 0.41s system 0% cpu 3:55.95 total

# master
 1.61s user 0.41s system 0% cpu 3:57.48 total
```