### PR TITLE
Uprate adoption calculator

### DIFF
--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/questions/adoption_employment_adopter_a.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/questions/adoption_employment_adopter_a.txt
@@ -18,7 +18,7 @@
 
 This is your total take-home pay before any deductions, eg tax.
 
-# Have you earned (or will you have earned) more than £112 per week between %{lower_earnings_start_date(match_date)} and %{lower_earnings_end_date(match_date)}?
+# Have you earned (or will you have earned) more than %{lower_earnings_amount(match_date)} per week between %{lower_earnings_start_date(match_date)} and %{lower_earnings_end_date(match_date)}?
 
 [choice: lel_1]
 * yes: Yes

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/questions/adoption_employment_adopter_b.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/questions/adoption_employment_adopter_b.txt
@@ -18,7 +18,7 @@
 
 This is their total take-home pay before any deductions, eg tax.
 
-# Has your partner earned (or will they have earned) more than £112 per week between %{lower_earnings_start_date(match_date)} and %{lower_earnings_end_date(match_date)}?
+# Has your partner earned (or will they have earned) more than %{lower_earnings_amount(match_date)} per week between %{lower_earnings_start_date(match_date)} and %{lower_earnings_end_date(match_date)}?
 
 [choice: lel_2]
 * yes: Yes

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/questions/birth_employment_mother.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/questions/birth_employment_mother.txt
@@ -18,7 +18,7 @@
 
 This is her total take-home pay before any deductions, eg tax.
 
-# Has the mother earned (or will she have earned) more than £112 per week between %{lower_earnings_start_date(due_date)} and %{lower_earnings_end_date(due_date)}?
+# Has the mother earned (or will she have earned) more than %{lower_earnings_amount(due_date)} per week between %{lower_earnings_start_date(due_date)} and %{lower_earnings_end_date(due_date)}?
 
 [choice: lel_1]
 * yes: Yes

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/questions/birth_employment_partner.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/questions/birth_employment_partner.txt
@@ -18,7 +18,7 @@
 
 This is their total take-home pay before any deductions, eg tax.
 
-# Has the mother’s partner earned (or will they have earned) more than £112 per week between %{lower_earnings_start_date(due_date)} and %{lower_earnings_end_date(due_date)}?
+# Has the mother’s partner earned (or will they have earned) more than %{lower_earnings_amount(due_date)} per week between %{lower_earnings_start_date(due_date)} and %{lower_earnings_end_date(due_date)}?
 
 [choice: lel_2]
 * yes: Yes

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/additional-pat-leave.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/additional-pat-leave.txt
@@ -2,9 +2,10 @@
 
 ##Additional paternity leave
 
-If the mother returns to work early, their partner may be able to take up to 26 weeks off as [additional paternity leave](/paternity-pay-leave/leave).
+If the mother returns to work early, her partner may be able to take up to 26 weeks off as [additional paternity leave](/paternity-pay-leave/leave).
 
  | Dates
 - | -
-Additional paternity leave must be used between | %{start_of_additional_paternity_leave(due_date)} to %{end_of_additional_paternity_leave(due_date)}
+Additional paternity leave can start | 20 weeks after the birth
+Additional paternity leave must finish | by the child's first birthday
 Tell the partner’s employer | 8 weeks before they want to start additional paternity leave

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/additional-pat-pay.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/additional-pat-pay.txt
@@ -4,7 +4,29 @@
 
 The mother’s partner can get [additional paternity pay](/paternity-pay-leave/pay) while they’re on additional paternity leave. The pay stops when the mother’s maternity pay would have ended.
 
- | Dates and amounts
-- | -
-Weekly rate  | %{rate_of_paternity_pay(salary_2)}
-Total pay | %{total_aspp(salary_2)}
+###Dates and amounts
+
+$IF range_in_2013_2014_fin_year?(due_date)
+
+Weekly rate (between 6 April 2013 and 5 April 2014) | £136.78, or 90% of their average weekly earnings (whichever is lower).
+
+$ENDIF
+
+$IF range_in_2014_2015_fin_year?(due_date)
+
+Weekly rate (between 6 April 2014 and 5 April 2015) | £138.18, or 90% of their average weekly earnings (whichever is lower).
+
+$ENDIF
+
+$IF range_in_2015_2016_fin_year?(due_date)
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
+
+$ENDIF
+
+$IF NOT range_in_2013_2014_fin_year?(due_date) AND NOT range_in_2014_2015_fin_year?(due_date) AND NOT range_in_2015_2016_fin_year?(due_date)
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
+
+$ENDIF
+

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-additional-pat-leave-perm2.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-additional-pat-leave-perm2.txt
@@ -6,5 +6,6 @@ If your partner returns to work early, you may be able to take up to 26 weeks of
 
  | Dates
 - | -
-Additional paternity leave must be used between | %{start_of_additional_paternity_leave(match_date)} to %{end_of_additional_paternity_leave(match_date)}
+Additional paternity leave can start | 20 weeks after the birth
+Additional paternity leave must finish | by the child's first birthday
 Tell your employer | 8 weeks before they want to start additional paternity leave

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-additional-pat-leave.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-additional-pat-leave.txt
@@ -6,5 +6,6 @@ If you return to work early, your partner may be able to take up to 26 weeks off
 
  | Dates
 - | -
-Additional paternity leave must be used between | %{start_of_additional_paternity_leave(match_date)} to %{end_of_additional_paternity_leave(match_date)}
+Additional paternity leave can start | 20 weeks after the birth
+Additional paternity leave must finish | by the child's first birthday
 Tell your partner's employer | 8 weeks before they want to start additional paternity leave

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-additional-pat-pay-perm2.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-additional-pat-pay-perm2.txt
@@ -6,5 +6,27 @@ You can get [additional paternity pay](/paternity-pay-leave/pay) while you are o
 
  | Dates and amounts
 - | -
-Weekly rate  | %{rate_of_paternity_pay(salary_1)}
-Total pay | %{total_aspp(salary_1)}
+
+$IF range_in_2013_2014_fin_year?(match_date)
+
+Weekly rate (between 6 April 2013 and 5 April 2014) | £136.78, or 90% of their average weekly earnings (whichever is lower).
+
+$ENDIF
+
+$IF range_in_2014_2015_fin_year?(match_date)
+
+Weekly rate (between 6 April 2014 and 5 April 2015) | £138.18, or 90% of their average weekly earnings (whichever is lower).
+
+$ENDIF
+
+$IF range_in_2015_2016_fin_year?(match_date)
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
+
+$ENDIF
+
+$IF NOT range_in_2013_2014_fin_year?(match_date) AND NOT range_in_2014_2015_fin_year?(match_date) AND NOT range_in_2015_2016_fin_year?(match_date)
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
+
+$ENDIF

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-additional-pat-pay.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-additional-pat-pay.txt
@@ -6,5 +6,27 @@ Your partner can get [additional paternity pay](/paternity-pay-leave/pay) while 
 
  | Dates and amounts
 - | -
-Weekly rate  | %{rate_of_paternity_pay(salary_2)}
-Total pay | %{total_aspp(salary_2)}
+
+$IF range_in_2013_2014_fin_year?(match_date)
+
+Weekly rate (between 6 April 2013 and 5 April 2014) | £136.78, or 90% of their average weekly earnings (whichever is lower).
+
+$ENDIF
+
+$IF range_in_2014_2015_fin_year?(match_date)
+
+Weekly rate (between 6 April 2014 and 5 April 2015) | £138.18, or 90% of their average weekly earnings (whichever is lower).
+
+$ENDIF
+
+$IF range_in_2015_2016_fin_year?(match_date)
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
+
+$ENDIF
+
+$IF NOT range_in_2013_2014_fin_year?(match_date) AND NOT range_in_2014_2015_fin_year?(match_date) AND NOT range_in_2015_2016_fin_year?(match_date)
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
+
+$ENDIF

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-both-shared-leave-perm2.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-both-shared-leave-perm2.txt
@@ -8,5 +8,5 @@ The parents can choose how to share this leave between them. They can each take 
 
  | Dates
 - | -
-Shared parental leave must be used between | %{placement_date} to %{end_of_shared_parental_leave(placement_date)}
+Shared parental leave must be used | Within a year of the birth
 Tell the parent’s employers | 8 weeks before their first block of SPL

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-both-shared-leave.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-both-shared-leave.txt
@@ -8,5 +8,5 @@ The parents can choose how to share this leave between them. They can each take 
 
  | Dates
 - | -
