### PR TITLE
Add St Martin and Saint-Barthélemy to marriage abroad logic

### DIFF
--- a/lib/smart_answer/calculators/marriage_abroad_data_query.rb
+++ b/lib/smart_answer/calculators/marriage_abroad_data_query.rb
@@ -13,11 +13,11 @@ module SmartAnswer::Calculators
 
     DUTCH_CARIBBEAN_ISLANDS = %w(aruba bonaire-st-eustatius-saba curacao st-maarten)
 
-    NON_COMMONWEALTH_COUNTRIES = %w(afghanistan albania algeria american-samoa andorra angola anguilla argentina armenia aruba austria azerbaijan bahrain belarus belgium benin bermuda bhutan bolivia bonaire-st-eustatius-saba bosnia-and-herzegovina brazil british-indian-ocean-territory british-virgin-islands bulgaria burkina-faso burma burundi cambodia cape-verde cayman-islands central-african-republic chad chile china colombia comoros congo democratic-republic-of-congo costa-rica cote-d-ivoire croatia cuba curacao czech-republic denmark djibouti dominican-republic ecuador egypt el-salvador equatorial-guinea eritrea estonia ethiopia falkland-islands fiji finland france french-guiana french-polynesia gabon georgia germany gibraltar greece guadeloupe guatemala guinea guinea-bissau haiti honduras hong-kong hungary iceland indonesia iran iraq ireland israel italy japan jordan kazakhstan south-korea kosovo kuwait kyrgyzstan laos latvia lebanon liberia libya liechtenstein lithuania luxembourg macao macedonia madagascar mali marshall-islands martinique mauritania mayotte mexico micronesia moldova monaco mongolia montenegro montserrat morocco nepal netherlands new-caledonia nicaragua niger north-korea norway oman palau panama paraguay peru philippines pitcairn-island poland portugal qatar reunion romania russia rwanda san-marino sao-tome-and-principe saudi-arabia senegal serbia slovakia slovenia somalia south-georgia-and-south-sandwich-islands south-sudan spain st-helena-ascension-and-tristan-da-cunha st-maarten st-pierre-and-miquelon sudan suriname sweden switzerland syria taiwan tajikistan thailand timor-leste togo tunisia turkmenistan turks-and-caicos-islands ukraine united-arab-emirates usa uruguay uzbekistan venezuela wallis-and-futuna western-sahara vietnam yemen zimbabwe)
+    NON_COMMONWEALTH_COUNTRIES = %w(afghanistan albania algeria american-samoa andorra angola anguilla argentina armenia aruba austria azerbaijan bahrain belarus belgium benin bermuda bhutan bolivia bonaire-st-eustatius-saba bosnia-and-herzegovina brazil british-indian-ocean-territory british-virgin-islands bulgaria burkina-faso burma burundi cambodia cape-verde cayman-islands central-african-republic chad chile china colombia comoros congo democratic-republic-of-congo costa-rica cote-d-ivoire croatia cuba curacao czech-republic denmark djibouti dominican-republic ecuador egypt el-salvador equatorial-guinea eritrea estonia ethiopia falkland-islands fiji finland france french-guiana french-polynesia gabon georgia germany gibraltar greece guadeloupe guatemala guinea guinea-bissau haiti honduras hong-kong hungary iceland indonesia iran iraq ireland israel italy japan jordan kazakhstan south-korea kosovo kuwait kyrgyzstan laos latvia lebanon liberia libya liechtenstein lithuania luxembourg macao macedonia madagascar mali marshall-islands martinique mauritania mayotte mexico micronesia moldova monaco mongolia montenegro montserrat morocco nepal netherlands new-caledonia nicaragua niger north-korea norway oman palau panama paraguay peru philippines pitcairn-island poland portugal qatar reunion romania russia rwanda saint-barthelemy san-marino sao-tome-and-principe saudi-arabia senegal serbia slovakia slovenia somalia south-georgia-and-south-sandwich-islands south-sudan spain st-helena-ascension-and-tristan-da-cunha st-maarten st-martin st-pierre-and-miquelon sudan suriname sweden switzerland syria taiwan tajikistan thailand timor-leste togo tunisia turkmenistan turks-and-caicos-islands ukraine united-arab-emirates usa uruguay uzbekistan venezuela wallis-and-futuna western-sahara vietnam yemen zimbabwe)
 
     OS_CONSULAR_CNI_COUNTRIES = %w(albania algeria angola armenia austria azerbaijan bahrain belarus belgium bolivia bosnia-and-herzegovina brazil bulgaria chile croatia cuba denmark dominican-republic el-salvador estonia ethiopia georgia germany greece guatemala honduras hungary iceland indonesia italy japan jordan kazakhstan kuwait kyrgyzstan latvia libya lithuania luxembourg macedonia moldova montenegro netherlands nepal norway oman panama poland romania russia serbia slovenia spain sudan sweden tajikistan tunisia turkmenistan ukraine uzbekistan venezuela)
 
