### PR TITLE
Avoid using SmartAnswer::FlowRegistry in integration tests

### DIFF
--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -5,6 +5,12 @@ module SmartAnswer
     attr_reader :nodes, :outcomes
     attr_accessor :state, :status, :need_id
 
+    def self.build
+      new.tap do |flow|
+        flow.define
+      end
+    end
+
     def initialize(&block)
       @nodes = []
       @state = nil

--- a/lib/smart_answer/flow_registry.rb
+++ b/lib/smart_answer/flow_registry.rb
@@ -96,9 +96,7 @@ module SmartAnswer
       if SMART_ANSWER_FLOW_NAMES.include?(name)
         class_prefix = name.gsub("-", "_").camelize
         namespaced_class = "SmartAnswer::#{class_prefix}Flow".constantize
-        flow = namespaced_class.new
-        flow.define
-        flow
+        namespaced_class.build
       else
         absolute_path = @load_path.join("#{name}.rb").to_s
         Flow.new do

--- a/test/integration/smart_answer_flows/additional_commodity_code_test.rb
+++ b/test/integration/smart_answer_flows/additional_commodity_code_test.rb
@@ -1,11 +1,13 @@
 require_relative "../../test_helper"
 require_relative "flow_test_helper"
 
+require "smart_answer_flows/additional-commodity-code"
+
 class AdditionalCommodityCodeTest < ActiveSupport::TestCase
   include FlowTestHelper
 
   setup do
-    setup_for_testing_flow "additional-commodity-code"
+    setup_for_testing_flow SmartAnswer::AdditionalCommodityCodeFlow
   end
   ## Q1
   should "ask how much starch glucose the product contains" do

--- a/test/integration/smart_answer_flows/adoption_calculator_test.rb
+++ b/test/integration/smart_answer_flows/adoption_calculator_test.rb
@@ -3,12 +3,14 @@ require_relative '../../test_helper'
 require_relative 'flow_test_helper'
 require_relative '../../../lib/smart_answer/date_helper'
 
+require "smart_answer_flows/maternity-paternity-calculator"
+
 class AdoptionCalculatorTest < ActiveSupport::TestCase
   include DateHelper
   include FlowTestHelper
 
   setup do
-    setup_for_testing_flow 'maternity-paternity-calculator'
+    setup_for_testing_flow SmartAnswer::MaternityPaternityCalculatorFlow
   end
   ## Q1
   should "ask what type of leave or pay you want to check" do

--- a/test/integration/smart_answer_flows/am_i_getting_minimum_wage_test.rb
+++ b/test/integration/smart_answer_flows/am_i_getting_minimum_wage_test.rb
@@ -1,11 +1,13 @@
 require_relative "../../test_helper"
 require_relative "flow_test_helper"
 
+require "smart_answer_flows/am-i-getting-minimum-wage"
+
 class AmIGettingMinimumWageTest < ActiveSupport::TestCase
   include FlowTestHelper
 
   setup do
-    setup_for_testing_flow "am-i-getting-minimum-wage"
+    setup_for_testing_flow SmartAnswer::AmIGettingMinimumWageFlow
   end
 
   # Q1

--- a/test/integration/smart_answer_flows/appeal_a_benefits_decision_test.rb
+++ b/test/integration/smart_answer_flows/appeal_a_benefits_decision_test.rb
@@ -2,11 +2,13 @@
 require_relative '../../test_helper'
 require_relative 'flow_test_helper'
 
+require "smart_answer_flows/appeal-a-benefits-decision"
+
 class AppealABenefitsDecisionTest < ActiveSupport::TestCase
   include FlowTestHelper
 
   setup do
-    setup_for_testing_flow 'appeal-a-benefits-decision'
+    setup_for_testing_flow SmartAnswer::AppealABenefitsDecisionFlow
   end
   # Q1
   should "ask 'already appealed the decision?'" do

--- a/test/integration/smart_answer_flows/apply_tier_4_visa_test.rb
+++ b/test/integration/smart_answer_flows/apply_tier_4_visa_test.rb
@@ -2,11 +2,13 @@
 require_relative '../../test_helper'
 require_relative 'flow_test_helper'
 
