### PR TITLE
Hack-fix failing autoloading of flows.

### DIFF
--- a/lib/smart_answer/flow_registry.rb
+++ b/lib/smart_answer/flow_registry.rb
@@ -95,6 +95,7 @@ module SmartAnswer
     def build_flow(name)
       if SMART_ANSWER_FLOW_NAMES.include?(name)
         class_prefix = name.gsub("-", "_").camelize
+        load "lib/smart_answer_flows/#{name}.rb" if Rails.env.development?
         namespaced_class = "SmartAnswer::#{class_prefix}Flow".constantize
         namespaced_class.build
       else


### PR DESCRIPTION
Now that most of the smart answer flows are classes
as of [this commit](https://github.com/alphagov/smart-answers/commit/0800f52b001f3d0d4bed9a497b7ab0aa2ce60f9d), in development environment
we get uninitialized constant SmartAnswer::<FlowName> error after changing the flow files and need to restart the server to reload the flow code correctly.

This is because the flows dir structure and namespaces do not follow rails conventions and autoloading fails. This is a rather hackish solution that force-reloads the class every time it is being loaded in dev environment.

Thoughts? 
@floehopper 