### PR TITLE
Use DSL validate blocks for validation in Ruby smart answer flows

### DIFF
--- a/lib/smart_answer_flows/appeal-a-benefits-decision.rb
+++ b/lib/smart_answer_flows/appeal-a-benefits-decision.rb
@@ -93,11 +93,14 @@ module SmartAnswer
         from { 5.years.ago }
         to { Date.today }
 
+        validate do |response|
+          response >= written_explanation_request_date
+        end
+
         calculate :appeal_expiry_date do |response|
           decision_date = decision_letter_date
           received_date = response
           request_date = written_explanation_request_date
-          raise InvalidResponse if received_date < request_date
           received_within_a_month = received_date < 1.month.since(request_date)
 
           if received_within_a_month

--- a/lib/smart_answer_flows/apply-tier-4-visa.rb
+++ b/lib/smart_answer_flows/apply-tier-4-visa.rb
@@ -38,15 +38,15 @@ module SmartAnswer
 
         save_input_as :sponsor_id
 
-        calculate :data do
+        precalculate :data do
           Calculators::StaticDataQuery.new("apply_tier_4_visa_data").data
         end
 
-        calculate :sponsor_name do |response|
-          name = data["post"].merge(data["online"])[response]
-          raise InvalidResponse, :error unless name
-          name
+        next_node_calculation :sponsor_name do |response|
+          data["post"].merge(data["online"])[response]
         end
+
+        validate(:error) { sponsor_name.present? }
 
         calculate :post_or_online do |response|
           if data["post"].keys.include?(response)

--- a/lib/smart_answer_flows/calculate-agricultural-holiday-entitlement.rb
+++ b/lib/smart_answer_flows/calculate-agricultural-holiday-entitlement.rb
@@ -66,10 +66,9 @@ module SmartAnswer
           calculator.available_days
         end
 
+        validate { |response| response <= available_days }
+
         calculate :total_days_worked do |response|
-          if response > available_days
-            raise SmartAnswer::InvalidResponse
-          end
           response
         end
 
@@ -79,11 +78,10 @@ module SmartAnswer
       value_question :how_many_weeks_at_current_employer?, parse: Integer do
         next_node :done
 
+        #Has to be less than a full year
+        validate { |response| response < 52 }
+
         calculate :holiday_entitlement_days do |response|
-          #Has to be less than a full year
-          if (response > 51)
-            raise SmartAnswer::InvalidResponse
-          end
           if !days_worked_per_week.nil?
             days = calculator.holiday_days(days_worked_per_week)
           elsif !weeks_from_october_1.nil?

--- a/lib/smart_answer_flows/calculate-married-couples-allowance.rb
+++ b/lib/smart_answer_flows/calculate-married-couples-allowance.rb
@@ -57,9 +57,7 @@ module SmartAnswer
       money_question :whats_the_husbands_income? do
         save_input_as :income
 
-        calculate :income_greater_than_0 do |response|
-          raise SmartAnswer::InvalidResponse if response < 1
-        end
+        validate { |response| response > 0 }
 
         next_node do |response|
           limit = (is_before_april_changes ? 26100.0 : 27000.0)
@@ -74,9 +72,7 @@ module SmartAnswer
       money_question :whats_the_highest_earners_income? do
         save_input_as :income
 
-        calculate :income_greater_than_0 do |response|
-          raise SmartAnswer::InvalidResponse if response < 1
-        end
+        validate { |response| response > 0 }
 
         next_node do |response|
           limit = (is_before_april_changes ? 26100.0 : 27000.0)

--- a/test/integration/smart_answer_flows/calculate_agricultural_holiday_entitlement_test.rb
+++ b/test/integration/smart_answer_flows/calculate_agricultural_holiday_entitlement_test.rb
@@ -70,6 +70,16 @@ class CalculateAgriculturalHolidayEntitlementTest < ActiveSupport::TestCase
             assert_state_variable :holiday_entitlement_days, "9.5"
           end
         end
+
+        context "worked more than 51 weeks" do
+          setup do
+            add_response "52"
+          end
+
+          should "indicate that response is invalid" do
+            assert_current_node :how_many_weeks_at_current_employer?, error: true
+          end
+        end
       end
     end
 
@@ -224,6 +234,16 @@ class CalculateAgriculturalHolidayEntitlementTest < ActiveSupport::TestCase
           should "have some holidays" do
             assert_state_variable :holiday_entitlement_days, 13
           end
+        end
+      end
+
+      context "worked more than the available number of days" do
+        setup do
+          add_response "33"
+        end
+
+        should "indicate that response is invalid" do
+          assert_current_node :how_many_total_days?, error: true
         end
       end
     end


### PR DESCRIPTION
This PR illustrates another type of change we're planning to make across the Ruby smart answers.

There are many places where `calculate` blocks are used to conditionally raise a `SmartAnswer:: InvalidResponse` exception depending on whether the user's response is valid. However, the Ruby DSL already provides for `validate` blocks which are already used in a _few_ places.

Although in some ways it feels as if using the `validate` blocks ties us more into the DSL, we think that it's useful in making all the validation more explicit and separates it from calculation logic.

Again this isn't intended as an end goal, but another small step on the way to separating all the concerns in the Ruby smart answers into a more maintainable form.