+require "smart_answer_flows/apply-tier-4-visa"
+
 class ApplyTier4VisaTest < ActiveSupport::TestCase
   include FlowTestHelper
 
   setup do
-    setup_for_testing_flow 'apply-tier-4-visa'
+    setup_for_testing_flow SmartAnswer::ApplyTier4VisaFlow
   end
 
   should "Ask are you going to do" do

--- a/test/integration/smart_answer_flows/benefit_cap_calculator_test.rb
+++ b/test/integration/smart_answer_flows/benefit_cap_calculator_test.rb
@@ -2,11 +2,13 @@
 require_relative '../../test_helper'
 require_relative 'flow_test_helper'
 
+require "smart_answer_flows/benefit-cap-calculator"
+
 class BenefitCapCalculatorTest < ActiveSupport::TestCase
   include FlowTestHelper
 
   setup do
-    setup_for_testing_flow 'benefit-cap-calculator'
+    setup_for_testing_flow SmartAnswer::BenefitCapCalculatorFlow
   end
 
   context "Benefit cap calculator" do

--- a/test/integration/smart_answer_flows/benefits_abroad_test.rb
+++ b/test/integration/smart_answer_flows/benefits_abroad_test.rb
@@ -3,12 +3,14 @@ require_relative '../../test_helper'
 require_relative 'flow_test_helper'
 require 'gds_api/test_helpers/worldwide'
 
+require "smart_answer_flows/benefits-abroad"
+
 class BenefitsAbroadTest < ActiveSupport::TestCase
   include FlowTestHelper
   include GdsApi::TestHelpers::Worldwide
 
   setup do
-    setup_for_testing_flow 'benefits-abroad'
+    setup_for_testing_flow SmartAnswer::BenefitsAbroadFlow
     worldwide_api_has_locations %w(australia barbados belarus brazil brunei canada chad
           croatia denmark eritrea france ghana iceland japan laos luxembourg malta
           micronesia mozambique nicaragua panama portugal turkey venezuela vietnam)

--- a/test/integration/smart_answer_flows/calculate_agricultural_holiday_entitlement_test.rb
+++ b/test/integration/smart_answer_flows/calculate_agricultural_holiday_entitlement_test.rb
@@ -2,11 +2,13 @@
 require_relative '../../test_helper'
 require_relative 'flow_test_helper'
 
+require "smart_answer_flows/calculate-agricultural-holiday-entitlement"
+
 class CalculateAgriculturalHolidayEntitlementTest < ActiveSupport::TestCase
   include FlowTestHelper
 
   setup do
-    setup_for_testing_flow 'calculate-agricultural-holiday-entitlement'
+    setup_for_testing_flow SmartAnswer::CalculateAgriculturalHolidayEntitlementFlow
   end
 
   should "ask what your days worked per week is" do

--- a/test/integration/smart_answer_flows/calculate_child_maintenance_test.rb
+++ b/test/integration/smart_answer_flows/calculate_child_maintenance_test.rb
@@ -2,11 +2,13 @@
 require_relative '../../test_helper'
 require_relative 'flow_test_helper'
 
+require "smart_answer_flows/calculate-your-child-maintenance"
+
 class CalculateChildMaintentanceTest < ActiveSupport::TestCase
   include FlowTestHelper
 
   setup do
-    setup_for_testing_flow 'calculate-your-child-maintenance'
+    setup_for_testing_flow SmartAnswer::CalculateYourChildMaintenanceFlow
   end
 
   ## Q0

--- a/test/integration/smart_answer_flows/calculate_married_couples_allowance_test.rb
+++ b/test/integration/smart_answer_flows/calculate_married_couples_allowance_test.rb
@@ -2,11 +2,13 @@
 require_relative '../../test_helper'
 require_relative 'flow_test_helper'
 
+require "smart_answer_flows/calculate-married-couples-allowance"
+
 class CalculateMarriedCouplesAllowanceTest < ActiveSupport::TestCase
   include FlowTestHelper
 
   setup do
