### PR TITLE
Flatten statutory sick pay tests

### DIFF
--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -36,7 +36,7 @@ end
 # Question 3
 multiple_choice :employee_work_different_days? do
   option yes: :not_regular_schedule # Answer 4
-    option no: :first_sick_day? # Question 4
+  option no: :first_sick_day? # Question 4
 end
 
 # Question 4

--- a/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
@@ -9,345 +9,199 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
     setup_for_testing_flow 'calculate-statutory-sick-pay'
   end
 
-  context "Already getting maternity allowance" do
-    context "Getting statutory maternity pay" do
-      should "go to result A1" do
-        add_response "statutory_maternity_pay"
-        assert_current_node :already_getting_maternity # A1
-      end
+  context "Getting statutory maternity pay" do
+    should "go to result A1" do
+      add_response "statutory_maternity_pay"
+      assert_current_node :already_getting_maternity # A1
+    end
+  end
+
+  context "Getting maternity allowance" do
+    should "go to result A1" do
+      add_response "maternity_allowance"
+      assert_current_node :already_getting_maternity # A1
+    end
+  end
+
+  context "Not getting maternity allowance" do
+    setup do
+      add_response "ordinary_statutory_paternity_pay,statutory_adoption_pay"
     end
 
-    context "Getting maternity allowance" do
-      should "go to result A1" do
-        add_response "maternity_allowance"
-        assert_current_node :already_getting_maternity # A1
-      end
+    should "set adoption warning state variable" do
+      assert_state_variable :paternity_maternity_warning, true
+    end
+    should "take you to Q2" do
+      assert_current_node :employee_tell_within_limit? # Q2
+    end
+  end
+
+  context "Getting additional statutory paternity pay" do
+    setup do
+      add_response "additional_statutory_paternity_pay"
     end
 
-    context "Not getting maternity allowance" do
+    should "set adoption warning state variable" do
+      assert_state_variable :paternity_maternity_warning, true
+    end
+
+    should "take you to Q2" do
+      assert_current_node :employee_tell_within_limit? # Q2
+    end
+
+    context "employee didn't tell employer within time limit" do
       setup do
-        add_response "ordinary_statutory_paternity_pay,statutory_adoption_pay"
+        add_response :no
       end
 
-      should "set adoption warning state variable" do
-        assert_state_variable :paternity_maternity_warning, true
+      should "go to entitled_to_sick_pay outcome" do
+        assert_current_node :employee_work_different_days?
+        add_response :no
+        assert_current_node :first_sick_day?
+        add_response '2014-03-02'
+        assert_current_node :last_sick_day?
+        add_response '2014-06-02'
+        assert_current_node :paid_at_least_8_weeks?
+        add_response 'before_payday'
+        assert_current_node :how_often_pay_employee_pay_patterns?
+        add_response 'irregularly'
+        assert_current_node :pay_amount_if_not_sick?
+        add_response '3000'
+        assert_current_node :contractual_days_covered_by_earnings?
+        add_response '17'
+        assert_current_node :off_sick_4_days?
+        add_response 'no'
+        assert_current_node :usual_work_days?
+        add_response '1,2,3,4,5'
+        assert_current_node :entitled_to_sick_pay
+        assert_phrase_list :proof_of_illness, [:enough_notice]
+        assert_phrase_list :paternity_adoption_warning, [:paternity_warning]
       end
-      should "take you to Q2" do
-        assert_current_node :employee_tell_within_limit? # Q2
-      end
-    end
-    context "Not getting maternity allowance" do
+    end # answer no to employer told in time
+
+    context "employee told employer within time limit" do
       setup do
-        add_response "additional_statutory_paternity_pay"
+        add_response :yes
+      end
+      should "take you to Q3" do
+        assert_current_node :employee_work_different_days? # Q3
       end
 
