### PR TITLE
[In Fact Check - DO NOT MERGE] Updates to calculate-statutory-sick-pay

### DIFF
--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -70,13 +70,13 @@ date_question :last_sick_day? do
   next_node(:must_be_sick_for_4_days)
 end
 
-# Question 11
+# Question 6
 multiple_choice :has_linked_sickness? do
   option yes: :linked_sickness_start_date?
   option no: :paid_at_least_8_weeks?
 end
 
-# Question 11.1
+# Question 6.1
 date_question :linked_sickness_start_date? do
   from { Date.new(2010, 1, 1) }
   to { Date.today }
@@ -88,7 +88,7 @@ date_question :linked_sickness_start_date? do
   next_node(:linked_sickness_end_date?)
 end
 
-# Question 11.2
+# Question 6.2
 date_question :linked_sickness_end_date? do
   from { Date.new(2010, 1, 1) }
   to { Date.today }
@@ -102,7 +102,7 @@ date_question :linked_sickness_end_date? do
   next_node(:paid_at_least_8_weeks?)
 end
 
-# Question 5.1
+# Question 7.1
 multiple_choice :paid_at_least_8_weeks? do
   option eight_weeks_more: :how_often_pay_employee_pay_patterns? # Question 5.2
   option eight_weeks_less: :total_earnings_before_sick_period? # Question 8
@@ -111,7 +111,7 @@ multiple_choice :paid_at_least_8_weeks? do
   save_input_as :eight_weeks_earnings
 end
 
-# Question 5.2
+# Question 7.2
 multiple_choice :how_often_pay_employee_pay_patterns? do
   option :weekly
   option :fortnightly
@@ -125,7 +125,7 @@ multiple_choice :how_often_pay_employee_pay_patterns? do
   next_node(:pay_amount_if_not_sick?) # Question 7
 end
 
-# Question 6
+# Question 8
 date_question :last_payday_before_sickness? do
   from { Date.new(2010, 1, 1) }
   to { Date.today }
@@ -148,7 +148,7 @@ date_question :last_payday_before_sickness? do
   next_node(:last_payday_before_offset?)
 end
 
-# Question 6.1
+# Question 8.1
 date_question :last_payday_before_offset? do
   from { Date.new(2010, 1, 1) }
   to { Date.today }
@@ -170,7 +170,7 @@ date_question :last_payday_before_offset? do
   next_node(:total_employee_earnings?)
 end
 
-# Question 6.2
+# Question 8.2
 money_question :total_employee_earnings? do
   save_input_as :relevant_period_pay
 
@@ -183,14 +183,14 @@ money_question :total_employee_earnings? do
   next_node :usual_work_days?
 end
 
-# Question 7
+# Question 9
 money_question :pay_amount_if_not_sick? do
   save_input_as :relevant_contractual_pay
 
   next_node :contractual_days_covered_by_earnings?
 end
 
-# Question 7.1
+# Question 9.1
 value_question :contractual_days_covered_by_earnings? do
   save_input_as :contractual_earnings_days
 
@@ -202,14 +202,14 @@ value_question :contractual_days_covered_by_earnings? do
   next_node :usual_work_days?
 end
 
-# Question 8
+# Question 10
 money_question :total_earnings_before_sick_period? do
   save_input_as :earnings
 
   next_node :days_covered_by_earnings?
 end
 
-# Question 8.1
+# Question 10.1
 value_question :days_covered_by_earnings? do
 
   calculate :employee_average_weekly_earnings do |response|
@@ -221,7 +221,7 @@ value_question :days_covered_by_earnings? do
   next_node :usual_work_days?
 end
 
-# Q13
+# Q11
 checkbox_question :usual_work_days? do
   %w{1 2 3 4 5 6 0}.each { |n| option n.to_s }
 

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -93,10 +93,6 @@ date_question :linked_sickness_end_date? do
   from { Date.new(2010, 1, 1) }
   to { Date.today }
 
-  calculate :sick_end_date do |response|
-    response
-  end
-
   calculate :prior_sick_days do |response|
     start_date = sick_start_date
     last_day_sick = response
@@ -254,7 +250,6 @@ checkbox_question :usual_work_days? do
   # Answer 8
   next_node_if(:maximum_entitlement_reached) do |response|
     days_worked = response.split(',').size
-
     prior_sick_days and prior_sick_days.to_i >= (days_worked * 28 + 3)
   end
 

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -108,7 +108,7 @@ date_question :linked_sickness_end_date? do
   end
 
   calculate :prior_sick_days do |response|
-    start_date = sick_end_date_for_awe
+    start_date = sick_start_date_for_awe
     last_day_sick = response
     (last_day_sick - start_date).to_i + 1
   end

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -193,9 +193,6 @@ multiple_choice :off_sick_4_days? do
   option yes: :linked_sickness_start_date?
   option :no
 
-  next_node_if(:not_earned_enough) do
-    employee_average_weekly_earnings < Calculators::StatutorySickPayCalculator.lower_earning_limit_on(sick_start_date)
-  end
   next_node :usual_work_days?
 end
 
@@ -204,9 +201,7 @@ date_question :linked_sickness_start_date? do
   from { Date.new(2010, 1, 1) }
   to { Date.today }
 
-  next_node_if(:not_earned_enough) do |response|
-    employee_average_weekly_earnings < Calculators::StatutorySickPayCalculator.lower_earning_limit_on(response)
-  end
+
   next_node(:how_many_days_sick?)
 end
 
@@ -219,6 +214,10 @@ end
 # Q13
 checkbox_question :usual_work_days? do
   %w{1 2 3 4 5 6 0}.each { |n| option n.to_s }
+
+  next_node_if(:not_earned_enough) do
+    employee_average_weekly_earnings < Calculators::StatutorySickPayCalculator.lower_earning_limit_on(sick_start_date)
+  end
 
   calculate :ssp_payment do
     Money.new(calculator.ssp_payment)

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -64,9 +64,46 @@ date_question :last_sick_day? do
     last_day_sick = response
     (last_day_sick - start_date).to_i + 1
   end
+
   validate { days_sick >= 1 }
-  next_node_if(:paid_at_least_8_weeks?) { days_sick > 3 }
+  next_node_if(:has_linked_sickness?) { days_sick > 3 }
   next_node(:must_be_sick_for_4_days)