-    setup_for_testing_flow 'calculate-married-couples-allowance'
+    setup_for_testing_flow SmartAnswer::CalculateMarriedCouplesAllowanceFlow
   end
 
   should "ask if you or partner were born before April 1935" do

--- a/test/integration/smart_answer_flows/calculate_state_pension_test.rb
+++ b/test/integration/smart_answer_flows/calculate_state_pension_test.rb
@@ -1,11 +1,13 @@
 require_relative '../../test_helper'
 require_relative 'flow_test_helper'
 
+require "smart_answer_flows/calculate-state-pension"
+
 class CalculateStatePensionTest < ActiveSupport::TestCase
   include FlowTestHelper
 
   setup do
-    setup_for_testing_flow 'calculate-state-pension'
+    setup_for_testing_flow SmartAnswer::CalculateStatePensionFlow
   end
 
   should "ask which calculation to perform" do

--- a/test/integration/smart_answer_flows/calculate_your_holiday_entitlement_test.rb
+++ b/test/integration/smart_answer_flows/calculate_your_holiday_entitlement_test.rb
@@ -2,11 +2,13 @@
 require_relative '../../test_helper'
 require_relative 'flow_test_helper'
 
+require "smart_answer_flows/calculate-your-holiday-entitlement"
+
 class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
   include FlowTestHelper
 
   setup do
-    setup_for_testing_flow 'calculate-your-holiday-entitlement'
+    setup_for_testing_flow SmartAnswer::CalculateYourHolidayEntitlementFlow
     @stubbed_calculator = SmartAnswer::Calculators::HolidayEntitlement.new
   end
 

--- a/test/integration/smart_answer_flows/check_uk_visa_test.rb
+++ b/test/integration/smart_answer_flows/check_uk_visa_test.rb
@@ -3,6 +3,8 @@ require_relative '../../test_helper'
 require_relative 'flow_test_helper'
 require 'gds_api/test_helpers/worldwide'
 
+require "smart_answer_flows/check-uk-visa"
+
 class CheckUkVisaTest < ActiveSupport::TestCase
   include FlowTestHelper
   include GdsApi::TestHelpers::Worldwide
@@ -10,7 +12,7 @@ class CheckUkVisaTest < ActiveSupport::TestCase
   setup do
     @location_slugs = %w(andorra anguilla armenia bolivia canada china colombia croatia mexico south-africa stateless-or-refugee syria turkey yemen oman united-arab-emirates qatar taiwan venezuela)
     worldwide_api_has_locations(@location_slugs)
-    setup_for_testing_flow 'check-uk-visa'
+    setup_for_testing_flow SmartAnswer::CheckUkVisaFlow
   end
 
   should "ask what passport do you have" do

--- a/test/integration/smart_answer_flows/check_uk_visa_v2_test.rb
+++ b/test/integration/smart_answer_flows/check_uk_visa_v2_test.rb
@@ -3,6 +3,8 @@ require_relative '../../test_helper'
 require_relative 'flow_test_helper'
 require 'gds_api/test_helpers/worldwide'
 
+require "smart_answer_flows/check-uk-visa-v2"
+
 class CheckUkVisaV2Test < ActiveSupport::TestCase
   include FlowTestHelper
   include GdsApi::TestHelpers::Worldwide
@@ -10,7 +12,7 @@ class CheckUkVisaV2Test < ActiveSupport::TestCase
   setup do
     @location_slugs = %w(andorra anguilla armenia bolivia canada china colombia croatia mexico south-africa stateless-or-refugee syria turkey yemen oman united-arab-emirates qatar taiwan venezuela)
     worldwide_api_has_locations(@location_slugs)
-    setup_for_testing_flow 'check-uk-visa-v2'
+    setup_for_testing_flow SmartAnswer::CheckUkVisaV2Flow
   end
 
   should "ask what passport do you have" do

--- a/test/integration/smart_answer_flows/childcare_costs_for_tax_credits_test.rb
+++ b/test/integration/smart_answer_flows/childcare_costs_for_tax_credits_test.rb
@@ -2,11 +2,13 @@
 require_relative '../../test_helper'
 require_relative 'flow_test_helper'
 