-      should "set adoption warning state variable" do
-        assert_state_variable :paternity_maternity_warning, true
-      end
-      should "take you to Q2" do
-        assert_current_node :employee_tell_within_limit? # Q2
-      end
-
-      context "employee didn't tell employer within time limit" do
-        setup do
-          add_response :no
-        end
-        should "ask if employee works different days of the week" do
-          assert_current_node :employee_work_different_days?
-        end
-
-        context "answer no" do
-          setup do
-            add_response :no
-          end
-          should "ask when the first sick day was" do
-            assert_current_node :first_sick_day?
-          end
-
-          context "answer 2 March 2014" do
-            setup do
-              add_response Date.parse('2 March 2014')
-            end
-            should "ask when the last sick day was" do
-              assert_current_node :last_sick_day?
-            end
-
-            context "answer 2 June 2014" do
-              setup do
-                add_response Date.parse('2 June 2014')
-              end
-              should "ask if employer paid 8 weeks of earnings" do
-                assert_current_node :paid_at_least_8_weeks?
-              end
-
-              context "answer before_payday" do
-                setup do
-                  add_response 'before_payday'
-                end
-                should "ask how often employee is paid" do
-                  assert_current_node :how_often_pay_employee_pay_patterns?
-                end
-
-                context "answer irregularly" do
-                  setup do
-                    add_response 'irregularly'
-                  end
-                  should "ask how much they would have been paid on first payday" do
-                    assert_current_node :pay_amount_if_not_sick?
-                  end
-
-                  context "answer £3000" do
-                    setup do
-                      add_response '3000'
-                    end
-                    should "ask how many days earnings cover" do
-                      assert_current_node :contractual_days_covered_by_earnings?
-                    end
-
-                    context "answer 17 days" do
-                      setup do
-                        add_response '17'
-                      end
-                      should "ask if employee was off sick the previous 8 weeks for 4 days" do
-                        assert_current_node :off_sick_4_days?
-                      end
-
-                      context "answer no" do
-                        setup do
-                          add_response 'no'
-                        end
-                        should "ask which days of the week they usually work" do
-                          assert_current_node :usual_work_days?
-                        end
-
-                        context "answer monday to friday" do
-                          setup do
-                            add_response '1,2,3,4,5'
-                          end
-                          should "go to entitled_to_sick_pay outcome" do
-                            assert_current_node :entitled_to_sick_pay
-                            assert_phrase_list :proof_of_illness, [:enough_notice]
-                            assert_phrase_list :paternity_adoption_warning, [:paternity_warning]
-                          end
-                        end
-                      end
-                    end
-                  end
-                end
-              end
-            end
-          end
-        end
-      end # answer no to employer told in time
-
-      context "employee told employer within time limit" do
+      context "employee works different days of the week" do
         setup do
           add_response :yes
         end
-        should "take you to Q3" do
-          assert_current_node :employee_work_different_days? # Q3
+        should "go to result A4" do
+          assert_current_node :not_regular_schedule # A4
+        end
+      end
+
+      context "employee works regular days" do
+        setup do
+          add_response :no
+        end
+        should "take them to Q4" do
+          assert_current_node :first_sick_day? # Q4
         end
 
-        context "employee works different days of the week" do
+        context "answering first sick day" do
           setup do
-            add_response :yes
-          end
-          should "go to result A4" do
-            assert_current_node :not_regular_schedule # A4
-          end
-        end
-
-        context "employee works regular days" do
-          setup do
-            add_response :no
-          end
-          should "take them to Q4" do
-            assert_current_node :first_sick_day? # Q4
+            add_response '02/04/2013'
           end
 
-          context "answering first sick day" do
-            setup do
-              add_response '02/04/2013'
+          should "store response and move to Q5" do
+            assert_state_variable :sick_start_date, Date.parse(' 2 April 2013')
+            assert_current_node :last_sick_day? # Q5
+          end
+
+          context "answering last sick day" do
+            context "last sick day is less than 3 days after first" do
+              setup do
+                add_response '04/04/2013'
+              end
+              should "take you to result A2" do
+                assert_current_node :must_be_sick_for_4_days # A2
+              end
             end
 
-            should "store response and move to Q5" do
-              assert_state_variable :sick_start_date, Date.parse(' 2 April 2013')
-              assert_current_node :last_sick_day? # Q5
-            end
-
-            context "answering last sick day" do
-              context "last sick day is less than 3 days after first" do
-                setup do
-                  add_response '04/04/2013'
-                end
-                should "take you to result A2" do
-                  assert_current_node :must_be_sick_for_4_days # A2
-                end
+            context "last sick day is 3 days or more after first" do
+              setup do
+                add_response '10/04/2013'
+              end
+              should "store last sick day" do
+                assert_state_variable :sick_end_date, Date.parse('10 April 2013')
               end
 
-              context "last sick day is 3 days or more after first" do
+              should "ask had you paid employee at least 8 weeks" do # Q5.1
+                assert_current_node :paid_at_least_8_weeks?
+              end
+              # new 8 weeks question with three branches
+              context "answer yes, paid at least 8 weeks" do
                 setup do
-                  add_response '10/04/2013'
+                  add_response 'eight_weeks_more'
                 end
-                should "store last sick day" do
-                  assert_state_variable :sick_end_date, Date.parse('10 April 2013')
+                should "ask how often you pay employees" do # Q 5.2
+                  assert_current_node :how_often_pay_employee_pay_patterns?
+                  assert_state_variable :eight_weeks_earnings, 'eight_weeks_more'
                 end
 
-                should "ask had you paid employee at least 8 weeks" do # Q5.1
-                  assert_current_node :paid_at_least_8_weeks?
-                end
-                # new 8 weeks question with three branches
-                context "answer yes, paid at least 8 weeks" do
+                context "answer weekly" do
                   setup do
-                    add_response 'eight_weeks_more'
+                    add_response 'weekly'
                   end
-                  should "ask how often you pay employees" do # Q 5.2
-                    assert_current_node :how_often_pay_employee_pay_patterns?
-                    assert_state_variable :eight_weeks_earnings, 'eight_weeks_more'
+                  should "ask for last payday before start sick date" do # Q6
+                    assert_current_node :last_payday_before_sickness?
+                    assert_state_variable :pay_pattern, 'weekly'
                   end