-    OS_NO_CONSULAR_CNI_COUNTRIES = %w(argentina burundi czech-republic democratic-republic-of-congo mexico senegal slovakia taiwan usa uruguay)
+    OS_NO_CONSULAR_CNI_COUNTRIES = %w(argentina burundi czech-republic democratic-republic-of-congo mexico saint-barthelemy senegal st-martin slovakia taiwan usa uruguay)
 
     OS_NO_MARRIAGE_CONSULAR_SERVICES = %w(afghanistan american-samoa andorra aruba benin bhutan bonaire-st-eustatius-saba burkina-faso burundi cape-verde central-african-republic chad comoros congo costa-rica cote-d-ivoire curacao djibouti equatorial-guinea eritrea gabon guinea guinea-bissau haiti hong-kong iraq israel kosovo laos liberia liechtenstein macao madagascar mali marshall-islands mauritania micronesia monaco nicaragua niger palau paraguay rwanda san-marino sao-tome-and-principe south-sudan st-maarten suriname timor-leste togo western-sahara)
 
@@ -33,7 +33,7 @@ module SmartAnswer::Calculators
 
     CP_CONSULAR_COUNTRIES = %w(bulgaria cambodia croatia cyprus guatemala japan latvia moldova panama peru philippines venezuela vietnam)
 
-    COUNTRIES_WITHOUT_CONSULAR_FACILITIES = %w(aruba slovakia curacao bonaire-st-eustatius-saba st-maarten taiwan czech-republic argentina cote-d-ivoire burundi)
+    COUNTRIES_WITHOUT_CONSULAR_FACILITIES = %w(aruba slovakia curacao bonaire-st-eustatius-saba saint-barthelemy st-maarten st-martin taiwan czech-republic argentina cote-d-ivoire burundi)
 
     SS_MARRIAGE_COUNTRIES = %w(australia azerbaijan bolivia chile china colombia dominican-republic estonia germany kosovo latvia mongolia montenegro nicaragua russia san-marino hungary serbia)
 
@@ -54,6 +54,8 @@ module SmartAnswer::Calculators
     SS_21_DAYS_RESIDENCY_REQUIRED_COUNTRIES = %(albania australia azerbaijan bolivia cambodia chile china colombia costa-rica dominican-republic estonia germany hungary japan kosovo latvia lithuania mongolia montenegro nicaragua peru philippines russia san-marino serbia vietnam)
 
     OS_21_DAYS_RESIDENCY_REQUIRED_COUNTRIES = %(jordan oman qatar united-arab-emirates yemen)
+
+    SS_UNKNOWN_NO_EMBASSIES = %w(st-martin saint-barthelemy)
 
     def ss_21_days_residency_required_countries?(country_slug)
       SS_21_DAYS_RESIDENCY_REQUIRED_COUNTRIES.include?(country_slug)
@@ -155,6 +157,10 @@ module SmartAnswer::Calculators
     def requires_7_day_notice?(ceremony_country_slug, residency_country_slug)
       REQUIRES_7_DAY_NOTICE_CEREMONY_COUNTRIES.include?(ceremony_country_slug) &&
         REQUIRED_7_DAY_NOTICE_RESIDENCY_COUNTRIES.include?(residency_country_slug)
+    end
+
+    def ss_unknown_no_embassies?(country_slug)
+      SS_UNKNOWN_NO_EMBASSIES.include?(country_slug)
     end
   end
 end

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -292,6 +292,12 @@ multiple_choice :partner_opposite_or_same_sex? do
     (ceremony_country == 'finland') & (resident_of == 'uk') & (partner_nationality == 'partner_irish')
   }
 
+  define_predicate(:ss_unknown_no_embassies) {
+    data_query.ss_unknown_no_embassies?(ceremony_country)
+  }
+
+  next_node_if(:outcome_os_no_cni, ss_unknown_no_embassies)
+
   next_node_if(:outcome_ss_marriage_malta, -> {ceremony_country == "malta"})
 
   next_node_if(:outcome_os_affirmation, uk_resident_irish_partner_finland_ss_ceremony)
@@ -1223,10 +1229,10 @@ outcome :outcome_os_no_cni do
         phrases << :no_cni_os_dutch_caribbean_other_resident
       end
     else
-      if resident_of == 'uk'
-        phrases << :no_cni_os_not_dutch_caribbean_islands_uk_resident
-      elsif ceremony_country == residency_country
+      if ceremony_country == residency_country or data_query.ss_unknown_no_embassies?(ceremony_country)
         phrases << :no_cni_os_not_dutch_caribbean_islands_local_resident
+      elsif resident_of == 'uk'
+        phrases << :no_cni_os_not_dutch_caribbean_islands_uk_resident
       elsif ceremony_country != residency_country and resident_of != 'uk'
         phrases << :no_cni_os_not_dutch_caribbean_other_resident
       end