+require "smart_answer_flows/childcare-costs-for-tax-credits"
+
 class ChildcareCostsForTaxCreditsV2Test < ActiveSupport::TestCase
   include FlowTestHelper
 
   setup do
-    setup_for_testing_flow 'childcare-costs-for-tax-credits'
+    setup_for_testing_flow SmartAnswer::ChildcareCostsForTaxCreditsFlow
   end
 
   context "answering Q1" do

--- a/test/integration/smart_answer_flows/energy_grants_calculator_test.rb
+++ b/test/integration/smart_answer_flows/energy_grants_calculator_test.rb
@@ -2,11 +2,13 @@
 require_relative '../../test_helper'
 require_relative 'flow_test_helper'
 
+require "smart_answer_flows/energy-grants-calculator"
+
 class EnergyGrantsCalculatorTest < ActiveSupport::TestCase
   include FlowTestHelper
 
   setup do
-    setup_for_testing_flow 'energy-grants-calculator'
+    setup_for_testing_flow SmartAnswer::EnergyGrantsCalculatorFlow
   end
 
   context "Energy grants calculator" do

--- a/test/integration/smart_answer_flows/estimate_self_assessment_penalties_test.rb
+++ b/test/integration/smart_answer_flows/estimate_self_assessment_penalties_test.rb
@@ -1,6 +1,8 @@
 require_relative "../../test_helper"
 require_relative "flow_test_helper"
 