-
-                  context "answer weekly" do
+                  context "enter last payday before start of sickness" do
                     setup do
-                      add_response 'weekly'
+                      add_response '31/03/2013'
                     end
-                    should "ask for last payday before start sick date" do # Q6
-                      assert_current_node :last_payday_before_sickness?
-                      assert_state_variable :pay_pattern, 'weekly'
+                    should "ask for last normal payday before payday offset" do # Q6.1
+                      assert_current_node :last_payday_before_offset?
+
                     end
-                    context "enter last payday before start of sickness" do
+                    context "enter last payday before offset" do
                       setup do
-                        add_response '31/03/2013'
+                        add_response '31/01/2013'
                       end
-                      should "ask for last normal payday before payday offset" do # Q6.1
-                        assert_current_node :last_payday_before_offset?
-
+                      should "ask for total amount paid" do # Q 6.2
+                        assert_current_node :total_employee_earnings?
                       end
-                      context "enter last payday before offset" do
+                      context "enter total amount paid between paydays" do
                         setup do
-                          add_response '31/01/2013'
+                          add_response '4000'
                         end
-                        should "ask for total amount paid" do # Q 6.2
-                          assert_current_node :total_employee_earnings?
-                        end
-                        context "enter total amount paid between paydays" do
-                          setup do
-                            add_response '4000'
-                          end
-                          should "ask about PIW" do # Q11
-                            assert_current_node :off_sick_4_days?
-                          end
-
-                          context "answer yes" do
-                            setup do
-                              add_response :yes
-                            end
-                            should "ask for start date of linked period of sickness" do # Q11.1
-                              assert_current_node :linked_sickness_start_date?
-                            end
-                            context "enter previous sickness start date" do
-                              setup do
-                                add_response ' 1/01/2013'
-                              end
-                              should "ask how many days sick the employee had in this previous period" do # Q12
-                                assert_current_node :how_many_days_sick?
-                              end
-                              context "answer 6 days" do
-                                setup do
-                                  add_response '6'
-                                end
-                                should "ask which days of the week do they work" do # Q13
-                                  assert_current_node :usual_work_days?
-                                end
-                                context "answer weekdays" do
-                                  setup do
-                                    add_response '1,2,3,4,5'
-                                  end
-                                  should "take you to result A6" do # A6
-                                    assert_current_node :entitled_to_sick_pay
-                                  end
-                                end
-                              end
-                            end
-                          end
-                          context "answer no" do
-                            setup do
-                              add_response 'no'
-                            end
-                            should "ask which days of the week they work" do # Q13
-                              assert_current_node :usual_work_days?
-                            end
-                            context "answer weekdays" do
-                              setup do
-                                add_response '1,2,3,4,5'
-                              end
-                              should "take you to result 6 without first days (no PIW)" do
-                                assert_current_node :entitled_to_sick_pay
-                                assert_phrase_list :entitled_to_esa, [:esa]
-                                assert_phrase_list :paternity_adoption_warning, [:paternity_warning]
-                              end
-                            end
-                          end
-                        end
-                      end
-                    end
-                  end
-                end
-
-                context "answer no, employee is new and fell sick before payday" do
-                  setup do
-                    add_response 'before_payday'
-                  end
-                  should "ask how often you pay employees" do # Q 5.2
-                    assert_current_node :how_often_pay_employee_pay_patterns?
-                  end
-                  context "answer monthly" do
-                    setup do
-                      add_response 'monthly'
-                    end
-                    should "ask how much you would have paid on their first payday" do # Q7
-                      assert_current_node :pay_amount_if_not_sick?
-                    end
-                    context "answer £2000" do
-                      setup do
-                        add_response '2000'
-                      end
-                      should "ask how many days the period covers" do # Q7.1
-                        assert_current_node :contractual_days_covered_by_earnings?
-                      end
-                      context "answer 30" do
-                        setup do
-                          add_response '30'
-                        end
-                        should "ask abou PIW" do # Q11.1
+                        should "ask about PIW" do # Q11
                           assert_current_node :off_sick_4_days?
                         end
 
                         context "answer yes" do
                           setup do
-                            add_response 'yes'
+                            add_response :yes
                           end
-                          should "ask for start date of linked sickness" do # Q11
+                          should "ask for start date of linked period of sickness" do # Q11.1
                             assert_current_node :linked_sickness_start_date?
                           end
                           context "enter previous sickness start date" do
                             setup do
-                              add_response '12/03/2013'
+                              add_response ' 1/01/2013'
                             end
-                            should "ask how many previous sick days were taken" do # Q12
+                            should "ask how many days sick the employee had in this previous period" do # Q12
                               assert_current_node :how_many_days_sick?
                             end
-                            context "answer 4" do
+                            context "answer 6 days" do
                               setup do
-                                add_response '4'
+                                add_response '6'
                               end
-                              should "ask which days they work" do # Q13
+                              should "ask which days of the week do they work" do # Q13
                                 assert_current_node :usual_work_days?
                               end
-                              context "answer three days a week" do
+                              context "answer weekdays" do
                                 setup do
