### PR TITLE
Add :to_i parse option to value_questions

### DIFF
--- a/lib/smart_answer/question/value.rb
+++ b/lib/smart_answer/question/value.rb
@@ -9,6 +9,8 @@ module SmartAnswer
       def parse_input(raw_input)
         if Integer == @parse
           Integer(raw_input)
+        elsif :to_i == @parse
+          raw_input.to_i
         else
           super
         end

--- a/lib/smart_answer_flows/shared_logic/maternity-calculator.rb
+++ b/lib/smart_answer_flows/shared_logic/maternity-calculator.rb
@@ -193,9 +193,9 @@ multiple_choice :when_in_the_month_is_the_employee_paid? do
 end
 
 ## QM13
-value_question :what_specific_date_each_month_is_the_employee_paid? do
+value_question :what_specific_date_each_month_is_the_employee_paid?, parse: :to_i do
   calculate :pay_day_in_month do |response|
-    day = response.to_i
+    day = response
     raise InvalidResponse unless day > 0 and day < 32
     calculator.pay_day_in_month = day
   end

--- a/lib/smart_answer_flows/shared_logic/paternity-calculator.rb
+++ b/lib/smart_answer_flows/shared_logic/paternity-calculator.rb
@@ -369,10 +369,10 @@ multiple_choice :monthly_pay_paternity? do
 end
 
 ## QP17
-value_question :specific_date_each_month_paternity? do
+value_question :specific_date_each_month_paternity?, parse: :to_i do
 
   calculate :pay_day_in_month do |response|
-    day = response.to_i
+    day = response
     raise InvalidResponse unless day > 0 and day < 32
     calculator.pay_day_in_month = day
   end

--- a/test/unit/flow_test.rb
+++ b/test/unit/flow_test.rb
@@ -72,7 +72,7 @@ class FlowTest < ActiveSupport::TestCase
     assert_equal :what_colour_are_the_bottles?, s.questions.first.name
   end
 
-  test "Can build value question nodes with response parsed to Integer object" do
+  test "Can build value question nodes with parse option specified" do
     s = SmartAnswer::Flow.new do
       value_question :how_many_green_bottles?, parse: Integer do
         save_input_as :num_bottles

--- a/test/unit/value_question_test.rb
+++ b/test/unit/value_question_test.rb
@@ -19,7 +19,7 @@ module SmartAnswer
       assert_equal '123', new_state.myval
     end
 
-    test "Value is saved as an Integer specified by parse option" do
+    test "Value is saved as an Integer using Integer() when specified by parse option" do
       q = Question::Value.new(:example, parse: Integer) do
         save_input_as :myval
         next_node :done
@@ -27,6 +27,16 @@ module SmartAnswer
 
       new_state = q.transition(@initial_state, "123")
       assert_equal 123, new_state.myval
+    end
+
+    test "Value is saved as an Integer using String#to_i when specified by parse option" do
+      q = Question::Value.new(:example, parse: :to_i) do
+        save_input_as :myval
+        next_node :done
+      end
+
+      new_state = q.transition(@initial_state, "")
+      assert_equal 0, new_state.myval
     end
 
     test "Value is saved as a String if parse option specifies unknown type" do


### PR DESCRIPTION
Following on from #1629, this PR provides a less strict integer parsing option
for `value_question`.

Some `value_questions` are using `String#to_i` in `calculate` blocks to parse
string responses into integers. Ideally we'd be consistently using the same
parsing mechanism for all value questions expecting an integer response, but
it's difficult to determine whether the differences are by accident or design.
So for the moment, providing two mechanisms i.e. using `Integer()` or
`String#to_i` feels like a small improvement and at least makes the difference
more explicit. We can decide whether to try to combine these alternative
mechanisms later.

It's worth noting that using the new `:to_i` parse option instead of converting
the string response within a `calculate` block in the flow will result in a
few small changes in behaviour. If the user enters a non-integer string
response, the **parsed** `Integer` will be used in (a) the URL path segment;
(b) the "Previous Answers" section; and (c) the pre-filled value if the user
clicks on the "Change" link for the relevant previous question.

I think this new behaviour, while different, is actually better. Also the old
URL paths and query strings will still work sensibly. So I'm happy to go with
it.

This PR includes an example of using the new `:to_i` option, but I plan to
introduce similar future changes directly into `master` to minimise merge
problems.