+require "smart_answer_flows/estimate-self-assessment-penalties"
+
 TEST_CALCULATOR_DATES = {
   online_filing_deadline: {
     :"2011-12" => Date.new(2013, 1, 31),
@@ -22,7 +24,7 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
   include FlowTestHelper
 
   setup do
-    setup_for_testing_flow "estimate-self-assessment-penalties"
+    setup_for_testing_flow SmartAnswer::EstimateSelfAssessmentPenaltiesFlow
   end
 
   should "ask which year you want to estimate" do

--- a/test/integration/smart_answer_flows/flow_test_helper.rb
+++ b/test/integration/smart_answer_flows/flow_test_helper.rb
@@ -3,8 +3,7 @@ module FlowTestHelper
     if flow_slug_or_class.is_a?(String)
       @flow = SmartAnswer::FlowRegistry.instance.find(flow_slug_or_class)
     else
-      @flow = flow_slug_or_class.new
-      @flow.define
+      @flow = flow_slug_or_class.build
     end
     @responses = []
   end

--- a/test/integration/smart_answer_flows/flow_test_helper.rb
+++ b/test/integration/smart_answer_flows/flow_test_helper.rb
@@ -1,6 +1,11 @@
 module FlowTestHelper
-  def setup_for_testing_flow(flow_slug)
-    @flow = SmartAnswer::FlowRegistry.instance.find(flow_slug)
+  def setup_for_testing_flow(flow_slug_or_class)
+    if flow_slug_or_class.is_a?(String)
+      @flow = SmartAnswer::FlowRegistry.instance.find(flow_slug_or_class)
+    else
+      @flow = flow_slug_or_class.new
+      @flow.define
+    end
     @responses = []
   end
 

--- a/test/integration/smart_answer_flows/help_if_you_are_arrested_abroad_test.rb
+++ b/test/integration/smart_answer_flows/help_if_you_are_arrested_abroad_test.rb
@@ -2,6 +2,8 @@ require_relative "../../test_helper"
 require_relative "flow_test_helper"
 require 'gds_api/test_helpers/worldwide'
 
+require "smart_answer_flows/help-if-you-are-arrested-abroad"
+
 class HelpIfYouAreArrestedAbroad < ActiveSupport::TestCase
   include FlowTestHelper
   include GdsApi::TestHelpers::Worldwide
@@ -9,7 +11,7 @@ class HelpIfYouAreArrestedAbroad < ActiveSupport::TestCase
   setup do
     @location_slugs = %w(aruba belgium greece iran syria)
     worldwide_api_has_locations(@location_slugs)
-    setup_for_testing_flow "help-if-you-are-arrested-abroad"
+    setup_for_testing_flow SmartAnswer::HelpIfYouAreArrestedAbroadFlow
   end
 
   should "ask which country the arrest is in" do

--- a/test/integration/smart_answer_flows/inherits_someone_dies_without_will_test.rb
+++ b/test/integration/smart_answer_flows/inherits_someone_dies_without_will_test.rb
@@ -2,11 +2,13 @@
 require_relative '../../test_helper'
 require_relative 'flow_test_helper'
 
+require "smart_answer_flows/inherits-someone-dies-without-will"
+
 class InheritsSomeoneDiesWithoutWillTest < ActiveSupport::TestCase
   include FlowTestHelper
 
   setup do
-    setup_for_testing_flow 'inherits-someone-dies-without-will'
+    setup_for_testing_flow SmartAnswer::InheritsSomeoneDiesWithoutWillFlow
   end
 
   context "england-and-wales" do

--- a/test/integration/smart_answer_flows/legalisation_document_checker_test.rb
+++ b/test/integration/smart_answer_flows/legalisation_document_checker_test.rb
@@ -2,11 +2,13 @@
 require_relative "../../test_helper"
 require_relative "flow_test_helper"
 
+require "smart_answer_flows/legalisation-document-checker"
+
 class DocumentLegalisationCheckerTest < ActiveSupport::TestCase
   include FlowTestHelper
 
   setup do
-    setup_for_testing_flow "legalisation-document-checker"
+    setup_for_testing_flow SmartAnswer::LegalisationDocumentCheckerFlow
   end
 
   should "ask which documents you would like legalised" do

--- a/test/integration/smart_answer_flows/maternity_calculator_test.rb
+++ b/test/integration/smart_answer_flows/maternity_calculator_test.rb
@@ -3,12 +3,14 @@ require_relative '../../test_helper'
 require_relative 'flow_test_helper'
 require_relative '../../../lib/smart_answer/date_helper'
 
+require "smart_answer_flows/maternity-paternity-calculator"
+
 class MaternityCalculatorTest < ActiveSupport::TestCase
   include DateHelper
   include FlowTestHelper
 
   setup do
-    setup_for_testing_flow 'maternity-paternity-calculator'
+    setup_for_testing_flow SmartAnswer::MaternityPaternityCalculatorFlow
   end
   ## Q1
   should "ask what type of leave or pay you want to check" do

--- a/test/integration/smart_answer_flows/minimum_wage_calculator_employers_test.rb
+++ b/test/integration/smart_answer_flows/minimum_wage_calculator_employers_test.rb
@@ -1,11 +1,13 @@
 require_relative "../../test_helper"
 require_relative "flow_test_helper"
 
+require "smart_answer_flows/minimum-wage-calculator-employers"
+
 class MinimumWageCalculatorEmployersTest < ActiveSupport::TestCase
   include FlowTestHelper
 
   setup do
-    setup_for_testing_flow "minimum-wage-calculator-employers"
+    setup_for_testing_flow SmartAnswer::MinimumWageCalculatorEmployersFlow
   end
 
   # Q1

--- a/test/integration/smart_answer_flows/overseas_passports_test.rb
+++ b/test/integration/smart_answer_flows/overseas_passports_test.rb
@@ -3,6 +3,8 @@ require_relative '../../test_helper'
 require_relative 'flow_test_helper'
 require 'gds_api/test_helpers/worldwide'
 
+require "smart_answer_flows/overseas-passports"
+
 class OverseasPassportsTest < ActiveSupport::TestCase
   include FlowTestHelper
   include GdsApi::TestHelpers::Worldwide
@@ -10,7 +12,7 @@ class OverseasPassportsTest < ActiveSupport::TestCase
   setup do
     @location_slugs = %w(albania algeria afghanistan australia austria azerbaijan bahamas bangladesh benin british-indian-ocean-territory burma burundi cambodia cameroon china congo georgia greece haiti hong-kong india iran iraq ireland italy jamaica jordan kenya kyrgyzstan laos malta nepal nigeria pakistan pitcairn-island saudi-arabia syria south-africa spain sri-lanka st-helena-ascension-and-tristan-da-cunha st-maarten st-martin tajikistan tanzania timor-leste turkey turkmenistan ukraine united-kingdom united-arab-emirates usa uzbekistan yemen zimbabwe venezuela vietnam zambia)
     worldwide_api_has_locations(@location_slugs)
-    setup_for_testing_flow 'overseas-passports'
+    setup_for_testing_flow SmartAnswer::OverseasPassportsFlow
   end
 
   ## Q1

--- a/test/integration/smart_answer_flows/paternity_calculator_test.rb
+++ b/test/integration/smart_answer_flows/paternity_calculator_test.rb
@@ -3,12 +3,14 @@ require_relative '../../test_helper'
 require_relative 'flow_test_helper'
 require_relative '../../../lib/smart_answer/date_helper'
 
+require "smart_answer_flows/maternity-paternity-calculator"
+
 class PaternityCalculatorTest < ActiveSupport::TestCase
   include DateHelper
   include FlowTestHelper
 
   setup do
-    setup_for_testing_flow 'maternity-paternity-calculator'
+    setup_for_testing_flow SmartAnswer::MaternityPaternityCalculatorFlow
   end
   ## Q1
   should "ask what type of leave or pay you want to check" do

--- a/test/integration/smart_answer_flows/pip_checker_test.rb
+++ b/test/integration/smart_answer_flows/pip_checker_test.rb
@@ -2,11 +2,13 @@
 require_relative '../../test_helper'
 require_relative 'flow_test_helper'
 
+require "smart_answer_flows/pip-checker"
+
 class PIPCheckerTest < ActiveSupport::TestCase
   include FlowTestHelper
 
   setup do
-    setup_for_testing_flow 'pip-checker'
+    setup_for_testing_flow SmartAnswer::PipCheckerFlow
   end
 
   should "ask if you're getting DLA" do

--- a/test/integration/smart_answer_flows/plan_adoption_leave_test.rb
+++ b/test/integration/smart_answer_flows/plan_adoption_leave_test.rb
@@ -2,12 +2,14 @@
 require_relative '../../test_helper'
 require_relative 'flow_test_helper'
 
+require "smart_answer_flows/plan-adoption-leave"
+
 class PlanAdoptionLeaveTest < ActiveSupport::TestCase
   include FlowTestHelper
 
   context "test basic flow" do
     setup do
-      setup_for_testing_flow 'plan-adoption-leave'
+      setup_for_testing_flow SmartAnswer::PlanAdoptionLeaveFlow
     end
 
     should "start on the baby_due_date? question" do

--- a/test/integration/smart_answer_flows/register_a_birth_test.rb
+++ b/test/integration/smart_answer_flows/register_a_birth_test.rb
@@ -3,6 +3,8 @@ require_relative '../../test_helper'
 require_relative 'flow_test_helper'
 require 'gds_api/test_helpers/worldwide'
 
+require "smart_answer_flows/register-a-birth"
+
 class RegisterABirthTest < ActiveSupport::TestCase
   include FlowTestHelper
   include GdsApi::TestHelpers::Worldwide
@@ -10,7 +12,7 @@ class RegisterABirthTest < ActiveSupport::TestCase
   setup do
     @location_slugs = %w(afghanistan algeria andorra australia bangladesh barbados belize cambodia cameroon democratic-republic-of-congo el-salvador estonia germany guatemala grenada india iran iraq israel laos libya maldives morocco netherlands north-korea pakistan philippines serbia sierra-leone spain sri-lanka st-kitts-and-nevis thailand turkey uganda united-arab-emirates venezuela)
     worldwide_api_has_locations(@location_slugs)
-    setup_for_testing_flow 'register-a-birth'
+    setup_for_testing_flow SmartAnswer::RegisterABirthFlow
   end
 
   should "ask which country the child was born in" do

--- a/test/integration/smart_answer_flows/register_a_death_test.rb
+++ b/test/integration/smart_answer_flows/register_a_death_test.rb
@@ -3,6 +3,8 @@ require_relative '../../test_helper'
 require_relative 'flow_test_helper'
 require 'gds_api/test_helpers/worldwide'
 
+require "smart_answer_flows/register-a-death"
+
 class RegisterADeathTest < ActiveSupport::TestCase
   include FlowTestHelper
   include GdsApi::TestHelpers::Worldwide
@@ -10,7 +12,7 @@ class RegisterADeathTest < ActiveSupport::TestCase
   setup do
     @location_slugs = %w(afghanistan algeria andorra argentina australia austria barbados belgium brazil cameroon dominica egypt france germany iran italy kenya libya morocco nigeria north-korea pakistan  poland serbia slovakia spain st-kitts-and-nevis uganda)
     worldwide_api_has_locations(@location_slugs)
-    setup_for_testing_flow 'register-a-death'
+    setup_for_testing_flow SmartAnswer::RegisterADeathFlow
   end
 
   should "ask where the death happened" do

--- a/test/integration/smart_answer_flows/report_a_lost_or_stolen_passport_test.rb
+++ b/test/integration/smart_answer_flows/report_a_lost_or_stolen_passport_test.rb
@@ -2,6 +2,8 @@ require_relative "../../test_helper"
 require_relative "flow_test_helper"
 require 'gds_api/test_helpers/worldwide'
 
+require "smart_answer_flows/report-a-lost-or-stolen-passport"
+
 class ReportALostOrStolenPassportV2Test < ActiveSupport::TestCase
   include FlowTestHelper
   include GdsApi::TestHelpers::Worldwide
@@ -13,7 +15,7 @@ class ReportALostOrStolenPassportV2Test < ActiveSupport::TestCase
       json = read_fixture_file("worldwide/#{location}_organisations.json")
       worldwide_api_has_organisations_for_location(location, json)
     end
-    setup_for_testing_flow "report-a-lost-or-stolen-passport"
+    setup_for_testing_flow SmartAnswer::ReportALostOrStolenPassportFlow
   end
 
   should "ask where the passport was lost or stolen" do

--- a/test/integration/smart_answer_flows/simplified_expenses_checker_test.rb
+++ b/test/integration/smart_answer_flows/simplified_expenses_checker_test.rb
@@ -1,11 +1,13 @@
 require_relative "../../test_helper"
 require_relative "flow_test_helper"
 
+require "smart_answer_flows/simplified-expenses-checker"
+
 class SimplifiedExpensesCheckerTest < ActiveSupport::TestCase
   include FlowTestHelper
 
   setup do
-    setup_for_testing_flow "simplified-expenses-checker"
+    setup_for_testing_flow SmartAnswer::SimplifiedExpensesCheckerFlow
   end
 
   context "you can't use simplified expenses result (Q1, Q2, result 1)" do

--- a/test/integration/smart_answer_flows/simplified_expenses_checker_v2_test.rb
+++ b/test/integration/smart_answer_flows/simplified_expenses_checker_v2_test.rb
@@ -1,11 +1,13 @@
 require_relative "../../test_helper"
 require_relative "flow_test_helper"
 
+require "smart_answer_flows/simplified-expenses-checker-v2"
+
 class SimplifiedExpensesCheckerV2Test < ActiveSupport::TestCase
   include FlowTestHelper
 
   setup do
-    setup_for_testing_flow "simplified-expenses-checker-v2"
+    setup_for_testing_flow SmartAnswer::SimplifiedExpensesCheckerV2Flow
   end
 
   context "you can't use simplified expenses result (Q1, Q2, result 1)" do

--- a/test/integration/smart_answer_flows/state_pension_through_partner_test.rb
+++ b/test/integration/smart_answer_flows/state_pension_through_partner_test.rb
@@ -4,11 +4,13 @@ require_relative '../../test_helper'
 require_relative 'flow_test_helper'
 require 'gds_api/test_helpers/worldwide'
 
+require "smart_answer_flows/state-pension-through-partner"
+
 class StatePensionThroughPartnerTest < ActiveSupport::TestCase
   include FlowTestHelper
 
   setup do
-    setup_for_testing_flow 'state-pension-through-partner'
+    setup_for_testing_flow SmartAnswer::StatePensionThroughPartnerFlow
   end
 
   context "old1 - married" do

--- a/test/integration/smart_answer_flows/state_pension_topup_test.rb
+++ b/test/integration/smart_answer_flows/state_pension_topup_test.rb
@@ -2,11 +2,13 @@
 require_relative '../../test_helper'
 require_relative 'flow_test_helper'
 
+require "smart_answer_flows/state-pension-topup"
+
 class CalculateStatePensionTopupTest < ActiveSupport::TestCase
   include FlowTestHelper
 
   setup do
-    setup_for_testing_flow 'state-pension-topup'
+    setup_for_testing_flow SmartAnswer::StatePensionTopupFlow
   end
 
   should "ask date of birth" do

--- a/test/integration/smart_answer_flows/student_finance_calculator_test.rb
+++ b/test/integration/smart_answer_flows/student_finance_calculator_test.rb
@@ -2,11 +2,13 @@
 require_relative '../../test_helper'
 require_relative 'flow_test_helper'
 
+require "smart_answer_flows/student-finance-calculator"
+
 class StudentFinanceCalculatorTest < ActiveSupport::TestCase
   include FlowTestHelper
 
   setup do
-    setup_for_testing_flow 'student-finance-calculator'
+    setup_for_testing_flow SmartAnswer::StudentFinanceCalculatorFlow
   end
 
   should "ask when your course starts" do

--- a/test/integration/smart_answer_flows/towing_rules_test.rb
+++ b/test/integration/smart_answer_flows/towing_rules_test.rb
@@ -2,11 +2,13 @@
 require_relative '../../test_helper'
 require_relative 'flow_test_helper'
 
+require "smart_answer_flows/towing-rules"
+
 class TowingRulesTest < ActiveSupport::TestCase
   include FlowTestHelper
 
   setup do
-    setup_for_testing_flow 'towing-rules'
+    setup_for_testing_flow SmartAnswer::TowingRulesFlow
   end
   ## Cars and light vehicles
   ##

--- a/test/integration/smart_answer_flows/uk_benefits_abroad_test.rb
+++ b/test/integration/smart_answer_flows/uk_benefits_abroad_test.rb
@@ -3,12 +3,14 @@ require_relative '../../test_helper'
 require_relative 'flow_test_helper'
 require 'gds_api/test_helpers/worldwide'
 
+require "smart_answer_flows/uk-benefits-abroad"
+
 class UKBenefitsAbroadTest < ActiveSupport::TestCase
   include FlowTestHelper
   include GdsApi::TestHelpers::Worldwide
 
   setup do
-    setup_for_testing_flow 'uk-benefits-abroad'
+    setup_for_testing_flow SmartAnswer::UkBenefitsAbroadFlow
     worldwide_api_has_locations %w(albania austria canada jamaica kosovo)
   end
 

--- a/test/integration/smart_answer_flows/vat_payment_deadlines_test.rb
+++ b/test/integration/smart_answer_flows/vat_payment_deadlines_test.rb
@@ -2,13 +2,15 @@
 require_relative '../../test_helper'
 require_relative 'flow_test_helper'
 
+require "smart_answer_flows/vat-payment-deadlines"
+
 class VatPaymentDeadlinesTest < ActiveSupport::TestCase
   include FlowTestHelper
 
   setup do
     WebMock.stub_request(:get, WorkingDays::BANK_HOLIDAYS_URL).
       to_return(body: File.open(fixture_file('bank_holidays.json')))
-    setup_for_testing_flow 'vat-payment-deadlines'
+    setup_for_testing_flow SmartAnswer::VatPaymentDeadlinesFlow
   end
 
   should "ask when your VAT accounting period ends" do


### PR DESCRIPTION
The motivation behind this is to reduce our dependency on the `SmartAnswer::FlowRegistry` in the hope that this will make it possible to simplify or even remove the `FLOW_REGISTRY_OPTIONS` mechanism for configuring the registry singleton. I also think this change makes the tests simpler and more explicit.

I've converted the integration tests for all of the smart answer flows, **except** the following which are currently being worked on by @tadast & @BenJanecke:

* calculate-employee-redundancy-pay
* calculate-your-redundancy-pay
* calculate-statutory-sick-pay
* marriage-abroad

Once these ones have been made, we should be able to simplify the code in `FlowTestHelper#setup_for_testing_flow`.