-                                  add_response '1,2,3'
+                                  add_response '1,2,3,4,5'
                                 end
-                                should "take you to result A6" do
+                                should "take you to result A6" do # A6
                                   assert_current_node :entitled_to_sick_pay
                                 end
                               end
@@ -367,6 +221,8 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
                             end
                             should "take you to result 6 without first days (no PIW)" do
                               assert_current_node :entitled_to_sick_pay
+                              assert_phrase_list :entitled_to_esa, [:esa]
+                              assert_phrase_list :paternity_adoption_warning, [:paternity_warning]
                             end
                           end
                         end
@@ -374,52 +230,61 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
                     end
                   end
                 end
+              end
 
-                context "answer no, paid less than 8 weeks earnings" do
+              context "answer no, employee is new and fell sick before payday" do
+                setup do
+                  add_response 'before_payday'
+                end
+                should "ask how often you pay employees" do # Q 5.2
+                  assert_current_node :how_often_pay_employee_pay_patterns?
+                end
+                context "answer monthly" do
                   setup do
-                    add_response :eight_weeks_less
+                    add_response 'monthly'
                   end
-                  should "ask what total earnings before sick start date" do # Q8
-                    assert_current_node :total_earnings_before_sick_period?
+                  should "ask how much you would have paid on their first payday" do # Q7
+                    assert_current_node :pay_amount_if_not_sick?
                   end
-                  context "answer £3000" do
+                  context "answer £2000" do
                     setup do
-                      add_response '3000'
+                      add_response '2000'
                     end
-                    should "ask how many days does this period cover" do # Q8.1
-                      assert_current_node :days_covered_by_earnings?
+                    should "ask how many days the period covers" do # Q7.1
+                      assert_current_node :contractual_days_covered_by_earnings?
                     end
-                    context "answer 35 days" do
+                    context "answer 30" do
                       setup do
-                        add_response '35'
+                        add_response '30'
                       end
-                      should "ask the PIW question" do # Q11
+                      should "ask abou PIW" do # Q11.1
                         assert_current_node :off_sick_4_days?
                       end
+
                       context "answer yes" do
                         setup do
                           add_response 'yes'
                         end
-                        should "ask for start date of previous sickness" do # Q 11.1
+                        should "ask for start date of linked sickness" do # Q11
                           assert_current_node :linked_sickness_start_date?
                         end
                         context "enter previous sickness start date" do
                           setup do
-                            add_response '24/03/2013'
+                            add_response '12/03/2013'
                           end
                           should "ask how many previous sick days were taken" do # Q12
                             assert_current_node :how_many_days_sick?
                           end
-                          context "answer 5 days" do
+                          context "answer 4" do
                             setup do
-                              add_response '5'
+                              add_response '4'
                             end
                             should "ask which days they work" do # Q13
                               assert_current_node :usual_work_days?
                             end
-                            context "answer weekdays" do
+                            context "answer three days a week" do
                               setup do
-                                add_response '1,2,3,4,5'
+                                add_response '1,2,3'
                               end
                               should "take you to result A6" do
                                 assert_current_node :entitled_to_sick_pay
@@ -448,12 +313,86 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
                   end
                 end
               end
+
+              context "answer no, paid less than 8 weeks earnings" do
+                setup do
+                  add_response :eight_weeks_less
+                end
+                should "ask what total earnings before sick start date" do # Q8
+                  assert_current_node :total_earnings_before_sick_period?
+                end
+                context "answer £3000" do
+                  setup do
+                    add_response '3000'
+                  end
+                  should "ask how many days does this period cover" do # Q8.1
+                    assert_current_node :days_covered_by_earnings?
+                  end
+                  context "answer 35 days" do
+                    setup do
+                      add_response '35'
+                    end
+                    should "ask the PIW question" do # Q11
+                      assert_current_node :off_sick_4_days?
+                    end
+                    context "answer yes" do
+                      setup do
+                        add_response 'yes'
+                      end
+                      should "ask for start date of previous sickness" do # Q 11.1
+                        assert_current_node :linked_sickness_start_date?
+                      end
+                      context "enter previous sickness start date" do
+                        setup do
+                          add_response '24/03/2013'
+                        end
+                        should "ask how many previous sick days were taken" do # Q12
+                          assert_current_node :how_many_days_sick?
+                        end
+                        context "answer 5 days" do
+                          setup do
+                            add_response '5'
+                          end
+                          should "ask which days they work" do # Q13
+                            assert_current_node :usual_work_days?
+                          end
+                          context "answer weekdays" do
+                            setup do
+                              add_response '1,2,3,4,5'
+                            end
+                            should "take you to result A6" do
+                              assert_current_node :entitled_to_sick_pay
+                            end
+                          end
+                        end
+                      end
+                    end
+                    context "answer no" do
+                      setup do
+                        add_response 'no'
+                      end
+                      should "ask which days of the week they work" do # Q13
+                        assert_current_node :usual_work_days?
+                      end
+                      context "answer weekdays" do
+                        setup do
+                          add_response '1,2,3,4,5'
+                        end
+                        should "take you to result 6 without first days (no PIW)" do
+                          assert_current_node :entitled_to_sick_pay
+                        end
+                      end
+                    end
+                  end
+                end
+              end
             end
           end
         end
