### PR TITLE
Add regression tests for student finance calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,46 @@ Test a single Smartdown flow by running:
 
 [smartdown-scenarios]: https://github.com/alphagov/smartdown/blob/master/doc/scenarios.md
 
+### Adding regression tests to Smart Answers
+
+1. Generate a set of responses for the flow that you want to add regression tests to.
+
+        $ rails r script/generate-questions-and-responses-for-smart-answer.rb <name-of-smart-answer>
+
+2. Commit the generated questions-and-responses.yml file (in test/data) to git.
+
+3. Change the file by adding/removing and changing the responses:
+
+  * Add responses for any of the TODO items in the file.
+
+  * Remove responses that you don't think cause the code to follow different branches, e.g. it might be useful to remove all but one (or a small number) of countries to avoid a combinatorial explosion of input responses.
+
+  * Combine responses for checkbox questions where the effect of combining them doesn't affect the number of branches of the code that are exercised.
+
+4. Commit the updated questions-and-responses.yml file to git.
+
+5. Generate a set of input responses and expected results for the Smart Answer.
+
+        $ rails r script/generate-responses-and-expected-results-for-smart-answer.rb <name-of-smart-answer>
+
+6. Commit the generated responses-and-expected-results.yml file (in test/data) to git.
+
+7. Run the regression test to generate the HTML of each outcome reached by the set of input responses.
+
+        $ TEST_COVERAGE=true ruby test/regression/smart_answers_regression_test.rb
+
+8. Commit the generated outcome HTML files (in test/artefacts) to git.
+
+9. Inspect the code coverage report for the Smart Answer under test (`open coverage/rcov/index.html` and find the smart answer under test).
+
+  * If all the branches in the flow have been exercisde then you don't need to do anything else at this time.
+
+  * If there are branches in the flow that haven't been exercised then:
+
+      * Determine the responses required to exercise those branches.
+
+      * Go to Step 3, add the new responses and continue through the steps up to Step 9.
+
 ## Issues/todos
 
 Please see the [github issues](https://github.com/alphagov/smart-answers/issues) page.

--- a/lib/smart_answer_test_helper.rb
+++ b/lib/smart_answer_test_helper.rb
@@ -1,0 +1,30 @@
+class SmartAnswerTestHelper
+  def self.data_path
+    Rails.root.join('test', 'data')
+  end
+
+  def initialize(flow_name)
+    @flow_name = flow_name
+  end
+
+  def question_and_responses_path
+    data_path.join(question_and_responses_filename)
+  end
+
+  def write_questions_and_responses(questions_and_responses)
+    FileUtils.mkdir_p(data_path)
+    File.open(question_and_responses_path, 'w') do |file|
+      file.puts(questions_and_responses.to_yaml)
+    end
+  end
+
+  private
+
+  def question_and_responses_filename
+    "#{@flow_name}-questions-and-responses.yml"
+  end
+
+  def data_path
+    self.class.data_path
+  end
+end

--- a/lib/smart_answer_test_helper.rb
+++ b/lib/smart_answer_test_helper.rb
@@ -18,10 +18,24 @@ class SmartAnswerTestHelper
     end
   end
 
+  def responses_and_expected_results_path
+    data_path.join(responses_and_expected_results_filename)
+  end
+
+  def write_responses_and_expected_results(data)
+    File.open(responses_and_expected_results_path, 'w') do |file|
+      file.puts(data.to_yaml)
+    end
+  end
+
   private
 
   def question_and_responses_filename
     "#{@flow_name}-questions-and-responses.yml"
+  end
+
+  def responses_and_expected_results_filename
+    "#{@flow_name}-responses-and-expected-results.yml"
   end
 
   def data_path

--- a/lib/smart_answer_test_helper.rb
+++ b/lib/smart_answer_test_helper.rb
@@ -3,6 +3,14 @@ class SmartAnswerTestHelper
     Rails.root.join('test', 'data')
   end
 
+  def self.artefacts_path
+    Rails.root.join('test', 'artefacts')
+  end
+
+  def self.responses_and_expected_results
+    Dir[data_path.join('*-responses-and-expected-results.yml')]
+  end
+
   def initialize(flow_name)
     @flow_name = flow_name
   end
@@ -28,6 +36,27 @@ class SmartAnswerTestHelper
     end
   end
 
+  def read_responses_and_expected_results
+    responses_and_expected_results_yaml = File.read(responses_and_expected_results_path)
+    YAML.load(responses_and_expected_results_yaml)
+  end
+
+  def save_output(responses, response)
+    filename = [responses.join('-'), 'html'].join('.')
+    path = artefacts_path.join(@flow_name)
+    FileUtils.mkdir_p(path)
+    path_to_output = path.join(filename)
+    File.open(path_to_output, 'w') do |file|
+      file.puts(response.body)
+    end
+    path_to_output
+  end
+
+  def delete_saved_output_files
+    path = artefacts_path.join(@flow_name)
+    FileUtils.rm_f(path.join('*.html'))
+  end
+
   private
 
   def question_and_responses_filename
@@ -40,5 +69,9 @@ class SmartAnswerTestHelper
 
   def data_path
     self.class.data_path
+  end
+
+  def artefacts_path
+    self.class.artefacts_path
   end
 end

--- a/script/generate-questions-and-responses-for-smart-answer.rb
+++ b/script/generate-questions-and-responses-for-smart-answer.rb
@@ -1,0 +1,42 @@
+unless flow_name = ARGV.shift
+  puts "Usage: #{__FILE__} <flow-name>"
+  exit 1
+end
+
+smart_answer_helper = SmartAnswerTestHelper.new(flow_name)
+
+flow = SmartAnswer::FlowRegistry.instance.find(flow_name)
+questions_and_responses = {}
+unknown_questions = []
+
+flow.questions.each do |question|
+  if question.is_a?(SmartAnswer::Question::CountrySelect)
+    questions_and_responses[question.name] = question.options.map(&:slug)
+  elsif question.respond_to?(:options)
+    questions_and_responses[question.name] = question.options
+  else
+    # Find the question text so that we can write it to the YAML file
+    question_node = flow.node(question)
+    i18n_prefix = ['flow', flow_name].join('.')
+    begin
+      question_text = QuestionPresenter.new(i18n_prefix, question_node).title
+    rescue I18n::MissingInterpolationArgument => e
+      question_text = e.string
+    end
+
+    questions_and_responses[question.name] = [
+      "TODO: #{question_text}"
+    ]
+    unknown_questions << [question.name, question_text]
+  end
+end
+
+smart_answer_helper.write_questions_and_responses(questions_and_responses)
+
+puts "Questions and responses written to: #{smart_answer_helper.question_and_responses_path}"
+if unknown_questions.any?
+  puts "You'll need to manually add responses for:"
+  unknown_questions.each do |(question_name, question_text)|
+    puts "* #{question_text} (#{question_name})"
+  end
+end

--- a/script/generate-responses-and-expected-results-for-smart-answer.rb
+++ b/script/generate-responses-and-expected-results-for-smart-answer.rb
@@ -1,0 +1,46 @@
+unless flow_name = ARGV.shift
+  puts "Usage: #{__FILE__} <flow-name>"
+  exit 1
+end
+
+smart_answer_helper = SmartAnswerTestHelper.new(flow_name)
+
+questions_and_responses_path = smart_answer_helper.question_and_responses_path
+unless File.exists?(questions_and_responses_path)
+  puts "Questions and responses file doesn't exist."
+  puts "Generate it using the generate-responses-for-smart-answer script."
+  exit 1
+end
+
+questions_and_responses_yaml = File.read(questions_and_responses_path)
+QUESTIONS_AND_RESPONSES = YAML.load(questions_and_responses_yaml)
+
+flow = SmartAnswer::FlowRegistry.instance.find(flow_name)
+RESPONSES_AND_EXPECTED_RESULTS = []
+
+def answer_question(flow, state)
+  question_name      = state.current_node
+  existing_responses = state.responses
+
+  QUESTIONS_AND_RESPONSES[question_name].each do |response|
+    responses    = existing_responses + [response]
+    state        = flow.process(responses)
+    current_node = flow.node(state.current_node)
+
+    RESPONSES_AND_EXPECTED_RESULTS << {
+      current_node: question_name,
+      responses: responses.map(&:to_s),
+      outcome_node: current_node.outcome?
+    }
+
+    unless current_node.outcome? || state.error
+      answer_question(flow, state)
+    end
+  end
+end
+
+state = flow.start_state
+answer_question(flow, state)
+
+smart_answer_helper.write_responses_and_expected_results(RESPONSES_AND_EXPECTED_RESULTS)
+puts "Responses and expected results written to #{smart_answer_helper.responses_and_expected_results_path}"

--- a/test/artefacts/student-finance-calculator/2014-2015-eu-full-time-6000.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-eu-full-time-6000.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="tuition-costs">Tuition costs</h2>
+
+<p>You could get a Tuition Fee Loan - £6,000 per year.</p>
+
+<p>The loan pays for the cost of your course and must be paid back.</p>
+
+<h2 id="living-costs">Living costs</h2>
+
+<p>Most EU full-time students don&rsquo;t <a href="/student-finance/who-qualifies">qualify</a> for help with living costs (known as &lsquo;maintenance&rsquo;).</p>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college. Usually, this doesn&rsquo;t have to be paid back.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Usually, you’ll only get student finance if you’re doing your first higher education qualification.</p>
+</div>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      EU student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=eu-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/eu-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-eu-part-time-6000.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-eu-part-time-6000.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="tuition-costs">Tuition costs</h2>
+
+<p>You could get a Tuition Fee Loan - £6,000 per year.</p>
+
+<p>The loan pays for the cost of your course and must be paid back.</p>
+
+<h2 id="living-costs">Living costs</h2>
+
+<p>EU part-time students don&rsquo;t qualify for help with living costs (known as &lsquo;maintenance&rsquo;).</p>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college. Usually, this doesn&rsquo;t have to be paid back.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Usually, you’ll only get student finance if you’re doing your first higher education qualification.</p>
+</div>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      EU student part-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=eu-part-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/eu-part-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-100000.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-100000.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£2,871 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/100000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/100000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-100000.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-100000.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£2,871 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/100000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/100000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-100000.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-100000.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£2,871 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/100000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/100000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-100000.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-100000.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£2,871 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/100000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/100000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-100000.0-no-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-100000.0-no-dental-medical-healthcare.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£2,871 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/100000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/100000.0/no?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-100000.0-no-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-100000.0-no-none-of-the-above.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£2,871 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You don’t qualify for extra grants and allowances.</p>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/100000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/100000.0/no?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-100000.0-no-social-work.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-100000.0-no-social-work.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£2,871 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/100000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/100000.0/no?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-100000.0-no-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-100000.0-no-teacher-training.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£2,871 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/100000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/100000.0/no?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-24500.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-24500.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£2,725 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/24500.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/24500.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-24500.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-24500.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£2,725 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/24500.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/24500.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-24500.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-24500.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£2,725 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/24500.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/24500.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-24500.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-24500.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£2,725 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/24500.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/24500.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-24500.0-no-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-24500.0-no-dental-medical-healthcare.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£2,725 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/24500.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/24500.0/no?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-24500.0-no-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-24500.0-no-none-of-the-above.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£2,725 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You don’t qualify for extra grants and allowances.</p>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/24500.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/24500.0/no?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-24500.0-no-social-work.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-24500.0-no-social-work.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£2,725 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/24500.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/24500.0/no?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-24500.0-no-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-24500.0-no-teacher-training.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£2,725 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/24500.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/24500.0/no?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-35000.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-35000.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£3,671 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/35000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/35000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-35000.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-35000.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£3,671 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/35000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/35000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-35000.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-35000.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£3,671 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/35000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/35000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-35000.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-35000.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£3,671 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/35000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/35000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-35000.0-no-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-35000.0-no-dental-medical-healthcare.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£3,671 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/35000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/35000.0/no?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-35000.0-no-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-35000.0-no-none-of-the-above.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£3,671 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You don’t qualify for extra grants and allowances.</p>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/35000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/35000.0/no?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-35000.0-no-social-work.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-35000.0-no-social-work.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£3,671 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/35000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/35000.0/no?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-35000.0-no-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-35000.0-no-teacher-training.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£3,671 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/35000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/35000.0/no?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-43875.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-43875.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£4,314 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/43875.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/43875.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-43875.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-43875.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£4,314 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/43875.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/43875.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-43875.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-43875.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£4,314 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/43875.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/43875.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-43875.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-43875.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£4,314 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/43875.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/43875.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-43875.0-no-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-43875.0-no-dental-medical-healthcare.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£4,314 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/43875.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/43875.0/no?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-43875.0-no-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-43875.0-no-none-of-the-above.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£4,314 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You don’t qualify for extra grants and allowances.</p>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/43875.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/43875.0/no?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-43875.0-no-social-work.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-43875.0-no-social-work.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£4,314 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/43875.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/43875.0/no?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-43875.0-no-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-at-home-43875.0-no-teacher-training.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£4,314 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/43875.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/at-home/43875.0/no?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-100000.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-100000.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£5,038 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/100000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/100000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-100000.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-100000.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£5,038 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/100000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/100000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-100000.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-100000.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£5,038 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/100000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/100000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-100000.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-100000.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£5,038 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/100000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/100000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-100000.0-no-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-100000.0-no-dental-medical-healthcare.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£5,038 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/100000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/100000.0/no?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-100000.0-no-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-100000.0-no-none-of-the-above.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£5,038 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You don’t qualify for extra grants and allowances.</p>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/100000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/100000.0/no?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-100000.0-no-social-work.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-100000.0-no-social-work.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£5,038 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/100000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/100000.0/no?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-100000.0-no-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-100000.0-no-teacher-training.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£5,038 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/100000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/100000.0/no?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-24500.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-24500.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£6,058 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/24500.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/24500.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-24500.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-24500.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£6,058 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/24500.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/24500.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-24500.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-24500.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£6,058 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/24500.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/24500.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-24500.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-24500.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£6,058 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/24500.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/24500.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-24500.0-no-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-24500.0-no-dental-medical-healthcare.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£6,058 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/24500.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/24500.0/no?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-24500.0-no-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-24500.0-no-none-of-the-above.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£6,058 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You don’t qualify for extra grants and allowances.</p>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/24500.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/24500.0/no?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-24500.0-no-social-work.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-24500.0-no-social-work.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£6,058 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/24500.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/24500.0/no?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-24500.0-no-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-24500.0-no-teacher-training.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£6,058 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/24500.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/24500.0/no?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-35000.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-35000.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£7,004 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/35000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/35000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-35000.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-35000.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£7,004 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/35000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/35000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-35000.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-35000.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£7,004 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/35000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/35000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-35000.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-35000.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£7,004 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/35000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/35000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-35000.0-no-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-35000.0-no-dental-medical-healthcare.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£7,004 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/35000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/35000.0/no?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-35000.0-no-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-35000.0-no-none-of-the-above.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£7,004 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You don’t qualify for extra grants and allowances.</p>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/35000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/35000.0/no?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-35000.0-no-social-work.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-35000.0-no-social-work.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£7,004 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/35000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/35000.0/no?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-35000.0-no-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-35000.0-no-teacher-training.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£7,004 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/35000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/35000.0/no?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-43875.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-43875.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£7,647 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/43875.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/43875.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-43875.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-43875.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£7,647 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/43875.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/43875.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-43875.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-43875.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£7,647 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/43875.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/43875.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-43875.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-43875.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£7,647 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/43875.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/43875.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-43875.0-no-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-43875.0-no-dental-medical-healthcare.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£7,647 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/43875.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/43875.0/no?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-43875.0-no-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-43875.0-no-none-of-the-above.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£7,647 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You don’t qualify for extra grants and allowances.</p>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/43875.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/43875.0/no?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-43875.0-no-social-work.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-43875.0-no-social-work.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£7,647 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/43875.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/43875.0/no?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-43875.0-no-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-in-london-43875.0-no-teacher-training.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£7,647 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/43875.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-in-london/43875.0/no?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-100000.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-100000.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£3,610 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/100000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/100000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-100000.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-100000.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£3,610 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/100000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/100000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-100000.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-100000.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£3,610 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/100000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/100000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-100000.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-100000.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£3,610 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/100000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/100000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-100000.0-no-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-100000.0-no-dental-medical-healthcare.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£3,610 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/100000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/100000.0/no?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-100000.0-no-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-100000.0-no-none-of-the-above.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£3,610 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You don’t qualify for extra grants and allowances.</p>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/100000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/100000.0/no?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-100000.0-no-social-work.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-100000.0-no-social-work.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£3,610 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/100000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/100000.0/no?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-100000.0-no-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-100000.0-no-teacher-training.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£3,610 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/100000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/100000.0/no?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-24500.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-24500.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£3,862 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/24500.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/24500.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-24500.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-24500.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£3,862 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/24500.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/24500.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-24500.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-24500.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£3,862 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/24500.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/24500.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-24500.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-24500.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£3,862 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/24500.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/24500.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-24500.0-no-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-24500.0-no-dental-medical-healthcare.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£3,862 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/24500.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/24500.0/no?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-24500.0-no-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-24500.0-no-none-of-the-above.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£3,862 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You don’t qualify for extra grants and allowances.</p>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/24500.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/24500.0/no?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-24500.0-no-social-work.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-24500.0-no-social-work.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£3,862 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/24500.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/24500.0/no?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-24500.0-no-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-24500.0-no-teacher-training.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£3,862 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/24500.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/24500.0/no?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-35000.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-35000.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£4,808 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/35000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/35000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-35000.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-35000.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£4,808 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/35000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/35000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-35000.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-35000.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£4,808 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/35000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/35000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-35000.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-35000.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£4,808 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/35000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/35000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-35000.0-no-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-35000.0-no-dental-medical-healthcare.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£4,808 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/35000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/35000.0/no?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-35000.0-no-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-35000.0-no-none-of-the-above.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£4,808 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You don’t qualify for extra grants and allowances.</p>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/35000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/35000.0/no?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-35000.0-no-social-work.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-35000.0-no-social-work.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£4,808 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/35000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/35000.0/no?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-35000.0-no-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-35000.0-no-teacher-training.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£4,808 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/35000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/35000.0/no?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-43875.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-43875.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£5,451 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/43875.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/43875.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-43875.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-43875.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£5,451 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/43875.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/43875.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-43875.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-43875.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£5,451 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/43875.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/43875.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-43875.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-43875.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£5,451 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £150.23 a week (1 child) or up to £257.55 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,523 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,668 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/43875.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/43875.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-43875.0-no-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-43875.0-no-dental-medical-healthcare.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£5,451 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/43875.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/43875.0/no?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-43875.0-no-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-43875.0-no-none-of-the-above.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£5,451 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You don’t qualify for extra grants and allowances.</p>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/43875.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/43875.0/no?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-43875.0-no-social-work.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-43875.0-no-social-work.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£5,451 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/43875.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/43875.0/no?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-43875.0-no-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-full-time-6000.0-away-outside-london-43875.0-no-teacher-training.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£5,451 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/43875.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-full-time/6000.0/away-outside-london/43875.0/no?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-part-time-6000.0-has-disability,low-income-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-part-time-6000.0-has-disability,low-income-dental-medical-healthcare.html
@@ -1,0 +1,189 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>£6,000 Tuition Fee Loan</li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li>
+    <p><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</p>
+  </li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student part-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-part-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-part-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You have a disability, health condition or learning difficulty, eg dyslexia</li>
+        <li>You’re on a low income, eg you find it hard to pay for food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-part-time/6000.0?previous_response=has-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-part-time/6000.0/has-disability,low-income?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-part-time-6000.0-has-disability,low-income-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-part-time-6000.0-has-disability,low-income-none-of-the-above.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>£6,000 Tuition Fee Loan</li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student part-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-part-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-part-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You have a disability, health condition or learning difficulty, eg dyslexia</li>
+        <li>You’re on a low income, eg you find it hard to pay for food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-part-time/6000.0?previous_response=has-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-part-time/6000.0/has-disability,low-income?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-part-time-6000.0-has-disability,low-income-social-work.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-part-time-6000.0-has-disability,low-income-social-work.html
@@ -1,0 +1,189 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>£6,000 Tuition Fee Loan</li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li>
+    <p><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</p>
+  </li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student part-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-part-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-part-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You have a disability, health condition or learning difficulty, eg dyslexia</li>
+        <li>You’re on a low income, eg you find it hard to pay for food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-part-time/6000.0?previous_response=has-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-part-time/6000.0/has-disability,low-income?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-part-time-6000.0-has-disability,low-income-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-part-time-6000.0-has-disability,low-income-teacher-training.html
@@ -1,0 +1,189 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>£6,000 Tuition Fee Loan</li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li>
+    <p><a href="/teacher-training-funding">Funding for teacher training</a></p>
+  </li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student part-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-part-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-part-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You have a disability, health condition or learning difficulty, eg dyslexia</li>
+        <li>You’re on a low income, eg you find it hard to pay for food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-part-time/6000.0?previous_response=has-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-part-time/6000.0/has-disability,low-income?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-part-time-6000.0-no-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-part-time-6000.0-no-dental-medical-healthcare.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>£6,000 Tuition Fee Loan</li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student part-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-part-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-part-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-part-time/6000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-part-time/6000.0/no?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-part-time-6000.0-no-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-part-time-6000.0-no-none-of-the-above.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>£6,000 Tuition Fee Loan</li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You don’t qualify for extra grants and allowances.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student part-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-part-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-part-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-part-time/6000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-part-time/6000.0/no?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-part-time-6000.0-no-social-work.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-part-time-6000.0-no-social-work.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>£6,000 Tuition Fee Loan</li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student part-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-part-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-part-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-part-time/6000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-part-time/6000.0/no?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2014-2015-uk-part-time-6000.0-no-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2014-2015-uk-part-time-6000.0-no-teacher-training.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>£6,000 Tuition Fee Loan</li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2014 and August 2015</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2014-2015">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student part-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015?previous_response=uk-part-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-part-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-part-time/6000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2014-2015/uk-part-time/6000.0/no?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-eu-full-time-6000.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-eu-full-time-6000.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="tuition-costs">Tuition costs</h2>
+
+<p>You could get a Tuition Fee Loan - £6,000 per year.</p>
+
+<p>The loan pays for the cost of your course and must be paid back.</p>
+
+<h2 id="living-costs">Living costs</h2>
+
+<p>Most EU full-time students don&rsquo;t <a href="/student-finance/who-qualifies">qualify</a> for help with living costs (known as &lsquo;maintenance&rsquo;).</p>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college. Usually, this doesn&rsquo;t have to be paid back.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Usually, you’ll only get student finance if you’re doing your first higher education qualification.</p>
+</div>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      EU student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=eu-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/eu-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-eu-part-time-6000.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-eu-part-time-6000.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="tuition-costs">Tuition costs</h2>
+
+<p>You could get a Tuition Fee Loan - £6,000 per year.</p>
+
+<p>The loan pays for the cost of your course and must be paid back.</p>
+
+<h2 id="living-costs">Living costs</h2>
+
+<p>EU part-time students don&rsquo;t qualify for help with living costs (known as &lsquo;maintenance&rsquo;).</p>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college. Usually, this doesn&rsquo;t have to be paid back.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Usually, you’ll only get student finance if you’re doing your first higher education qualification.</p>
+</div>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      EU student part-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=eu-part-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/eu-part-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-100000.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-100000.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£2,967 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/100000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/100000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-100000.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-100000.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£2,967 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/100000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/100000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-100000.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-100000.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£2,967 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/100000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/100000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-100000.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-100000.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£2,967 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/100000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/100000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-100000.0-no-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-100000.0-no-dental-medical-healthcare.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£2,967 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/100000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/100000.0/no?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-100000.0-no-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-100000.0-no-none-of-the-above.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£2,967 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You don’t qualify for extra grants and allowances.</p>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/100000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/100000.0/no?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-100000.0-no-social-work.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-100000.0-no-social-work.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£2,967 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/100000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/100000.0/no?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-100000.0-no-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-100000.0-no-teacher-training.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£2,967 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/100000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/100000.0/no?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-24500.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-24500.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£2,872 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/24500.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/24500.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-24500.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-24500.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£2,872 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/24500.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/24500.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-24500.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-24500.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£2,872 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/24500.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/24500.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-24500.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-24500.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£2,872 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/24500.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/24500.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-24500.0-no-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-24500.0-no-dental-medical-healthcare.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£2,872 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/24500.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/24500.0/no?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-24500.0-no-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-24500.0-no-none-of-the-above.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£2,872 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You don’t qualify for extra grants and allowances.</p>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/24500.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/24500.0/no?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-24500.0-no-social-work.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-24500.0-no-social-work.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£2,872 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/24500.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/24500.0/no?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-24500.0-no-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-24500.0-no-teacher-training.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£2,872 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/24500.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/24500.0/no?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-35000.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-35000.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£3,818 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/35000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/35000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-35000.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-35000.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£3,818 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/35000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/35000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-35000.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-35000.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£3,818 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/35000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/35000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-35000.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-35000.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£3,818 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/35000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/35000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-35000.0-no-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-35000.0-no-dental-medical-healthcare.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£3,818 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/35000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/35000.0/no?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-35000.0-no-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-35000.0-no-none-of-the-above.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£3,818 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You don’t qualify for extra grants and allowances.</p>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/35000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/35000.0/no?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-35000.0-no-social-work.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-35000.0-no-social-work.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£3,818 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/35000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/35000.0/no?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-35000.0-no-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-35000.0-no-teacher-training.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£3,818 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/35000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/35000.0/no?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-43875.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-43875.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£4,461 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/43875.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/43875.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-43875.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-43875.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£4,461 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/43875.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/43875.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-43875.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-43875.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£4,461 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/43875.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/43875.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-43875.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-43875.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£4,461 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/43875.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/43875.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-43875.0-no-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-43875.0-no-dental-medical-healthcare.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£4,461 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/43875.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/43875.0/no?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-43875.0-no-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-43875.0-no-none-of-the-above.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£4,461 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You don’t qualify for extra grants and allowances.</p>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/43875.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/43875.0/no?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-43875.0-no-social-work.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-43875.0-no-social-work.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£4,461 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/43875.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/43875.0/no?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-43875.0-no-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-at-home-43875.0-no-teacher-training.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£4,461 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Living with parents</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=at-home">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/43875.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/at-home/43875.0/no?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-100000.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-100000.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£5,205 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/100000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/100000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-100000.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-100000.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£5,205 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/100000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/100000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-100000.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-100000.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£5,205 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/100000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/100000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-100000.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-100000.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£5,205 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/100000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/100000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-100000.0-no-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-100000.0-no-dental-medical-healthcare.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£5,205 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/100000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/100000.0/no?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-100000.0-no-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-100000.0-no-none-of-the-above.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£5,205 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You don’t qualify for extra grants and allowances.</p>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/100000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/100000.0/no?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-100000.0-no-social-work.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-100000.0-no-social-work.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£5,205 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/100000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/100000.0/no?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-100000.0-no-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-100000.0-no-teacher-training.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£5,205 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/100000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/100000.0/no?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-24500.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-24500.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£6,316 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/24500.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/24500.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-24500.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-24500.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£6,316 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/24500.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/24500.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-24500.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-24500.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£6,316 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/24500.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/24500.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-24500.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-24500.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£6,316 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/24500.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/24500.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-24500.0-no-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-24500.0-no-dental-medical-healthcare.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£6,316 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/24500.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/24500.0/no?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-24500.0-no-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-24500.0-no-none-of-the-above.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£6,316 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You don’t qualify for extra grants and allowances.</p>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/24500.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/24500.0/no?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-24500.0-no-social-work.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-24500.0-no-social-work.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£6,316 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/24500.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/24500.0/no?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-24500.0-no-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-24500.0-no-teacher-training.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£6,316 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/24500.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/24500.0/no?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-35000.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-35000.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£7,262 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/35000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/35000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-35000.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-35000.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£7,262 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/35000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/35000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-35000.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-35000.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£7,262 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/35000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/35000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-35000.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-35000.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£7,262 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/35000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/35000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-35000.0-no-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-35000.0-no-dental-medical-healthcare.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£7,262 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/35000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/35000.0/no?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-35000.0-no-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-35000.0-no-none-of-the-above.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£7,262 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You don’t qualify for extra grants and allowances.</p>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/35000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/35000.0/no?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-35000.0-no-social-work.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-35000.0-no-social-work.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£7,262 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/35000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/35000.0/no?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-35000.0-no-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-35000.0-no-teacher-training.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£7,262 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/35000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/35000.0/no?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-43875.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-43875.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£7,905 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/43875.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/43875.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-43875.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-43875.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£7,905 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/43875.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/43875.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-43875.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-43875.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£7,905 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/43875.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/43875.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-43875.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-43875.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£7,905 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/43875.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/43875.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-43875.0-no-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-43875.0-no-dental-medical-healthcare.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£7,905 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/43875.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/43875.0/no?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-43875.0-no-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-43875.0-no-none-of-the-above.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£7,905 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You don’t qualify for extra grants and allowances.</p>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/43875.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/43875.0/no?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-43875.0-no-social-work.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-43875.0-no-social-work.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£7,905 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/43875.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/43875.0/no?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-43875.0-no-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-in-london-43875.0-no-teacher-training.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£7,905 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying in London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-in-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/43875.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-in-london/43875.0/no?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-100000.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-100000.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£3,731 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/100000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/100000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-100000.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-100000.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£3,731 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/100000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/100000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-100000.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-100000.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£3,731 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/100000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/100000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-100000.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-100000.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£3,731 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/100000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/100000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-100000.0-no-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-100000.0-no-dental-medical-healthcare.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£3,731 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/100000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/100000.0/no?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-100000.0-no-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-100000.0-no-none-of-the-above.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£3,731 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You don’t qualify for extra grants and allowances.</p>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/100000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/100000.0/no?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-100000.0-no-social-work.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-100000.0-no-social-work.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£3,731 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/100000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/100000.0/no?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-100000.0-no-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-100000.0-no-teacher-training.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£3,731 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £100,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london?previous_response=100000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/100000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/100000.0/no?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-24500.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-24500.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£4,047 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/24500.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/24500.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-24500.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-24500.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£4,047 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/24500.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/24500.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-24500.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-24500.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£4,047 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/24500.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/24500.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-24500.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-24500.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£4,047 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/24500.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/24500.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-24500.0-no-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-24500.0-no-dental-medical-healthcare.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£4,047 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/24500.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/24500.0/no?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-24500.0-no-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-24500.0-no-none-of-the-above.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£4,047 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You don’t qualify for extra grants and allowances.</p>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/24500.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/24500.0/no?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-24500.0-no-social-work.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-24500.0-no-social-work.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£4,047 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/24500.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/24500.0/no?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-24500.0-no-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-24500.0-no-teacher-training.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£4,047 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£3,387 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £24,500</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london?previous_response=24500.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/24500.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/24500.0/no?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-35000.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-35000.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£4,993 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/35000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/35000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-35000.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-35000.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£4,993 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/35000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/35000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-35000.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-35000.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£4,993 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/35000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/35000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-35000.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-35000.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£4,993 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/35000.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/35000.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-35000.0-no-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-35000.0-no-dental-medical-healthcare.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£4,993 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/35000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/35000.0/no?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-35000.0-no-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-35000.0-no-none-of-the-above.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£4,993 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You don’t qualify for extra grants and allowances.</p>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/35000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/35000.0/no?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-35000.0-no-social-work.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-35000.0-no-social-work.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£4,993 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/35000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/35000.0/no?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-35000.0-no-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-35000.0-no-teacher-training.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£4,993 Maintenance Loan (for living costs)</p>
+  </li>
+  <li>
+    <p>£1,494 Maintenance Grant (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £35,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london?previous_response=35000.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/35000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/35000.0/no?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-43875.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-43875.0-children-under-17,dependant-adult,has-disability,low-income-dental-medical-healthcare.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£5,636 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/43875.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/43875.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-43875.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-43875.0-children-under-17,dependant-adult,has-disability,low-income-none-of-the-above.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£5,636 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/43875.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/43875.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-43875.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-43875.0-children-under-17,dependant-adult,has-disability,low-income-social-work.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£5,636 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/43875.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/43875.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-43875.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-43875.0-children-under-17,dependant-adult,has-disability,low-income-teacher-training.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£5,636 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>up to £155.24 a week (1 child) or up to £266.15 a week (2 or more children) <a href="/childcare-grant">Childcare Grant</a></li>
+  <li>up to £1,573 per year <a href="/parents-learning-allowance">Parents’ Learning Allowance</a></li>
+  <li>
+    <p><a href="/child-tax-credit">Child Tax Credit</a></p>
+  </li>
+  <li>
+    <p>up to £2,757 per year <a href="/adult-dependants-grant">Adult Dependant’s Grant</a></p>
+  </li>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You’ve got children under 17</li>
+        <li>An adult depends on you financially</li>
+        <li>You’ve a disability, health condition or learning difficulty -  eg dyslexia</li>
+        <li>You’re on low income - eg you find it hard to pay for basics like food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/43875.0?previous_response=children-under-17%2Cdependant-adult%2Chas-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/43875.0/children-under-17,dependant-adult,has-disability,low-income?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-43875.0-no-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-43875.0-no-dental-medical-healthcare.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£5,636 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/43875.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/43875.0/no?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-43875.0-no-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-43875.0-no-none-of-the-above.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£5,636 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You don’t qualify for extra grants and allowances.</p>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/43875.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/43875.0/no?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-43875.0-no-social-work.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-43875.0-no-social-work.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£5,636 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/43875.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/43875.0/no?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-43875.0-no-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-full-time-6000.0-away-outside-london-43875.0-no-teacher-training.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>
+    <p>£6,000 Tuition Fee Loan</p>
+  </li>
+  <li>
+    <p>£5,636 Maintenance Loan (for living costs)</p>
+  </li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student full-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-full-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Where will you live while studying?</td>
+      <td class="previous-question-body">
+      Not living with parents and studying outside of London</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0?previous_response=away-outside-london">
+            Change<span class="visuallyhidden"> answer to "Where will you live while studying?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What&#39;s your annual household income?</td>
+      <td class="previous-question-body">
+      £43,875</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london?previous_response=43875.0">
+            Change<span class="visuallyhidden"> answer to "What&#39;s your annual household income?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/43875.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-full-time/6000.0/away-outside-london/43875.0/no?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-part-time-6000.0-has-disability,low-income-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-part-time-6000.0-has-disability,low-income-dental-medical-healthcare.html
@@ -1,0 +1,189 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>£6,000 Tuition Fee Loan</li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li>
+    <p><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</p>
+  </li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student part-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-part-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-part-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You have a disability, health condition or learning difficulty, eg dyslexia</li>
+        <li>You’re on a low income, eg you find it hard to pay for food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-part-time/6000.0?previous_response=has-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-part-time/6000.0/has-disability,low-income?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-part-time-6000.0-has-disability,low-income-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-part-time-6000.0-has-disability,low-income-none-of-the-above.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>£6,000 Tuition Fee Loan</li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student part-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-part-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-part-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You have a disability, health condition or learning difficulty, eg dyslexia</li>
+        <li>You’re on a low income, eg you find it hard to pay for food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-part-time/6000.0?previous_response=has-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-part-time/6000.0/has-disability,low-income?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-part-time-6000.0-has-disability,low-income-social-work.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-part-time-6000.0-has-disability,low-income-social-work.html
@@ -1,0 +1,189 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>£6,000 Tuition Fee Loan</li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li>
+    <p><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</p>
+  </li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student part-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-part-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-part-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You have a disability, health condition or learning difficulty, eg dyslexia</li>
+        <li>You’re on a low income, eg you find it hard to pay for food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-part-time/6000.0?previous_response=has-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-part-time/6000.0/has-disability,low-income?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-part-time-6000.0-has-disability,low-income-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-part-time-6000.0-has-disability,low-income-teacher-training.html
@@ -1,0 +1,189 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>£6,000 Tuition Fee Loan</li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li>
+    <p><a href="/disabled-students-allowances-dsas">Disabled Students&rsquo; Allowances</a></p>
+  </li>
+  <li>
+    <p><a href="/extra-money-pay-university/university-and-college-hardship-funds">University and college hardship funds</a> (extra help with costs while studying)</p>
+  </li>
+  <li>
+    <p><a href="/teacher-training-funding">Funding for teacher training</a></p>
+  </li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student part-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-part-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-part-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>You have a disability, health condition or learning difficulty, eg dyslexia</li>
+        <li>You’re on a low income, eg you find it hard to pay for food and accommodation</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-part-time/6000.0?previous_response=has-disability%2Clow-income">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-part-time/6000.0/has-disability,low-income?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-part-time-6000.0-no-dental-medical-healthcare.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-part-time-6000.0-no-dental-medical-healthcare.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>£6,000 Tuition Fee Loan</li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/nhs-bursaries">NHS Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student part-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-part-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-part-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-part-time/6000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Dental, medical or healthcare</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-part-time/6000.0/no?previous_response=dental-medical-healthcare">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-part-time-6000.0-no-none-of-the-above.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-part-time-6000.0-no-none-of-the-above.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>£6,000 Tuition Fee Loan</li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You don’t qualify for extra grants and allowances.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student part-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-part-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-part-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-part-time/6000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+       None of these</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-part-time/6000.0/no?previous_response=none-of-the-above">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-part-time-6000.0-no-social-work.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-part-time-6000.0-no-social-work.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>£6,000 Tuition Fee Loan</li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/social-work-bursaries">Social Work Bursary</a> (NHS funding towards your fees and living costs)</li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student part-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-part-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-part-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-part-time/6000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Social work</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-part-time/6000.0/no?previous_response=social-work">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/artefacts/student-finance-calculator/2015-2016-uk-part-time-6000.0-no-teacher-training.html
+++ b/test/artefacts/student-finance-calculator/2015-2016-uk-part-time-6000.0-no-teacher-training.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" media="all" href="/smartanswers/application.css" />
+    <link rel="stylesheet" media="print" href="/smartanswers/print.css" />
+    <title>Student finance calculator - GOV.UK</title>
+    <script src="/smartanswers/smart-answers.js" defer="defer"></script>
+    <meta name="robots" content="noindex">
+
+  </head>
+<body class="mainstream">
+
+  
+
+  <div id="wrapper" class="answer smart_answer">
+    
+
+<main id="content" role="main">
+  <div id="js-replaceable"  class="smart-answer-questions group">
+      
+
+  <header class="page-header group">
+    <div>
+      <h1>
+        Student finance calculator
+      </h1>
+    </div>
+  </header>
+
+    <div class="article-container outcome">
+  <article class="outcome group">
+    <div class="result-info">
+      <div class="inner group">
+          
+<div class="summary">
+<p>This is an estimate of your student finance. You must apply to find out exactly what you’ll get.</p>
+</div>
+
+<h2 id="student-finance">Student finance</h2>
+
+<p>You could get per year:</p>
+
+<ul>
+  <li>£6,000 Tuition Fee Loan</li>
+</ul>
+
+<h3 id="extra-student-funding">Extra student funding</h3>
+
+<p>You could get:</p>
+
+<ul>
+  <li><a href="/teacher-training-funding">Funding for teacher training</a></li>
+</ul>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Your result is an estimate. Usually, you only get student finance if you’re doing your first higher education qualification - check if you <a href="/student-finance/who-qualifies">qualify</a>.</p>
+</div>
+
+<h2 id="extra-help">Extra help</h2>
+
+<p>You could get a <a href="/extra-money-pay-university">bursary or scholarship</a> from your university or college.</p>
+
+<p>You might be able to get <a href="/travel-grants-medical-dental-students-england">help with the costs of travel for study or work placements</a> as part of your course.</p>
+
+<p>Use the <a rel="external" href="http://www.family-action.org.uk/section.aspx?id=21211">Family Action grant search</a> to check whether you qualify for funding from a charitable trust.</p>
+
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Student loans have to be paid back - grants, bursaries and allowances don’t.</p>
+</div>
+
+<h2 id="your-next-steps">Your next steps</h2>
+
+<ol class="steps">
+<li><p>Find out how to <a href="/apply-for-student-finance">apply</a> for student finance</p>
+</li>
+<li><p>Check if you <a href="/student-finance/who-qualifies">qualify</a> for student finance</p>
+</li>
+</ol>
+
+      </div>
+    </div>
+  </article>
+</div>
+
+    <div class="previous-answers ">
+    <div class="done-questions">
+      <article>
+            <h3 class="previous-answers-title">
+              Previous answers
+            </h3>
+          <a class="start-right" href="/student-finance-calculator">Start again</a>
+        <table>
+          <tbody>
+              
+    <tr class="section">
+    <td class="previous-question-title">When does your course start?</td>
+      <td class="previous-question-body">
+      Between September 2015 and August 2016</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y?previous_response=2015-2016">
+            Change<span class="visuallyhidden"> answer to "When does your course start?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">What type of student are you?</td>
+      <td class="previous-question-body">
+      UK student part-time</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016?previous_response=uk-part-time">
+            Change<span class="visuallyhidden"> answer to "What type of student are you?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">How much are your tuition fees per year?</td>
+      <td class="previous-question-body">
+      £6,000</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-part-time?previous_response=6000.0">
+            Change<span class="visuallyhidden"> answer to "How much are your tuition fees per year?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Do any of the following apply (you might get extra funding)?</td>
+      <td class="previous-question-body"><ul>
+        <li>None of these</li>
+      </ul></td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-part-time/6000.0?previous_response=no">
+            Change<span class="visuallyhidden"> answer to "Do any of the following apply (you might get extra funding)?"</span>
+</a>      </td>
+  </tr>
+
+              
+    <tr class="section">
+    <td class="previous-question-title">Are you studying one of these courses?</td>
+      <td class="previous-question-body">
+      Teacher training</td>
+
+      <td class="link-right">
+          <a href="/student-finance-calculator/y/2015-2016/uk-part-time/6000.0/no?previous_response=teacher-training">
+            Change<span class="visuallyhidden"> answer to "Are you studying one of these courses?"</span>
+</a>      </td>
+  </tr>
+
+          </tbody>
+        </table>
+      </article>
+    </div>
+  </div>
+
+
+
+  </div>
+
+  <div class="meta-wrapper">
+    <div id="report-a-problem"></div>
+    <div class="meta-data group">
+  <div class="inner">
+    <div class="print-and-modified-date group">
+      <p class="modified-date">Last updated:  1 January 2015</p>
+    </div>
+  </div>
+</div>
+
+  </div>
+</main>
+
+  </div>
+</body>
+</html>

--- a/test/data/student-finance-calculator-questions-and-responses.yml
+++ b/test/data/student-finance-calculator-questions-and-responses.yml
@@ -1,0 +1,32 @@
+--- 
+:when_does_your_course_start?: 
+- 2014-2015
+- 2015-2016
+:what_type_of_student_are_you?: 
+- uk-full-time
+- uk-part-time
+- eu-full-time
+- eu-part-time
+:how_much_are_your_tuition_fees_per_year?: 
+- "TODO: How much are your tuition fees per year?"
+:where_will_you_live_while_studying?: 
+- at-home
+- away-outside-london
+- away-in-london
+:whats_your_household_income?: 
+- "TODO: What's your annual household income?"
+:do_any_of_the_following_apply_uk_full_time_students_only?: 
+- children-under-17
+- dependant-adult
+- has-disability
+- low-income
+- "no"
+:do_any_of_the_following_apply_all_uk_students?: 
+- has-disability
+- low-income
+- "no"
+:what_course_are_you_studying?: 
+- teacher-training
+- dental-medical-healthcare
+- social-work
+- none-of-the-above

--- a/test/data/student-finance-calculator-questions-and-responses.yml
+++ b/test/data/student-finance-calculator-questions-and-responses.yml
@@ -1,31 +1,30 @@
---- 
-:when_does_your_course_start?: 
+---
+:when_does_your_course_start?:
 - 2014-2015
 - 2015-2016
-:what_type_of_student_are_you?: 
+:what_type_of_student_are_you?:
 - uk-full-time
 - uk-part-time
 - eu-full-time
 - eu-part-time
-:how_much_are_your_tuition_fees_per_year?: 
-- "TODO: How much are your tuition fees per year?"
-:where_will_you_live_while_studying?: 
+:how_much_are_your_tuition_fees_per_year?:
+- 6000
+:where_will_you_live_while_studying?:
 - at-home
 - away-outside-london
 - away-in-london
-:whats_your_household_income?: 
-- "TODO: What's your annual household income?"
-:do_any_of_the_following_apply_uk_full_time_students_only?: 
-- children-under-17
-- dependant-adult
-- has-disability
-- low-income
+:whats_your_household_income?:
+- 100000
+- 43875
+- 35000
+- 24500
+:do_any_of_the_following_apply_uk_full_time_students_only?:
+- children-under-17,dependant-adult,has-disability,low-income
 - "no"
-:do_any_of_the_following_apply_all_uk_students?: 
-- has-disability
-- low-income
+:do_any_of_the_following_apply_all_uk_students?:
+- has-disability,low-income
 - "no"
-:what_course_are_you_studying?: 
+:what_course_are_you_studying?:
 - teacher-training
 - dental-medical-healthcare
 - social-work

--- a/test/data/student-finance-calculator-responses-and-expected-results.yml
+++ b/test/data/student-finance-calculator-responses-and-expected-results.yml
@@ -1,0 +1,2839 @@
+--- 
+- :current_node: :when_does_your_course_start?
+  :responses: 
+  - 2014-2015
+  :outcome_node: false
+- :current_node: :what_type_of_student_are_you?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  :outcome_node: false
+- :current_node: :how_much_are_your_tuition_fees_per_year?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000"
+  :outcome_node: false
+- :current_node: :where_will_you_live_while_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  :outcome_node: false
+- :current_node: :whats_your_household_income?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "100000"
+  :outcome_node: false
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "100000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "100000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "100000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "100000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "100000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "100000.0"
+  - "no"
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "100000.0"
+  - "no"
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "100000.0"
+  - "no"
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "100000.0"
+  - "no"
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "100000.0"
+  - "no"
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :whats_your_household_income?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "43875"
+  :outcome_node: false
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "43875.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "43875.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "43875.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "43875.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "43875.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "43875.0"
+  - "no"
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "43875.0"
+  - "no"
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "43875.0"
+  - "no"
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "43875.0"
+  - "no"
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "43875.0"
+  - "no"
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :whats_your_household_income?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "35000"
+  :outcome_node: false
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "35000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "35000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "35000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "35000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "35000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "35000.0"
+  - "no"
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "35000.0"
+  - "no"
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "35000.0"
+  - "no"
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "35000.0"
+  - "no"
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "35000.0"
+  - "no"
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :whats_your_household_income?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "24500"
+  :outcome_node: false
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "24500.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "24500.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "24500.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "24500.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "24500.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "24500.0"
+  - "no"
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "24500.0"
+  - "no"
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "24500.0"
+  - "no"
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "24500.0"
+  - "no"
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "24500.0"
+  - "no"
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :where_will_you_live_while_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  :outcome_node: false
+- :current_node: :whats_your_household_income?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "100000"
+  :outcome_node: false
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "100000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "100000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "100000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "100000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "100000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "100000.0"
+  - "no"
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "100000.0"
+  - "no"
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "100000.0"
+  - "no"
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "100000.0"
+  - "no"
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "100000.0"
+  - "no"
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :whats_your_household_income?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "43875"
+  :outcome_node: false
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "43875.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "43875.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "43875.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "43875.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "43875.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "43875.0"
+  - "no"
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "43875.0"
+  - "no"
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "43875.0"
+  - "no"
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "43875.0"
+  - "no"
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "43875.0"
+  - "no"
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :whats_your_household_income?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "35000"
+  :outcome_node: false
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "35000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "35000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "35000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "35000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "35000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "35000.0"
+  - "no"
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "35000.0"
+  - "no"
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "35000.0"
+  - "no"
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "35000.0"
+  - "no"
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "35000.0"
+  - "no"
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :whats_your_household_income?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "24500"
+  :outcome_node: false
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "24500.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "24500.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "24500.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "24500.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "24500.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "24500.0"
+  - "no"
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "24500.0"
+  - "no"
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "24500.0"
+  - "no"
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "24500.0"
+  - "no"
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "24500.0"
+  - "no"
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :where_will_you_live_while_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  :outcome_node: false
+- :current_node: :whats_your_household_income?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "100000"
+  :outcome_node: false
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "100000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "100000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "100000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "100000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "100000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "100000.0"
+  - "no"
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "100000.0"
+  - "no"
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "100000.0"
+  - "no"
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "100000.0"
+  - "no"
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "100000.0"
+  - "no"
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :whats_your_household_income?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "43875"
+  :outcome_node: false
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "43875.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "43875.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "43875.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "43875.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "43875.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "43875.0"
+  - "no"
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "43875.0"
+  - "no"
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "43875.0"
+  - "no"
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "43875.0"
+  - "no"
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "43875.0"
+  - "no"
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :whats_your_household_income?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "35000"
+  :outcome_node: false
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "35000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "35000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "35000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "35000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "35000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "35000.0"
+  - "no"
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "35000.0"
+  - "no"
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "35000.0"
+  - "no"
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "35000.0"
+  - "no"
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "35000.0"
+  - "no"
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :whats_your_household_income?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "24500"
+  :outcome_node: false
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "24500.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "24500.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "24500.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "24500.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "24500.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "24500.0"
+  - "no"
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "24500.0"
+  - "no"
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "24500.0"
+  - "no"
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "24500.0"
+  - "no"
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "24500.0"
+  - "no"
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :what_type_of_student_are_you?
+  :responses: 
+  - 2014-2015
+  - uk-part-time
+  :outcome_node: false
+- :current_node: :how_much_are_your_tuition_fees_per_year?
+  :responses: 
+  - 2014-2015
+  - uk-part-time
+  - "6000"
+  :outcome_node: false
+- :current_node: :do_any_of_the_following_apply_all_uk_students?
+  :responses: 
+  - 2014-2015
+  - uk-part-time
+  - "6000.0"
+  - has-disability,low-income
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-part-time
+  - "6000.0"
+  - has-disability,low-income
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-part-time
+  - "6000.0"
+  - has-disability,low-income
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-part-time
+  - "6000.0"
+  - has-disability,low-income
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-part-time
+  - "6000.0"
+  - has-disability,low-income
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :do_any_of_the_following_apply_all_uk_students?
+  :responses: 
+  - 2014-2015
+  - uk-part-time
+  - "6000.0"
+  - "no"
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-part-time
+  - "6000.0"
+  - "no"
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-part-time
+  - "6000.0"
+  - "no"
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-part-time
+  - "6000.0"
+  - "no"
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2014-2015
+  - uk-part-time
+  - "6000.0"
+  - "no"
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :what_type_of_student_are_you?
+  :responses: 
+  - 2014-2015
+  - eu-full-time
+  :outcome_node: false
+- :current_node: :how_much_are_your_tuition_fees_per_year?
+  :responses: 
+  - 2014-2015
+  - eu-full-time
+  - "6000"
+  :outcome_node: true
+- :current_node: :what_type_of_student_are_you?
+  :responses: 
+  - 2014-2015
+  - eu-part-time
+  :outcome_node: false
+- :current_node: :how_much_are_your_tuition_fees_per_year?
+  :responses: 
+  - 2014-2015
+  - eu-part-time
+  - "6000"
+  :outcome_node: true
+- :current_node: :when_does_your_course_start?
+  :responses: 
+  - 2015-2016
+  :outcome_node: false
+- :current_node: :what_type_of_student_are_you?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  :outcome_node: false
+- :current_node: :how_much_are_your_tuition_fees_per_year?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000"
+  :outcome_node: false
+- :current_node: :where_will_you_live_while_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  :outcome_node: false
+- :current_node: :whats_your_household_income?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "100000"
+  :outcome_node: false
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "100000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "100000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "100000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "100000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "100000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "100000.0"
+  - "no"
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "100000.0"
+  - "no"
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "100000.0"
+  - "no"
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "100000.0"
+  - "no"
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "100000.0"
+  - "no"
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :whats_your_household_income?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "43875"
+  :outcome_node: false
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "43875.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "43875.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "43875.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "43875.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "43875.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "43875.0"
+  - "no"
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "43875.0"
+  - "no"
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "43875.0"
+  - "no"
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "43875.0"
+  - "no"
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "43875.0"
+  - "no"
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :whats_your_household_income?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "35000"
+  :outcome_node: false
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "35000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "35000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "35000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "35000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "35000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "35000.0"
+  - "no"
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "35000.0"
+  - "no"
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "35000.0"
+  - "no"
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "35000.0"
+  - "no"
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "35000.0"
+  - "no"
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :whats_your_household_income?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "24500"
+  :outcome_node: false
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "24500.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "24500.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "24500.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "24500.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "24500.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "24500.0"
+  - "no"
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "24500.0"
+  - "no"
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "24500.0"
+  - "no"
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "24500.0"
+  - "no"
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - at-home
+  - "24500.0"
+  - "no"
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :where_will_you_live_while_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  :outcome_node: false
+- :current_node: :whats_your_household_income?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "100000"
+  :outcome_node: false
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "100000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "100000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "100000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "100000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "100000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "100000.0"
+  - "no"
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "100000.0"
+  - "no"
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "100000.0"
+  - "no"
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "100000.0"
+  - "no"
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "100000.0"
+  - "no"
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :whats_your_household_income?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "43875"
+  :outcome_node: false
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "43875.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "43875.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "43875.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "43875.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "43875.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "43875.0"
+  - "no"
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "43875.0"
+  - "no"
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "43875.0"
+  - "no"
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "43875.0"
+  - "no"
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "43875.0"
+  - "no"
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :whats_your_household_income?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "35000"
+  :outcome_node: false
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "35000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "35000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "35000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "35000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "35000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "35000.0"
+  - "no"
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "35000.0"
+  - "no"
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "35000.0"
+  - "no"
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "35000.0"
+  - "no"
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "35000.0"
+  - "no"
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :whats_your_household_income?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "24500"
+  :outcome_node: false
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "24500.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "24500.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "24500.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "24500.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "24500.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "24500.0"
+  - "no"
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "24500.0"
+  - "no"
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "24500.0"
+  - "no"
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "24500.0"
+  - "no"
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-outside-london
+  - "24500.0"
+  - "no"
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :where_will_you_live_while_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  :outcome_node: false
+- :current_node: :whats_your_household_income?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "100000"
+  :outcome_node: false
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "100000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "100000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "100000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "100000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "100000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "100000.0"
+  - "no"
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "100000.0"
+  - "no"
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "100000.0"
+  - "no"
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "100000.0"
+  - "no"
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "100000.0"
+  - "no"
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :whats_your_household_income?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "43875"
+  :outcome_node: false
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "43875.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "43875.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "43875.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "43875.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "43875.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "43875.0"
+  - "no"
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "43875.0"
+  - "no"
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "43875.0"
+  - "no"
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "43875.0"
+  - "no"
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "43875.0"
+  - "no"
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :whats_your_household_income?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "35000"
+  :outcome_node: false
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "35000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "35000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "35000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "35000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "35000.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "35000.0"
+  - "no"
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "35000.0"
+  - "no"
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "35000.0"
+  - "no"
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "35000.0"
+  - "no"
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "35000.0"
+  - "no"
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :whats_your_household_income?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "24500"
+  :outcome_node: false
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "24500.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "24500.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "24500.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "24500.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "24500.0"
+  - children-under-17,dependant-adult,has-disability,low-income
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "24500.0"
+  - "no"
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "24500.0"
+  - "no"
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "24500.0"
+  - "no"
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "24500.0"
+  - "no"
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-full-time
+  - "6000.0"
+  - away-in-london
+  - "24500.0"
+  - "no"
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :what_type_of_student_are_you?
+  :responses: 
+  - 2015-2016
+  - uk-part-time
+  :outcome_node: false
+- :current_node: :how_much_are_your_tuition_fees_per_year?
+  :responses: 
+  - 2015-2016
+  - uk-part-time
+  - "6000"
+  :outcome_node: false
+- :current_node: :do_any_of_the_following_apply_all_uk_students?
+  :responses: 
+  - 2015-2016
+  - uk-part-time
+  - "6000.0"
+  - has-disability,low-income
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-part-time
+  - "6000.0"
+  - has-disability,low-income
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-part-time
+  - "6000.0"
+  - has-disability,low-income
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-part-time
+  - "6000.0"
+  - has-disability,low-income
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-part-time
+  - "6000.0"
+  - has-disability,low-income
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :do_any_of_the_following_apply_all_uk_students?
+  :responses: 
+  - 2015-2016
+  - uk-part-time
+  - "6000.0"
+  - "no"
+  :outcome_node: false
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-part-time
+  - "6000.0"
+  - "no"
+  - teacher-training
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-part-time
+  - "6000.0"
+  - "no"
+  - dental-medical-healthcare
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-part-time
+  - "6000.0"
+  - "no"
+  - social-work
+  :outcome_node: true
+- :current_node: :what_course_are_you_studying?
+  :responses: 
+  - 2015-2016
+  - uk-part-time
+  - "6000.0"
+  - "no"
+  - none-of-the-above
+  :outcome_node: true
+- :current_node: :what_type_of_student_are_you?
+  :responses: 
+  - 2015-2016
+  - eu-full-time
+  :outcome_node: false
+- :current_node: :how_much_are_your_tuition_fees_per_year?
+  :responses: 
+  - 2015-2016
+  - eu-full-time
+  - "6000"
+  :outcome_node: true
+- :current_node: :what_type_of_student_are_you?
+  :responses: 
+  - 2015-2016
+  - eu-part-time
+  :outcome_node: false
+- :current_node: :how_much_are_your_tuition_fees_per_year?
+  :responses: 
+  - 2015-2016
+  - eu-part-time
+  - "6000"
+  :outcome_node: true


### PR DESCRIPTION
We want tests that give us confidence to make some larger changes to the existing Smart Answers (e.g. switching to ERB templates).

The current integration tests aren't good enough as they don't exercise the flows completely, and they rely on using the internals of the flows (e.g. tests that assert things about the phrase lists).

These regression tests aim to comprehensively test the Smart Answers and only rely on the generated html, which should allow us to change the implementation without worrying about breaking the tests.

Testing Smart Answers in this way involves:

1. Creating a questions-and-responses file that contains a set of responses that should be used for each question (see scripts/generate-questions-and-responses-for-smart-answer.rb).

2. Creating a responses-and-expected-results file that contains each combination of results from the questions-and-responses file, along with the node name and whether it's an outcome node (see scripts/generate-responses-and-expected-results-for-smart-answer.rb).

3. Running the smart_answers_regression_test to test the smart answer using each combination of responses from the responses-and-expected-results file.

Running the smart_answers_regression_test in this branch takes around 100 seconds, which isn't an insignificant amount of time. I have some ways of optimising the tests so that they only run when changes to the flows or input responses mean that the saved outcomes might be different. I didn't want to add them to this pull request as I'm more interested in what people about the approach in general.

We don't imagine these tests being very long lived. We'd hope to use them while we're making changes to the Smart Answers and for them to be replaced with more focussed tests over time.

Any questions and/or thoughts about this approach?