### PR TITLE
Ignore commas in numeric responses to value questions

### DIFF
--- a/lib/smart_answer/question/value.rb
+++ b/lib/smart_answer/question/value.rb
@@ -8,16 +8,22 @@ module SmartAnswer
 
       def parse_input(raw_input)
         if Integer == @parse
-          Integer(raw_input)
+          Integer(without_commas(raw_input))
         elsif :to_i == @parse
-          raw_input.to_i
+          without_commas(raw_input).to_i
         elsif Float == @parse
-          Float(raw_input)
+          Float(without_commas(raw_input))
         elsif :to_f == @parse
-          raw_input.to_f
+          without_commas(raw_input).to_f
         else
           super
         end
+      end
+
+      private
+
+      def without_commas(raw_input)
+        raw_input.delete(',')
       end
     end
   end

--- a/test/unit/value_question_test.rb
+++ b/test/unit/value_question_test.rb
@@ -32,6 +32,11 @@ module SmartAnswer
         assert_equal 123, new_state.myval
       end
 
+      should "save integer value as an Integer ignoring commas" do
+        new_state = @q.transition(@initial_state, "1,234,567")
+        assert_equal 1_234_567, new_state.myval
+      end
+
       should "raise ArgumentError for non-integer value" do
         assert_raises(ArgumentError) { @q.transition(@initial_state, "1.5") }
       end
@@ -52,6 +57,11 @@ module SmartAnswer
       should "save valid value as an Integer" do
         new_state = @q.transition(@initial_state, "123")
         assert_equal 123, new_state.myval
+      end
+
+      should "save integer value as an Integer ignoring commas" do
+        new_state = @q.transition(@initial_state, "1,234,567")
+        assert_equal 1_234_567, new_state.myval
       end
 
       should "save non-integer value as an Integer" do
@@ -78,6 +88,11 @@ module SmartAnswer
         assert_equal 1.23, new_state.myval
       end
 
+      should "save float value as a Float ignoring commas" do
+        new_state = @q.transition(@initial_state, "1,234,567.89")
+        assert_equal 1_234_567.89, new_state.myval
+      end
+
       should "raise ArgumentError for non-float value" do
         assert_raises(ArgumentError) { @q.transition(@initial_state, "not-a-float") }
       end
@@ -98,6 +113,11 @@ module SmartAnswer
       should "save float value as a Float" do
         new_state = @q.transition(@initial_state, "1.23")
         assert_equal 1.23, new_state.myval
+      end
+
+      should "save float value as a Float ignoring commas" do
+        new_state = @q.transition(@initial_state, "1,234,567.89")
+        assert_equal 1_234_567.89, new_state.myval
       end
 
       should "save non-float value as zero" do


### PR DESCRIPTION
There are 3 places in the `simplified-expenses-checker` flow (and in the `v2`
flow of the same name) which explicitly ignore commas in numeric responses:

* https://github.com/alphagov/smart-answers/blob/2014c530db5d5179ba1734039ee00933c528e71a/lib/smart_answer_flows/simplified-expenses-checker.rb#L182
* https://github.com/alphagov/smart-answers/blob/2014c530db5d5179ba1734039ee00933c528e71a/lib/smart_answer_flows/simplified-expenses-checker.rb#L206
* https://github.com/alphagov/smart-answers/blob/2014c530db5d5179ba1734039ee00933c528e71a/lib/smart_answer_flows/simplified-expenses-checker.rb#L223

This seems a reasonable thing to do, but I feel as if it would be better to do
it consistently and centrally for all numeric responses to value questions.