-      end # answer yes to employer told in time
-    end
+      end
+    end # answer yes to employer told in time
   end
+
   context "average weekly earnings is less than the LEL on sick start date" do
     setup do
       add_response 'none' # Q1

--- a/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
@@ -77,12 +77,13 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
         assert_phrase_list :proof_of_illness, [:enough_notice]
         assert_phrase_list :paternity_adoption_warning, [:paternity_warning]
       end
-    end # answer no to employer told in time
+    end
 
     context "employee told employer within time limit" do
       setup do
         add_response :yes
       end
+
       should "take you to Q3" do
         assert_current_node :employee_work_different_days? # Q3
       end
@@ -97,300 +98,192 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       end
 
       context "employee works regular days" do
-        setup do
+        should "require to be sick more than 4 days to get sick pay" do
           add_response :no
-        end
-        should "take them to Q4" do
           assert_current_node :first_sick_day? # Q4
+          add_response '2013-04-02'
+          assert_state_variable :sick_start_date, Date.parse(' 2 April 2013')
+          assert_current_node :last_sick_day? # Q5
+
+          add_response '2013-04-04'
+          assert_current_node :must_be_sick_for_4_days # A2
         end
 
-        context "answering first sick day" do
-          setup do
-            add_response '02/04/2013'
-          end
+        should "lead to entitled_to_sick_pay outcome when there is a linked sickness" do
+          add_response :no
+          assert_current_node :first_sick_day? # Q4
+          add_response '2013-04-02'
+          assert_state_variable :sick_start_date, Date.parse(' 2 April 2013')
+          assert_current_node :last_sick_day? # Q5
 
-          should "store response and move to Q5" do
-            assert_state_variable :sick_start_date, Date.parse(' 2 April 2013')
-            assert_current_node :last_sick_day? # Q5
-          end
+          add_response '2013-04-10'
+          assert_state_variable :sick_end_date, Date.parse('10 April 2013')
+          assert_current_node :paid_at_least_8_weeks?
 
-          context "answering last sick day" do
-            context "last sick day is less than 3 days after first" do
-              setup do
-                add_response '04/04/2013'
-              end
-              should "take you to result A2" do
-                assert_current_node :must_be_sick_for_4_days # A2
-              end
-            end
+          add_response 'eight_weeks_more'
+          assert_current_node :how_often_pay_employee_pay_patterns?
+          assert_state_variable :eight_weeks_earnings, 'eight_weeks_more'
+          add_response 'weekly'
+          assert_current_node :last_payday_before_sickness?
+          assert_state_variable :pay_pattern, 'weekly'
+          add_response '2013-03-31'
+          assert_current_node :last_payday_before_offset?
+          add_response '2013-01-31'
+          assert_current_node :total_employee_earnings?
+          add_response '4000'
+          assert_current_node :off_sick_4_days?
 
-            context "last sick day is 3 days or more after first" do
-              setup do
-                add_response '10/04/2013'
-              end
-              should "store last sick day" do
-                assert_state_variable :sick_end_date, Date.parse('10 April 2013')
-              end
+          add_response 'yes'
+          assert_current_node :linked_sickness_start_date?
+          add_response '2013-01-01'
+          assert_current_node :how_many_days_sick?
+          add_response '6'
+          assert_current_node :usual_work_days?
+          add_response '1,2,3,4,5'
+          assert_current_node :entitled_to_sick_pay
+        end
 
-              should "ask had you paid employee at least 8 weeks" do # Q5.1
-                assert_current_node :paid_at_least_8_weeks?
-              end
-              # new 8 weeks question with three branches
-              context "answer yes, paid at least 8 weeks" do
-                setup do
-                  add_response 'eight_weeks_more'
-                end
-                should "ask how often you pay employees" do # Q 5.2
-                  assert_current_node :how_often_pay_employee_pay_patterns?
-                  assert_state_variable :eight_weeks_earnings, 'eight_weeks_more'
-                end
+        should "lead to entitled_to_sick_pay without first days when there is no linked sickness" do
+          add_response :no
+          assert_current_node :first_sick_day? # Q4
+          add_response '2013-04-02'
+          assert_state_variable :sick_start_date, Date.parse(' 2 April 2013')
+          assert_current_node :last_sick_day? # Q5
 
-                context "answer weekly" do
-                  setup do
-                    add_response 'weekly'
-                  end
-                  should "ask for last payday before start sick date" do # Q6
-                    assert_current_node :last_payday_before_sickness?
-                    assert_state_variable :pay_pattern, 'weekly'
-                  end
-                  context "enter last payday before start of sickness" do
-                    setup do
-                      add_response '31/03/2013'
-                    end
-                    should "ask for last normal payday before payday offset" do # Q6.1
-                      assert_current_node :last_payday_before_offset?
+          add_response '2013-04-10'
+          assert_state_variable :sick_end_date, Date.parse('10 April 2013')
+          assert_current_node :paid_at_least_8_weeks?
 
