### PR TITLE
Respond with 404 not 500 when format is unknown

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::Base
   before_action :set_analytics_headers
 
   rescue_from GdsApi::TimedOutException, with: :error_503
+  rescue_from ActionController::UnknownFormat, with: :error_404
 
 protected
 

--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -139,6 +139,13 @@ class SmartAnswersControllerTest < ActionController::TestCase
       assert_equal 503, response.status
     end
 
+    should "404 Not Found if request is for an unknown format" do
+      @controller.stubs(:respond_to).raises(ActionController::UnknownFormat)
+
+      get :show, id: 'sample'
+      assert_response :not_found
+    end
+
     should "send slimmer analytics headers" do
       get :show, id: 'sample'
       assert_equal "smart_answer", @response.headers["X-Slimmer-Format"]


### PR DESCRIPTION
This addresses a set of exceptions which appear regularly in Errbit e.g. [these ones][1].

I've been able to reproduce the `500 Internal Server Error` locally and to use
a `rescue_from` statement in `ApplicationController` to respond with a
`404 Not Found` instead. The latter seems to be more appropriate and will
reduce the noise we're seeing in the Errbit reports.

Note that there appears to be some slightly odd behaviour when the unknown
format is `.js` in that the text "404 error" rendered by
`ApplicationController#error` is rendered **without** any layout. This appears
to be behaviour provided by `slimmer`. Although this behaviour seems odd to me
it feels out of scope of this change and in any case, this commit should still
make things better than they are at the moment.

[1]: https://errbit.production.alphagov.co.uk/apps/533c35ae0da1159384044f5f/problems/55583e4765786355f0919a00