### PR TITLE
[Don't merge] Make test coverage data available for smart answer flows

### DIFF
--- a/lib/smart_answer/flow_registry.rb
+++ b/lib/smart_answer/flow_registry.rb
@@ -1,3 +1,5 @@
+require "smart_answer_flows/additional-commodity-code"
+
 module SmartAnswer
   class FlowRegistry
     class NotFound < StandardError; end
@@ -51,10 +53,16 @@ module SmartAnswer
     end
 
     def build_flow(name)
-      absolute_path = @load_path.join("#{name}.rb").to_s
-      Flow.new do
-        eval(File.read(absolute_path), binding, absolute_path)
-        name(name)
+      if name == 'additional-commodity-code'
+        flow = AdditionalCommodityCode.new
+        flow.define
+        flow
+      else
+        absolute_path = @load_path.join("#{name}.rb").to_s
+        Flow.new do
+          eval(File.read(absolute_path), binding, absolute_path)
+          name(name)
+        end
       end
     end
 

--- a/lib/smart_answer_flows/additional-commodity-code.rb
+++ b/lib/smart_answer_flows/additional-commodity-code.rb
@@ -1,3 +1,10 @@
+module SmartAnswer
+
+class AdditionalCommodityCode < Flow
+
+  def define
+name 'additional-commodity-code'
+
 status :published
 satisfies_need "100233"
 
@@ -187,4 +194,8 @@ outcome :commodity_code_result do
       ''
     end
   end
+end
+
+  end
+end
 end


### PR DESCRIPTION
## DO NOT MERGE

This is a "spike" which demonstrates how to obtain test coverage data for
the `additional-commodity-code` flow. This data was not [previously
available][1], because the flow files were being read and eval'ed rather than
simply required. The latter is [necessary for SimpleCov to record coverage
data][2] for the file.

By extracting the existing DSL code into a `define` method on a subclass of
`SmartAnswer::Flow`, we can safely require the file separately from
instantiating the flow. This feels like a better state of affairs in general,
but it specifically addresses the test coverage problem above.

We'd really like to have this coverage data available so we can have confidence
that we're not breaking anything as we continue to refactor the app.

Note that I've intentionally not fixed the indentation in the
`additional-commodity-code` flow file so that it's easier to see my changes.

I think it would be simple enough to make this change for all smart answer
flows and then the code in `SmartAnswer::FlowRegistry#build_flow` could be
considerably simplified.

[1]: https://ci-new.alphagov.co.uk/job/govuk_smart_answers/2396/rcov/
[2]: https://github.com/colszowka/simplecov/issues/38