+end
+
+# Question 11
+multiple_choice :has_linked_sickness? do
+  option yes: :linked_sickness_start_date?
+  option no: :paid_at_least_8_weeks?
+end
+
+# Question 11.1
+date_question :linked_sickness_start_date? do
+  from { Date.new(2010, 1, 1) }
+  to { Date.today }
+
+  calculate :sick_start_date do |response|
+    response
+  end
+
+  next_node(:linked_sickness_end_date?)
+end
+
+# Question 11.2
+date_question :linked_sickness_end_date? do
+  from { Date.new(2010, 1, 1) }
+  to { Date.today }
+
+  calculate :sick_end_date do |response|
+    response
+  end
+
+  calculate :prior_sick_days do |response|
+    start_date = sick_start_date
+    last_day_sick = response
+    (last_day_sick - start_date).to_i + 1
+  end
+
+  next_node(:paid_at_least_8_weeks?)
 end
 
 # Question 5.1
@@ -147,7 +184,7 @@ money_question :total_employee_earnings? do
       relevant_period_to: relevant_period_to, relevant_period_from: relevant_period_from)
   end
 
-  next_node :off_sick_4_days?
+  next_node :usual_work_days?
 end
 
 # Question 7
@@ -166,7 +203,7 @@ value_question :contractual_days_covered_by_earnings? do
     days_worked = response
     Calculators::StatutorySickPayCalculator.contractual_earnings_awe(pay, days_worked)
   end
-  next_node :off_sick_4_days?
+  next_node :usual_work_days?
 end
 
 # Question 8
@@ -185,29 +222,6 @@ value_question :days_covered_by_earnings? do
     Calculators::StatutorySickPayCalculator.total_earnings_awe(pay, days_worked)
   end
 
-  next_node :off_sick_4_days?
-end
-
-# Question 11
-multiple_choice :off_sick_4_days? do
-  option yes: :linked_sickness_start_date?
-  option :no
-
-  next_node :usual_work_days?
-end
-
-# Question 11.1
-date_question :linked_sickness_start_date? do
-  from { Date.new(2010, 1, 1) }
-  to { Date.today }
-
-
-  next_node(:how_many_days_sick?)
-end
-
-# Q12
-value_question :how_many_days_sick? do
-  save_input_as :prior_sick_days
   next_node :usual_work_days?
 end
 

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -43,7 +43,12 @@ end
 date_question :first_sick_day? do
   from { Date.new(2011, 1, 1) }
   to { Date.today }
+
   calculate :sick_start_date do |response|
+    response
+  end
+
+  calculate :sick_start_date_for_awe do |response|
     response
   end
 
@@ -55,7 +60,12 @@ end
 date_question :last_sick_day? do
   from { Date.new(2011, 1, 1) }
   to { Date.today }
+
   calculate :sick_end_date do |response|
+    response
+  end
+
+  calculate :sick_end_date_for_awe do |response|
     response
   end
 
@@ -81,7 +91,7 @@ date_question :linked_sickness_start_date? do
   from { Date.new(2010, 1, 1) }
   to { Date.today }
 
-  calculate :sick_start_date do |response|
+  calculate :sick_start_date_for_awe do |response|
     response
   end
 
@@ -93,12 +103,12 @@ date_question :linked_sickness_end_date? do
   from { Date.new(2010, 1, 1) }
   to { Date.today }
 
-  calculate :sick_end_date do |response|
+  calculate :sick_end_date_for_awe do |response|
     response
   end
 
   calculate :prior_sick_days do |response|
-    start_date = sick_start_date
+    start_date = sick_end_date_for_awe
     last_day_sick = response
     (last_day_sick - start_date).to_i + 1
   end

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -93,6 +93,10 @@ date_question :linked_sickness_end_date? do
   from { Date.new(2010, 1, 1) }
   to { Date.today }
 
+  calculate :sick_end_date do |response|
+    response
+  end
+
   calculate :prior_sick_days do |response|
     start_date = sick_start_date
     last_day_sick = response

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -36,7 +36,7 @@ end
 # Question 3
 multiple_choice :employee_work_different_days? do
   option yes: :not_regular_schedule # Answer 4
-    option no: :first_sick_day? # Question 4
+  option no: :first_sick_day? # Question 4
 end
 
 # Question 4

--- a/lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml
+++ b/lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml
@@ -73,54 +73,7 @@ en-GB:
         hint: This can include non-working days and bank holidays
         error_message:  End date should be on or after start date
 
-      # Q5.1
-      paid_at_least_8_weeks?:
-        title: On %{sick_start_date} had you paid your employee at least 8 weeks of earnings?
-        options:
-          eight_weeks_more: "Yes, paid at least 8 weeks earnings"
-          eight_weeks_less: "No, paid less than 8 weeks earnings"
-          before_payday: "No, employee is new and fell sick before their first payday"
-
-      # Q5.2
-      how_often_pay_employee_pay_patterns?:
-        title: How often do you pay the employee?
-
       # Question 6
-      last_payday_before_sickness?:
-        title: What was the last normal payday before %{sick_start_date}?
-        error_message: You must enter a date before %{sick_start_date}
-
-      # Question 6.1
-      last_payday_before_offset?:
-        title: What was the last normal payday on or before %{pay_day_offset}?
-        error_message: You must enter a date on or before %{pay_day_offset}
-
-      # Question 6.2
-      total_employee_earnings?:
-        title: Enter the total amount (before deductions like Income Tax and National Insurance) of your employee’s earnings on paydays between %{relevant_period_from} and %{relevant_period_to}.
-        body: |
-          Different rules apply for [directors of limited companies incorporated before 1 October 2009](/statutory-sick-pay-how-different-employment-types-affect-what-you-pay)
-        error_message: Please enter a number greater than 0
-
-      # Question 7
-      pay_amount_if_not_sick?:
-        title: Enter how much you would have paid the employee on their first payday if they hadn’t been sick.
-
-      # Question 7.1
-      contractual_days_covered_by_earnings?:
-        title: How many days does the period represented by these earnings cover?
-        hint: If it’s 2 weeks and 3 days enter ‘17’.
-
-      # Question 8
-      total_earnings_before_sick_period?:
-        title: Enter the total earnings paid before %{sick_start_date}.
-
-      # Question 8.1
-      days_covered_by_earnings?:
-        title: How many days does the period represented by these earnings cover?
-        hint: If it’s 2 weeks and 3 days enter ‘17’.
-
-      # Question 11
       has_linked_sickness?:
         title: Was your employee off sick within the previous 8 weeks for 4 or more days (including non-working days, weekends and holidays)?
         body: |
@@ -128,21 +81,68 @@ en-GB:
 
           *[PIW]: Period of Incapacity for Work
 
