### PR TITLE
Remove minitest-reporters Gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,6 @@ group :test do
   gem 'simplecov-rcov', '~> 0.2.3', :require => false
   gem 'poltergeist', '1.6.0'
   gem 'timecop'
-  gem 'minitest-reporters', '~> 1.0.11'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,6 @@ GEM
     airbrake (3.1.17)
       builder
       multi_json
-    ansi (1.5.0)
     arel (6.0.0)
     ast (2.0.0)
     astrolabe (1.3.0)
@@ -129,11 +128,6 @@ GEM
     mime-types (1.25.1)
     mini_portile (0.6.2)
     minitest (5.5.1)
-    minitest-reporters (1.0.11)
-      ansi
-      builder
-      minitest (>= 5.0)
-      ruby-progressbar
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     multi_json (1.11.0)
@@ -300,7 +294,6 @@ DEPENDENCIES
   logstasher (= 0.4.8)
   lrucache (= 0.1.4)
   minitest (~> 5.1)
-  minitest-reporters (~> 1.0.11)
   mocha (= 1.1.0)
   nokogiri
   parser

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -13,6 +13,6 @@ export GOVUK_APP_DOMAIN=dev.gov.uk
 export GOVUK_ASSET_HOST=http://static.dev.gov.uk
 
 export DISPLAY=:99
-RAILS_ENV=test SPEC_REPORTER=true TEST_COVERAGE=true bundle exec rake test
+RAILS_ENV=test TEST_COVERAGE=true bundle exec rake test
 
 bundle exec rake assets:precompile

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,12 +16,6 @@ FLOW_REGISTRY_OPTIONS[:preload_flows] = true
 require 'minitest/unit'
 require 'rails/test_help'
 
-
-if ENV['SPEC_REPORTER']
-  require "minitest/reporters"
-  Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new
-end
-
 require 'mocha/setup'
 
 require 'webmock/minitest'


### PR DESCRIPTION
This was added in bda81db4d948d79ba43a38e740c6ea657ece8be3.

It's configured to display the test output in a different format in Jenkins.

I find the test output in Jenkins hard to read and it makes it hard to see any
errors and failures.

I made a number of tests fail to demonstrate the difference in output between
using the SpecReporter and the standard Minitest output. You can see the
difference in my gist[1].

[1]: https://gist.github.com/chrisroos/44696c502f2dac8d6270