-                    end
-                    context "enter last payday before offset" do
-                      setup do
-                        add_response '31/01/2013'
-                      end
-                      should "ask for total amount paid" do # Q 6.2
-                        assert_current_node :total_employee_earnings?
-                      end
-                      context "enter total amount paid between paydays" do
-                        setup do
-                          add_response '4000'
-                        end
-                        should "ask about PIW" do # Q11
-                          assert_current_node :off_sick_4_days?
-                        end
+          add_response 'eight_weeks_more'
+          assert_current_node :how_often_pay_employee_pay_patterns?
+          assert_state_variable :eight_weeks_earnings, 'eight_weeks_more'
+          add_response 'weekly'
+          assert_current_node :last_payday_before_sickness?
+          assert_state_variable :pay_pattern, 'weekly'
+          add_response '2013-03-31'
+          assert_current_node :last_payday_before_offset?
+          add_response '2013-01-31'
+          assert_current_node :total_employee_earnings?
+          add_response '4000'
+          assert_current_node :off_sick_4_days?
 
-                        context "answer yes" do
-                          setup do
-                            add_response :yes
-                          end
-                          should "ask for start date of linked period of sickness" do # Q11.1
-                            assert_current_node :linked_sickness_start_date?
-                          end
-                          context "enter previous sickness start date" do
-                            setup do
-                              add_response ' 1/01/2013'
-                            end
-                            should "ask how many days sick the employee had in this previous period" do # Q12
-                              assert_current_node :how_many_days_sick?
-                            end
-                            context "answer 6 days" do
-                              setup do
-                                add_response '6'
-                              end
-                              should "ask which days of the week do they work" do # Q13
-                                assert_current_node :usual_work_days?
-                              end
-                              context "answer weekdays" do
-                                setup do
-                                  add_response '1,2,3,4,5'
-                                end
-                                should "take you to result A6" do # A6
-                                  assert_current_node :entitled_to_sick_pay
-                                end
-                              end
-                            end
-                          end
-                        end
-                        context "answer no" do
-                          setup do
-                            add_response 'no'
-                          end
-                          should "ask which days of the week they work" do # Q13
-                            assert_current_node :usual_work_days?
-                          end
-                          context "answer weekdays" do
-                            setup do
-                              add_response '1,2,3,4,5'
-                            end
-                            should "take you to result 6 without first days (no PIW)" do
-                              assert_current_node :entitled_to_sick_pay
-                              assert_phrase_list :entitled_to_esa, [:esa]
-                              assert_phrase_list :paternity_adoption_warning, [:paternity_warning]
-                            end
-                          end
-                        end
-                      end
-                    end
-                  end
-                end
-              end
+          add_response 'no'
+          assert_current_node :usual_work_days?
+          add_response '1,2,3,4,5'
+          assert_current_node :entitled_to_sick_pay
+          assert_phrase_list :entitled_to_esa, [:esa]
+          assert_phrase_list :paternity_adoption_warning, [:paternity_warning]
+        end
 
-              context "answer no, employee is new and fell sick before payday" do
-                setup do
-                  add_response 'before_payday'
-                end
-                should "ask how often you pay employees" do # Q 5.2
-                  assert_current_node :how_often_pay_employee_pay_patterns?
-                end
-                context "answer monthly" do
-                  setup do
-                    add_response 'monthly'
-                  end
-                  should "ask how much you would have paid on their first payday" do # Q7
-                    assert_current_node :pay_amount_if_not_sick?
-                  end
-                  context "answer £2000" do
-                    setup do
-                      add_response '2000'
-                    end
-                    should "ask how many days the period covers" do # Q7.1
-                      assert_current_node :contractual_days_covered_by_earnings?
-                    end
-                    context "answer 30" do
-                      setup do
-                        add_response '30'
-                      end
-                      should "ask abou PIW" do # Q11.1
-                        assert_current_node :off_sick_4_days?
-                      end
+        should "lead to entitled_to_sick_pay if worker got sick before payday and had linked sickness" do
+          add_response :no
+          assert_current_node :first_sick_day? # Q4
+          add_response '2013-04-02'
+          assert_state_variable :sick_start_date, Date.parse(' 2 April 2013')
+          assert_current_node :last_sick_day? # Q5
 
