### PR TITLE
Use erb templates for additional commodity code outcome titles

### DIFF
--- a/lib/smart_answer_flows/additional-commodity-code.rb
+++ b/lib/smart_answer_flows/additional-commodity-code.rb
@@ -176,14 +176,6 @@ module SmartAnswer
         precalculate :commodity_code do
           calculator.commodity_code
         end
-
-        precalculate :conditional_result do
-          if commodity_code == 'X'
-            PhraseList.new(:result_with_no_commodity_code)
-          else
-            PhraseList.new(:result_with_commodity_code)
-          end
-        end
       end
     end
   end

--- a/lib/smart_answer_flows/additional-commodity-code.rb
+++ b/lib/smart_answer_flows/additional-commodity-code.rb
@@ -176,6 +176,10 @@ module SmartAnswer
         precalculate :commodity_code do
           calculator.commodity_code
         end
+
+        precalculate :has_commodity_code? do
+          commodity_code != 'X'
+        end
       end
     end
   end

--- a/lib/smart_answer_flows/additional-commodity-code/commodity_code_result.txt.erb
+++ b/lib/smart_answer_flows/additional-commodity-code/commodity_code_result.txt.erb
@@ -1,3 +1,3 @@
-<% if commodity_code != 'X' -%>
+<% if has_commodity_code? -%>
 Use these four digits together with the ten-digit commodity code from Trade Tariff.
 <% end -%>

--- a/lib/smart_answer_flows/additional-commodity-code/commodity_code_result_title.txt.erb
+++ b/lib/smart_answer_flows/additional-commodity-code/commodity_code_result_title.txt.erb
@@ -1,4 +1,4 @@
-<% if commodity_code == 'X' -%>
+<% unless has_commodity_code? -%>
 The product composition you indicated is not possible.
 <% else -%>
 The Meursing code for a product with this composition is 7<%= commodity_code %>.

--- a/lib/smart_answer_flows/additional-commodity-code/commodity_code_result_title.txt.erb
+++ b/lib/smart_answer_flows/additional-commodity-code/commodity_code_result_title.txt.erb
@@ -1,0 +1,5 @@
+<% if commodity_code == 'X' -%>
+The product composition you indicated is not possible.
+<% else -%>
+The Meursing code for a product with this composition is 7<%= commodity_code %>.
+<% end -%>

--- a/lib/smart_answer_flows/locales/en/additional-commodity-code.yml
+++ b/lib/smart_answer_flows/locales/en/additional-commodity-code.yml
@@ -6,9 +6,6 @@ en-GB:
         Use this tool to look up the additional code (Meursing code) for import or export of goods containing certain types of milk and sugars covered Regulation (EC) No. 1216/09.
       meta:
         description: Look up the additional code (Meursing code) required for import or export of goods containing certain types of milk and sugars
-      phrases:
-        result_with_commodity_code: The Meursing code for a product with this composition is 7%{commodity_code}.
-        result_with_no_commodity_code: The product composition you indicated is not possible.
       how_much_starch_glucose?:
         title: How much starch or glucose does the product contain?
         hint: The values represent % by weight
@@ -101,5 +98,3 @@ en-GB:
         options:
           "0": "0-5.99"
           "6": "6 or more"
-      commodity_code_result:
-        title: "%{conditional_result}"


### PR DESCRIPTION
I've introduced support for using ERB templates to render Outcome titles, and updated the additional-commodity-code Smart Answer to use an ERB template.

There's currently some duplication between `OutcomePresenter#title` and `OutcomePresenter#body` but I plan to address that separately.