-      # Question 11.1
+      # Question 6.1
       linked_sickness_start_date?:
         title: Enter the start date for this linked period of sickness.
 
-      # Question 11.2
+      # Question 6.2
       linked_sickness_end_date?:
         title: Enter the end date for this linked period of sickness.
 
-      # Question 12
+      # Q7.1
+      paid_at_least_8_weeks?:
+        title: On %{sick_start_date} had you paid your employee at least 8 weeks of earnings?
+        options:
+          eight_weeks_more: "Yes, paid at least 8 weeks earnings"
+          eight_weeks_less: "No, paid less than 8 weeks earnings"
+          before_payday: "No, employee is new and fell sick before their first payday"
+
+      # Q7.2
+      how_often_pay_employee_pay_patterns?:
+        title: How often do you pay the employee?
+
+      # Question 8
+      last_payday_before_sickness?:
+        title: What was the last normal payday before %{sick_start_date}?
+        error_message: You must enter a date before %{sick_start_date}
+
+      # Question 8.1
+      last_payday_before_offset?:
+        title: What was the last normal payday on or before %{pay_day_offset}?
+        error_message: You must enter a date on or before %{pay_day_offset}
+
+      # Question 8.2
+      total_employee_earnings?:
+        title: Enter the total amount (before deductions like Income Tax and National Insurance) of your employee’s earnings on paydays between %{relevant_period_from} and %{relevant_period_to}.
+        body: |
+          Different rules apply for [directors of limited companies incorporated before 1 October 2009](/statutory-sick-pay-how-different-employment-types-affect-what-you-pay)
+        error_message: Please enter a number greater than 0
+
+      # Question 9
+      pay_amount_if_not_sick?:
+        title: Enter how much you would have paid the employee on their first payday if they hadn’t been sick.
+
+      # Question 9.1
+      contractual_days_covered_by_earnings?:
+        title: How many days does the period represented by these earnings cover?
+        hint: If it’s 2 weeks and 3 days enter ‘17’.
+
+      # Question 10
+      total_earnings_before_sick_period?:
+        title: Enter the total earnings paid before %{sick_start_date}.
+
+      # Question 10.1
+      days_covered_by_earnings?:
+        title: How many days does the period represented by these earnings cover?
+        hint: If it’s 2 weeks and 3 days enter ‘17’.
+
+      # Question 11
       how_many_days_sick?:
         title: During the previous illness(es), how many normal workdays did your employee take off sick?
         hint: ‘Normal workdays’ are the days your employee works on a regular basis.
         error_message: Please enter a number greater than 0
 
-      # Question 13:
+      # Question 12:
       usual_work_days?:
         title: Which days of the week do they usually work?
         options:

--- a/lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml
+++ b/lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml
@@ -121,7 +121,7 @@ en-GB:
         hint: If it’s 2 weeks and 3 days enter ‘17’.
 
       # Question 11
-      off_sick_4_days?:
+      has_linked_sickness?:
         title: Was your employee off sick within the previous 8 weeks for 4 or more days (including non-working days, weekends and holidays)?
         body: |
           These are called ‘linked Periods of Incapacity for Work (PIW)’. Check if an employee’s [PIW links to a previous one.](/government/publications/statutory-sick-pay-tables-for-linking-periods-of-incapacity-for-work)
@@ -131,6 +131,10 @@ en-GB:
       # Question 11.1
       linked_sickness_start_date?:
         title: Enter the start date for this linked period of sickness.
+
+      # Question 11.2
+      linked_sickness_end_date?:
+        title: Enter the end date for this linked period of sickness.
 
       # Question 12
       how_many_days_sick?:

--- a/lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml
+++ b/lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml
@@ -91,7 +91,7 @@ en-GB:
 
       # Q7.1
       paid_at_least_8_weeks?:
-        title: On %{sick_start_date} had you paid your employee at least 8 weeks of earnings?
+        title: On %{sick_start_date_for_awe} had you paid your employee at least 8 weeks of earnings?
         options:
           eight_weeks_more: "Yes, paid at least 8 weeks earnings"
           eight_weeks_less: "No, paid less than 8 weeks earnings"
@@ -103,8 +103,8 @@ en-GB:
 
       # Question 8
       last_payday_before_sickness?:
-        title: What was the last normal payday before %{sick_start_date}?
-        error_message: You must enter a date before %{sick_start_date}
+        title: What was the last normal payday before %{sick_start_date_for_awe}?
+        error_message: You must enter a date before %{sick_start_date_for_awe}
 
       # Question 8.1
       last_payday_before_offset?:
@@ -129,7 +129,7 @@ en-GB:
 
       # Question 10
       total_earnings_before_sick_period?:
-        title: Enter the total earnings paid before %{sick_start_date}.
+        title: Enter the total earnings paid before %{sick_start_date_for_awe}.
 
       # Question 10.1
       days_covered_by_earnings?:

--- a/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
@@ -76,12 +76,13 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
         assert_phrase_list :proof_of_illness, [:enough_notice]
         assert_phrase_list :paternity_adoption_warning, [:paternity_warning]
       end
-    end # answer no to employer told in time
+    end
 
     context "employee told employer within time limit" do
       setup do
         add_response :yes
       end
+
       should "take you to Q3" do
         assert_current_node :employee_work_different_days? # Q3
       end
@@ -96,300 +97,192 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       end
 
       context "employee works regular days" do
-        setup do
+        should "require to be sick more than 4 days to get sick pay" do
           add_response :no
-        end
-        should "take them to Q4" do
           assert_current_node :first_sick_day? # Q4
+          add_response '2013-04-02'
+          assert_state_variable :sick_start_date, Date.parse(' 2 April 2013')
+          assert_current_node :last_sick_day? # Q5
+
+          add_response '2013-04-04'
+          assert_current_node :must_be_sick_for_4_days # A2
         end
 
-        context "answering first sick day" do
-          setup do
-            add_response '02/04/2013'
-          end
+        should "lead to entitled_to_sick_pay outcome when there is a linked sickness" do
+          add_response :no
+          assert_current_node :first_sick_day? # Q4
+          add_response '2013-04-02'
+          assert_state_variable :sick_start_date, Date.parse(' 2 April 2013')
+          assert_current_node :last_sick_day? # Q5
 
-          should "store response and move to Q5" do
-            assert_state_variable :sick_start_date, Date.parse(' 2 April 2013')
-            assert_current_node :last_sick_day? # Q5
-          end
+          add_response '2013-04-10'
+          assert_state_variable :sick_end_date, Date.parse('10 April 2013')
+          assert_current_node :paid_at_least_8_weeks?
 