--- a/test/integration/smart_answer_flows/marriage_abroad_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_test.rb
@@ -8,7 +8,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
   include GdsApi::TestHelpers::Worldwide
 
   setup do
-    @location_slugs = %w(albania american-samoa anguilla argentina armenia aruba australia austria azerbaijan bahamas belarus belgium bonaire-st-eustatius-saba brazil british-indian-ocean-territory burma burundi cambodia canada china costa-rica cote-d-ivoire croatia colombia cyprus czech-republic denmark ecuador egypt estonia finland france germany greece indonesia iran ireland italy japan jordan kazakhstan laos latvia lebanon lithuania macedonia malta mayotte mexico monaco morocco netherlands nicaragua north-korea oman guatemala paraguay peru philippines poland portugal qatar russia rwanda san-marino saudi-arabia serbia slovakia south-africa st-maarten south-korea spain sweden switzerland thailand turkey turkmenistan united-arab-emirates usa uzbekistan vietnam wallis-and-futuna yemen zimbabwe)
+    @location_slugs = %w(albania american-samoa anguilla argentina armenia aruba australia austria azerbaijan bahamas belarus belgium bonaire-st-eustatius-saba brazil british-indian-ocean-territory burma burundi cambodia canada china costa-rica cote-d-ivoire croatia colombia cyprus czech-republic denmark ecuador egypt estonia finland france germany greece indonesia iran ireland italy japan jordan kazakhstan laos latvia lebanon lithuania macedonia malta mayotte mexico monaco morocco netherlands nicaragua north-korea oman guatemala paraguay peru philippines poland portugal qatar russia rwanda saint-barthelemy san-marino saudi-arabia serbia slovakia south-africa st-maarten st-martin south-korea spain sweden switzerland thailand turkey turkmenistan united-arab-emirates usa uzbekistan vietnam wallis-and-futuna yemen zimbabwe)
     worldwide_api_has_locations(@location_slugs)
     setup_for_testing_flow 'marriage-abroad'
   end
@@ -2616,6 +2616,56 @@ class MarriageAbroadTest < ActiveSupport::TestCase
       add_response 'same_sex'
 
       assert_current_node :outcome_cp_all_other_countries
+    end
+  end
+
+  context "Saint-Barthélemy" do
+    setup do
+      worldwide_api_has_no_organisations_for_location('st-martin')
+      worldwide_api_has_no_organisations_for_location('saint-barthelemy')
+      add_response 'saint-barthelemy'
+      add_response 'other'
+      add_response 'st-martin'
+      add_response 'partner_british'
+    end
+
+    should "suggest to contact local authorities even if the user is in third country for OS (because they don't have many embassies)" do
+      add_response 'opposite_sex'
+
+      assert_current_node :outcome_os_no_cni
+      assert_phrase_list :no_cni_os_outcome, [:no_cni_os_not_dutch_caribbean_islands_local_resident, :get_legal_advice, :cni_os_consular_facilities_unavailable]
+    end
+
+    should "suggest to contact local authorities even if the user is in third country for SS (because they don't have many embassies)" do
+      add_response 'same_sex'
+
+      assert_current_node :outcome_os_no_cni
+      assert_phrase_list :no_cni_os_outcome, [:no_cni_os_not_dutch_caribbean_islands_local_resident, :get_legal_advice, :cni_os_consular_facilities_unavailable]
+    end
+  end
+
+  context "St Martin" do
+    setup do
+      worldwide_api_has_no_organisations_for_location('st-martin')
+      worldwide_api_has_no_organisations_for_location('saint-barthelemy')
+      add_response 'st-martin'
+      add_response 'other'
+      add_response 'saint-barthelemy'
+      add_response 'partner_british'
+    end
+
+    should "suggest to contact local authorities even if the user is in third country for OS (because they don't have many embassies)" do
+      add_response 'opposite_sex'
+
+      assert_current_node :outcome_os_no_cni
+      assert_phrase_list :no_cni_os_outcome, [:no_cni_os_not_dutch_caribbean_islands_local_resident, :get_legal_advice, :cni_os_consular_facilities_unavailable]
+    end
+
+    should "suggest to contact local authorities even if the user is in third country for SS (because they don't have many embassies)" do
+      add_response 'same_sex'
+
+      assert_current_node :outcome_os_no_cni
+      assert_phrase_list :no_cni_os_outcome, [:no_cni_os_not_dutch_caribbean_islands_local_resident, :get_legal_advice, :cni_os_consular_facilities_unavailable]
     end
   end
 end


### PR DESCRIPTION
Those two countries were recently added to the worldwide API
but had no corresponding logic to handle them. This change leads
to "no British consular facilities" outcome for both countries,
as advised by FCO.

Some paths affected:

/marriage-abroad/y/st-martin/other/st-martin/partner_british/same_sex

/marriage-abroad/y/saint-barthelemy/other/afghanistan/partner_british/opposite_sex
