### PR TITLE
Standardize boot.rb and rely on bundler to load all gems

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -3,7 +3,6 @@ require 'yaml'
 require 'syck'
 YAML::ENGINE.yamler = 'syck'
 
-# Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
-require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+require 'bundler/setup' # Set up gems listed in the Gemfile.

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,8 +1,7 @@
-require 'rubygems'
-require 'yaml'
-require 'syck'
-YAML::ENGINE.yamler = 'syck'
-
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
+
+require 'yaml'
+require 'syck'
+YAML::ENGINE.yamler = 'syck'


### PR DESCRIPTION
* Change `config/boot.rb` to match fresh Rails v4.2.1 app.

* The syck gem is included in the Gemfile and so we don't need the
`require 'rubygems'` statement, as long as we move the `require 'syck'`
statement below the `require 'bundler/setup'` statement. `require 'yaml'`
can appear anywhere before the `YAML::ENGINE.yamler` assignment,
because YAML is part of the standard library.

These changes mean that our application boot is more like that of a standard
Rails app and allows people to avoid needing to use `bundle exec` to run the
tests using [this technique][1].

[1]: https://tomafro.net/2012/06/tip-bundler-with-binstubs