-          context "answering last sick day" do
-            context "last sick day is less than 3 days after first" do
-              setup do
-                add_response '04/04/2013'
-              end
-              should "take you to result A2" do
-                assert_current_node :must_be_sick_for_4_days # A2
-              end
-            end
+          add_response 'eight_weeks_more'
+          assert_current_node :how_often_pay_employee_pay_patterns?
+          assert_state_variable :eight_weeks_earnings, 'eight_weeks_more'
+          add_response 'weekly'
+          assert_current_node :last_payday_before_sickness?
+          assert_state_variable :pay_pattern, 'weekly'
+          add_response '2013-03-31'
+          assert_current_node :last_payday_before_offset?
+          add_response '2013-01-31'
+          assert_current_node :total_employee_earnings?
+          add_response '4000'
+          assert_current_node :off_sick_4_days?
 
-            context "last sick day is 3 days or more after first" do
-              setup do
-                add_response '10/04/2013'
-              end
-              should "store last sick day" do
-                assert_state_variable :sick_end_date, Date.parse('10 April 2013')
-              end
+          add_response 'yes'
+          assert_current_node :linked_sickness_start_date?
+          add_response '2013-01-01'
+          assert_current_node :how_many_days_sick?
+          add_response '6'
+          assert_current_node :usual_work_days?
+          add_response '1,2,3,4,5'
+          assert_current_node :entitled_to_sick_pay
+        end
 
-              should "ask had you paid employee at least 8 weeks" do # Q5.1
-                assert_current_node :paid_at_least_8_weeks?
-              end
-              # new 8 weeks question with three branches
-              context "answer yes, paid at least 8 weeks" do
-                setup do
-                  add_response 'eight_weeks_more'
-                end
-                should "ask how often you pay employees" do # Q 5.2
-                  assert_current_node :how_often_pay_employee_pay_patterns?
-                  assert_state_variable :eight_weeks_earnings, 'eight_weeks_more'
-                end
+        should "lead to entitled_to_sick_pay without first days when there is no linked sickness" do
+          add_response :no
+          assert_current_node :first_sick_day? # Q4
+          add_response '2013-04-02'
+          assert_state_variable :sick_start_date, Date.parse(' 2 April 2013')
+          assert_current_node :last_sick_day? # Q5
 
-                context "answer weekly" do
-                  setup do
-                    add_response 'weekly'
-                  end
-                  should "ask for last payday before start sick date" do # Q6
-                    assert_current_node :last_payday_before_sickness?
-                    assert_state_variable :pay_pattern, 'weekly'
-                  end
-                  context "enter last payday before start of sickness" do
-                    setup do
-                      add_response '31/03/2013'
-                    end
-                    should "ask for last normal payday before payday offset" do # Q6.1
-                      assert_current_node :last_payday_before_offset?
+          add_response '2013-04-10'
+          assert_state_variable :sick_end_date, Date.parse('10 April 2013')
+          assert_current_node :paid_at_least_8_weeks?
 
-                    end
-                    context "enter last payday before offset" do
-                      setup do
-                        add_response '31/01/2013'
-                      end
-                      should "ask for total amount paid" do # Q 6.2
-                        assert_current_node :total_employee_earnings?
-                      end
-                      context "enter total amount paid between paydays" do
-                        setup do
-                          add_response '4000'
-                        end
-                        should "ask about PIW" do # Q11
-                          assert_current_node :off_sick_4_days?
-                        end
+          add_response 'eight_weeks_more'
+          assert_current_node :how_often_pay_employee_pay_patterns?
+          assert_state_variable :eight_weeks_earnings, 'eight_weeks_more'
+          add_response 'weekly'
+          assert_current_node :last_payday_before_sickness?
+          assert_state_variable :pay_pattern, 'weekly'
+          add_response '2013-03-31'
+          assert_current_node :last_payday_before_offset?
+          add_response '2013-01-31'
+          assert_current_node :total_employee_earnings?
+          add_response '4000'
+          assert_current_node :off_sick_4_days?
 
-                        context "answer yes" do
-                          setup do
-                            add_response :yes
-                          end
-                          should "ask for start date of linked period of sickness" do # Q11.1
-                            assert_current_node :linked_sickness_start_date?
-                          end
-                          context "enter previous sickness start date" do
-                            setup do
-                              add_response ' 1/01/2013'
-                            end
-                            should "ask how many days sick the employee had in this previous period" do # Q12
-                              assert_current_node :how_many_days_sick?
-                            end
-                            context "answer 6 days" do
-                              setup do
-                                add_response '6'
-                              end
-                              should "ask which days of the week do they work" do # Q13
-                                assert_current_node :usual_work_days?
-                              end
-                              context "answer weekdays" do
-                                setup do
-                                  add_response '1,2,3,4,5'
-                                end
-                                should "take you to result A6" do # A6
-                                  assert_current_node :entitled_to_sick_pay
-                                end
-                              end
-                            end
-                          end
-                        end
-                        context "answer no" do
-                          setup do
-                            add_response 'no'
-                          end
-                          should "ask which days of the week they work" do # Q13
-                            assert_current_node :usual_work_days?
-                          end
-                          context "answer weekdays" do
-                            setup do
-                              add_response '1,2,3,4,5'
-                            end
-                            should "take you to result 6 without first days (no PIW)" do
-                              assert_current_node :entitled_to_sick_pay
-                              assert_phrase_list :entitled_to_esa, [:esa]
-                              assert_phrase_list :paternity_adoption_warning, [:paternity_warning]
-                            end
-                          end
-                        end
-                      end
-                    end
-                  end
-                end
-              end
+          add_response 'no'
+          assert_current_node :usual_work_days?
+          add_response '1,2,3,4,5'
+          assert_current_node :entitled_to_sick_pay
+          assert_phrase_list :entitled_to_esa, [:esa]
+          assert_phrase_list :paternity_adoption_warning, [:paternity_warning]
+        end
 