-                      context "answer yes" do
-                        setup do
-                          add_response 'yes'
-                        end
-                        should "ask for start date of linked sickness" do # Q11
-                          assert_current_node :linked_sickness_start_date?
-                        end
-                        context "enter previous sickness start date" do
-                          setup do
-                            add_response '12/03/2013'
-                          end
-                          should "ask how many previous sick days were taken" do # Q12
-                            assert_current_node :how_many_days_sick?
-                          end
-                          context "answer 4" do
-                            setup do
-                              add_response '4'
-                            end
-                            should "ask which days they work" do # Q13
-                              assert_current_node :usual_work_days?
-                            end
-                            context "answer three days a week" do
-                              setup do
-                                add_response '1,2,3'
-                              end
-                              should "take you to result A6" do
-                                assert_current_node :entitled_to_sick_pay
-                              end
-                            end
-                          end
-                        end
-                      end
-                      context "answer no" do
-                        setup do
-                          add_response 'no'
-                        end
-                        should "ask which days of the week they work" do # Q13
-                          assert_current_node :usual_work_days?
-                        end
-                        context "answer weekdays" do
-                          setup do
-                            add_response '1,2,3,4,5'
-                          end
-                          should "take you to result 6 without first days (no PIW)" do
-                            assert_current_node :entitled_to_sick_pay
-                          end
-                        end
-                      end
-                    end
-                  end
-                end
-              end
+          add_response '2013-04-10'
+          assert_state_variable :sick_end_date, Date.parse('10 April 2013')
+          assert_current_node :paid_at_least_8_weeks?
 
-              context "answer no, paid less than 8 weeks earnings" do
-                setup do
-                  add_response :eight_weeks_less
-                end
-                should "ask what total earnings before sick start date" do # Q8
-                  assert_current_node :total_earnings_before_sick_period?
-                end
-                context "answer £3000" do
-                  setup do
-                    add_response '3000'
-                  end
-                  should "ask how many days does this period cover" do # Q8.1
-                    assert_current_node :days_covered_by_earnings?
-                  end
-                  context "answer 35 days" do
-                    setup do
-                      add_response '35'
-                    end
-                    should "ask the PIW question" do # Q11
-                      assert_current_node :off_sick_4_days?
-                    end
-                    context "answer yes" do
-                      setup do
-                        add_response 'yes'
-                      end
-                      should "ask for start date of previous sickness" do # Q 11.1
-                        assert_current_node :linked_sickness_start_date?
-                      end
-                      context "enter previous sickness start date" do
-                        setup do
-                          add_response '24/03/2013'
-                        end
-                        should "ask how many previous sick days were taken" do # Q12
-                          assert_current_node :how_many_days_sick?
-                        end
-                        context "answer 5 days" do
-                          setup do
-                            add_response '5'
-                          end
-                          should "ask which days they work" do # Q13
-                            assert_current_node :usual_work_days?
-                          end
-                          context "answer weekdays" do
-                            setup do
-                              add_response '1,2,3,4,5'
-                            end
-                            should "take you to result A6" do
-                              assert_current_node :entitled_to_sick_pay
-                            end
-                          end
-                        end
-                      end
-                    end
-                    context "answer no" do
-                      setup do
-                        add_response 'no'
-                      end
-                      should "ask which days of the week they work" do # Q13
-                        assert_current_node :usual_work_days?
-                      end
-                      context "answer weekdays" do
-                        setup do
-                          add_response '1,2,3,4,5'
-                        end
-                        should "take you to result 6 without first days (no PIW)" do
-                          assert_current_node :entitled_to_sick_pay
-                        end
-                      end
-                    end
-                  end
-                end
-              end
-            end
-          end
+          add_response 'before_payday'
+          assert_current_node :how_often_pay_employee_pay_patterns?
+          add_response 'monthly'
+          assert_current_node :pay_amount_if_not_sick?
+          add_response '2000'
+          assert_current_node :contractual_days_covered_by_earnings?
+          add_response '30'
+          assert_current_node :off_sick_4_days?
+
+          add_response 'yes'
+          assert_current_node :linked_sickness_start_date?
+          add_response '2013-03-12'
+          assert_current_node :how_many_days_sick?
+          add_response '4'
+          assert_current_node :usual_work_days?
+          add_response '1,2,3'
+          assert_current_node :entitled_to_sick_pay
+        end
+
+        should "lead to entitled_to_sick_pay if worker got sick before payday and had no linked sickness" do
+          add_response :no
+          assert_current_node :first_sick_day? # Q4
+          add_response '2013-04-02'
+          assert_state_variable :sick_start_date, Date.parse(' 2 April 2013')
+          assert_current_node :last_sick_day? # Q5
+
+          add_response '2013-04-10'
+          assert_state_variable :sick_end_date, Date.parse('10 April 2013')
+          assert_current_node :paid_at_least_8_weeks?
+
+          add_response 'before_payday'
+          assert_current_node :how_often_pay_employee_pay_patterns?
+          add_response 'monthly'
+          assert_current_node :pay_amount_if_not_sick?
+          add_response '2000'
+          assert_current_node :contractual_days_covered_by_earnings?
+          add_response '30'
+          assert_current_node :off_sick_4_days?
+
+          add_response 'no'
+          assert_current_node :usual_work_days?
+          add_response '1,2,3,4,5'
+          assert_current_node :entitled_to_sick_pay
+        end
+
+        should "lead to entitled_to_sick_pay if worker got sick before being employed for 8 weeks and had linked sickness" do
+          add_response :no
+          assert_current_node :first_sick_day? # Q4
+          add_response '2013-04-02'
+          assert_state_variable :sick_start_date, Date.parse(' 2 April 2013')
+          assert_current_node :last_sick_day? # Q5
+
+          add_response '2013-04-10'
+          assert_state_variable :sick_end_date, Date.parse('10 April 2013')
+          assert_current_node :paid_at_least_8_weeks?
+
+          add_response :eight_weeks_less
+          assert_current_node :total_earnings_before_sick_period?
+          add_response '3000'
+          assert_current_node :days_covered_by_earnings?
+          add_response '35'
+          assert_current_node :off_sick_4_days?
+
+          add_response 'yes'
+          assert_current_node :linked_sickness_start_date?
+          add_response '2013-03-24'
+          assert_current_node :how_many_days_sick?
+          add_response '5'
+          assert_current_node :usual_work_days?
+          add_response '1,2,3,4,5'
+          assert_current_node :entitled_to_sick_pay
+        end
+
+        should "lead to entitled_to_sick_pay if worker got sick before being employed for 8 weeks and had no linked sickness" do
+          add_response :no
+          assert_current_node :first_sick_day? # Q4
+          add_response '2013-04-02'
+          assert_state_variable :sick_start_date, Date.parse(' 2 April 2013')
+          assert_current_node :last_sick_day? # Q5
+
+          add_response '2013-04-10'
+          assert_state_variable :sick_end_date, Date.parse('10 April 2013')
+          assert_current_node :paid_at_least_8_weeks?
+
+          add_response :eight_weeks_less
+          assert_current_node :total_earnings_before_sick_period?
+          add_response '3000'
+          assert_current_node :days_covered_by_earnings?
+          add_response '35'
+          assert_current_node :off_sick_4_days?
+
+          add_response 'no'
+          assert_current_node :usual_work_days?
+          add_response '1,2,3,4,5'
+          assert_current_node :entitled_to_sick_pay
         end
       end
