### PR TITLE
Speed up DuplicateFlowTest

### DIFF
--- a/test/functional/duplicate_flow_test.rb
+++ b/test/functional/duplicate_flow_test.rb
@@ -4,6 +4,14 @@ require_relative '../../lib/smartdown_adapter/registry.rb'
 require_relative '../../lib/smart_answer/flow_registry.rb'
 
 class DuplicateFlowTest < Minitest::Test
+  def setup
+    @original = FLOW_REGISTRY_OPTIONS[:preload_flows]
+    FLOW_REGISTRY_OPTIONS[:preload_flows] = false
+  end
+
+  def teardown
+    FLOW_REGISTRY_OPTIONS[:preload_flows] = @original
+  end
 
   should "Not have any smartdown and smartanswer flows with the same name" do
     SmartdownAdapter::Registry.reset_instance


### PR DESCRIPTION
This test takes about 15 seconds to run on my machine. Most of the time appears
to be taken in loading the Smartdown flows, notably the `pay-leave-for-parents`
and the `pay-leave-for-parents-adoption` flows. These are being (re-)loaded,
because the singleton instance is being reset. Unfortunately I couldn't tell
from the [commit note](aea5d2aa56076c33962dc10093d47f9ae6199abe) why this reset is necessary, so I didn't feel comfortable
just removing it.

However, I noticed that the `Smartdown::Registry#available_methods` method being
tested returns a list of flow names which are **only** based on filenames - it
does **not** rely on instantiating the flows themselves. So it seems as if it
should be safe to temporarily disable flow preloading for the duration of just
this test.

With this change in place, the test takes much less than 1 second to run.