-              context "answer no, employee is new and fell sick before payday" do
-                setup do
-                  add_response 'before_payday'
-                end
-                should "ask how often you pay employees" do # Q 5.2
-                  assert_current_node :how_often_pay_employee_pay_patterns?
-                end
-                context "answer monthly" do
-                  setup do
-                    add_response 'monthly'
-                  end
-                  should "ask how much you would have paid on their first payday" do # Q7
-                    assert_current_node :pay_amount_if_not_sick?
-                  end
-                  context "answer £2000" do
-                    setup do
-                      add_response '2000'
-                    end
-                    should "ask how many days the period covers" do # Q7.1
-                      assert_current_node :contractual_days_covered_by_earnings?
-                    end
-                    context "answer 30" do
-                      setup do
-                        add_response '30'
-                      end
-                      should "ask abou PIW" do # Q11.1
-                        assert_current_node :off_sick_4_days?
-                      end
+        should "lead to entitled_to_sick_pay if worker got sick before payday and had linked sickness" do
+          add_response :no
+          assert_current_node :first_sick_day? # Q4
+          add_response '2013-04-02'
+          assert_state_variable :sick_start_date, Date.parse(' 2 April 2013')
+          assert_current_node :last_sick_day? # Q5
 
-                      context "answer yes" do
-                        setup do
-                          add_response 'yes'
-                        end
-                        should "ask for start date of linked sickness" do # Q11
-                          assert_current_node :linked_sickness_start_date?
-                        end
-                        context "enter previous sickness start date" do
-                          setup do
-                            add_response '12/03/2013'
-                          end
-                          should "ask how many previous sick days were taken" do # Q12
-                            assert_current_node :how_many_days_sick?
-                          end
-                          context "answer 4" do
-                            setup do
-                              add_response '4'
-                            end
-                            should "ask which days they work" do # Q13
-                              assert_current_node :usual_work_days?
-                            end
-                            context "answer three days a week" do
-                              setup do
-                                add_response '1,2,3'
-                              end
-                              should "take you to result A6" do
-                                assert_current_node :entitled_to_sick_pay
-                              end
-                            end
-                          end
-                        end
-                      end
-                      context "answer no" do
-                        setup do
-                          add_response 'no'
-                        end
-                        should "ask which days of the week they work" do # Q13
-                          assert_current_node :usual_work_days?
-                        end
-                        context "answer weekdays" do
-                          setup do
-                            add_response '1,2,3,4,5'
-                          end
-                          should "take you to result 6 without first days (no PIW)" do
-                            assert_current_node :entitled_to_sick_pay
-                          end
-                        end
-                      end
-                    end
-                  end
-                end
-              end
+          add_response '2013-04-10'
+          assert_state_variable :sick_end_date, Date.parse('10 April 2013')
+          assert_current_node :paid_at_least_8_weeks?
 
-              context "answer no, paid less than 8 weeks earnings" do
-                setup do
-                  add_response :eight_weeks_less
-                end
-                should "ask what total earnings before sick start date" do # Q8
-                  assert_current_node :total_earnings_before_sick_period?
-                end
-                context "answer £3000" do
-                  setup do
-                    add_response '3000'
-                  end
-                  should "ask how many days does this period cover" do # Q8.1
-                    assert_current_node :days_covered_by_earnings?
-                  end
-                  context "answer 35 days" do
-                    setup do
-                      add_response '35'
-                    end
-                    should "ask the PIW question" do # Q11
-                      assert_current_node :off_sick_4_days?
-                    end
-                    context "answer yes" do
-                      setup do
-                        add_response 'yes'
-                      end
-                      should "ask for start date of previous sickness" do # Q 11.1
-                        assert_current_node :linked_sickness_start_date?
-                      end
-                      context "enter previous sickness start date" do
-                        setup do
-                          add_response '24/03/2013'
-                        end
-                        should "ask how many previous sick days were taken" do # Q12
-                          assert_current_node :how_many_days_sick?
-                        end
-                        context "answer 5 days" do
-                          setup do
-                            add_response '5'
-                          end
-                          should "ask which days they work" do # Q13
-                            assert_current_node :usual_work_days?
-                          end
-                          context "answer weekdays" do
-                            setup do
-                              add_response '1,2,3,4,5'
-                            end
-                            should "take you to result A6" do
-                              assert_current_node :entitled_to_sick_pay
-                            end
-                          end
-                        end
-                      end
-                    end
-                    context "answer no" do
-                      setup do
-                        add_response 'no'
-                      end
-                      should "ask which days of the week they work" do # Q13
-                        assert_current_node :usual_work_days?
-                      end
-                      context "answer weekdays" do
-                        setup do
-                          add_response '1,2,3,4,5'
-                        end
-                        should "take you to result 6 without first days (no PIW)" do
-                          assert_current_node :entitled_to_sick_pay
-                        end
-                      end
-                    end
-                  end
-                end
-              end
-            end
-          end
+          add_response 'before_payday'
+          assert_current_node :how_often_pay_employee_pay_patterns?
+          add_response 'monthly'
+          assert_current_node :pay_amount_if_not_sick?
+          add_response '2000'
+          assert_current_node :contractual_days_covered_by_earnings?
+          add_response '30'
+          assert_current_node :off_sick_4_days?
+
+          add_response 'yes'
+          assert_current_node :linked_sickness_start_date?
+          add_response '2013-03-12'
+          assert_current_node :how_many_days_sick?
+          add_response '4'
+          assert_current_node :usual_work_days?
+          add_response '1,2,3'
+          assert_current_node :entitled_to_sick_pay
+        end
+
+        should "lead to entitled_to_sick_pay if worker got sick before payday and had no linked sickness" do
+          add_response :no
+          assert_current_node :first_sick_day? # Q4
+          add_response '2013-04-02'
+          assert_state_variable :sick_start_date, Date.parse(' 2 April 2013')
+          assert_current_node :last_sick_day? # Q5
+
+          add_response '2013-04-10'
+          assert_state_variable :sick_end_date, Date.parse('10 April 2013')
+          assert_current_node :paid_at_least_8_weeks?
+
+          add_response 'before_payday'
+          assert_current_node :how_often_pay_employee_pay_patterns?
+          add_response 'monthly'
+          assert_current_node :pay_amount_if_not_sick?
+          add_response '2000'
+          assert_current_node :contractual_days_covered_by_earnings?
+          add_response '30'
+          assert_current_node :off_sick_4_days?
+
+          add_response 'no'
+          assert_current_node :usual_work_days?
+          add_response '1,2,3,4,5'
+          assert_current_node :entitled_to_sick_pay
+        end
+
+        should "lead to entitled_to_sick_pay if worker got sick before being employed for 8 weeks and had linked sickness" do
+          add_response :no
+          assert_current_node :first_sick_day? # Q4
+          add_response '2013-04-02'
+          assert_state_variable :sick_start_date, Date.parse(' 2 April 2013')
+          assert_current_node :last_sick_day? # Q5
+
+          add_response '2013-04-10'
+          assert_state_variable :sick_end_date, Date.parse('10 April 2013')
+          assert_current_node :paid_at_least_8_weeks?
+
+          add_response :eight_weeks_less
+          assert_current_node :total_earnings_before_sick_period?
+          add_response '3000'
+          assert_current_node :days_covered_by_earnings?
+          add_response '35'
+          assert_current_node :off_sick_4_days?
+
+          add_response 'yes'
+          assert_current_node :linked_sickness_start_date?
+          add_response '2013-03-24'
+          assert_current_node :how_many_days_sick?
+          add_response '5'
+          assert_current_node :usual_work_days?
+          add_response '1,2,3,4,5'
+          assert_current_node :entitled_to_sick_pay
+        end
+
+        should "lead to entitled_to_sick_pay if worker got sick before being employed for 8 weeks and had no linked sickness" do
+          add_response :no
+          assert_current_node :first_sick_day? # Q4
+          add_response '2013-04-02'
+          assert_state_variable :sick_start_date, Date.parse(' 2 April 2013')
+          assert_current_node :last_sick_day? # Q5
+
+          add_response '2013-04-10'
+          assert_state_variable :sick_end_date, Date.parse('10 April 2013')
+          assert_current_node :paid_at_least_8_weeks?
+
+          add_response :eight_weeks_less
+          assert_current_node :total_earnings_before_sick_period?
+          add_response '3000'
+          assert_current_node :days_covered_by_earnings?
+          add_response '35'
+          assert_current_node :off_sick_4_days?
+
+          add_response 'no'
+          assert_current_node :usual_work_days?
+          add_response '1,2,3,4,5'
+          assert_current_node :entitled_to_sick_pay
         end
       end