-Shared parental leave must be used between | %{placement_date} to %{end_of_shared_parental_leave(placement_date)}
+Shared parental leave must be used | Within a year of the birth
 Tell the parent’s employers | 8 weeks before their first block of SPL

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-both-shared-pay-perm2.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-both-shared-pay-perm2.txt
@@ -6,5 +6,50 @@ The parents can both get [shared parental pay](/shared-parental-leave-and-pay/ov
 
  | Amount
 - | -
-Your partner's shared parental pay | %{rate_of_shpp(salary_2)}
-Your shared parental pay | %{rate_of_shpp(salary_1)}
+$IF range_in_2013_2014_fin_year?(match_date)
+
+Your shared parental pay (between 6 April 2013 and 5 April 2014) | £136.78 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2014_2015_fin_year?(match_date)
+
+Your shared parental pay (between 6 April 2014 and 5 April 2015) | £138.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2015_2016_fin_year?(match_date)
+
+Your shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF NOT range_in_2013_2014_fin_year?(match_date) AND NOT range_in_2014_2015_fin_year?(match_date) AND NOT range_in_2015_2016_fin_year?(match_date)
+
+Your shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2013_2014_fin_year?(match_date)
+
+Your Partner's shared parental pay (between 6 April 2013 and 5 April 2014) | £136.78 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2014_2015_fin_year?(match_date)
+
+Your Partner's shared parental pay (between 6 April 2014 and 5 April 2015) | £138.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2015_2016_fin_year?(match_date)
+
+Your Partner's shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF NOT range_in_2013_2014_fin_year?(match_date) AND NOT range_in_2014_2015_fin_year?(match_date) AND NOT range_in_2015_2016_fin_year?(match_date)
+
+Your Partner's shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-both-shared-pay.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-both-shared-pay.txt
@@ -6,5 +6,50 @@ The parents can both get [shared parental pay](/shared-parental-leave-and-pay/ov
 
  | Amount
 - | -
-Your shared parental pay | %{rate_of_shpp(salary_1)}
-Your partner's shared parental pay | %{rate_of_shpp(salary_2)}
+$IF range_in_2013_2014_fin_year?(match_date)
+
+Your shared parental pay (between 6 April 2013 and 5 April 2014) | £136.78 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2014_2015_fin_year?(match_date)
+
+Your shared parental pay (between 6 April 2014 and 5 April 2015) | £138.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2015_2016_fin_year?(match_date)
+
+Your shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF NOT range_in_2013_2014_fin_year?(match_date) AND NOT range_in_2014_2015_fin_year?(match_date) AND NOT range_in_2015_2016_fin_year?(match_date)
+
+Your shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2013_2014_fin_year?(match_date)
+
+Your Partner's shared parental pay (between 6 April 2013 and 5 April 2014) | £136.78 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2014_2015_fin_year?(match_date)
+
+Your Partner's shared parental pay (between 6 April 2014 and 5 April 2015) | £138.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2015_2016_fin_year?(match_date)
+
+Your Partner's shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF NOT range_in_2013_2014_fin_year?(match_date) AND NOT range_in_2014_2015_fin_year?(match_date) AND NOT range_in_2015_2016_fin_year?(match_date)
+
+Your Partner's shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-mat-pay-perm2.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-mat-pay-perm2.txt
@@ -6,9 +6,31 @@ Your partner can get up to 39 weeks of [adoption pay](/adoption-pay-leave/pay).
 
  | Dates and amounts
 - | -
-First 6 weeks | %{rate_of_smp_6_weeks(salary_2)} per week
-Next 33 weeks | %{rate_of_smp_33_weeks(salary_2)} per week
-Total estimated pay | %{total_smp(salary_2)}
+First 6 weeks | 90% of your partner's average weekly earnings (before tax)
+
+$IF range_in_2013_2014_fin_year?(match_date)
+
+Remaining weeks (between 6 April 2013 and 5 April 2014) | £136.78 per week or 90% of your partner's average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2014_2015_fin_year?(match_date)
+
+Remaining weeks (between 6 April 2014 and 5 April 2015) | £138.18 per week or 90% of your partner's average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2015_2016_fin_year?(match_date)
+
+Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of your partner's average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF NOT range_in_2013_2014_fin_year?(match_date) AND NOT range_in_2014_2015_fin_year?(match_date) AND NOT range_in_2015_2016_fin_year?(match_date)
+
+Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of your partner's average weekly earnings (before tax), whichever is lower
+
+$ENDIF
 Tell your partner's employer | 28 days before they want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-mat-pay.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-mat-pay.txt
@@ -6,9 +6,31 @@ You can get up to 39 weeks of [adoption pay](/adoption-pay-leave/pay).
 
  | Dates and amounts
 - | -
-First 6 weeks | %{rate_of_smp_6_weeks(salary_1)} per week
-Next 33 weeks | %{rate_of_smp_33_weeks(salary_1)} per week
-Total estimated pay | %{total_smp(salary_1)}
+First 6 weeks | 90% of your average weekly earnings (before tax)
+
+$IF range_in_2013_2014_fin_year?(match_date)
+
+Remaining weeks (between 6 April 2013 and 5 April 2014) | £136.78 per week or 90% of your average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2014_2015_fin_year?(match_date)
+
+Remaining weeks (between 6 April 2014 and 5 April 2015) | £138.18 per week or 90% of your average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2015_2016_fin_year?(match_date)
+
+Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of your average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF NOT range_in_2013_2014_fin_year?(match_date) AND NOT range_in_2014_2015_fin_year?(match_date) AND NOT range_in_2015_2016_fin_year?(match_date)
+
+Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of your average weekly earnings (before tax), whichever is lower
+
+$ENDIF
 Tell your employer | 28 days before they want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-mat-shared-leave-perm2.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-mat-shared-leave-perm2.txt
@@ -10,5 +10,5 @@ They can take SPL in up to 3 blocks, going back to work between the blocks.
 
  | Dates
 - | -
-Shared parental leave must be used between | %{placement_date} to %{end_of_shared_parental_leave(placement_date)}
+Shared parental leave must be used | Within a year of the birth
 Tell your partner's employer | 8 weeks before the first block of SPL

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-mat-shared-leave.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-mat-shared-leave.txt
@@ -10,5 +10,5 @@ They can take SPL in up to 3 blocks, going back to work between the blocks.
 
  | Dates
 - | -
-Shared parental leave must be used between | %{placement_date} to %{end_of_shared_parental_leave(placement_date)}
+Shared parental leave must be used | Within a year of the birth
 Tell your employer | 8 weeks before the first block of SPL

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-mat-shared-pay-perm2.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-mat-shared-pay-perm2.txt
@@ -6,4 +6,27 @@ Your partner can get [shared parental pay](/shared-parental-leave-and-pay/overvi
 
  | Amount
 - | -
-Shared parental pay | %{rate_of_shpp(salary_2)}
+
+$IF range_in_2013_2014_fin_year?(match_date)
+
+Shared Parental Pay (between 6 April 2013 and 5 April 2014) | £136.78 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2014_2015_fin_year?(match_date)
+
+Shared Parental Pay (between 6 April 2014 and 5 April 2015) | £138.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2015_2016_fin_year?(match_date)
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF NOT range_in_2013_2014_fin_year?(match_date) AND NOT range_in_2014_2015_fin_year?(match_date) AND NOT range_in_2015_2016_fin_year?(match_date)
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-mat-shared-pay.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-mat-shared-pay.txt
@@ -6,4 +6,27 @@ You can get [shared parental pay](/shared-parental-leave-and-pay/overview). It l
 
  | Amount
 - | -
-Shared parental pay | %{rate_of_shpp(salary_2)}
+
+$IF range_in_2013_2014_fin_year?(match_date)
+
+Shared Parental Pay (between 6 April 2013 and 5 April 2014) | £136.78 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2014_2015_fin_year?(match_date)
+
+Shared Parental Pay (between 6 April 2014 and 5 April 2015) | £138.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2015_2016_fin_year?(match_date)
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF NOT range_in_2013_2014_fin_year?(match_date) AND NOT range_in_2014_2015_fin_year?(match_date) AND NOT range_in_2015_2016_fin_year?(match_date)
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-pat-leave-perm2.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-pat-leave-perm2.txt
@@ -6,5 +6,5 @@ You can take up to 2 weeks of [ordinary paternity leave](/paternity-pay-leave/le
 
  | Dates
 - | -
-Paternity leave must be used between | %{placement_date} to %{latest_pat_leave(placement_date)}
+Paternity leave must be used | within 56 days of the birth.
 Tell your employer | %{paternity_leave_notice_date(placement_date)}

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-pat-leave.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-pat-leave.txt
@@ -6,5 +6,5 @@ Your partner can take up to 2 weeks of [ordinary paternity leave](/paternity-pay
 
  | Dates
 - | -
-Paternity leave must be used between | %{placement_date} to %{latest_pat_leave(placement_date)}
+Paternity leave must be used | within 56 days of the birth.
 Tell your partner's employer | %{paternity_leave_notice_date(placement_date)}

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-pat-pay-perm2.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-pat-pay-perm2.txt
@@ -6,5 +6,36 @@ You can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
 
  | Dates and amounts
 - | -
-Weekly rate | %{rate_of_paternity_pay(salary_1)}
+$IF range_in_2013_2014_fin_year?(match_date)
+
+Weekly rate (between 6 April 2013 and 5 April 2014) | £136.78 per week or 90% of your average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2014_2015_fin_year?(match_date)
+
+Weekly rate (between 6 April 2014 and 5 April 2015) | £138.18 per week or 90% of your average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2015_2016_fin_year?(match_date)
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of your average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF NOT range_in_2013_2014_fin_year?(match_date) AND NOT range_in_2014_2015_fin_year?(match_date) AND NOT range_in_2015_2016_fin_year?(match_date)
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of your average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2013_2014_fin_year?(match_date)
+
 Tell your employer | 28 days before they want to start paternity pay
+
+$ELSE
+
+Tell your employer | %{paternity_leave_notice_date(match_date)}
+
+$ENDIF

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-pat-pay.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-pat-pay.txt
@@ -6,5 +6,36 @@ Your partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
 
  | Dates and amounts
 - | -
-Weekly rate | %{rate_of_paternity_pay(salary_2)}
+$IF range_in_2013_2014_fin_year?(match_date)
+
+Weekly rate (between 6 April 2013 and 5 April 2014) | £136.78 per week or 90% of your partner's average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2014_2015_fin_year?(match_date)
+
+Weekly rate (between 6 April 2014 and 5 April 2015) | £138.18 per week or 90% of your partner's average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2015_2016_fin_year?(match_date)
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of your partner's average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF NOT range_in_2013_2014_fin_year?(match_date) AND NOT range_in_2014_2015_fin_year?(match_date) AND NOT range_in_2015_2016_fin_year?(match_date)
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of your partner's average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2013_2014_fin_year?(match_date)
+
 Tell your partner's employer | 28 days before they want to start paternity pay
+
+$ELSE
+
+Tell your partner's employer | %{paternity_leave_notice_date(match_date)}
+
+$ENDIF

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-pat-shared-leave-perm2.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-pat-shared-leave-perm2.txt
@@ -10,5 +10,5 @@ The partner can take SPL in up to 3 blocks, going back to work between the block
 
  | Dates
 - | -
-Shared parental leave must be used between | %{placement_date} to %{end_of_shared_parental_leave(placement_date)}
+Shared parental leave must be used | Within a year of the birth
 Tell you employer | 8 weeks before the first block of SPL

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-pat-shared-leave.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-pat-shared-leave.txt
@@ -10,5 +10,5 @@ The partner can take SPL in up to 3 blocks, going back to work between the block
 
  | Dates
 - | -
-Shared parental leave must be used between | %{placement_date} to %{end_of_shared_parental_leave(placement_date)}
+Shared parental leave must be used | Within a year of the birth
 Tell your partner's employer | 8 weeks before the first block of SPL

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-pat-shared-pay-perm2.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-pat-shared-pay-perm2.txt
@@ -6,4 +6,27 @@ You can get [shared parental pay](/shared-parental-leave-and-pay/overview). It l
 
  | Amount
 - | -
-Shared parental pay | %{rate_of_shpp(salary_1)}
+
+$IF range_in_2013_2014_fin_year?(match_date)
+
+Shared Parental Pay (between 6 April 2013 and 5 April 2014) | £136.78 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2014_2015_fin_year?(match_date)
+
+Shared Parental Pay (between 6 April 2014 and 5 April 2015) | £138.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2015_2016_fin_year?(match_date)
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF NOT range_in_2013_2014_fin_year?(match_date) AND NOT range_in_2014_2015_fin_year?(match_date) AND NOT range_in_2015_2016_fin_year?(match_date)
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-pat-shared-pay.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/adoption-pat-shared-pay.txt
@@ -6,4 +6,27 @@ Your partner can get [shared parental pay](/shared-parental-leave-and-pay/overvi
 
  | Amount
 - | -
-Shared parental pay | %{rate_of_shpp(salary_2)}
+
+$IF range_in_2013_2014_fin_year?(match_date)
+
+Shared Parental Pay (between 6 April 2013 and 5 April 2014) | £136.78 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2014_2015_fin_year?(match_date)
+
+Shared Parental Pay (between 6 April 2014 and 5 April 2015) | £138.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2015_2016_fin_year?(match_date)
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF NOT range_in_2013_2014_fin_year?(match_date) AND NOT range_in_2014_2015_fin_year?(match_date) AND NOT range_in_2015_2016_fin_year?(match_date)
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/both-shared-leave.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/both-shared-leave.txt
@@ -8,5 +8,5 @@ The parents can choose how to share this leave between them. They can each take 
 
  | Dates
 - | -
-Shared parental leave must be used between | %{due_date} to %{end_of_shared_parental_leave(due_date)}
+Shared parental leave must be used | Within a year of the birth
 Tell the parent’s employer | 8 weeks before their first block of SPL

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/both-shared-pay.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/both-shared-pay.txt
@@ -4,7 +4,52 @@
 
 The mother and her partner can both get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance the mother has received.
 
- | Amount
-- | -
-Mother’s shared parental pay | %{rate_of_shpp(salary_1)}
-Partner’s shared parental pay | %{rate_of_shpp(salary_2)}
+###Amount
+
+$IF range_in_2013_2014_fin_year?(due_date)
+
+Mother’s shared parental pay (between 6 April 2013 and 5 April 2014) | £136.78 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2014_2015_fin_year?(due_date)
+
+Mother’s shared parental pay (between 6 April 2014 and 5 April 2015) | £138.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2015_2016_fin_year?(due_date)
+
+Mother’s shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF NOT range_in_2013_2014_fin_year?(due_date) AND NOT range_in_2014_2015_fin_year?(due_date) AND NOT range_in_2015_2016_fin_year?(due_date)
+
+Mother’s shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2013_2014_fin_year?(due_date)
+
+Partner's shared parental pay (between 6 April 2013 and 5 April 2014) | £136.78 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2014_2015_fin_year?(due_date)
+
+Partner's shared parental pay (between 6 April 2014 and 5 April 2015) | £138.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2015_2016_fin_year?(due_date)
+
+Partner's shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF NOT range_in_2013_2014_fin_year?(due_date) AND NOT range_in_2014_2015_fin_year?(due_date) AND NOT range_in_2015_2016_fin_year?(due_date)
+
+Partner's shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/mat-allowance.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/mat-allowance.txt
@@ -4,10 +4,32 @@
 
 The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
 
- | Dates and amounts
-- | -
+###Dates and amounts
+
 Maternity allowance can start on | %{start_of_maternity_allowance(due_date)}
-Weekly rate | %{rate_of_maternity_allowance(salary_1_66_weeks)}
-Total estimated allowance | %{total_maternity_allowance(salary_1_66_weeks)}
+
+$IF range_in_2013_2014_fin_year?(due_date)
+
+Weekly rate (between 6 April 2013 and 5 April 2014) | £136.78, or 90% of her average weekly earnings (whichever is lower)
+
+$ENDIF
+
+$IF range_in_2014_2015_fin_year?(due_date)
+
+Weekly rate (between 6 April 2014 and 5 April 2015) | £138.18, or 90% of her average weekly earnings (whichever is lower)
+
+$ENDIF
+
+$IF range_in_2015_2016_fin_year?(due_date)
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+$ENDIF
+
+$IF NOT range_in_2013_2014_fin_year?(due_date) AND NOT range_in_2014_2015_fin_year?(due_date) AND NOT range_in_2015_2016_fin_year?(due_date)
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+$ENDIF
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/mat-pay.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/mat-pay.txt
@@ -4,11 +4,34 @@
 
 The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
- | Dates and amounts
-- | -
-First 6 weeks | %{rate_of_smp_6_weeks(salary_1)} per week
-Next 33 weeks | %{rate_of_smp_33_weeks(salary_1)} per week
-Total estimated pay | %{total_smp(salary_1)}
-Tell the mother’s employer | 28 days before they want to start maternity pay
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+$IF range_in_2013_2014_fin_year?(due_date)
+
+Remaining weeks (between 6 April 2013 and 5 April 2014) | £136.78 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2014_2015_fin_year?(due_date)
+
+Remaining weeks (between 6 April 2014 and 5 April 2015) | £138.18 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2015_2016_fin_year?(due_date)
+
+Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF NOT range_in_2013_2014_fin_year?(due_date) AND NOT range_in_2014_2015_fin_year?(due_date) AND NOT range_in_2015_2016_fin_year?(due_date)
+
+Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/mat-shared-leave.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/mat-shared-leave.txt
@@ -10,5 +10,5 @@ She can take SPL in up to 3 blocks, going back to work between the blocks.
 
  | Dates
 - | -
-Shared parental leave must be used between | %{due_date} to %{end_of_shared_parental_leave(due_date)}
+Shared parental leave must be used | Within a year of the birth
 Tell the mother’s employer | 8 weeks before the first block of SPL

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/mat-shared-pay.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/mat-shared-pay.txt
@@ -4,6 +4,28 @@
 
 The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance they’ve received.
 
- | Amount
-- | -
-Shared parental pay | %{rate_of_shpp(salary_1)}
+###Amount
+
+$IF range_in_2013_2014_fin_year?(due_date)
+
+Shared Parental Pay (between 6 April 2013 and 5 April 2014) | £136.78 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2014_2015_fin_year?(due_date)
+
+Shared Parental Pay (between 6 April 2014 and 5 April 2015) | £138.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2015_2016_fin_year?(due_date)
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF NOT range_in_2013_2014_fin_year?(due_date) AND NOT range_in_2014_2015_fin_year?(due_date) AND NOT range_in_2015_2016_fin_year?(due_date)
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/pat-leave.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/pat-leave.txt
@@ -2,9 +2,9 @@
 
 ##Paternity leave
 
-The mother’s partner can take up to 2 weeks of [ordinary paternity leave](/paternity-pay-leave/leave).
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
 
  | Dates
 - | -
-Paternity leave must be used between | %{due_date} to %{latest_pat_leave(due_date)}
-Tell the partner’s employer | %{paternity_leave_notice_date(due_date)}
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | %{paternity_leave_notice_date(due_date)}

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/pat-pay.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/pat-pay.txt
@@ -4,7 +4,39 @@
 
 The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
 
- | Dates and amounts
-- | -
-Weekly rate | %{rate_of_paternity_pay(salary_2)}
+###Dates and amounts
+
+$IF range_in_2013_2014_fin_year?(due_date)
+
+Weekly rate (between 6 April 2013 and 5 April 2014) | £136.78 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2014_2015_fin_year?(due_date)
+
+Weekly rate (between 6 April 2014 and 5 April 2015) | £138.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2015_2016_fin_year?(due_date)
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF NOT range_in_2013_2014_fin_year?(due_date) AND NOT range_in_2014_2015_fin_year?(due_date) AND NOT range_in_2015_2016_fin_year?(due_date)
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2013_2014_fin_year?(due_date)
+
 Tell the partner’s employer | 28 days before they want to start paternity pay
+
+$ELSE
+
+Tell the partner’s employer | %{paternity_leave_notice_date(due_date)}
+
+$ENDIF
+

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/pat-shared-leave.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/pat-shared-leave.txt
@@ -10,5 +10,5 @@ The partner can take SPL in up to 3 blocks, going back to work between the block
 
  | Dates
 - | -
-Shared parental leave must be used between | %{due_date} to %{end_of_shared_parental_leave(due_date)}
+Shared parental leave must be used | Within a year of the birth
 Tell the partner’s employer | 8 weeks before the first block of SPL

--- a/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/pat-shared-pay.txt
+++ b/lib/smartdown_flows/pay-leave-for-parents-adoption/snippets/pat-shared-pay.txt
@@ -4,6 +4,28 @@
 
 The mother’s partner can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance the mother has received.
 
- | Amount
-- | -
-Shared parental pay | %{rate_of_shpp(salary_2)}
+###Amount
+
+$IF range_in_2013_2014_fin_year?(due_date)
+
+Shared Parental Pay (between 6 April 2013 and 5 April 2014) | £136.78 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2014_2015_fin_year?(due_date)
+
+Shared Parental Pay (between 6 April 2014 and 5 April 2015) | £138.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF range_in_2015_2016_fin_year?(due_date)
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF
+
+$IF NOT range_in_2013_2014_fin_year?(due_date) AND NOT range_in_2014_2015_fin_year?(due_date) AND NOT range_in_2015_2016_fin_year?(due_date)
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+$ENDIF

--- a/lib/smartdown_plugins/pay-leave-for-parents-adoption/render_time.rb
+++ b/lib/smartdown_plugins/pay-leave-for-parents-adoption/render_time.rb
@@ -231,63 +231,6 @@ module SmartdownPlugins
       rate_of_smp_33_weeks(salary_1, build_date_answer(Smartdown::Model::Answer::Date.new("2016-1-1")))
     end
 
-    def self.total_aspp(salary, due_date)
-      date = due_date.value
-      pay = 0
-      # Calculate pay for each week of the 39 week duration
-      39.times do
-        if (Date.new(2013, 05, 06)..Date.new(2014, 05, 05)).cover?(date)
-          pay += rate_of_paternity_pay_2013_2014(salary).value
-        elsif (Date.new(2013, 05, 06)..Date.new(2014, 05, 05)).cover?(date)
-          pay += rate_of_paternity_pay_2014_2015(salary).value
-        elsif (Date.new(2013, 05, 06)..Date.new(2014, 05, 05)).cover?(date)
-          pay += rate_of_paternity_pay_2015_2016(salary).value
-        else
-          pay += rate_of_paternity_pay_2015_2016(salary).value
-        end
-        date += 1.week
-      end
-      build_money_answer(pay)
-    end
-
-    def self.total_maternity_allowance(salary_1_66_weeks, due_date)
-      date = due_date.value
-      pay = 0
-      # Calculate pay for each week of the 39 week duration
-      39.times do
-        if (Date.new(2013, 05, 06)..Date.new(2014, 05, 05)).cover?(date)
-          pay += rate_of_maternity_allowance_2013_2014(salary_1_66_weeks).value
-        elsif (Date.new(2013, 05, 06)..Date.new(2014, 05, 05)).cover?(date)
-          pay += rate_of_maternity_allowance_2014_2015(salary_1_66_weeks).value
-        elsif (Date.new(2013, 05, 06)..Date.new(2014, 05, 05)).cover?(date)
-          pay += rate_of_maternity_allowance_2015_2016(salary_1_66_weeks).value
-        else
-          pay += rate_of_maternity_allowance_2015_2016(salary_1_66_weeks).value
-        end
-        date += 1.week
-      end
-      build_money_answer(pay)
-    end
-
-    def self.total_smp(salary_1, due_date)
-      date = due_date.value
-      initial_pay = (rate_of_smp_6_weeks(salary_1) * 6)
-      week_pay = 0
-      # Calculate pay for each week of the 33 week duration
-      33.times do
-        if (Date.new(2013, 05, 06)..Date.new(2014, 05, 05)).cover?(date)
-          week_pay += rate_of_smp_33_weeks_2013_2014(salary_1).value
-        elsif (Date.new(2013, 05, 06)..Date.new(2014, 05, 05)).cover?(date)
-          week_pay += rate_of_smp_33_weeks_2014_2015(salary_1).value
-        elsif (Date.new(2013, 05, 06)..Date.new(2014, 05, 05)).cover?(date)
-          week_pay += rate_of_smp_33_weeks_2015_2016(salary_1).value
-        else
-          week_pay += rate_of_smp_33_weeks_2015_2016(salary_1).value
-        end
-        date += 1.week
-      end
-      build_money_answer(initial_pay + week_pay)
-    end
 
   private
 

--- a/lib/smartdown_plugins/pay-leave-for-parents-adoption/render_time.rb
+++ b/lib/smartdown_plugins/pay-leave-for-parents-adoption/render_time.rb
@@ -4,6 +4,45 @@ require 'smartdown/model/answer/date'
 module SmartdownPlugins
   module PayLeaveForParentsAdoption
 
+    #Uprate helpers
+
+    def self.lower_earnings_amount(due_date)
+      start_date = lower_earnings_start_date(due_date)
+      if in_2013_2014_fin_year?(start_date)
+        build_money_answer(109)
+      elsif in_2014_2015_fin_year?(start_date)
+        build_money_answer(111)
+      elsif in_2015_2016_fin_year?(start_date)
+        build_money_answer(112)
+      else
+        build_money_answer(112)
+      end
+    end
+
+    def self.in_2013_2014_fin_year?(date)
+      (Date.new(2013, 05, 06)..Date.new(2014, 05, 05)).cover?(date.value)
+    end
+
+    def self.in_2014_2015_fin_year?(date)
+      (Date.new(2014, 05, 06)..Date.new(2015, 05, 05)).cover?(date.value)
+    end
+
+    def self.in_2015_2016_fin_year?(date)
+      (Date.new(2015, 05, 06)..Date.new(2016, 05, 05)).cover?(date.value)
+    end
+
+    def self.range_in_2013_2014_fin_year?(date)
+      date_in_39_week_range?(2013, 2014, date)
+    end
+
+    def self.range_in_2014_2015_fin_year?(date)
+      date_in_39_week_range?(2014, 2015, date)
+    end
+
+    def self.range_in_2015_2016_fin_year?(date)
+      date_in_39_week_range?(2015, 2016, date)
+    end
+
     #Flow helpers
 
     def self.qualifies_for_14_week_maternity_allowance?(employment_status_1, employment_status_2)
@@ -123,39 +162,141 @@ module SmartdownPlugins
 
     #Money calculations
 
-    def self.rate_of_maternity_allowance(salary_1_66_weeks)
-      build_money_answer(nine_tenths_weekly_salary_capped(salary_1_66_weeks))
+    def self.rate_of_maternity_allowance(salary_1_66_weeks, due_date)
+      build_money_answer(nine_tenths_weekly_salary_capped(salary_1_66_weeks, due_date))
     end
 
-    def self.rate_of_paternity_pay(salary_2)
-      build_money_answer(nine_tenths_weekly_salary_capped(salary_2))
+    def self.rate_of_maternity_allowance_2013_2014(salary)
+      rate_of_maternity_allowance(salary, build_date_answer(Smartdown::Model::Answer::Date.new("2014-1-1")))
     end
 
-    def self.rate_of_shpp(salary)
-      build_money_answer(nine_tenths_weekly_salary_capped(salary))
+    def self.rate_of_maternity_allowance_2014_2015(salary)
+      rate_of_maternity_allowance(salary, build_date_answer(Smartdown::Model::Answer::Date.new("2015-1-1")))
+    end
+
+    def self.rate_of_maternity_allowance_2015_2016(salary)
+      rate_of_maternity_allowance(salary, build_date_answer(Smartdown::Model::Answer::Date.new("2016-1-1")))
+    end
+
+    def self.rate_of_paternity_pay(salary_2, due_date)
+      build_money_answer(nine_tenths_weekly_salary_capped(salary_2, due_date))
+    end
+
+    def self.rate_of_paternity_pay_2013_2014(salary)
+      rate_of_paternity_pay(salary, build_date_answer(Smartdown::Model::Answer::Date.new("2014-1-1")))
+    end
+
+    def self.rate_of_paternity_pay_2014_2015(salary)
+      rate_of_paternity_pay(salary, build_date_answer(Smartdown::Model::Answer::Date.new("2015-1-1")))
+    end
+
+    def self.rate_of_paternity_pay_2015_2016(salary)
+      rate_of_paternity_pay(salary, build_date_answer(Smartdown::Model::Answer::Date.new("2016-1-1")))
+    end
+
+    def self.rate_of_shpp(salary, due_date)
+      build_money_answer(nine_tenths_weekly_salary_capped(salary, due_date))
+    end
+
+    def self.rate_of_shpp_2013_2014(salary)
+      rate_of_shpp(salary, build_date_answer(Smartdown::Model::Answer::Date.new("2014-1-1")))
+    end
+
+    def self.rate_of_shpp_2014_2015(salary)
+      rate_of_shpp(salary, build_date_answer(Smartdown::Model::Answer::Date.new("2015-1-1")))
+    end
+
+    def self.rate_of_shpp_2015_2016(salary)
+      rate_of_shpp(salary, build_date_answer(Smartdown::Model::Answer::Date.new("2016-1-1")))
     end
 
     def self.rate_of_smp_6_weeks(salary_1)
       build_money_answer((salary_1.value / 52) * 0.9)
     end
 
-    def self.rate_of_smp_33_weeks(salary_1)
-      build_money_answer(nine_tenths_weekly_salary_capped(salary_1))
+    def self.rate_of_smp_33_weeks(salary_1, due_date)
+      start_date = build_date_answer(due_date.value + 6.weeks)
+      build_money_answer(nine_tenths_weekly_salary_capped(salary_1, start_date))
     end
 
-    def self.total_aspp(salary_2)
-      build_money_answer(rate_of_paternity_pay(salary_2) * 26)
+    def self.rate_of_smp_33_weeks_2013_2014(salary_1)
+      rate_of_smp_33_weeks(salary_1, build_date_answer(Smartdown::Model::Answer::Date.new("2014-1-1")))
     end
 
-    def self.total_maternity_allowance(salary_1_66_weeks)
-      build_money_answer(rate_of_maternity_allowance(salary_1_66_weeks) * 39)
+    def self.rate_of_smp_33_weeks_2014_2015(salary_1)
+      rate_of_smp_33_weeks(salary_1, build_date_answer(Smartdown::Model::Answer::Date.new("2015-1-1")))
     end
 
-    def self.total_smp(salary_1)
-      build_money_answer((rate_of_smp_6_weeks(salary_1) * 6) + (rate_of_smp_33_weeks(salary_1) * 33))
+    def self.rate_of_smp_33_weeks_2015_2016(salary_1)
+      rate_of_smp_33_weeks(salary_1, build_date_answer(Smartdown::Model::Answer::Date.new("2016-1-1")))
+    end
+
+    def self.total_aspp(salary, due_date)
+      date = due_date.value
+      pay = 0
+      # Calculate pay for each week of the 39 week duration
+      39.times do
+        if (Date.new(2013, 05, 06)..Date.new(2014, 05, 05)).cover?(date)
+          pay += rate_of_paternity_pay_2013_2014(salary).value
+        elsif (Date.new(2013, 05, 06)..Date.new(2014, 05, 05)).cover?(date)
+          pay += rate_of_paternity_pay_2014_2015(salary).value
+        elsif (Date.new(2013, 05, 06)..Date.new(2014, 05, 05)).cover?(date)
+          pay += rate_of_paternity_pay_2015_2016(salary).value
+        else
+          pay += rate_of_paternity_pay_2015_2016(salary).value
+        end
+        date += 1.week
+      end
+      build_money_answer(pay)
+    end
+
+    def self.total_maternity_allowance(salary_1_66_weeks, due_date)
+      date = due_date.value
+      pay = 0
+      # Calculate pay for each week of the 39 week duration
+      39.times do
+        if (Date.new(2013, 05, 06)..Date.new(2014, 05, 05)).cover?(date)
+          pay += rate_of_maternity_allowance_2013_2014(salary_1_66_weeks).value
+        elsif (Date.new(2013, 05, 06)..Date.new(2014, 05, 05)).cover?(date)
+          pay += rate_of_maternity_allowance_2014_2015(salary_1_66_weeks).value
+        elsif (Date.new(2013, 05, 06)..Date.new(2014, 05, 05)).cover?(date)
+          pay += rate_of_maternity_allowance_2015_2016(salary_1_66_weeks).value
+        else
+          pay += rate_of_maternity_allowance_2015_2016(salary_1_66_weeks).value
+        end
+        date += 1.week
+      end
+      build_money_answer(pay)
+    end
+
+    def self.total_smp(salary_1, due_date)
+      date = due_date.value
+      initial_pay = (rate_of_smp_6_weeks(salary_1) * 6)
+      week_pay = 0
+      # Calculate pay for each week of the 33 week duration
+      33.times do
+        if (Date.new(2013, 05, 06)..Date.new(2014, 05, 05)).cover?(date)
+          week_pay += rate_of_smp_33_weeks_2013_2014(salary_1).value
+        elsif (Date.new(2013, 05, 06)..Date.new(2014, 05, 05)).cover?(date)
+          week_pay += rate_of_smp_33_weeks_2014_2015(salary_1).value
+        elsif (Date.new(2013, 05, 06)..Date.new(2014, 05, 05)).cover?(date)
+          week_pay += rate_of_smp_33_weeks_2015_2016(salary_1).value
+        else
+          week_pay += rate_of_smp_33_weeks_2015_2016(salary_1).value
+        end
+        date += 1.week
+      end
+      build_money_answer(initial_pay + week_pay)
     end
 
   private
+
+    def self.date_in_39_week_range?(range_start, range_end, date)
+      start_date = date.value
+      end_date = start_date + 39.weeks
+      (Date.new(range_start, 05, 06)..Date.new(range_end, 05, 05)).cover?(start_date) ||
+      (Date.new(range_start, 05, 06)..Date.new(range_end, 05, 05)).cover?(end_date)
+    end
 
     def self.build_date_answer(date)
       Smartdown::Model::Answer::Date.new(date.to_s)
@@ -173,10 +314,20 @@ module SmartdownPlugins
       (date - date.wday) - 1.day
     end
 
-    def self.nine_tenths_weekly_salary_capped(salary)
+    def self.nine_tenths_weekly_salary_capped(salary, start_date)
+      if in_2013_2014_fin_year?(start_date)
+        max_rate = 136.78
+      elsif in_2014_2015_fin_year?(start_date)
+        max_rate = 138.18
+      elsif in_2015_2016_fin_year?(start_date)
+        max_rate = 139.58
+      else
+        max_rate = 139.58
+      end
+
       weekly_salary = salary.value / 52
       rate = weekly_salary * 0.9
-      rate < 139.58 ? rate : 139.58
+      [ rate, max_rate ].min
     end
   end
 end

--- a/test/unit/smartdown_plugins/pay-leave-for-parents_adoption_test.rb
+++ b/test/unit/smartdown_plugins/pay-leave-for-parents_adoption_test.rb
@@ -57,21 +57,6 @@ module SmartdownPlugins
         salary_1 = Smartdown::Model::Answer::Salary.new("150-week")
         assert_equal 135.0, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_shpp(salary_1, date)
       end
-
-      should "total_aspp returns the rate_of_paternity_pay * 26" do
-        salary = Smartdown::Model::Answer::Salary.new("200-week")
-        assert_equal 5393.219999999999, SmartdownPlugins::PayLeaveForParentsAdoption.total_aspp(salary, date)
-      end
-
-      should "total_maternity_allowance returns the rate_of_maternity_allowance * 39" do
-        salary_1 = Smartdown::Model::Answer::Salary.new("200-week")
-        assert_equal 5393.219999999999, SmartdownPlugins::PayLeaveForParentsAdoption.total_maternity_allowance(salary_1, date)
-      end
-
-      should "total_smp returns the rate_of_smp_6_weeks * 6 + rate_of_smp_33_weeks * 33 (totaling 39 weeks)" do
-        salary_1 = Smartdown::Model::Answer::Salary.new("200-week")
-        assert_equal 5635.74, SmartdownPlugins::PayLeaveForParentsAdoption.total_smp(salary_1, date)
-      end
     end
 
     context "due date in 2014-2015 range" do
@@ -123,21 +108,6 @@ module SmartdownPlugins
       should "rate_of_shpp returns 90% of the given weekly salary when it is less than £138.18" do
         salary_1 = Smartdown::Model::Answer::Salary.new("150-week")
         assert_equal 135.0, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_shpp(salary_1, date)
-      end
-
-      should "total_aspp returns the rate_of_paternity_pay * 26" do
-        salary = Smartdown::Model::Answer::Salary.new("200-week")
-        assert_equal 5443.619999999998, SmartdownPlugins::PayLeaveForParentsAdoption.total_aspp(salary, date)
-      end
-
-      should "total_maternity_allowance returns the rate_of_maternity_allowance * 39" do
-        salary_1 = Smartdown::Model::Answer::Salary.new("200-week")
-        assert_equal 5443.619999999998, SmartdownPlugins::PayLeaveForParentsAdoption.total_maternity_allowance(salary_1, date)
-      end
-
-      should "total_smp returns the rate_of_smp_6_weeks * 6 + rate_of_smp_33_weeks * 33 (totaling 39 weeks)" do
-        salary_1 = Smartdown::Model::Answer::Salary.new("200-week")
-        assert_equal 5686.1399999999985, SmartdownPlugins::PayLeaveForParentsAdoption.total_smp(salary_1, date)
       end
     end
 
@@ -191,21 +161,6 @@ module SmartdownPlugins
         salary_1 = Smartdown::Model::Answer::Salary.new("150-week")
         assert_equal 135.0, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_shpp(salary_1, date)
       end
-
-      should "total_aspp returns the rate_of_paternity_pay * 26" do
-        salary = Smartdown::Model::Answer::Salary.new("200-week")
-        assert_equal 5443.619999999998, SmartdownPlugins::PayLeaveForParentsAdoption.total_aspp(salary, date)
-      end
-
-      should "total_maternity_allowance returns the rate_of_maternity_allowance * 39" do
-        salary_1 = Smartdown::Model::Answer::Salary.new("200-week")
-        assert_equal 5443.619999999998, SmartdownPlugins::PayLeaveForParentsAdoption.total_maternity_allowance(salary_1, date)
-      end
-
-      should "total_smp returns the rate_of_smp_6_weeks * 6 + rate_of_smp_33_weeks * 33 (totaling 39 weeks)" do
-        salary_1 = Smartdown::Model::Answer::Salary.new("200-week")
-        assert_equal 5686.1399999999985, SmartdownPlugins::PayLeaveForParentsAdoption.total_smp(salary_1, date)
-      end
     end
 
     context "due date outside all ranges" do
@@ -253,21 +208,6 @@ module SmartdownPlugins
       should "rate_of_shpp returns 90% of the given weekly salary when it is less than £139.58" do
         salary_1 = Smartdown::Model::Answer::Salary.new("150-week")
         assert_equal 135.0, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_shpp(salary_1, date)
-      end
-
-      should "total_aspp returns the rate_of_paternity_pay * 26" do
-        salary = Smartdown::Model::Answer::Salary.new("200-week")
-        assert_equal 5443.619999999998, SmartdownPlugins::PayLeaveForParentsAdoption.total_aspp(salary, date)
-      end
-
-      should "total_maternity_allowance returns the rate_of_maternity_allowance * 39" do
-        salary_1 = Smartdown::Model::Answer::Salary.new("200-week")
-        assert_equal 5443.619999999998, SmartdownPlugins::PayLeaveForParentsAdoption.total_maternity_allowance(salary_1, date)
-      end
-
-      should "total_smp returns the rate_of_smp_6_weeks * 6 + rate_of_smp_33_weeks * 33 (totaling 39 weeks)" do
-        salary_1 = Smartdown::Model::Answer::Salary.new("200-week")
-        assert_equal 5686.1399999999985, SmartdownPlugins::PayLeaveForParentsAdoption.total_smp(salary_1, date)
       end
     end
 

--- a/test/unit/smartdown_plugins/pay-leave-for-parents_adoption_test.rb
+++ b/test/unit/smartdown_plugins/pay-leave-for-parents_adoption_test.rb
@@ -5,8 +5,271 @@ require 'smartdown_plugins/pay-leave-for-parents-adoption/render_time'
 module SmartdownPlugins
 
   class PayLeaveForParentsAdoptionTest < ActiveSupport::TestCase
-
     due_date = Smartdown::Model::Answer::Date.new("2015-1-1")
+
+    context "due date in 2013-2014 range" do
+      date = Smartdown::Model::Answer::Date.new("2014-1-1")
+
+      should "be in 2013-2014 range" do
+        assert_equal true, SmartdownPlugins::PayLeaveForParentsAdoption.in_2013_2014_fin_year?(date)
+      end
+
+      should "return £ 109 for lower_earnings_amount" do
+        assert_equal 109, SmartdownPlugins::PayLeaveForParentsAdoption.lower_earnings_amount(date)
+      end
+
+      should "rate_of_smp_33_weeks returns 90% of the given weekly salary when it is less than £136.78" do
+        salary_1 = Smartdown::Model::Answer::Salary.new("150-week")
+        assert_equal 135.0, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_smp_33_weeks(salary_1, date)
+      end
+
+      should "rate_of_smp_33_weeks returns 136.78 when 90% of the given weekly salary is higher than £136.78" do
+        salary_1 = Smartdown::Model::Answer::Salary.new("200-week")
+        assert_equal 136.78, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_smp_33_weeks(salary_1, date)
+      end
+
+      should "rate_of_maternity_allowance returns 136.78 when 90% of the given weekly salary is higher than £136.78" do
+        salary_1 = Smartdown::Model::Answer::Salary.new("200-week")
+        assert_equal 136.78, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_maternity_allowance(salary_1, date)
+      end
+
+      should "rate_of_maternity_allowance returns 90% of the given weekly salary when it is less than £136.78" do
+        salary_1 = Smartdown::Model::Answer::Salary.new("150-week")
+        assert_equal 135.0, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_maternity_allowance(salary_1, date)
+      end
+
+      should "rate_of_paternity_pay returns 136.78 when 90% of the given weekly salary is higher than £136.78" do
+        salary_2 = Smartdown::Model::Answer::Salary.new("200-week")
+        assert_equal 136.78, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_paternity_pay(salary_2, date)
+      end
+
+      should "rate_of_paternity_pay returns 90% of the given weekly salary when it is less than £136.78" do
+        salary_2 = Smartdown::Model::Answer::Salary.new("150-week")
+        assert_equal 135.0, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_paternity_pay(salary_2, date)
+      end
+
+      should "rate_of_shpp returns 136.78 when 90% of the given weekly salary is higher than £136.78" do
+        salary_1 = Smartdown::Model::Answer::Salary.new("200-week")
+        assert_equal 136.78, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_shpp(salary_1, date)
+      end
+
+      should "rate_of_shpp returns 90% of the given weekly salary when it is less than £136.78" do
+        salary_1 = Smartdown::Model::Answer::Salary.new("150-week")
+        assert_equal 135.0, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_shpp(salary_1, date)
+      end
+
+      should "total_aspp returns the rate_of_paternity_pay * 26" do
+        salary = Smartdown::Model::Answer::Salary.new("200-week")
+        assert_equal 5393.219999999999, SmartdownPlugins::PayLeaveForParentsAdoption.total_aspp(salary, date)
+      end
+
+      should "total_maternity_allowance returns the rate_of_maternity_allowance * 39" do
+        salary_1 = Smartdown::Model::Answer::Salary.new("200-week")
+        assert_equal 5393.219999999999, SmartdownPlugins::PayLeaveForParentsAdoption.total_maternity_allowance(salary_1, date)
+      end
+
+      should "total_smp returns the rate_of_smp_6_weeks * 6 + rate_of_smp_33_weeks * 33 (totaling 39 weeks)" do
+        salary_1 = Smartdown::Model::Answer::Salary.new("200-week")
+        assert_equal 5635.74, SmartdownPlugins::PayLeaveForParentsAdoption.total_smp(salary_1, date)
+      end
+    end
+
+    context "due date in 2014-2015 range" do
+      date = Smartdown::Model::Answer::Date.new("2015-1-1")
+
+      should "be in 2013-2014 range" do
+        assert_equal true, SmartdownPlugins::PayLeaveForParentsAdoption.in_2014_2015_fin_year?(date)
+      end
+
+      should "return £ 111 for lower_earnings_amount" do
+        assert_equal 111, SmartdownPlugins::PayLeaveForParentsAdoption.lower_earnings_amount(date)
+      end
+
+      should "rate_of_smp_33_weeks returns 90% of the given weekly salary when it is less than £138.18" do
+        salary_1 = Smartdown::Model::Answer::Salary.new("150-week")
+        assert_equal 135.0, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_smp_33_weeks(salary_1, date)
+      end
+
+      should "rate_of_smp_33_weeks returns 138.18 when 90% of the given weekly salary is higher than £138.18" do
+        salary_1 = Smartdown::Model::Answer::Salary.new("200-week")
+        assert_equal 138.18, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_smp_33_weeks(salary_1, date)
+      end
+
+      should "rate_of_maternity_allowance returns 139.58 when 90% of the given weekly salary is higher than £138.18" do
+        salary_1 = Smartdown::Model::Answer::Salary.new("200-week")
+        assert_equal 138.18, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_maternity_allowance(salary_1, date)
+      end
+
+      should "rate_of_maternity_allowance returns 90% of the given weekly salary when it is less than £138.18" do
+        salary_1 = Smartdown::Model::Answer::Salary.new("150-week")
+        assert_equal 135.0, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_maternity_allowance(salary_1, date)
+      end
+
+      should "rate_of_paternity_pay returns 138.18 when 90% of the given weekly salary is higher than £138.18" do
+        salary_2 = Smartdown::Model::Answer::Salary.new("200-week")
+        assert_equal 138.18, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_paternity_pay(salary_2, date)
+      end
+
+      should "rate_of_paternity_pay returns 90% of the given weekly salary when it is less than £138.18" do
+        salary_2 = Smartdown::Model::Answer::Salary.new("150-week")
+        assert_equal 135.0, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_paternity_pay(salary_2, date)
+      end
+
+      should "rate_of_shpp returns 138.18 when 90% of the given weekly salary is higher than £138.18" do
+        salary_1 = Smartdown::Model::Answer::Salary.new("200-week")
+        assert_equal 138.18, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_shpp(salary_1, date)
+      end
+
+      should "rate_of_shpp returns 90% of the given weekly salary when it is less than £138.18" do
+        salary_1 = Smartdown::Model::Answer::Salary.new("150-week")
+        assert_equal 135.0, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_shpp(salary_1, date)
+      end
+
+      should "total_aspp returns the rate_of_paternity_pay * 26" do
+        salary = Smartdown::Model::Answer::Salary.new("200-week")
+        assert_equal 5443.619999999998, SmartdownPlugins::PayLeaveForParentsAdoption.total_aspp(salary, date)
+      end
+
+      should "total_maternity_allowance returns the rate_of_maternity_allowance * 39" do
+        salary_1 = Smartdown::Model::Answer::Salary.new("200-week")
+        assert_equal 5443.619999999998, SmartdownPlugins::PayLeaveForParentsAdoption.total_maternity_allowance(salary_1, date)
+      end
+
+      should "total_smp returns the rate_of_smp_6_weeks * 6 + rate_of_smp_33_weeks * 33 (totaling 39 weeks)" do
+        salary_1 = Smartdown::Model::Answer::Salary.new("200-week")
+        assert_equal 5686.1399999999985, SmartdownPlugins::PayLeaveForParentsAdoption.total_smp(salary_1, date)
+      end
+    end
+
+    context "due date in 2015-2016 range" do
+      date = Smartdown::Model::Answer::Date.new("2016-1-1")
+
+      should "be in 2015-2016 range" do
+        assert_equal true, SmartdownPlugins::PayLeaveForParentsAdoption.in_2015_2016_fin_year?(date)
+      end
+
+      should "return £ 112 for lower_earnings_amount" do
+        assert_equal 112, SmartdownPlugins::PayLeaveForParentsAdoption.lower_earnings_amount(date)
+      end
+
+      should "rate_of_smp_33_weeks returns 90% of the given weekly salary when it is less than £139.58" do
+        salary_1 = Smartdown::Model::Answer::Salary.new("150-week")
+        assert_equal 135.0, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_smp_33_weeks(salary_1, date)
+      end
+
+      should "rate_of_smp_33_weeks returns 139.58 when 90% of the given weekly salary is higher than £139.58" do
+        salary_1 = Smartdown::Model::Answer::Salary.new("200-week")
+        assert_equal 139.58, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_smp_33_weeks(salary_1, date)
+      end
+
+      should "rate_of_maternity_allowance returns 139.58 when 90% of the given weekly salary is higher than £139.58" do
+        salary_1 = Smartdown::Model::Answer::Salary.new("200-week")
+        assert_equal 139.58, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_maternity_allowance(salary_1, date)
+      end
+
+      should "rate_of_maternity_allowance returns 90% of the given weekly salary when it is less than £139.58" do
+        salary_1 = Smartdown::Model::Answer::Salary.new("150-week")
+        assert_equal 135.0, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_maternity_allowance(salary_1, date)
+      end
+
+      should "rate_of_paternity_pay returns 139.58 when 90% of the given weekly salary is higher than £139.58" do
+        salary_2 = Smartdown::Model::Answer::Salary.new("200-week")
+        assert_equal 139.58, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_paternity_pay(salary_2, date)
+      end
+
+      should "rate_of_paternity_pay returns 90% of the given weekly salary when it is less than £139.58" do
+        salary_2 = Smartdown::Model::Answer::Salary.new("150-week")
+        assert_equal 135.0, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_paternity_pay(salary_2, date)
+      end
+
+      should "rate_of_shpp returns 139.58 when 90% of the given weekly salary is higher than £139.58" do
+        salary_1 = Smartdown::Model::Answer::Salary.new("200-week")
+        assert_equal 139.58, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_shpp(salary_1, date)
+      end
+
+      should "rate_of_shpp returns 90% of the given weekly salary when it is less than £139.58" do
+        salary_1 = Smartdown::Model::Answer::Salary.new("150-week")
+        assert_equal 135.0, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_shpp(salary_1, date)
+      end
+
+      should "total_aspp returns the rate_of_paternity_pay * 26" do
+        salary = Smartdown::Model::Answer::Salary.new("200-week")
+        assert_equal 5443.619999999998, SmartdownPlugins::PayLeaveForParentsAdoption.total_aspp(salary, date)
+      end
+
+      should "total_maternity_allowance returns the rate_of_maternity_allowance * 39" do
+        salary_1 = Smartdown::Model::Answer::Salary.new("200-week")
+        assert_equal 5443.619999999998, SmartdownPlugins::PayLeaveForParentsAdoption.total_maternity_allowance(salary_1, date)
+      end
+
+      should "total_smp returns the rate_of_smp_6_weeks * 6 + rate_of_smp_33_weeks * 33 (totaling 39 weeks)" do
+        salary_1 = Smartdown::Model::Answer::Salary.new("200-week")
+        assert_equal 5686.1399999999985, SmartdownPlugins::PayLeaveForParentsAdoption.total_smp(salary_1, date)
+      end
+    end
+
+    context "due date outside all ranges" do
+      date = Smartdown::Model::Answer::Date.new("2022-1-1")
+
+      should "return the latest_pat_leave known lower_earnings_amount" do
+        assert_equal 112, SmartdownPlugins::PayLeaveForParentsAdoption.lower_earnings_amount(date)
+      end
+
+      should "rate_of_smp_33_weeks returns 90% of the given weekly salary when it is less than £139.58" do
+        salary_1 = Smartdown::Model::Answer::Salary.new("150-week")
+        assert_equal 135.0, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_smp_33_weeks(salary_1, date)
+      end
+
+      should "rate_of_smp_33_weeks returns 139.58 when 90% of the given weekly salary is higher than £139.58" do
+        salary_1 = Smartdown::Model::Answer::Salary.new("200-week")
+        assert_equal 139.58, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_smp_33_weeks(salary_1, date)
+      end
+
+      should "rate_of_maternity_allowance returns 139.58 when 90% of the given weekly salary is higher than £139.58" do
+        salary_1 = Smartdown::Model::Answer::Salary.new("200-week")
+        assert_equal 139.58, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_maternity_allowance(salary_1, date)
+      end
+
+      should "rate_of_maternity_allowance returns 90% of the given weekly salary when it is less than £139.58" do
+        salary_1 = Smartdown::Model::Answer::Salary.new("150-week")
+        assert_equal 135.0, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_maternity_allowance(salary_1, date)
+      end
+
+      should "rate_of_paternity_pay returns 139.58 when 90% of the given weekly salary is higher than £139.58" do
+        salary_2 = Smartdown::Model::Answer::Salary.new("200-week")
+        assert_equal 139.58, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_paternity_pay(salary_2, date)
+      end
+
+      should "rate_of_paternity_pay returns 90% of the given weekly salary when it is less than £139.58" do
+        salary_2 = Smartdown::Model::Answer::Salary.new("150-week")
+        assert_equal 135.0, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_paternity_pay(salary_2, date)
+      end
+
+      should "rate_of_shpp returns 139.58 when 90% of the given weekly salary is higher than £139.58" do
+        salary_1 = Smartdown::Model::Answer::Salary.new("200-week")
+        assert_equal 139.58, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_shpp(salary_1, date)
+      end
+
+      should "rate_of_shpp returns 90% of the given weekly salary when it is less than £139.58" do
+        salary_1 = Smartdown::Model::Answer::Salary.new("150-week")
+        assert_equal 135.0, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_shpp(salary_1, date)
+      end
+
+      should "total_aspp returns the rate_of_paternity_pay * 26" do
+        salary = Smartdown::Model::Answer::Salary.new("200-week")
+        assert_equal 5443.619999999998, SmartdownPlugins::PayLeaveForParentsAdoption.total_aspp(salary, date)
+      end
+
+      should "total_maternity_allowance returns the rate_of_maternity_allowance * 39" do
+        salary_1 = Smartdown::Model::Answer::Salary.new("200-week")
+        assert_equal 5443.619999999998, SmartdownPlugins::PayLeaveForParentsAdoption.total_maternity_allowance(salary_1, date)
+      end
+
+      should "total_smp returns the rate_of_smp_6_weeks * 6 + rate_of_smp_33_weeks * 33 (totaling 39 weeks)" do
+        salary_1 = Smartdown::Model::Answer::Salary.new("200-week")
+        assert_equal 5686.1399999999985, SmartdownPlugins::PayLeaveForParentsAdoption.total_smp(salary_1, date)
+      end
+    end
 
     test "continuity_start_date" do
       expected = Smartdown::Model::Answer::Date.new("2014-3-29")
@@ -78,69 +341,10 @@ module SmartdownPlugins
       assert_equal expected, SmartdownPlugins::PayLeaveForParentsAdoption.start_of_maternity_allowance(due_date)
     end
 
-
-    test "rate_of_maternity_allowance returns 139.58 when 90% of the given weekly salary is higher than £139.58" do
-      salary_1 = Smartdown::Model::Answer::Salary.new("200-week")
-      assert_equal 139.58, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_maternity_allowance(salary_1)
-    end
-
-    test "rate_of_maternity_allowance returns 90% of the given weekly salary when it is less than £139.58" do
-      salary_1 = Smartdown::Model::Answer::Salary.new("150-week")
-      assert_equal 135.0, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_maternity_allowance(salary_1)
-    end
-
-    test "rate_of_paternity_pay returns 139.58 when 90% of the given weekly salary is higher than £139.58" do
-      salary_2 = Smartdown::Model::Answer::Salary.new("200-week")
-      assert_equal 139.58, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_paternity_pay(salary_2)
-    end
-
-    test "rate_of_paternity_pay returns 90% of the given weekly salary when it is less than £139.58" do
-      salary_2 = Smartdown::Model::Answer::Salary.new("150-week")
-      assert_equal 135.0, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_paternity_pay(salary_2)
-    end
-
-    test "rate_of_shpp returns 139.58 when 90% of the given weekly salary is higher than £139.58" do
-      salary_1 = Smartdown::Model::Answer::Salary.new("200-week")
-      assert_equal 139.58, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_shpp(salary_1)
-    end
-
-    test "rate_of_shpp returns 90% of the given weekly salary when it is less than £139.58" do
-      salary_1 = Smartdown::Model::Answer::Salary.new("150-week")
-      assert_equal 135.0, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_shpp(salary_1)
-    end
-
     test "rate_of_smp_6_weeks returns 90% of the given weekly salary" do
       salary_1 = Smartdown::Model::Answer::Salary.new("150-week")
       assert_equal 135.0, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_smp_6_weeks(salary_1)
     end
 
-    test "rate_of_smp_33_weeks returns 90% of the given weekly salary when it is less than £139.58" do
-      salary_1 = Smartdown::Model::Answer::Salary.new("150-week")
-      assert_equal 135.0, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_smp_33_weeks(salary_1)
-    end
-
-    test "rate_of_smp_33_weeks returns 139.58 when 90% of the given weekly salary is higher than £139.58" do
-      salary_1 = Smartdown::Model::Answer::Salary.new("200-week")
-      assert_equal 139.58, SmartdownPlugins::PayLeaveForParentsAdoption.rate_of_smp_33_weeks(salary_1)
-    end
-
-    test "total_aspp returns the rate_of_paternity_pay * 26" do
-      salary = Smartdown::Model::Answer::Salary.new("200-week")
-      SmartdownPlugins::PayLeaveForParentsAdoption.stubs(:rate_of_paternity_pay).with(salary).returns(139.58)
-      assert_equal 139.58 * 26, SmartdownPlugins::PayLeaveForParentsAdoption.total_aspp(salary)
-    end
-
-    test "total_maternity_allowance returns the rate_of_maternity_allowance * 39" do
-      salary_1 = Smartdown::Model::Answer::Salary.new("200-week")
-      SmartdownPlugins::PayLeaveForParentsAdoption.stubs(:rate_of_maternity_allowance).with(salary_1).returns(139.58)
-      assert_equal 139.58 * 39, SmartdownPlugins::PayLeaveForParentsAdoption.total_maternity_allowance(salary_1)
-    end
-
-    test "total_smp returns the rate_of_smp_6_weeks * 6 + rate_of_smp_33_weeks * 33 (totaling 39 weeks)" do
-      salary_1 = Smartdown::Model::Answer::Salary.new("200-week")
-      SmartdownPlugins::PayLeaveForParentsAdoption.stubs(:rate_of_smp_6_weeks).with(salary_1).returns(1.0)
-      SmartdownPlugins::PayLeaveForParentsAdoption.stubs(:rate_of_smp_33_weeks).with(salary_1).returns(100.0)
-      assert_equal 3306.0, SmartdownPlugins::PayLeaveForParentsAdoption.total_smp(salary_1)
-    end
   end
 end


### PR DESCRIPTION
* Check the due date and show the lel at the beginning of that period
* Check if due_date is in a specific range and show the rate for that period
* Check the match_date and show the lel at the beginning of that period
* Check if match_date is in a specific range and show the rate for that period

To test visit 
/pay-leave-for-parents-adoption/y/yes/no/2014-1-1/employee/employee/yes/yes/400-week/yes/yes/yes/400-week/yes

You should see rates for both 2013/2014 and 2014/2015