### PR TITLE
Avoid errors when requests exclude the response param

### DIFF
--- a/app/presenters/smart_answer_presenter.rb
+++ b/app/presenters/smart_answer_presenter.rb
@@ -152,7 +152,7 @@ class SmartAnswerPresenter
 
   def all_responses
     normalize_responses_param.dup.tap do |responses|
-      if params[:next]
+      if params[:next] && params[:response]
         responses << params[:response]
       end
     end

--- a/test/unit/presenters/smart_answer_presenter_test.rb
+++ b/test/unit/presenters/smart_answer_presenter_test.rb
@@ -1,0 +1,12 @@
+require_relative '../../test_helper'
+
+class SmartAnswerPresenterTest < ActiveSupport::TestCase
+  test 'should not append an empty element to the responses array if there is no response in the params' do
+    params    = { next: true, response: nil }
+    request   = stub(params: params)
+    flow      = SmartAnswer::Flow.new
+    presenter = SmartAnswerPresenter.new(request, flow)
+
+    assert_equal [], presenter.all_responses
+  end
+end


### PR DESCRIPTION
This is one way of addressing #1654, although @floehopper discusses an
alternative approach in 28785dd848d206e80e82c6c147b0db719258862a.

The problem we were seeing was caused by a combination of:

* The `parse: Integer` option being set on a `value_question`.

* The presence of a `nil` response in the `SmartAnswerPresenter#all_responses`
array

This fix feels OK to me as the current implementation implies that the presence
of `:next` in the params should mean that `:response` is also present.

The effect of this change is for the
`SmartAnswersController#redirect_response_to_canonical_url` behaviour to kick
in and redirect the user back to the URL without the `next` parameter.