-    end # answer yes to employer told in time
+    end
   end
 
   context "average weekly earnings is less than the LEL on sick start date" do
@@ -397,15 +290,15 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response 'none' # Q1
       add_response 'yes' # Q2
       add_response 'no' # Q3
-      add_response '10/06/2013' # Q4
-      add_response '20/06/2013' # Q5
+      add_response '2013-06-10' # Q4
+      add_response '2013-06-20' # Q5
       add_response 'before_payday' # Q5.1
       add_response 'weekly' # Q5.2
       add_response '100' # Q7
       add_response '7' # Q7.1
       add_response 'no' # Q11
     end
-    should "take you to result A5 as awe < LEL (as of 10/06/2013)" do
+    should "take you to result A5 as awe < LEL (as of 2013-06-10)" do
       assert_state_variable :employee_average_weekly_earnings, 100
       assert_current_node :not_earned_enough
     end
@@ -416,8 +309,8 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response 'none'
       add_response 'yes'
       add_response 'no'
-      add_response '10/06/2013'
-      add_response '12/06/2013'
+      add_response '2013-06-10'
+      add_response '2013-06-12'
     end
     should "take you to result A7 - must be sick for at least 4 days in a row" do
       assert_current_node :must_be_sick_for_4_days
@@ -429,15 +322,15 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response 'none'
       add_response 'yes'
       add_response 'no'
-      add_response '10/06/2013'
-      add_response '20/06/2013'
+      add_response '2013-06-10'
+      add_response '2013-06-20'
       add_response 'eight_weeks_more'
       add_response 'monthly'
-      add_response '31/05/2013'
-      add_response '31/03/2013'
+      add_response '2013-05-31'
+      add_response '2013-03-31'
       add_response '4000'
       add_response 'yes'
-      add_response '01/01/2013'
+      add_response '2013-01-01'
       add_response '183'
       add_response '1,2,3,4,5'
     end

--- a/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
@@ -297,6 +297,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response '100' # Q7
       add_response '7' # Q7.1
       add_response 'no' # Q11
+      add_response '1,2,3,4,5' # Q13
     end
     should "take you to result A5 as awe < LEL (as of 2013-06-10)" do
       assert_state_variable :employee_average_weekly_earnings, 100

--- a/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
@@ -177,7 +177,6 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
           add_response 'yes'
           assert_current_node :linked_sickness_start_date?
           add_response '2013-03-12'
-          assert_state_variable :sick_start_date, Date.parse('12 March 2013')
           assert_current_node :linked_sickness_end_date?
           add_response '2013-03-16'
           assert_current_node :paid_at_least_8_weeks?
@@ -228,7 +227,6 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
           add_response 'yes'
           assert_current_node :linked_sickness_start_date?
           add_response '2013-03-24'
-          assert_state_variable :sick_start_date, Date.parse('24 March 2013')
           assert_current_node :linked_sickness_end_date?
           add_response '2013-03-29'
           assert_current_node :paid_at_least_8_weeks?

--- a/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
@@ -60,6 +60,8 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
         add_response '2014-03-02'
         assert_current_node :last_sick_day?
         add_response '2014-06-02'
+        assert_current_node :has_linked_sickness?
+        add_response 'no'
         assert_current_node :paid_at_least_8_weeks?
         add_response 'before_payday'
         assert_current_node :how_often_pay_employee_pay_patterns?
@@ -68,8 +70,6 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
         add_response '3000'
         assert_current_node :contractual_days_covered_by_earnings?
         add_response '17'
-        assert_current_node :off_sick_4_days?
-        add_response 'no'
         assert_current_node :usual_work_days?
         add_response '1,2,3,4,5'
         assert_current_node :entitled_to_sick_pay
@@ -114,11 +114,11 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
           add_response '2013-04-02'
           assert_state_variable :sick_start_date, Date.parse(' 2 April 2013')
           assert_current_node :last_sick_day? # Q5
-
           add_response '2013-04-10'
           assert_state_variable :sick_end_date, Date.parse('10 April 2013')
+          assert_current_node :has_linked_sickness?
+          add_response 'no'
           assert_current_node :paid_at_least_8_weeks?
-
           add_response 'eight_weeks_more'
           assert_current_node :how_often_pay_employee_pay_patterns?
           assert_state_variable :eight_weeks_earnings, 'eight_weeks_more'
@@ -130,13 +130,6 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
           add_response '2013-01-31'
           assert_current_node :total_employee_earnings?
           add_response '4000'
-          assert_current_node :off_sick_4_days?
-
-          add_response 'yes'
-          assert_current_node :linked_sickness_start_date?
-          add_response '2013-01-01'
-          assert_current_node :how_many_days_sick?
-          add_response '6'
           assert_current_node :usual_work_days?
           add_response '1,2,3,4,5'
           assert_current_node :entitled_to_sick_pay
@@ -151,8 +144,9 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
 
           add_response '2013-04-10'
           assert_state_variable :sick_end_date, Date.parse('10 April 2013')