-    end # answer yes to employer told in time
+    end
   end
 
   context "average weekly earnings is less than the LEL on sick start date" do
@@ -398,15 +291,15 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response 'none' # Q1
       add_response 'yes' # Q2
       add_response 'no' # Q3
-      add_response '10/06/2013' # Q4
-      add_response '20/06/2013' # Q5
+      add_response '2013-06-10' # Q4
+      add_response '2013-06-20' # Q5
       add_response 'before_payday' # Q5.1
       add_response 'weekly' # Q5.2
       add_response '100' # Q7
       add_response '7' # Q7.1
       add_response 'no' # Q11
     end
-    should "take you to result A5 as awe < LEL (as of 10/06/2013)" do
+    should "take you to result A5 as awe < LEL (as of 2013-06-10)" do
       assert_state_variable :employee_average_weekly_earnings, 100
       assert_current_node :not_earned_enough
     end
@@ -417,8 +310,8 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response 'none'
       add_response 'yes'
       add_response 'no'
-      add_response '10/06/2013'
-      add_response '12/06/2013'
+      add_response '2013-06-10'
+      add_response '2013-06-12'
     end
     should "take you to result A7 - must be sick for at least 4 days in a row" do
       assert_current_node :must_be_sick_for_4_days
@@ -430,15 +323,15 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response 'none'
       add_response 'yes'
       add_response 'no'
-      add_response '10/06/2013'
-      add_response '20/06/2013'
+      add_response '2013-06-10'
+      add_response '2013-06-20'
       add_response 'eight_weeks_more'
       add_response 'monthly'
-      add_response '31/05/2013'
-      add_response '31/03/2013'
+      add_response '2013-05-31'
+      add_response '2013-03-31'
       add_response '4000'
       add_response 'yes'
-      add_response '01/01/2013'
+      add_response '2013-01-01'
       add_response '183'
       add_response '1,2,3,4,5'
     end


### PR DESCRIPTION
This is up for discussion, but @BenJanecke and I think it makes it easier to change the tests. 

This PR is a result of us trying to move Q11 right after Q5 in statutory sick pay calculator, which requires a lot of tests to change. We were not able to effectively refactor tests as this task gets particularly difficult with multiple levels of nesting (16 levels of nesting was the deepest level I think). It's difficult mainly because the contexts branch out, introducing a new question requires similar "branching" at a different level, thus essentially making change harder than a complete rewrite (subjective).

Flattening tests introduces some duplication in test setup. I believe we could avoid this by using setup methods with descriptive names e.g. `setup_employee_who_noticed_on_time_about_sickness_of_4_days`. But I wanted to get feedback about this PR in general before proceeding with this idea.

Flattening the test also makes it a bit harder to write good test descriptions, but I think the ones on master need significant improvements anyway. In this particular case removing context with descriptions does not cause much harm, because reading assertions/responses is quite descriptive eg:

```ruby
        assert_current_node :employee_work_different_days?
        add_response :no
        assert_current_node :first_sick_day?
        add_response '2014-03-02'
        assert_current_node :last_sick_day?
        add_response '2014-06-02'
```

Moreover, even with some duplication the result is `259 additions and 427 deletions.` It may not be the best metric of readability, but should indicate reduction of syntactic noise in the test file.

Best reviewed in ["Split" mode](https://github.com/blog/1884-introducing-split-diffs)

Please share your thoughts :)