### PR TITLE
Check for missing outcome artefacts in regression tests

### DIFF
--- a/lib/smart_answer_test_helper.rb
+++ b/lib/smart_answer_test_helper.rb
@@ -41,9 +41,13 @@ class SmartAnswerTestHelper
     YAML.load(responses_and_expected_results_yaml)
   end
 
+  def path_to_outputs_for_flow
+    artefacts_path.join(@flow_name)
+  end
+
   def save_output(responses, response)
     filename = [responses.join('-'), 'html'].join('.')
-    path = artefacts_path.join(@flow_name)
+    path = path_to_outputs_for_flow
     FileUtils.mkdir_p(path)
     path_to_output = path.join(filename)
     File.open(path_to_output, 'w') do |file|

--- a/test/regression/smart_answers_regression_test.rb
+++ b/test/regression/smart_answers_regression_test.rb
@@ -2,6 +2,9 @@ require_relative "../test_helper"
 require 'gds_api/test_helpers/content_api'
 
 class SmartAnswerResponsesAndExpectedResultsTest < ActionController::TestCase
+  self.i_suck_and_my_tests_are_order_dependent!
+  RUN_ME_LAST = 'zzzzzzzzzzz run me last'
+
   include GdsApi::TestHelpers::ContentApi
 
   tests SmartAnswersController
@@ -39,6 +42,11 @@ class SmartAnswerResponsesAndExpectedResultsTest < ActionController::TestCase
             assert_equal '', diff_output
           end
         end
+      end
+
+      should "#{RUN_ME_LAST} and generate the same set of output files" do
+        diff_output = `git diff --stat #{smart_answer_helper.path_to_outputs_for_flow}`
+        assert_equal '', diff_output, "Unexpected difference in outputs for flow:"
       end
     end
   end


### PR DESCRIPTION
A change to a flow (and its associated `questions-and-responses` & `responses-and-expected-results` files) can mean that one or more outcome HTML artefacts are no longer generated when the regression tests are run. We want the regression tests to fail in this scenario and that's the behaviour I've added in this PR.

I've also taken the opportunity to remove the parts of the old-style integration tests which cover outcome nodes, because these are now covered by the regression tests. I've belatedly realised that these may not belong in this PR, but let me know what you think.