+          assert_current_node :has_linked_sickness?
+          add_response 'no'
           assert_current_node :paid_at_least_8_weeks?
-
           add_response 'eight_weeks_more'
           assert_current_node :how_often_pay_employee_pay_patterns?
           assert_state_variable :eight_weeks_earnings, 'eight_weeks_more'
@@ -164,9 +158,6 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
           add_response '2013-01-31'
           assert_current_node :total_employee_earnings?
           add_response '4000'
-          assert_current_node :off_sick_4_days?
-
-          add_response 'no'
           assert_current_node :usual_work_days?
           add_response '1,2,3,4,5'
           assert_current_node :entitled_to_sick_pay
@@ -180,11 +171,16 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
           add_response '2013-04-02'
           assert_state_variable :sick_start_date, Date.parse(' 2 April 2013')
           assert_current_node :last_sick_day? # Q5
-
           add_response '2013-04-10'
           assert_state_variable :sick_end_date, Date.parse('10 April 2013')
+          assert_current_node :has_linked_sickness?
+          add_response 'yes'
+          assert_current_node :linked_sickness_start_date?
+          add_response '2013-03-12'
+          assert_state_variable :sick_start_date, Date.parse('12 March 2013')
+          assert_current_node :linked_sickness_end_date?
+          add_response '2013-03-16'
           assert_current_node :paid_at_least_8_weeks?
-
           add_response 'before_payday'
           assert_current_node :how_often_pay_employee_pay_patterns?
           add_response 'monthly'
@@ -192,13 +188,6 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
           add_response '2000'
           assert_current_node :contractual_days_covered_by_earnings?
           add_response '30'
-          assert_current_node :off_sick_4_days?
-
-          add_response 'yes'
-          assert_current_node :linked_sickness_start_date?
-          add_response '2013-03-12'
-          assert_current_node :how_many_days_sick?
-          add_response '4'
           assert_current_node :usual_work_days?
           add_response '1,2,3'
           assert_current_node :entitled_to_sick_pay
@@ -210,11 +199,11 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
           add_response '2013-04-02'
           assert_state_variable :sick_start_date, Date.parse(' 2 April 2013')
           assert_current_node :last_sick_day? # Q5
-
           add_response '2013-04-10'
           assert_state_variable :sick_end_date, Date.parse('10 April 2013')
+          assert_current_node :has_linked_sickness?
+          add_response 'no'
           assert_current_node :paid_at_least_8_weeks?
-
           add_response 'before_payday'
           assert_current_node :how_often_pay_employee_pay_patterns?
           add_response 'monthly'
@@ -222,9 +211,6 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
           add_response '2000'
           assert_current_node :contractual_days_covered_by_earnings?
           add_response '30'
-          assert_current_node :off_sick_4_days?
-
-          add_response 'no'
           assert_current_node :usual_work_days?
           add_response '1,2,3,4,5'
           assert_current_node :entitled_to_sick_pay
@@ -236,23 +222,21 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
           add_response '2013-04-02'
           assert_state_variable :sick_start_date, Date.parse(' 2 April 2013')
           assert_current_node :last_sick_day? # Q5
-
           add_response '2013-04-10'
           assert_state_variable :sick_end_date, Date.parse('10 April 2013')
+          assert_current_node :has_linked_sickness?
+          add_response 'yes'
+          assert_current_node :linked_sickness_start_date?
+          add_response '2013-03-24'
+          assert_state_variable :sick_start_date, Date.parse('24 March 2013')
+          assert_current_node :linked_sickness_end_date?
+          add_response '2013-03-29'
           assert_current_node :paid_at_least_8_weeks?
-
           add_response :eight_weeks_less
           assert_current_node :total_earnings_before_sick_period?
           add_response '3000'
           assert_current_node :days_covered_by_earnings?
           add_response '35'
-          assert_current_node :off_sick_4_days?
-
-          add_response 'yes'
-          assert_current_node :linked_sickness_start_date?
-          add_response '2013-03-24'
-          assert_current_node :how_many_days_sick?
-          add_response '5'
           assert_current_node :usual_work_days?
           add_response '1,2,3,4,5'
           assert_current_node :entitled_to_sick_pay
@@ -264,19 +248,16 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
           add_response '2013-04-02'
           assert_state_variable :sick_start_date, Date.parse(' 2 April 2013')
           assert_current_node :last_sick_day? # Q5
-
           add_response '2013-04-10'
           assert_state_variable :sick_end_date, Date.parse('10 April 2013')
+          assert_current_node :has_linked_sickness?
+          add_response 'no'
           assert_current_node :paid_at_least_8_weeks?
-
           add_response :eight_weeks_less
           assert_current_node :total_earnings_before_sick_period?
           add_response '3000'
           assert_current_node :days_covered_by_earnings?
           add_response '35'
-          assert_current_node :off_sick_4_days?
-
-          add_response 'no'
           assert_current_node :usual_work_days?
           add_response '1,2,3,4,5'
           assert_current_node :entitled_to_sick_pay
@@ -292,11 +273,11 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response 'no' # Q3
       add_response '2013-06-10' # Q4
       add_response '2013-06-20' # Q5
+      add_response 'no' # Q11
       add_response 'before_payday' # Q5.1
       add_response 'weekly' # Q5.2
       add_response '100' # Q7
       add_response '7' # Q7.1
-      add_response 'no' # Q11
       add_response '1,2,3,4,5' # Q13
     end
     should "take you to result A5 as awe < LEL (as of 2013-06-10)" do
@@ -319,23 +300,22 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
   end
 
   context "no SSP payable as already had maximum" do
-    setup do
+    should "take you to result A8 as already claimed > 28 weeks (max amount)" do
       add_response 'none'
       add_response 'yes'
       add_response 'no'
-      add_response '2013-06-10'
-      add_response '2013-06-20'
+      add_response '2014-10-10'
+      add_response '2014-10-20'
+      add_response 'yes'
+      add_response '2014-05-01'
+      add_response '2014-09-20'
       add_response 'eight_weeks_more'
       add_response 'monthly'
-      add_response '2013-05-31'
-      add_response '2013-03-31'
+      add_response '2013-04-01'
+      add_response '2013-02-3'
       add_response '4000'
-      add_response 'yes'
-      add_response '2013-01-01'
-      add_response '183'
       add_response '1,2,3,4,5'
-    end
-    should "take you to result A8 as already claimed > 28 weeks (max amount)" do
+
       assert_current_node :maximum_entitlement_reached
     end
   end
@@ -347,14 +327,14 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response :no
       add_response Date.parse("2013-01-07")
       add_response Date.parse("2013-05-03")
+      add_response :yes
+      add_response Date.parse("2013-01-07")
+      add_response Date.parse("2013-01-15")
       add_response :eight_weeks_more
       add_response :monthly
       add_response Date.parse("2012-12-28")
       add_response Date.parse("2012-10-26")
       add_response 1600.0
-      add_response :yes
-      add_response Date.parse("2012-11-11")
-      add_response 8
       add_response "3,6"
 
       assert_current_node :entitled_to_sick_pay
@@ -384,14 +364,14 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response :no
       add_response Date.parse("2013-01-07")
       add_response Date.parse("2013-05-03")
+      add_response :yes
+      add_response Date.parse("2013-01-07")
+      add_response Date.parse("2013-02-03")
       add_response :eight_weeks_more
       add_response :monthly
       add_response Date.parse("2012-12-28")
       add_response Date.parse("2012-10-26")
       add_response 1250.75
-      add_response :yes
-      add_response Date.parse("2012-11-09")
-      add_response 23
       add_response "2,3,4"
 
       assert_current_node :entitled_to_sick_pay
@@ -421,12 +401,12 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response :no
       add_response Date.parse("2013-01-07")
       add_response Date.parse("2013-05-03")
+      add_response :no
       add_response :eight_weeks_more
       add_response :irregularly
       add_response Date.parse("2012-12-28")
       add_response Date.parse("2012-10-26")
       add_response 3000.0
-      add_response :no
       add_response "1,2,3,4"
 
       assert_current_node :entitled_to_sick_pay
@@ -457,12 +437,12 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response :no
       add_response Date.parse("2013-01-07")
       add_response Date.parse("2013-05-03")
+      add_response :no
       add_response :eight_weeks_more
       add_response :irregularly
       add_response Date.parse("2012-12-28")
       add_response Date.parse("2012-10-26")
       add_response 3000.0
-      add_response :no
       add_response "1,2,3,4"
 
       assert_current_node :entitled_to_sick_pay

--- a/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
@@ -300,18 +300,31 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
   context "no SSP payable as already had maximum" do
     should "take you to result A8 as already claimed > 28 weeks (max amount)" do
       add_response 'none'
+      assert_current_node :employee_tell_within_limit?
       add_response 'yes'
+      assert_current_node :employee_work_different_days?
       add_response 'no'
+      assert_current_node :first_sick_day?
       add_response '2014-10-10'
+      assert_current_node :last_sick_day?
       add_response '2014-10-20'
+      assert_current_node :has_linked_sickness?
       add_response 'yes'
+      assert_current_node :linked_sickness_start_date?
       add_response '2014-05-01'
+      assert_current_node :linked_sickness_end_date?
       add_response '2014-09-20'
+      assert_current_node :paid_at_least_8_weeks?
       add_response 'eight_weeks_more'
+      assert_current_node :how_often_pay_employee_pay_patterns?
       add_response 'monthly'
+      assert_current_node :last_payday_before_sickness?
       add_response '2013-04-01'
+      assert_current_node :last_payday_before_offset?
       add_response '2013-02-3'
+      assert_current_node :total_employee_earnings?
       add_response '4000'
+      assert_current_node :usual_work_days?
       add_response '1,2,3,4,5'
 
       assert_current_node :maximum_entitlement_reached

--- a/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
@@ -325,15 +325,15 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response :ordinary_statutory_paternity_pay
       add_response :yes
       add_response :no
-      add_response Date.parse("2013-01-07")
-      add_response Date.parse("2013-05-03")
+      add_response "2013-01-07"
+      add_response "2013-05-03"
       add_response :yes
-      add_response Date.parse("2013-01-07")
-      add_response Date.parse("2013-01-15")
+      add_response "2013-01-07"
+      add_response "2013-01-15"
       add_response :eight_weeks_more
       add_response :monthly
-      add_response Date.parse("2012-12-28")
-      add_response Date.parse("2012-10-26")
+      add_response "2012-12-28"
+      add_response "2012-10-26"
       add_response 1600.0
       add_response "3,6"
 
@@ -362,15 +362,15 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response :ordinary_statutory_paternity_pay
       add_response :yes
       add_response :no
-      add_response Date.parse("2013-01-07")
-      add_response Date.parse("2013-05-03")
+      add_response "2013-01-07"
+      add_response "2013-05-03"
       add_response :yes
-      add_response Date.parse("2013-01-07")
-      add_response Date.parse("2013-02-03")
+      add_response "2013-01-07"
+      add_response "2013-02-03"
       add_response :eight_weeks_more
       add_response :monthly
-      add_response Date.parse("2012-12-28")
-      add_response Date.parse("2012-10-26")
+      add_response "2012-12-28"
+      add_response "2012-10-26"
       add_response 1250.75
       add_response "2,3,4"
 
@@ -399,13 +399,13 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response :ordinary_statutory_paternity_pay
       add_response :yes
       add_response :no
-      add_response Date.parse("2013-01-07")
-      add_response Date.parse("2013-05-03")
+      add_response "2013-01-07"
+      add_response "2013-05-03"
       add_response :no
       add_response :eight_weeks_more
       add_response :irregularly
-      add_response Date.parse("2012-12-28")
-      add_response Date.parse("2012-10-26")
+      add_response "2012-12-28"
+      add_response "2012-10-26"
       add_response 3000.0
       add_response "1,2,3,4"
 
@@ -435,13 +435,13 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response :additional_statutory_paternity_pay
       add_response :yes
       add_response :no
-      add_response Date.parse("2013-01-07")
-      add_response Date.parse("2013-05-03")
+      add_response "2013-01-07"
+      add_response "2013-05-03"
       add_response :no
       add_response :eight_weeks_more
       add_response :irregularly
-      add_response Date.parse("2012-12-28")
-      add_response Date.parse("2012-10-26")
+      add_response "2012-12-28"
+      add_response "2012-10-26"
       add_response 3000.0
       add_response "1,2,3,4"
 


### PR DESCRIPTION
I believe this is the related [Pivotal Tracker story](https://www.pivotaltracker.com/story/show/93691714).

We now ask for previous periods of sickness earlier so we can use the correct dates when asking for and calculating AWE

Test url for deploy 

http://smartanswers.dev.gov.uk/calculate-statutory-sick-pay/y/none/yes/no/2014-08-10/2014-08-20/yes/2014-05-01/2014-08-20/eight_weeks_more/monthly/2013-04-01/2013-02-03/4000.0/1,2,3,4,5