### PR TITLE
Add regression test to ensure all nodes are reached

### DIFF
--- a/script/generate-responses-and-expected-results-for-smart-answer.rb
+++ b/script/generate-responses-and-expected-results-for-smart-answer.rb
@@ -23,17 +23,18 @@ def answer_question(flow, state)
   existing_responses = state.responses
 
   QUESTIONS_AND_RESPONSES[question_name].each do |response|
-    responses    = existing_responses + [response]
-    state        = flow.process(responses)
-    current_node = flow.node(state.current_node)
+    responses = existing_responses + [response]
+    state     = flow.process(responses)
+    next_node = flow.node(state.current_node)
 
     RESPONSES_AND_EXPECTED_RESULTS << {
       current_node: question_name,
       responses: responses.map(&:to_s),
-      outcome_node: current_node.outcome?
+      next_node: next_node.name,
+      outcome_node: next_node.outcome?
     }
 
-    unless current_node.outcome? || state.error
+    unless next_node.outcome? || state.error
       answer_question(flow, state)
     end
   end

--- a/test/data/additional-commodity-code-files.yml
+++ b/test/data/additional-commodity-code-files.yml
@@ -2,7 +2,7 @@
 lib/smart_answer_flows/additional-commodity-code.rb: d7f38b15cd1c6e000f0cdc5f562f3912
 lib/smart_answer_flows/locales/en/additional-commodity-code.yml: 1bd6a7da656f81f10992dcbae147f9b5
 test/data/additional-commodity-code-questions-and-responses.yml: f2149cbfa6ec8c5ead572f0a89542a79
-test/data/additional-commodity-code-responses-and-expected-results.yml: af16012af254608b78a5b2953e742efd
+test/data/additional-commodity-code-responses-and-expected-results.yml: 6ca51c22f472dbe159ac81f31006a7b1
 lib/smart_answer_flows/additional-commodity-code/commodity_code_result_body.govspeak.erb: bf2f9f34f2146c74bdf08bf4fef64875
 lib/smart_answer_flows/additional-commodity-code/commodity_code_result_title.txt.erb: b4147ea8166904c0ab01c7f4063692bd
 lib/smart_answer/calculators/commodity_code_calculator.rb: e0aba9021dacb17e95d60337bdbed247

--- a/test/data/additional-commodity-code-responses-and-expected-results.yml
+++ b/test/data/additional-commodity-code-responses-and-expected-results.yml
@@ -2,17 +2,20 @@
 - :current_node: :how_much_starch_glucose?
   :responses: 
   - "0"
+  :next_node: :how_much_sucrose_1?
   :outcome_node: false
 - :current_node: :how_much_sucrose_1?
   :responses: 
   - "0"
   - "0"
+  :next_node: :how_much_milk_fat?
   :outcome_node: false
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "0"
   - "0"
+  :next_node: :how_much_milk_protein_ab?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -20,6 +23,7 @@
   - "0"
   - "0"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -27,6 +31,7 @@
   - "0"
   - "0"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -34,6 +39,7 @@
   - "0"
   - "0"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -41,6 +47,7 @@
   - "0"
   - "0"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -48,6 +55,7 @@
   - "0"
   - "0"
   - "30"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -55,12 +63,14 @@
   - "0"
   - "0"
   - "60"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "0"
   - "1"
+  :next_node: :how_much_milk_protein_ab?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -68,6 +78,7 @@
   - "0"
   - "1"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -75,6 +86,7 @@
   - "0"
   - "1"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -82,6 +94,7 @@
   - "0"
   - "1"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -89,6 +102,7 @@
   - "0"
   - "1"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -96,6 +110,7 @@
   - "0"
   - "1"
   - "30"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -103,12 +118,14 @@
   - "0"
   - "1"
   - "60"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "0"
   - "3"
+  :next_node: :how_much_milk_protein_c?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -116,6 +133,7 @@
   - "0"
   - "3"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -123,6 +141,7 @@
   - "0"
   - "3"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -130,12 +149,14 @@
   - "0"
   - "3"
   - "12"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "0"
   - "6"
+  :next_node: :how_much_milk_protein_d?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -143,6 +164,7 @@
   - "0"
   - "6"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -150,6 +172,7 @@
   - "0"
   - "6"
   - "4"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -157,12 +180,14 @@
   - "0"
   - "6"
   - "15"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "0"
   - "9"
+  :next_node: :how_much_milk_protein_ef?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -170,6 +195,7 @@
   - "0"
   - "9"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -177,6 +203,7 @@
   - "0"
   - "9"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -184,12 +211,14 @@
   - "0"
   - "9"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "0"
   - "12"
+  :next_node: :how_much_milk_protein_ef?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -197,6 +226,7 @@
   - "0"
   - "12"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -204,6 +234,7 @@
   - "0"
   - "12"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -211,12 +242,14 @@
   - "0"
   - "12"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "0"
   - "18"
+  :next_node: :how_much_milk_protein_gh?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -224,6 +257,7 @@
   - "0"
   - "18"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -231,12 +265,14 @@
   - "0"
   - "18"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "0"
   - "26"
+  :next_node: :how_much_milk_protein_gh?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -244,6 +280,7 @@
   - "0"
   - "26"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -251,41 +288,48 @@
   - "0"
   - "26"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "0"
   - "40"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "0"
   - "55"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "0"
   - "70"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "0"
   - "85"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_sucrose_1?
   :responses: 
   - "0"
   - "5"
+  :next_node: :how_much_milk_fat?
   :outcome_node: false
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "5"
   - "0"
+  :next_node: :how_much_milk_protein_ab?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -293,6 +337,7 @@
   - "5"
   - "0"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -300,6 +345,7 @@
   - "5"
   - "0"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -307,6 +353,7 @@
   - "5"
   - "0"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -314,6 +361,7 @@
   - "5"
   - "0"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -321,6 +369,7 @@
   - "5"
   - "0"
   - "30"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -328,12 +377,14 @@
   - "5"
   - "0"
   - "60"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "5"
   - "1"
+  :next_node: :how_much_milk_protein_ab?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -341,6 +392,7 @@
   - "5"
   - "1"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -348,6 +400,7 @@
   - "5"
   - "1"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -355,6 +408,7 @@
   - "5"
   - "1"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -362,6 +416,7 @@
   - "5"
   - "1"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -369,6 +424,7 @@
   - "5"
   - "1"
   - "30"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -376,12 +432,14 @@
   - "5"
   - "1"
   - "60"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "5"
   - "3"
+  :next_node: :how_much_milk_protein_c?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -389,6 +447,7 @@
   - "5"
   - "3"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -396,6 +455,7 @@
   - "5"
   - "3"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -403,12 +463,14 @@
   - "5"
   - "3"
   - "12"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "5"
   - "6"
+  :next_node: :how_much_milk_protein_d?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -416,6 +478,7 @@
   - "5"
   - "6"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -423,6 +486,7 @@
   - "5"
   - "6"
   - "4"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -430,12 +494,14 @@
   - "5"
   - "6"
   - "15"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "5"
   - "9"
+  :next_node: :how_much_milk_protein_ef?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -443,6 +509,7 @@
   - "5"
   - "9"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -450,6 +517,7 @@
   - "5"
   - "9"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -457,12 +525,14 @@
   - "5"
   - "9"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "5"
   - "12"
+  :next_node: :how_much_milk_protein_ef?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -470,6 +540,7 @@
   - "5"
   - "12"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -477,6 +548,7 @@
   - "5"
   - "12"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -484,12 +556,14 @@
   - "5"
   - "12"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "5"
   - "18"
+  :next_node: :how_much_milk_protein_gh?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -497,6 +571,7 @@
   - "5"
   - "18"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -504,12 +579,14 @@
   - "5"
   - "18"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "5"
   - "26"
+  :next_node: :how_much_milk_protein_gh?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -517,6 +594,7 @@
   - "5"
   - "26"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -524,41 +602,48 @@
   - "5"
   - "26"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "5"
   - "40"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "5"
   - "55"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "5"
   - "70"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "5"
   - "85"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_sucrose_1?
   :responses: 
   - "0"
   - "30"
+  :next_node: :how_much_milk_fat?
   :outcome_node: false
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "30"
   - "0"
+  :next_node: :how_much_milk_protein_ab?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -566,6 +651,7 @@
   - "30"
   - "0"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -573,6 +659,7 @@
   - "30"
   - "0"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -580,6 +667,7 @@
   - "30"
   - "0"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -587,6 +675,7 @@
   - "30"
   - "0"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -594,6 +683,7 @@
   - "30"
   - "0"
   - "30"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -601,12 +691,14 @@
   - "30"
   - "0"
   - "60"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "30"
   - "1"
+  :next_node: :how_much_milk_protein_ab?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -614,6 +706,7 @@
   - "30"
   - "1"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -621,6 +714,7 @@
   - "30"
   - "1"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -628,6 +722,7 @@
   - "30"
   - "1"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -635,6 +730,7 @@
   - "30"
   - "1"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -642,6 +738,7 @@
   - "30"
   - "1"
   - "30"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -649,12 +746,14 @@
   - "30"
   - "1"
   - "60"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "30"
   - "3"
+  :next_node: :how_much_milk_protein_c?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -662,6 +761,7 @@
   - "30"
   - "3"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -669,6 +769,7 @@
   - "30"
   - "3"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -676,12 +777,14 @@
   - "30"
   - "3"
   - "12"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "30"
   - "6"
+  :next_node: :how_much_milk_protein_d?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -689,6 +792,7 @@
   - "30"
   - "6"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -696,6 +800,7 @@
   - "30"
   - "6"
   - "4"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -703,12 +808,14 @@
   - "30"
   - "6"
   - "15"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "30"
   - "9"
+  :next_node: :how_much_milk_protein_ef?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -716,6 +823,7 @@
   - "30"
   - "9"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -723,6 +831,7 @@
   - "30"
   - "9"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -730,12 +839,14 @@
   - "30"
   - "9"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "30"
   - "12"
+  :next_node: :how_much_milk_protein_ef?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -743,6 +854,7 @@
   - "30"
   - "12"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -750,6 +862,7 @@
   - "30"
   - "12"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -757,12 +870,14 @@
   - "30"
   - "12"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "30"
   - "18"
+  :next_node: :how_much_milk_protein_gh?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -770,6 +885,7 @@
   - "30"
   - "18"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -777,12 +893,14 @@
   - "30"
   - "18"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "30"
   - "26"
+  :next_node: :how_much_milk_protein_gh?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -790,6 +908,7 @@
   - "30"
   - "26"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -797,41 +916,48 @@
   - "30"
   - "26"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "30"
   - "40"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "30"
   - "55"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "30"
   - "70"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "30"
   - "85"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_sucrose_1?
   :responses: 
   - "0"
   - "50"
+  :next_node: :how_much_milk_fat?
   :outcome_node: false
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "50"
   - "0"
+  :next_node: :how_much_milk_protein_ab?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -839,6 +965,7 @@
   - "50"
   - "0"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -846,6 +973,7 @@
   - "50"
   - "0"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -853,6 +981,7 @@
   - "50"
   - "0"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -860,6 +989,7 @@
   - "50"
   - "0"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -867,6 +997,7 @@
   - "50"
   - "0"
   - "30"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -874,12 +1005,14 @@
   - "50"
   - "0"
   - "60"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "50"
   - "1"
+  :next_node: :how_much_milk_protein_ab?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -887,6 +1020,7 @@
   - "50"
   - "1"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -894,6 +1028,7 @@
   - "50"
   - "1"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -901,6 +1036,7 @@
   - "50"
   - "1"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -908,6 +1044,7 @@
   - "50"
   - "1"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -915,6 +1052,7 @@
   - "50"
   - "1"
   - "30"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -922,12 +1060,14 @@
   - "50"
   - "1"
   - "60"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "50"
   - "3"
+  :next_node: :how_much_milk_protein_c?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -935,6 +1075,7 @@
   - "50"
   - "3"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -942,6 +1083,7 @@
   - "50"
   - "3"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -949,12 +1091,14 @@
   - "50"
   - "3"
   - "12"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "50"
   - "6"
+  :next_node: :how_much_milk_protein_d?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -962,6 +1106,7 @@
   - "50"
   - "6"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -969,6 +1114,7 @@
   - "50"
   - "6"
   - "4"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -976,12 +1122,14 @@
   - "50"
   - "6"
   - "15"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "50"
   - "9"
+  :next_node: :how_much_milk_protein_ef?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -989,6 +1137,7 @@
   - "50"
   - "9"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -996,6 +1145,7 @@
   - "50"
   - "9"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -1003,12 +1153,14 @@
   - "50"
   - "9"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "50"
   - "12"
+  :next_node: :how_much_milk_protein_ef?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -1016,6 +1168,7 @@
   - "50"
   - "12"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -1023,6 +1176,7 @@
   - "50"
   - "12"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -1030,12 +1184,14 @@
   - "50"
   - "12"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "50"
   - "18"
+  :next_node: :how_much_milk_protein_gh?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -1043,6 +1199,7 @@
   - "50"
   - "18"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -1050,12 +1207,14 @@
   - "50"
   - "18"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "50"
   - "26"
+  :next_node: :how_much_milk_protein_gh?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -1063,6 +1222,7 @@
   - "50"
   - "26"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -1070,41 +1230,48 @@
   - "50"
   - "26"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "50"
   - "40"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "50"
   - "55"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "50"
   - "70"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "50"
   - "85"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_sucrose_1?
   :responses: 
   - "0"
   - "70"
+  :next_node: :how_much_milk_fat?
   :outcome_node: false
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "70"
   - "0"
+  :next_node: :how_much_milk_protein_ab?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1112,6 +1279,7 @@
   - "70"
   - "0"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1119,6 +1287,7 @@
   - "70"
   - "0"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1126,6 +1295,7 @@
   - "70"
   - "0"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1133,6 +1303,7 @@
   - "70"
   - "0"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1140,6 +1311,7 @@
   - "70"
   - "0"
   - "30"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1147,12 +1319,14 @@
   - "70"
   - "0"
   - "60"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "70"
   - "1"
+  :next_node: :how_much_milk_protein_ab?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1160,6 +1334,7 @@
   - "70"
   - "1"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1167,6 +1342,7 @@
   - "70"
   - "1"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1174,6 +1350,7 @@
   - "70"
   - "1"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1181,6 +1358,7 @@
   - "70"
   - "1"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1188,6 +1366,7 @@
   - "70"
   - "1"
   - "30"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1195,12 +1374,14 @@
   - "70"
   - "1"
   - "60"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "70"
   - "3"
+  :next_node: :how_much_milk_protein_c?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -1208,6 +1389,7 @@
   - "70"
   - "3"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -1215,6 +1397,7 @@
   - "70"
   - "3"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -1222,12 +1405,14 @@
   - "70"
   - "3"
   - "12"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "70"
   - "6"
+  :next_node: :how_much_milk_protein_d?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -1235,6 +1420,7 @@
   - "70"
   - "6"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -1242,6 +1428,7 @@
   - "70"
   - "6"
   - "4"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -1249,12 +1436,14 @@
   - "70"
   - "6"
   - "15"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "70"
   - "9"
+  :next_node: :how_much_milk_protein_ef?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -1262,6 +1451,7 @@
   - "70"
   - "9"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -1269,6 +1459,7 @@
   - "70"
   - "9"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -1276,12 +1467,14 @@
   - "70"
   - "9"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "70"
   - "12"
+  :next_node: :how_much_milk_protein_ef?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -1289,6 +1482,7 @@
   - "70"
   - "12"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -1296,6 +1490,7 @@
   - "70"
   - "12"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -1303,12 +1498,14 @@
   - "70"
   - "12"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "70"
   - "18"
+  :next_node: :how_much_milk_protein_gh?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -1316,6 +1513,7 @@
   - "70"
   - "18"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -1323,12 +1521,14 @@
   - "70"
   - "18"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "70"
   - "26"
+  :next_node: :how_much_milk_protein_gh?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -1336,6 +1536,7 @@
   - "70"
   - "26"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -1343,45 +1544,53 @@
   - "70"
   - "26"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "70"
   - "40"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "70"
   - "55"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "70"
   - "70"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "0"
   - "70"
   - "85"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_starch_glucose?
   :responses: 
   - "5"
+  :next_node: :how_much_sucrose_1?
   :outcome_node: false
 - :current_node: :how_much_sucrose_1?
   :responses: 
   - "5"
   - "0"
+  :next_node: :how_much_milk_fat?
   :outcome_node: false
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "0"
   - "0"
+  :next_node: :how_much_milk_protein_ab?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1389,6 +1598,7 @@
   - "0"
   - "0"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1396,6 +1606,7 @@
   - "0"
   - "0"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1403,6 +1614,7 @@
   - "0"
   - "0"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1410,6 +1622,7 @@
   - "0"
   - "0"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1417,6 +1630,7 @@
   - "0"
   - "0"
   - "30"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1424,12 +1638,14 @@
   - "0"
   - "0"
   - "60"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "0"
   - "1"
+  :next_node: :how_much_milk_protein_ab?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1437,6 +1653,7 @@
   - "0"
   - "1"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1444,6 +1661,7 @@
   - "0"
   - "1"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1451,6 +1669,7 @@
   - "0"
   - "1"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1458,6 +1677,7 @@
   - "0"
   - "1"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1465,6 +1685,7 @@
   - "0"
   - "1"
   - "30"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1472,12 +1693,14 @@
   - "0"
   - "1"
   - "60"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "0"
   - "3"
+  :next_node: :how_much_milk_protein_c?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -1485,6 +1708,7 @@
   - "0"
   - "3"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -1492,6 +1716,7 @@
   - "0"
   - "3"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -1499,12 +1724,14 @@
   - "0"
   - "3"
   - "12"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "0"
   - "6"
+  :next_node: :how_much_milk_protein_d?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -1512,6 +1739,7 @@
   - "0"
   - "6"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -1519,6 +1747,7 @@
   - "0"
   - "6"
   - "4"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -1526,12 +1755,14 @@
   - "0"
   - "6"
   - "15"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "0"
   - "9"
+  :next_node: :how_much_milk_protein_ef?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -1539,6 +1770,7 @@
   - "0"
   - "9"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -1546,6 +1778,7 @@
   - "0"
   - "9"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -1553,12 +1786,14 @@
   - "0"
   - "9"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "0"
   - "12"
+  :next_node: :how_much_milk_protein_ef?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -1566,6 +1801,7 @@
   - "0"
   - "12"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -1573,6 +1809,7 @@
   - "0"
   - "12"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -1580,12 +1817,14 @@
   - "0"
   - "12"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "0"
   - "18"
+  :next_node: :how_much_milk_protein_gh?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -1593,6 +1832,7 @@
   - "0"
   - "18"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -1600,12 +1840,14 @@
   - "0"
   - "18"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "0"
   - "26"
+  :next_node: :how_much_milk_protein_gh?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -1613,6 +1855,7 @@
   - "0"
   - "26"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -1620,41 +1863,48 @@
   - "0"
   - "26"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "0"
   - "40"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "0"
   - "55"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "0"
   - "70"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "0"
   - "85"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_sucrose_1?
   :responses: 
   - "5"
   - "5"
+  :next_node: :how_much_milk_fat?
   :outcome_node: false
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "5"
   - "0"
+  :next_node: :how_much_milk_protein_ab?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1662,6 +1912,7 @@
   - "5"
   - "0"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1669,6 +1920,7 @@
   - "5"
   - "0"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1676,6 +1928,7 @@
   - "5"
   - "0"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1683,6 +1936,7 @@
   - "5"
   - "0"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1690,6 +1944,7 @@
   - "5"
   - "0"
   - "30"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1697,12 +1952,14 @@
   - "5"
   - "0"
   - "60"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "5"
   - "1"
+  :next_node: :how_much_milk_protein_ab?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1710,6 +1967,7 @@
   - "5"
   - "1"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1717,6 +1975,7 @@
   - "5"
   - "1"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1724,6 +1983,7 @@
   - "5"
   - "1"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1731,6 +1991,7 @@
   - "5"
   - "1"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1738,6 +1999,7 @@
   - "5"
   - "1"
   - "30"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1745,12 +2007,14 @@
   - "5"
   - "1"
   - "60"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "5"
   - "3"
+  :next_node: :how_much_milk_protein_c?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -1758,6 +2022,7 @@
   - "5"
   - "3"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -1765,6 +2030,7 @@
   - "5"
   - "3"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -1772,12 +2038,14 @@
   - "5"
   - "3"
   - "12"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "5"
   - "6"
+  :next_node: :how_much_milk_protein_d?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -1785,6 +2053,7 @@
   - "5"
   - "6"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -1792,6 +2061,7 @@
   - "5"
   - "6"
   - "4"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -1799,12 +2069,14 @@
   - "5"
   - "6"
   - "15"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "5"
   - "9"
+  :next_node: :how_much_milk_protein_ef?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -1812,6 +2084,7 @@
   - "5"
   - "9"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -1819,6 +2092,7 @@
   - "5"
   - "9"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -1826,12 +2100,14 @@
   - "5"
   - "9"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "5"
   - "12"
+  :next_node: :how_much_milk_protein_ef?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -1839,6 +2115,7 @@
   - "5"
   - "12"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -1846,6 +2123,7 @@
   - "5"
   - "12"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -1853,12 +2131,14 @@
   - "5"
   - "12"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "5"
   - "18"
+  :next_node: :how_much_milk_protein_gh?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -1866,6 +2146,7 @@
   - "5"
   - "18"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -1873,12 +2154,14 @@
   - "5"
   - "18"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "5"
   - "26"
+  :next_node: :how_much_milk_protein_gh?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -1886,6 +2169,7 @@
   - "5"
   - "26"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -1893,41 +2177,48 @@
   - "5"
   - "26"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "5"
   - "40"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "5"
   - "55"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "5"
   - "70"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "5"
   - "85"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_sucrose_1?
   :responses: 
   - "5"
   - "30"
+  :next_node: :how_much_milk_fat?
   :outcome_node: false
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "30"
   - "0"
+  :next_node: :how_much_milk_protein_ab?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1935,6 +2226,7 @@
   - "30"
   - "0"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1942,6 +2234,7 @@
   - "30"
   - "0"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1949,6 +2242,7 @@
   - "30"
   - "0"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1956,6 +2250,7 @@
   - "30"
   - "0"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1963,6 +2258,7 @@
   - "30"
   - "0"
   - "30"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1970,12 +2266,14 @@
   - "30"
   - "0"
   - "60"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "30"
   - "1"
+  :next_node: :how_much_milk_protein_ab?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1983,6 +2281,7 @@
   - "30"
   - "1"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1990,6 +2289,7 @@
   - "30"
   - "1"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -1997,6 +2297,7 @@
   - "30"
   - "1"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -2004,6 +2305,7 @@
   - "30"
   - "1"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -2011,6 +2313,7 @@
   - "30"
   - "1"
   - "30"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -2018,12 +2321,14 @@
   - "30"
   - "1"
   - "60"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "30"
   - "3"
+  :next_node: :how_much_milk_protein_c?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -2031,6 +2336,7 @@
   - "30"
   - "3"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -2038,6 +2344,7 @@
   - "30"
   - "3"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -2045,12 +2352,14 @@
   - "30"
   - "3"
   - "12"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "30"
   - "6"
+  :next_node: :how_much_milk_protein_d?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -2058,6 +2367,7 @@
   - "30"
   - "6"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -2065,6 +2375,7 @@
   - "30"
   - "6"
   - "4"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -2072,12 +2383,14 @@
   - "30"
   - "6"
   - "15"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "30"
   - "9"
+  :next_node: :how_much_milk_protein_ef?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -2085,6 +2398,7 @@
   - "30"
   - "9"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -2092,6 +2406,7 @@
   - "30"
   - "9"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -2099,12 +2414,14 @@
   - "30"
   - "9"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "30"
   - "12"
+  :next_node: :how_much_milk_protein_ef?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -2112,6 +2429,7 @@
   - "30"
   - "12"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -2119,6 +2437,7 @@
   - "30"
   - "12"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -2126,12 +2445,14 @@
   - "30"
   - "12"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "30"
   - "18"
+  :next_node: :how_much_milk_protein_gh?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -2139,6 +2460,7 @@
   - "30"
   - "18"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -2146,12 +2468,14 @@
   - "30"
   - "18"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "30"
   - "26"
+  :next_node: :how_much_milk_protein_gh?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -2159,6 +2483,7 @@
   - "30"
   - "26"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -2166,41 +2491,48 @@
   - "30"
   - "26"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "30"
   - "40"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "30"
   - "55"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "30"
   - "70"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "30"
   - "85"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_sucrose_1?
   :responses: 
   - "5"
   - "50"
+  :next_node: :how_much_milk_fat?
   :outcome_node: false
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "50"
   - "0"
+  :next_node: :how_much_milk_protein_ab?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -2208,6 +2540,7 @@
   - "50"
   - "0"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -2215,6 +2548,7 @@
   - "50"
   - "0"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -2222,6 +2556,7 @@
   - "50"
   - "0"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -2229,6 +2564,7 @@
   - "50"
   - "0"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -2236,6 +2572,7 @@
   - "50"
   - "0"
   - "30"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -2243,12 +2580,14 @@
   - "50"
   - "0"
   - "60"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "50"
   - "1"
+  :next_node: :how_much_milk_protein_ab?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -2256,6 +2595,7 @@
   - "50"
   - "1"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -2263,6 +2603,7 @@
   - "50"
   - "1"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -2270,6 +2611,7 @@
   - "50"
   - "1"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -2277,6 +2619,7 @@
   - "50"
   - "1"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -2284,6 +2627,7 @@
   - "50"
   - "1"
   - "30"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -2291,12 +2635,14 @@
   - "50"
   - "1"
   - "60"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "50"
   - "3"
+  :next_node: :how_much_milk_protein_c?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -2304,6 +2650,7 @@
   - "50"
   - "3"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -2311,6 +2658,7 @@
   - "50"
   - "3"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -2318,12 +2666,14 @@
   - "50"
   - "3"
   - "12"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "50"
   - "6"
+  :next_node: :how_much_milk_protein_d?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -2331,6 +2681,7 @@
   - "50"
   - "6"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -2338,6 +2689,7 @@
   - "50"
   - "6"
   - "4"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -2345,12 +2697,14 @@
   - "50"
   - "6"
   - "15"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "50"
   - "9"
+  :next_node: :how_much_milk_protein_ef?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -2358,6 +2712,7 @@
   - "50"
   - "9"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -2365,6 +2720,7 @@
   - "50"
   - "9"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -2372,12 +2728,14 @@
   - "50"
   - "9"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "50"
   - "12"
+  :next_node: :how_much_milk_protein_ef?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -2385,6 +2743,7 @@
   - "50"
   - "12"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -2392,6 +2751,7 @@
   - "50"
   - "12"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -2399,12 +2759,14 @@
   - "50"
   - "12"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "50"
   - "18"
+  :next_node: :how_much_milk_protein_gh?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -2412,6 +2774,7 @@
   - "50"
   - "18"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -2419,12 +2782,14 @@
   - "50"
   - "18"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "50"
   - "26"
+  :next_node: :how_much_milk_protein_gh?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -2432,6 +2797,7 @@
   - "50"
   - "26"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -2439,41 +2805,48 @@
   - "50"
   - "26"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "50"
   - "40"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "50"
   - "55"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "50"
   - "70"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "50"
   - "85"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_sucrose_1?
   :responses: 
   - "5"
   - "70"
+  :next_node: :how_much_milk_fat?
   :outcome_node: false
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "70"
   - "0"
+  :next_node: :how_much_milk_protein_ab?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -2481,6 +2854,7 @@
   - "70"
   - "0"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -2488,6 +2862,7 @@
   - "70"
   - "0"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -2495,6 +2870,7 @@
   - "70"
   - "0"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -2502,6 +2878,7 @@
   - "70"
   - "0"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -2509,6 +2886,7 @@
   - "70"
   - "0"
   - "30"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -2516,12 +2894,14 @@
   - "70"
   - "0"
   - "60"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "70"
   - "1"
+  :next_node: :how_much_milk_protein_ab?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -2529,6 +2909,7 @@
   - "70"
   - "1"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -2536,6 +2917,7 @@
   - "70"
   - "1"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -2543,6 +2925,7 @@
   - "70"
   - "1"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -2550,6 +2933,7 @@
   - "70"
   - "1"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -2557,6 +2941,7 @@
   - "70"
   - "1"
   - "30"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -2564,12 +2949,14 @@
   - "70"
   - "1"
   - "60"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "70"
   - "3"
+  :next_node: :how_much_milk_protein_c?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -2577,6 +2964,7 @@
   - "70"
   - "3"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -2584,6 +2972,7 @@
   - "70"
   - "3"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -2591,12 +2980,14 @@
   - "70"
   - "3"
   - "12"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "70"
   - "6"
+  :next_node: :how_much_milk_protein_d?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -2604,6 +2995,7 @@
   - "70"
   - "6"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -2611,6 +3003,7 @@
   - "70"
   - "6"
   - "4"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -2618,12 +3011,14 @@
   - "70"
   - "6"
   - "15"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "70"
   - "9"
+  :next_node: :how_much_milk_protein_ef?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -2631,6 +3026,7 @@
   - "70"
   - "9"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -2638,6 +3034,7 @@
   - "70"
   - "9"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -2645,12 +3042,14 @@
   - "70"
   - "9"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "70"
   - "12"
+  :next_node: :how_much_milk_protein_ef?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -2658,6 +3057,7 @@
   - "70"
   - "12"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -2665,6 +3065,7 @@
   - "70"
   - "12"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -2672,12 +3073,14 @@
   - "70"
   - "12"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "70"
   - "18"
+  :next_node: :how_much_milk_protein_gh?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -2685,6 +3088,7 @@
   - "70"
   - "18"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -2692,12 +3096,14 @@
   - "70"
   - "18"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "70"
   - "26"
+  :next_node: :how_much_milk_protein_gh?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -2705,6 +3111,7 @@
   - "70"
   - "26"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -2712,45 +3119,53 @@
   - "70"
   - "26"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "70"
   - "40"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "70"
   - "55"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "70"
   - "70"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "5"
   - "70"
   - "85"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_starch_glucose?
   :responses: 
   - "25"
+  :next_node: :how_much_sucrose_2?
   :outcome_node: false
 - :current_node: :how_much_sucrose_2?
   :responses: 
   - "25"
   - "0"
+  :next_node: :how_much_milk_fat?
   :outcome_node: false
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "0"
   - "0"
+  :next_node: :how_much_milk_protein_ab?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -2758,6 +3173,7 @@
   - "0"
   - "0"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -2765,6 +3181,7 @@
   - "0"
   - "0"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -2772,6 +3189,7 @@
   - "0"
   - "0"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -2779,6 +3197,7 @@
   - "0"
   - "0"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -2786,6 +3205,7 @@
   - "0"
   - "0"
   - "30"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -2793,12 +3213,14 @@
   - "0"
   - "0"
   - "60"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "0"
   - "1"
+  :next_node: :how_much_milk_protein_ab?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -2806,6 +3228,7 @@
   - "0"
   - "1"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -2813,6 +3236,7 @@
   - "0"
   - "1"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -2820,6 +3244,7 @@
   - "0"
   - "1"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -2827,6 +3252,7 @@
   - "0"
   - "1"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -2834,6 +3260,7 @@
   - "0"
   - "1"
   - "30"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -2841,12 +3268,14 @@
   - "0"
   - "1"
   - "60"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "0"
   - "3"
+  :next_node: :how_much_milk_protein_c?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -2854,6 +3283,7 @@
   - "0"
   - "3"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -2861,6 +3291,7 @@
   - "0"
   - "3"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -2868,12 +3299,14 @@
   - "0"
   - "3"
   - "12"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "0"
   - "6"
+  :next_node: :how_much_milk_protein_d?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -2881,6 +3314,7 @@
   - "0"
   - "6"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -2888,6 +3322,7 @@
   - "0"
   - "6"
   - "4"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -2895,12 +3330,14 @@
   - "0"
   - "6"
   - "15"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "0"
   - "9"
+  :next_node: :how_much_milk_protein_ef?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -2908,6 +3345,7 @@
   - "0"
   - "9"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -2915,6 +3353,7 @@
   - "0"
   - "9"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -2922,12 +3361,14 @@
   - "0"
   - "9"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "0"
   - "12"
+  :next_node: :how_much_milk_protein_ef?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -2935,6 +3376,7 @@
   - "0"
   - "12"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -2942,6 +3384,7 @@
   - "0"
   - "12"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -2949,12 +3392,14 @@
   - "0"
   - "12"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "0"
   - "18"
+  :next_node: :how_much_milk_protein_gh?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -2962,6 +3407,7 @@
   - "0"
   - "18"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -2969,12 +3415,14 @@
   - "0"
   - "18"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "0"
   - "26"
+  :next_node: :how_much_milk_protein_gh?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -2982,6 +3430,7 @@
   - "0"
   - "26"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -2989,41 +3438,48 @@
   - "0"
   - "26"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "0"
   - "40"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "0"
   - "55"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "0"
   - "70"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "0"
   - "85"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_sucrose_2?
   :responses: 
   - "25"
   - "5"
+  :next_node: :how_much_milk_fat?
   :outcome_node: false
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "5"
   - "0"
+  :next_node: :how_much_milk_protein_ab?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3031,6 +3487,7 @@
   - "5"
   - "0"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3038,6 +3495,7 @@
   - "5"
   - "0"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3045,6 +3503,7 @@
   - "5"
   - "0"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3052,6 +3511,7 @@
   - "5"
   - "0"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3059,6 +3519,7 @@
   - "5"
   - "0"
   - "30"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3066,12 +3527,14 @@
   - "5"
   - "0"
   - "60"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "5"
   - "1"
+  :next_node: :how_much_milk_protein_ab?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3079,6 +3542,7 @@
   - "5"
   - "1"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3086,6 +3550,7 @@
   - "5"
   - "1"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3093,6 +3558,7 @@
   - "5"
   - "1"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3100,6 +3566,7 @@
   - "5"
   - "1"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3107,6 +3574,7 @@
   - "5"
   - "1"
   - "30"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3114,12 +3582,14 @@
   - "5"
   - "1"
   - "60"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "5"
   - "3"
+  :next_node: :how_much_milk_protein_c?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -3127,6 +3597,7 @@
   - "5"
   - "3"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -3134,6 +3605,7 @@
   - "5"
   - "3"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -3141,12 +3613,14 @@
   - "5"
   - "3"
   - "12"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "5"
   - "6"
+  :next_node: :how_much_milk_protein_d?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -3154,6 +3628,7 @@
   - "5"
   - "6"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -3161,6 +3636,7 @@
   - "5"
   - "6"
   - "4"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -3168,12 +3644,14 @@
   - "5"
   - "6"
   - "15"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "5"
   - "9"
+  :next_node: :how_much_milk_protein_ef?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -3181,6 +3659,7 @@
   - "5"
   - "9"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -3188,6 +3667,7 @@
   - "5"
   - "9"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -3195,12 +3675,14 @@
   - "5"
   - "9"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "5"
   - "12"
+  :next_node: :how_much_milk_protein_ef?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -3208,6 +3690,7 @@
   - "5"
   - "12"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -3215,6 +3698,7 @@
   - "5"
   - "12"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -3222,12 +3706,14 @@
   - "5"
   - "12"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "5"
   - "18"
+  :next_node: :how_much_milk_protein_gh?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -3235,6 +3721,7 @@
   - "5"
   - "18"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -3242,12 +3729,14 @@
   - "5"
   - "18"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "5"
   - "26"
+  :next_node: :how_much_milk_protein_gh?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -3255,6 +3744,7 @@
   - "5"
   - "26"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -3262,41 +3752,48 @@
   - "5"
   - "26"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "5"
   - "40"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "5"
   - "55"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "5"
   - "70"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "5"
   - "85"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_sucrose_2?
   :responses: 
   - "25"
   - "30"
+  :next_node: :how_much_milk_fat?
   :outcome_node: false
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "30"
   - "0"
+  :next_node: :how_much_milk_protein_ab?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3304,6 +3801,7 @@
   - "30"
   - "0"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3311,6 +3809,7 @@
   - "30"
   - "0"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3318,6 +3817,7 @@
   - "30"
   - "0"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3325,6 +3825,7 @@
   - "30"
   - "0"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3332,6 +3833,7 @@
   - "30"
   - "0"
   - "30"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3339,12 +3841,14 @@
   - "30"
   - "0"
   - "60"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "30"
   - "1"
+  :next_node: :how_much_milk_protein_ab?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3352,6 +3856,7 @@
   - "30"
   - "1"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3359,6 +3864,7 @@
   - "30"
   - "1"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3366,6 +3872,7 @@
   - "30"
   - "1"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3373,6 +3880,7 @@
   - "30"
   - "1"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3380,6 +3888,7 @@
   - "30"
   - "1"
   - "30"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3387,12 +3896,14 @@
   - "30"
   - "1"
   - "60"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "30"
   - "3"
+  :next_node: :how_much_milk_protein_c?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -3400,6 +3911,7 @@
   - "30"
   - "3"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -3407,6 +3919,7 @@
   - "30"
   - "3"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -3414,12 +3927,14 @@
   - "30"
   - "3"
   - "12"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "30"
   - "6"
+  :next_node: :how_much_milk_protein_d?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -3427,6 +3942,7 @@
   - "30"
   - "6"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -3434,6 +3950,7 @@
   - "30"
   - "6"
   - "4"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -3441,12 +3958,14 @@
   - "30"
   - "6"
   - "15"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "30"
   - "9"
+  :next_node: :how_much_milk_protein_ef?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -3454,6 +3973,7 @@
   - "30"
   - "9"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -3461,6 +3981,7 @@
   - "30"
   - "9"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -3468,12 +3989,14 @@
   - "30"
   - "9"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "30"
   - "12"
+  :next_node: :how_much_milk_protein_ef?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -3481,6 +4004,7 @@
   - "30"
   - "12"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -3488,6 +4012,7 @@
   - "30"
   - "12"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -3495,12 +4020,14 @@
   - "30"
   - "12"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "30"
   - "18"
+  :next_node: :how_much_milk_protein_gh?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -3508,6 +4035,7 @@
   - "30"
   - "18"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -3515,12 +4043,14 @@
   - "30"
   - "18"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "30"
   - "26"
+  :next_node: :how_much_milk_protein_gh?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -3528,6 +4058,7 @@
   - "30"
   - "26"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -3535,41 +4066,48 @@
   - "30"
   - "26"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "30"
   - "40"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "30"
   - "55"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "30"
   - "70"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "30"
   - "85"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_sucrose_2?
   :responses: 
   - "25"
   - "50"
+  :next_node: :how_much_milk_fat?
   :outcome_node: false
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "50"
   - "0"
+  :next_node: :how_much_milk_protein_ab?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3577,6 +4115,7 @@
   - "50"
   - "0"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3584,6 +4123,7 @@
   - "50"
   - "0"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3591,6 +4131,7 @@
   - "50"
   - "0"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3598,6 +4139,7 @@
   - "50"
   - "0"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3605,6 +4147,7 @@
   - "50"
   - "0"
   - "30"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3612,12 +4155,14 @@
   - "50"
   - "0"
   - "60"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "50"
   - "1"
+  :next_node: :how_much_milk_protein_ab?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3625,6 +4170,7 @@
   - "50"
   - "1"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3632,6 +4178,7 @@
   - "50"
   - "1"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3639,6 +4186,7 @@
   - "50"
   - "1"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3646,6 +4194,7 @@
   - "50"
   - "1"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3653,6 +4202,7 @@
   - "50"
   - "1"
   - "30"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3660,12 +4210,14 @@
   - "50"
   - "1"
   - "60"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "50"
   - "3"
+  :next_node: :how_much_milk_protein_c?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -3673,6 +4225,7 @@
   - "50"
   - "3"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -3680,6 +4233,7 @@
   - "50"
   - "3"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -3687,12 +4241,14 @@
   - "50"
   - "3"
   - "12"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "50"
   - "6"
+  :next_node: :how_much_milk_protein_d?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -3700,6 +4256,7 @@
   - "50"
   - "6"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -3707,6 +4264,7 @@
   - "50"
   - "6"
   - "4"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -3714,12 +4272,14 @@
   - "50"
   - "6"
   - "15"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "50"
   - "9"
+  :next_node: :how_much_milk_protein_ef?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -3727,6 +4287,7 @@
   - "50"
   - "9"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -3734,6 +4295,7 @@
   - "50"
   - "9"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -3741,12 +4303,14 @@
   - "50"
   - "9"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "50"
   - "12"
+  :next_node: :how_much_milk_protein_ef?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -3754,6 +4318,7 @@
   - "50"
   - "12"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -3761,6 +4326,7 @@
   - "50"
   - "12"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -3768,12 +4334,14 @@
   - "50"
   - "12"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "50"
   - "18"
+  :next_node: :how_much_milk_protein_gh?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -3781,6 +4349,7 @@
   - "50"
   - "18"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -3788,12 +4357,14 @@
   - "50"
   - "18"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "50"
   - "26"
+  :next_node: :how_much_milk_protein_gh?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -3801,6 +4372,7 @@
   - "50"
   - "26"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -3808,45 +4380,53 @@
   - "50"
   - "26"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "50"
   - "40"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "50"
   - "55"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "50"
   - "70"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "25"
   - "50"
   - "85"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_starch_glucose?
   :responses: 
   - "50"
+  :next_node: :how_much_sucrose_3?
   :outcome_node: false
 - :current_node: :how_much_sucrose_3?
   :responses: 
   - "50"
   - "0"
+  :next_node: :how_much_milk_fat?
   :outcome_node: false
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "50"
   - "0"
   - "0"
+  :next_node: :how_much_milk_protein_ab?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3854,6 +4434,7 @@
   - "0"
   - "0"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3861,6 +4442,7 @@
   - "0"
   - "0"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3868,6 +4450,7 @@
   - "0"
   - "0"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3875,6 +4458,7 @@
   - "0"
   - "0"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3882,6 +4466,7 @@
   - "0"
   - "0"
   - "30"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3889,12 +4474,14 @@
   - "0"
   - "0"
   - "60"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "50"
   - "0"
   - "1"
+  :next_node: :how_much_milk_protein_ab?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3902,6 +4489,7 @@
   - "0"
   - "1"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3909,6 +4497,7 @@
   - "0"
   - "1"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3916,6 +4505,7 @@
   - "0"
   - "1"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3923,6 +4513,7 @@
   - "0"
   - "1"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3930,6 +4521,7 @@
   - "0"
   - "1"
   - "30"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -3937,12 +4529,14 @@
   - "0"
   - "1"
   - "60"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "50"
   - "0"
   - "3"
+  :next_node: :how_much_milk_protein_c?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -3950,6 +4544,7 @@
   - "0"
   - "3"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -3957,6 +4552,7 @@
   - "0"
   - "3"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -3964,12 +4560,14 @@
   - "0"
   - "3"
   - "12"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "50"
   - "0"
   - "6"
+  :next_node: :how_much_milk_protein_d?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -3977,6 +4575,7 @@
   - "0"
   - "6"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -3984,6 +4583,7 @@
   - "0"
   - "6"
   - "4"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -3991,12 +4591,14 @@
   - "0"
   - "6"
   - "15"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "50"
   - "0"
   - "9"
+  :next_node: :how_much_milk_protein_ef?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -4004,6 +4606,7 @@
   - "0"
   - "9"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -4011,6 +4614,7 @@
   - "0"
   - "9"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -4018,12 +4622,14 @@
   - "0"
   - "9"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "50"
   - "0"
   - "12"
+  :next_node: :how_much_milk_protein_ef?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -4031,6 +4637,7 @@
   - "0"
   - "12"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -4038,6 +4645,7 @@
   - "0"
   - "12"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -4045,12 +4653,14 @@
   - "0"
   - "12"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "50"
   - "0"
   - "18"
+  :next_node: :how_much_milk_protein_gh?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -4058,6 +4668,7 @@
   - "0"
   - "18"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -4065,12 +4676,14 @@
   - "0"
   - "18"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "50"
   - "0"
   - "26"
+  :next_node: :how_much_milk_protein_gh?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -4078,6 +4691,7 @@
   - "0"
   - "26"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -4085,41 +4699,48 @@
   - "0"
   - "26"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "50"
   - "0"
   - "40"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "50"
   - "0"
   - "55"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "50"
   - "0"
   - "70"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "50"
   - "0"
   - "85"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_sucrose_3?
   :responses: 
   - "50"
   - "5"
+  :next_node: :how_much_milk_fat?
   :outcome_node: false
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "50"
   - "5"
   - "0"
+  :next_node: :how_much_milk_protein_ab?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4127,6 +4748,7 @@
   - "5"
   - "0"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4134,6 +4756,7 @@
   - "5"
   - "0"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4141,6 +4764,7 @@
   - "5"
   - "0"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4148,6 +4772,7 @@
   - "5"
   - "0"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4155,6 +4780,7 @@
   - "5"
   - "0"
   - "30"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4162,12 +4788,14 @@
   - "5"
   - "0"
   - "60"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "50"
   - "5"
   - "1"
+  :next_node: :how_much_milk_protein_ab?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4175,6 +4803,7 @@
   - "5"
   - "1"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4182,6 +4811,7 @@
   - "5"
   - "1"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4189,6 +4819,7 @@
   - "5"
   - "1"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4196,6 +4827,7 @@
   - "5"
   - "1"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4203,6 +4835,7 @@
   - "5"
   - "1"
   - "30"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4210,12 +4843,14 @@
   - "5"
   - "1"
   - "60"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "50"
   - "5"
   - "3"
+  :next_node: :how_much_milk_protein_c?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -4223,6 +4858,7 @@
   - "5"
   - "3"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -4230,6 +4866,7 @@
   - "5"
   - "3"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -4237,12 +4874,14 @@
   - "5"
   - "3"
   - "12"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "50"
   - "5"
   - "6"
+  :next_node: :how_much_milk_protein_d?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -4250,6 +4889,7 @@
   - "5"
   - "6"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -4257,6 +4897,7 @@
   - "5"
   - "6"
   - "4"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -4264,12 +4905,14 @@
   - "5"
   - "6"
   - "15"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "50"
   - "5"
   - "9"
+  :next_node: :how_much_milk_protein_ef?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -4277,6 +4920,7 @@
   - "5"
   - "9"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -4284,6 +4928,7 @@
   - "5"
   - "9"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -4291,12 +4936,14 @@
   - "5"
   - "9"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "50"
   - "5"
   - "12"
+  :next_node: :how_much_milk_protein_ef?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -4304,6 +4951,7 @@
   - "5"
   - "12"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -4311,6 +4959,7 @@
   - "5"
   - "12"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -4318,12 +4967,14 @@
   - "5"
   - "12"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "50"
   - "5"
   - "18"
+  :next_node: :how_much_milk_protein_gh?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -4331,6 +4982,7 @@
   - "5"
   - "18"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -4338,12 +4990,14 @@
   - "5"
   - "18"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "50"
   - "5"
   - "26"
+  :next_node: :how_much_milk_protein_gh?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -4351,6 +5005,7 @@
   - "5"
   - "26"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -4358,41 +5013,48 @@
   - "5"
   - "26"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "50"
   - "5"
   - "40"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "50"
   - "5"
   - "55"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "50"
   - "5"
   - "70"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "50"
   - "5"
   - "85"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_sucrose_3?
   :responses: 
   - "50"
   - "30"
+  :next_node: :how_much_milk_fat?
   :outcome_node: false
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "50"
   - "30"
   - "0"
+  :next_node: :how_much_milk_protein_ab?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4400,6 +5062,7 @@
   - "30"
   - "0"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4407,6 +5070,7 @@
   - "30"
   - "0"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4414,6 +5078,7 @@
   - "30"
   - "0"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4421,6 +5086,7 @@
   - "30"
   - "0"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4428,6 +5094,7 @@
   - "30"
   - "0"
   - "30"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4435,12 +5102,14 @@
   - "30"
   - "0"
   - "60"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "50"
   - "30"
   - "1"
+  :next_node: :how_much_milk_protein_ab?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4448,6 +5117,7 @@
   - "30"
   - "1"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4455,6 +5125,7 @@
   - "30"
   - "1"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4462,6 +5133,7 @@
   - "30"
   - "1"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4469,6 +5141,7 @@
   - "30"
   - "1"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4476,6 +5149,7 @@
   - "30"
   - "1"
   - "30"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4483,12 +5157,14 @@
   - "30"
   - "1"
   - "60"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "50"
   - "30"
   - "3"
+  :next_node: :how_much_milk_protein_c?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -4496,6 +5172,7 @@
   - "30"
   - "3"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -4503,6 +5180,7 @@
   - "30"
   - "3"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -4510,12 +5188,14 @@
   - "30"
   - "3"
   - "12"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "50"
   - "30"
   - "6"
+  :next_node: :how_much_milk_protein_d?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -4523,6 +5203,7 @@
   - "30"
   - "6"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -4530,6 +5211,7 @@
   - "30"
   - "6"
   - "4"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -4537,12 +5219,14 @@
   - "30"
   - "6"
   - "15"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "50"
   - "30"
   - "9"
+  :next_node: :how_much_milk_protein_ef?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -4550,6 +5234,7 @@
   - "30"
   - "9"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -4557,6 +5242,7 @@
   - "30"
   - "9"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -4564,12 +5250,14 @@
   - "30"
   - "9"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "50"
   - "30"
   - "12"
+  :next_node: :how_much_milk_protein_ef?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -4577,6 +5265,7 @@
   - "30"
   - "12"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -4584,6 +5273,7 @@
   - "30"
   - "12"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -4591,12 +5281,14 @@
   - "30"
   - "12"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "50"
   - "30"
   - "18"
+  :next_node: :how_much_milk_protein_gh?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -4604,6 +5296,7 @@
   - "30"
   - "18"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -4611,12 +5304,14 @@
   - "30"
   - "18"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "50"
   - "30"
   - "26"
+  :next_node: :how_much_milk_protein_gh?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -4624,6 +5319,7 @@
   - "30"
   - "26"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -4631,45 +5327,53 @@
   - "30"
   - "26"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "50"
   - "30"
   - "40"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "50"
   - "30"
   - "55"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "50"
   - "30"
   - "70"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "50"
   - "30"
   - "85"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_starch_glucose?
   :responses: 
   - "75"
+  :next_node: :how_much_sucrose_4?
   :outcome_node: false
 - :current_node: :how_much_sucrose_4?
   :responses: 
   - "75"
   - "0"
+  :next_node: :how_much_milk_fat?
   :outcome_node: false
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "75"
   - "0"
   - "0"
+  :next_node: :how_much_milk_protein_ab?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4677,6 +5381,7 @@
   - "0"
   - "0"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4684,6 +5389,7 @@
   - "0"
   - "0"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4691,6 +5397,7 @@
   - "0"
   - "0"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4698,6 +5405,7 @@
   - "0"
   - "0"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4705,6 +5413,7 @@
   - "0"
   - "0"
   - "30"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4712,12 +5421,14 @@
   - "0"
   - "0"
   - "60"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "75"
   - "0"
   - "1"
+  :next_node: :how_much_milk_protein_ab?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4725,6 +5436,7 @@
   - "0"
   - "1"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4732,6 +5444,7 @@
   - "0"
   - "1"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4739,6 +5452,7 @@
   - "0"
   - "1"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4746,6 +5460,7 @@
   - "0"
   - "1"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4753,6 +5468,7 @@
   - "0"
   - "1"
   - "30"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4760,12 +5476,14 @@
   - "0"
   - "1"
   - "60"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "75"
   - "0"
   - "3"
+  :next_node: :how_much_milk_protein_c?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -4773,6 +5491,7 @@
   - "0"
   - "3"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -4780,6 +5499,7 @@
   - "0"
   - "3"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -4787,12 +5507,14 @@
   - "0"
   - "3"
   - "12"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "75"
   - "0"
   - "6"
+  :next_node: :how_much_milk_protein_d?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -4800,6 +5522,7 @@
   - "0"
   - "6"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -4807,6 +5530,7 @@
   - "0"
   - "6"
   - "4"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -4814,12 +5538,14 @@
   - "0"
   - "6"
   - "15"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "75"
   - "0"
   - "9"
+  :next_node: :how_much_milk_protein_ef?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -4827,6 +5553,7 @@
   - "0"
   - "9"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -4834,6 +5561,7 @@
   - "0"
   - "9"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -4841,12 +5569,14 @@
   - "0"
   - "9"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "75"
   - "0"
   - "12"
+  :next_node: :how_much_milk_protein_ef?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -4854,6 +5584,7 @@
   - "0"
   - "12"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -4861,6 +5592,7 @@
   - "0"
   - "12"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -4868,12 +5600,14 @@
   - "0"
   - "12"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "75"
   - "0"
   - "18"
+  :next_node: :how_much_milk_protein_gh?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -4881,6 +5615,7 @@
   - "0"
   - "18"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -4888,12 +5623,14 @@
   - "0"
   - "18"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "75"
   - "0"
   - "26"
+  :next_node: :how_much_milk_protein_gh?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -4901,6 +5638,7 @@
   - "0"
   - "26"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -4908,41 +5646,48 @@
   - "0"
   - "26"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "75"
   - "0"
   - "40"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "75"
   - "0"
   - "55"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "75"
   - "0"
   - "70"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "75"
   - "0"
   - "85"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_sucrose_4?
   :responses: 
   - "75"
   - "5"
+  :next_node: :how_much_milk_fat?
   :outcome_node: false
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "75"
   - "5"
   - "0"
+  :next_node: :how_much_milk_protein_ab?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4950,6 +5695,7 @@
   - "5"
   - "0"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4957,6 +5703,7 @@
   - "5"
   - "0"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4964,6 +5711,7 @@
   - "5"
   - "0"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4971,6 +5719,7 @@
   - "5"
   - "0"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4978,6 +5727,7 @@
   - "5"
   - "0"
   - "30"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4985,12 +5735,14 @@
   - "5"
   - "0"
   - "60"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "75"
   - "5"
   - "1"
+  :next_node: :how_much_milk_protein_ab?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -4998,6 +5750,7 @@
   - "5"
   - "1"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -5005,6 +5758,7 @@
   - "5"
   - "1"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -5012,6 +5766,7 @@
   - "5"
   - "1"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -5019,6 +5774,7 @@
   - "5"
   - "1"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -5026,6 +5782,7 @@
   - "5"
   - "1"
   - "30"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ab?
   :responses: 
@@ -5033,12 +5790,14 @@
   - "5"
   - "1"
   - "60"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "75"
   - "5"
   - "3"
+  :next_node: :how_much_milk_protein_c?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -5046,6 +5805,7 @@
   - "5"
   - "3"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -5053,6 +5813,7 @@
   - "5"
   - "3"
   - "2"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_c?
   :responses: 
@@ -5060,12 +5821,14 @@
   - "5"
   - "3"
   - "12"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "75"
   - "5"
   - "6"
+  :next_node: :how_much_milk_protein_d?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -5073,6 +5836,7 @@
   - "5"
   - "6"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -5080,6 +5844,7 @@
   - "5"
   - "6"
   - "4"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_d?
   :responses: 
@@ -5087,12 +5852,14 @@
   - "5"
   - "6"
   - "15"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "75"
   - "5"
   - "9"
+  :next_node: :how_much_milk_protein_ef?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -5100,6 +5867,7 @@
   - "5"
   - "9"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -5107,6 +5875,7 @@
   - "5"
   - "9"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -5114,12 +5883,14 @@
   - "5"
   - "9"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "75"
   - "5"
   - "12"
+  :next_node: :how_much_milk_protein_ef?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -5127,6 +5898,7 @@
   - "5"
   - "12"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -5134,6 +5906,7 @@
   - "5"
   - "12"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_ef?
   :responses: 
@@ -5141,12 +5914,14 @@
   - "5"
   - "12"
   - "18"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "75"
   - "5"
   - "18"
+  :next_node: :how_much_milk_protein_gh?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -5154,6 +5929,7 @@
   - "5"
   - "18"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -5161,12 +5937,14 @@
   - "5"
   - "18"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "75"
   - "5"
   - "26"
+  :next_node: :how_much_milk_protein_gh?
   :outcome_node: false
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -5174,6 +5952,7 @@
   - "5"
   - "26"
   - "0"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_protein_gh?
   :responses: 
@@ -5181,28 +5960,33 @@
   - "5"
   - "26"
   - "6"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "75"
   - "5"
   - "40"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "75"
   - "5"
   - "55"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "75"
   - "5"
   - "70"
+  :next_node: :commodity_code_result
   :outcome_node: true
 - :current_node: :how_much_milk_fat?
   :responses: 
   - "75"
   - "5"
   - "85"
+  :next_node: :commodity_code_result
   :outcome_node: true

--- a/test/data/am-i-getting-minimum-wage-files.yml
+++ b/test/data/am-i-getting-minimum-wage-files.yml
@@ -2,7 +2,7 @@
 lib/smart_answer_flows/am-i-getting-minimum-wage.rb: a5f9ccf8dfe0c6835ef605aa1c5cbacc
 lib/smart_answer_flows/locales/en/am-i-getting-minimum-wage.yml: 285c621a77cb625d08a440a9b74aa85e
 test/data/am-i-getting-minimum-wage-questions-and-responses.yml: 173bbd0ad46b728bdd6498fa71585ddc
-test/data/am-i-getting-minimum-wage-responses-and-expected-results.yml: 7f3e7ba3ea38a0013556638836f0af2d
+test/data/am-i-getting-minimum-wage-responses-and-expected-results.yml: ca94e66d32e727c77a4472dce71a198d
 lib/smart_answer_flows/shared_logic/minimum_wage.rb: 0266518e125cf1fd950e8b081c71274f
 lib/smart_answer/calculators/minimum_wage_calculator.rb: 1aca36bb1b33abf4cbef8171d9f13f3c
 lib/data/minimum_wage_data.yml: 55c71c9ff8252c17a679dad888ad5ad7

--- a/test/data/am-i-getting-minimum-wage-responses-and-expected-results.yml
+++ b/test/data/am-i-getting-minimum-wage-responses-and-expected-results.yml
@@ -2,23 +2,27 @@
 - :current_node: :what_would_you_like_to_check?
   :responses: 
   - current_payment
+  :next_node: :are_you_an_apprentice?
   :outcome_node: false
 - :current_node: :are_you_an_apprentice?
   :responses: 
   - current_payment
   - not_an_apprentice
+  :next_node: :how_old_are_you?
   :outcome_node: false
 - :current_node: :how_old_are_you?
   :responses: 
   - current_payment
   - not_an_apprentice
   - "15"
+  :next_node: :under_school_leaving_age
   :outcome_node: true
 - :current_node: :how_old_are_you?
   :responses: 
   - current_payment
   - not_an_apprentice
   - "25"
+  :next_node: :how_often_do_you_get_paid?
   :outcome_node: false
 - :current_node: :how_often_do_you_get_paid?
   :responses: 
@@ -26,6 +30,7 @@
   - not_an_apprentice
   - "25"
   - "1"
+  :next_node: :how_many_hours_do_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_do_you_work?
   :responses: 
@@ -34,6 +39,7 @@
   - "25"
   - "1"
   - "0"
+  :next_node: :how_much_are_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_are_you_paid_during_pay_period?
   :responses: 
@@ -43,6 +49,7 @@
   - "1"
   - "0.0"
   - "100"
+  :next_node: :how_many_hours_overtime_do_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -53,6 +60,7 @@
   - "0.0"
   - "100.0"
   - "0"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -64,6 +72,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -75,6 +84,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -87,6 +97,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -98,6 +109,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -110,6 +122,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -123,6 +136,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -135,6 +149,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -148,6 +163,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -158,6 +174,7 @@
   - "0.0"
   - "100.0"
   - "8"
+  :next_node: :what_is_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_is_overtime_pay_per_hour?
   :responses: 
@@ -169,6 +186,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -181,6 +199,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -193,6 +212,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -206,6 +226,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -218,6 +239,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -231,6 +253,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -245,6 +268,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -258,6 +282,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -272,6 +297,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_much_are_you_paid_during_pay_period?
   :responses: 
@@ -281,6 +307,7 @@
   - "1"
   - "0.0"
   - "300"
+  :next_node: :how_many_hours_overtime_do_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -291,6 +318,7 @@
   - "0.0"
   - "300.0"
   - "0"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -302,6 +330,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -313,6 +342,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -325,6 +355,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -336,6 +367,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -348,6 +380,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -361,6 +394,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -373,6 +407,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -386,6 +421,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -396,6 +432,7 @@
   - "0.0"
   - "300.0"
   - "8"
+  :next_node: :what_is_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_is_overtime_pay_per_hour?
   :responses: 
@@ -407,6 +444,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -419,6 +457,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -431,6 +470,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -444,6 +484,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -456,6 +497,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -469,6 +511,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -483,6 +526,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -496,6 +540,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -510,6 +555,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_do_you_work?
   :responses: 
@@ -518,6 +564,7 @@
   - "25"
   - "1"
   - "16"
+  :next_node: :how_much_are_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_are_you_paid_during_pay_period?
   :responses: 
@@ -527,6 +574,7 @@
   - "1"
   - "16.0"
   - "100"
+  :next_node: :how_many_hours_overtime_do_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -537,6 +585,7 @@
   - "16.0"
   - "100.0"
   - "0"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -548,6 +597,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -559,6 +609,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -571,6 +622,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -582,6 +634,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -594,6 +647,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -607,6 +661,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -619,6 +674,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -632,6 +688,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -642,6 +699,7 @@
   - "16.0"
   - "100.0"
   - "8"
+  :next_node: :what_is_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_is_overtime_pay_per_hour?
   :responses: 
@@ -653,6 +711,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -665,6 +724,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -677,6 +737,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -690,6 +751,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -702,6 +764,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -715,6 +778,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -729,6 +793,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -742,6 +807,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -756,6 +822,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_much_are_you_paid_during_pay_period?
   :responses: 
@@ -765,6 +832,7 @@
   - "1"
   - "16.0"
   - "300"
+  :next_node: :how_many_hours_overtime_do_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -775,6 +843,7 @@
   - "16.0"
   - "300.0"
   - "0"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -786,6 +855,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -797,6 +867,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -809,6 +880,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -820,6 +892,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -832,6 +905,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -845,6 +919,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -857,6 +932,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -870,6 +946,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -880,6 +957,7 @@
   - "16.0"
   - "300.0"
   - "8"
+  :next_node: :what_is_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_is_overtime_pay_per_hour?
   :responses: 
@@ -891,6 +969,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -903,6 +982,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -915,6 +995,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -928,6 +1009,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -940,6 +1022,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -953,6 +1036,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -967,6 +1051,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -980,6 +1065,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -994,6 +1080,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :how_often_do_you_get_paid?
   :responses: 
@@ -1001,6 +1088,7 @@
   - not_an_apprentice
   - "25"
   - "31"
+  :next_node: :how_many_hours_do_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_do_you_work?
   :responses: 
@@ -1009,6 +1097,7 @@
   - "25"
   - "31"
   - "0"
+  :next_node: :how_much_are_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_are_you_paid_during_pay_period?
   :responses: 
@@ -1018,6 +1107,7 @@
   - "31"
   - "0.0"
   - "100"
+  :next_node: :how_many_hours_overtime_do_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -1028,6 +1118,7 @@
   - "0.0"
   - "100.0"
   - "0"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -1039,6 +1130,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -1050,6 +1142,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -1062,6 +1155,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -1073,6 +1167,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -1085,6 +1180,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -1098,6 +1194,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -1110,6 +1207,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -1123,6 +1221,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -1133,6 +1232,7 @@
   - "0.0"
   - "100.0"
   - "8"
+  :next_node: :what_is_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_is_overtime_pay_per_hour?
   :responses: 
@@ -1144,6 +1244,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -1156,6 +1257,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -1168,6 +1270,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -1181,6 +1284,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -1193,6 +1297,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -1206,6 +1311,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -1220,6 +1326,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -1233,6 +1340,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -1247,6 +1355,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_much_are_you_paid_during_pay_period?
   :responses: 
@@ -1256,6 +1365,7 @@
   - "31"
   - "0.0"
   - "300"
+  :next_node: :how_many_hours_overtime_do_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -1266,6 +1376,7 @@
   - "0.0"
   - "300.0"
   - "0"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -1277,6 +1388,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -1288,6 +1400,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -1300,6 +1413,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -1311,6 +1425,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -1323,6 +1438,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -1336,6 +1452,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -1348,6 +1465,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -1361,6 +1479,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -1371,6 +1490,7 @@
   - "0.0"
   - "300.0"
   - "8"
+  :next_node: :what_is_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_is_overtime_pay_per_hour?
   :responses: 
@@ -1382,6 +1502,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -1394,6 +1515,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -1406,6 +1528,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -1419,6 +1542,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -1431,6 +1555,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -1444,6 +1569,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -1458,6 +1584,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -1471,6 +1598,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -1485,6 +1613,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_do_you_work?
   :responses: 
@@ -1493,6 +1622,7 @@
   - "25"
   - "31"
   - "16"
+  :next_node: :how_much_are_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_are_you_paid_during_pay_period?
   :responses: 
@@ -1502,6 +1632,7 @@
   - "31"
   - "16.0"
   - "100"
+  :next_node: :how_many_hours_overtime_do_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -1512,6 +1643,7 @@
   - "16.0"
   - "100.0"
   - "0"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -1523,6 +1655,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -1534,6 +1667,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -1546,6 +1680,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -1557,6 +1692,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -1569,6 +1705,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -1582,6 +1719,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -1594,6 +1732,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -1607,6 +1746,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -1617,6 +1757,7 @@
   - "16.0"
   - "100.0"
   - "8"
+  :next_node: :what_is_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_is_overtime_pay_per_hour?
   :responses: 
@@ -1628,6 +1769,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -1640,6 +1782,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -1652,6 +1795,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -1665,6 +1809,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -1677,6 +1822,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -1690,6 +1836,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -1704,6 +1851,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -1717,6 +1865,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -1731,6 +1880,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_much_are_you_paid_during_pay_period?
   :responses: 
@@ -1740,6 +1890,7 @@
   - "31"
   - "16.0"
   - "300"
+  :next_node: :how_many_hours_overtime_do_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -1750,6 +1901,7 @@
   - "16.0"
   - "300.0"
   - "0"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -1761,6 +1913,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -1772,6 +1925,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -1784,6 +1938,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -1795,6 +1950,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -1807,6 +1963,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -1820,6 +1977,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -1832,6 +1990,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -1845,6 +2004,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -1855,6 +2015,7 @@
   - "16.0"
   - "300.0"
   - "8"
+  :next_node: :what_is_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_is_overtime_pay_per_hour?
   :responses: 
@@ -1866,6 +2027,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -1878,6 +2040,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -1890,6 +2053,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -1903,6 +2067,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -1915,6 +2080,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -1928,6 +2094,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -1942,6 +2109,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -1955,6 +2123,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -1969,17 +2138,20 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :are_you_an_apprentice?
   :responses: 
   - current_payment
   - apprentice_under_19
+  :next_node: :how_often_do_you_get_paid?
   :outcome_node: false
 - :current_node: :how_often_do_you_get_paid?
   :responses: 
   - current_payment
   - apprentice_under_19
   - "1"
+  :next_node: :how_many_hours_do_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_do_you_work?
   :responses: 
@@ -1987,6 +2159,7 @@
   - apprentice_under_19
   - "1"
   - "0"
+  :next_node: :how_much_are_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_are_you_paid_during_pay_period?
   :responses: 
@@ -1995,6 +2168,7 @@
   - "1"
   - "0.0"
   - "100"
+  :next_node: :how_many_hours_overtime_do_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -2004,6 +2178,7 @@
   - "0.0"
   - "100.0"
   - "0"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -2014,6 +2189,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -2024,6 +2200,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -2035,6 +2212,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -2045,6 +2223,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -2056,6 +2235,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -2068,6 +2248,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -2079,6 +2260,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -2091,6 +2273,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -2100,6 +2283,7 @@
   - "0.0"
   - "100.0"
   - "8"
+  :next_node: :what_is_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_is_overtime_pay_per_hour?
   :responses: 
@@ -2110,6 +2294,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -2121,6 +2306,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -2132,6 +2318,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -2144,6 +2331,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -2155,6 +2343,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -2167,6 +2356,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -2180,6 +2370,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -2192,6 +2383,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -2205,6 +2397,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :how_much_are_you_paid_during_pay_period?
   :responses: 
@@ -2213,6 +2406,7 @@
   - "1"
   - "0.0"
   - "300"
+  :next_node: :how_many_hours_overtime_do_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -2222,6 +2416,7 @@
   - "0.0"
   - "300.0"
   - "0"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -2232,6 +2427,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -2242,6 +2438,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -2253,6 +2450,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -2263,6 +2461,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -2274,6 +2473,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -2286,6 +2486,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -2297,6 +2498,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -2309,6 +2511,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -2318,6 +2521,7 @@
   - "0.0"
   - "300.0"
   - "8"
+  :next_node: :what_is_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_is_overtime_pay_per_hour?
   :responses: 
@@ -2328,6 +2532,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -2339,6 +2544,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -2350,6 +2556,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -2362,6 +2569,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -2373,6 +2581,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -2385,6 +2594,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -2398,6 +2608,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -2410,6 +2621,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -2423,6 +2635,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :how_many_hours_do_you_work?
   :responses: 
@@ -2430,6 +2643,7 @@
   - apprentice_under_19
   - "1"
   - "16"
+  :next_node: :how_much_are_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_are_you_paid_during_pay_period?
   :responses: 
@@ -2438,6 +2652,7 @@
   - "1"
   - "16.0"
   - "100"
+  :next_node: :how_many_hours_overtime_do_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -2447,6 +2662,7 @@
   - "16.0"
   - "100.0"
   - "0"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -2457,6 +2673,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -2467,6 +2684,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -2478,6 +2696,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -2488,6 +2707,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -2499,6 +2719,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -2511,6 +2732,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -2522,6 +2744,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -2534,6 +2757,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -2543,6 +2767,7 @@
   - "16.0"
   - "100.0"
   - "8"
+  :next_node: :what_is_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_is_overtime_pay_per_hour?
   :responses: 
@@ -2553,6 +2778,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -2564,6 +2790,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -2575,6 +2802,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -2587,6 +2815,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -2598,6 +2827,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -2610,6 +2840,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -2623,6 +2854,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -2635,6 +2867,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -2648,6 +2881,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :how_much_are_you_paid_during_pay_period?
   :responses: 
@@ -2656,6 +2890,7 @@
   - "1"
   - "16.0"
   - "300"
+  :next_node: :how_many_hours_overtime_do_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -2665,6 +2900,7 @@
   - "16.0"
   - "300.0"
   - "0"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -2675,6 +2911,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -2685,6 +2922,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -2696,6 +2934,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -2706,6 +2945,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -2717,6 +2957,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -2729,6 +2970,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -2740,6 +2982,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -2752,6 +2995,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -2761,6 +3005,7 @@
   - "16.0"
   - "300.0"
   - "8"
+  :next_node: :what_is_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_is_overtime_pay_per_hour?
   :responses: 
@@ -2771,6 +3016,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -2782,6 +3028,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -2793,6 +3040,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -2805,6 +3053,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -2816,6 +3065,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -2828,6 +3078,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -2841,6 +3092,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -2853,6 +3105,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -2866,12 +3119,14 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :how_often_do_you_get_paid?
   :responses: 
   - current_payment
   - apprentice_under_19
   - "31"
+  :next_node: :how_many_hours_do_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_do_you_work?
   :responses: 
@@ -2879,6 +3134,7 @@
   - apprentice_under_19
   - "31"
   - "0"
+  :next_node: :how_much_are_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_are_you_paid_during_pay_period?
   :responses: 
@@ -2887,6 +3143,7 @@
   - "31"
   - "0.0"
   - "100"
+  :next_node: :how_many_hours_overtime_do_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -2896,6 +3153,7 @@
   - "0.0"
   - "100.0"
   - "0"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -2906,6 +3164,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -2916,6 +3175,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -2927,6 +3187,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -2937,6 +3198,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -2948,6 +3210,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -2960,6 +3223,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -2971,6 +3235,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -2983,6 +3248,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -2992,6 +3258,7 @@
   - "0.0"
   - "100.0"
   - "8"
+  :next_node: :what_is_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_is_overtime_pay_per_hour?
   :responses: 
@@ -3002,6 +3269,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -3013,6 +3281,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -3024,6 +3293,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -3036,6 +3306,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -3047,6 +3318,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -3059,6 +3331,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -3072,6 +3345,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -3084,6 +3358,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -3097,6 +3372,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_much_are_you_paid_during_pay_period?
   :responses: 
@@ -3105,6 +3381,7 @@
   - "31"
   - "0.0"
   - "300"
+  :next_node: :how_many_hours_overtime_do_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -3114,6 +3391,7 @@
   - "0.0"
   - "300.0"
   - "0"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -3124,6 +3402,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -3134,6 +3413,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -3145,6 +3425,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -3155,6 +3436,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -3166,6 +3448,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -3178,6 +3461,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -3189,6 +3473,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -3201,6 +3486,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -3210,6 +3496,7 @@
   - "0.0"
   - "300.0"
   - "8"
+  :next_node: :what_is_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_is_overtime_pay_per_hour?
   :responses: 
@@ -3220,6 +3507,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -3231,6 +3519,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -3242,6 +3531,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -3254,6 +3544,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -3265,6 +3556,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -3277,6 +3569,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -3290,6 +3583,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -3302,6 +3596,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -3315,6 +3610,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_do_you_work?
   :responses: 
@@ -3322,6 +3618,7 @@
   - apprentice_under_19
   - "31"
   - "16"
+  :next_node: :how_much_are_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_are_you_paid_during_pay_period?
   :responses: 
@@ -3330,6 +3627,7 @@
   - "31"
   - "16.0"
   - "100"
+  :next_node: :how_many_hours_overtime_do_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -3339,6 +3637,7 @@
   - "16.0"
   - "100.0"
   - "0"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -3349,6 +3648,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -3359,6 +3659,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -3370,6 +3671,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -3380,6 +3682,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -3391,6 +3694,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -3403,6 +3707,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -3414,6 +3719,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -3426,6 +3732,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -3435,6 +3742,7 @@
   - "16.0"
   - "100.0"
   - "8"
+  :next_node: :what_is_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_is_overtime_pay_per_hour?
   :responses: 
@@ -3445,6 +3753,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -3456,6 +3765,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -3467,6 +3777,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -3479,6 +3790,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -3490,6 +3802,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -3502,6 +3815,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -3515,6 +3829,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -3527,6 +3842,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -3540,6 +3856,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_much_are_you_paid_during_pay_period?
   :responses: 
@@ -3548,6 +3865,7 @@
   - "31"
   - "16.0"
   - "300"
+  :next_node: :how_many_hours_overtime_do_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -3557,6 +3875,7 @@
   - "16.0"
   - "300.0"
   - "0"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -3567,6 +3886,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -3577,6 +3897,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -3588,6 +3909,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -3598,6 +3920,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -3609,6 +3932,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -3621,6 +3945,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -3632,6 +3957,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -3644,6 +3970,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -3653,6 +3980,7 @@
   - "16.0"
   - "300.0"
   - "8"
+  :next_node: :what_is_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_is_overtime_pay_per_hour?
   :responses: 
@@ -3663,6 +3991,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -3674,6 +4003,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -3685,6 +4015,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -3697,6 +4028,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -3708,6 +4040,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -3720,6 +4053,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -3733,6 +4067,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -3745,6 +4080,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -3758,17 +4094,20 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :are_you_an_apprentice?
   :responses: 
   - current_payment
   - apprentice_over_19_first_year
+  :next_node: :how_often_do_you_get_paid?
   :outcome_node: false
 - :current_node: :how_often_do_you_get_paid?
   :responses: 
   - current_payment
   - apprentice_over_19_first_year
   - "1"
+  :next_node: :how_many_hours_do_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_do_you_work?
   :responses: 
@@ -3776,6 +4115,7 @@
   - apprentice_over_19_first_year
   - "1"
   - "0"
+  :next_node: :how_much_are_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_are_you_paid_during_pay_period?
   :responses: 
@@ -3784,6 +4124,7 @@
   - "1"
   - "0.0"
   - "100"
+  :next_node: :how_many_hours_overtime_do_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -3793,6 +4134,7 @@
   - "0.0"
   - "100.0"
   - "0"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -3803,6 +4145,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -3813,6 +4156,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -3824,6 +4168,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -3834,6 +4179,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -3845,6 +4191,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -3857,6 +4204,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -3868,6 +4216,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -3880,6 +4229,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -3889,6 +4239,7 @@
   - "0.0"
   - "100.0"
   - "8"
+  :next_node: :what_is_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_is_overtime_pay_per_hour?
   :responses: 
@@ -3899,6 +4250,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -3910,6 +4262,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -3921,6 +4274,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -3933,6 +4287,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -3944,6 +4299,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -3956,6 +4312,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -3969,6 +4326,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -3981,6 +4339,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -3994,6 +4353,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :how_much_are_you_paid_during_pay_period?
   :responses: 
@@ -4002,6 +4362,7 @@
   - "1"
   - "0.0"
   - "300"
+  :next_node: :how_many_hours_overtime_do_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -4011,6 +4372,7 @@
   - "0.0"
   - "300.0"
   - "0"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -4021,6 +4383,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -4031,6 +4394,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -4042,6 +4406,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -4052,6 +4417,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -4063,6 +4429,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -4075,6 +4442,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -4086,6 +4454,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -4098,6 +4467,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -4107,6 +4477,7 @@
   - "0.0"
   - "300.0"
   - "8"
+  :next_node: :what_is_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_is_overtime_pay_per_hour?
   :responses: 
@@ -4117,6 +4488,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -4128,6 +4500,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -4139,6 +4512,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -4151,6 +4525,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -4162,6 +4537,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -4174,6 +4550,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -4187,6 +4564,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -4199,6 +4577,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -4212,6 +4591,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :how_many_hours_do_you_work?
   :responses: 
@@ -4219,6 +4599,7 @@
   - apprentice_over_19_first_year
   - "1"
   - "16"
+  :next_node: :how_much_are_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_are_you_paid_during_pay_period?
   :responses: 
@@ -4227,6 +4608,7 @@
   - "1"
   - "16.0"
   - "100"
+  :next_node: :how_many_hours_overtime_do_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -4236,6 +4618,7 @@
   - "16.0"
   - "100.0"
   - "0"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -4246,6 +4629,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -4256,6 +4640,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -4267,6 +4652,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -4277,6 +4663,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -4288,6 +4675,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -4300,6 +4688,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -4311,6 +4700,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -4323,6 +4713,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -4332,6 +4723,7 @@
   - "16.0"
   - "100.0"
   - "8"
+  :next_node: :what_is_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_is_overtime_pay_per_hour?
   :responses: 
@@ -4342,6 +4734,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -4353,6 +4746,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -4364,6 +4758,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -4376,6 +4771,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -4387,6 +4783,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -4399,6 +4796,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -4412,6 +4810,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -4424,6 +4823,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -4437,6 +4837,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :how_much_are_you_paid_during_pay_period?
   :responses: 
@@ -4445,6 +4846,7 @@
   - "1"
   - "16.0"
   - "300"
+  :next_node: :how_many_hours_overtime_do_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -4454,6 +4856,7 @@
   - "16.0"
   - "300.0"
   - "0"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -4464,6 +4867,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -4474,6 +4878,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -4485,6 +4890,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -4495,6 +4901,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -4506,6 +4913,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -4518,6 +4926,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -4529,6 +4938,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -4541,6 +4951,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -4550,6 +4961,7 @@
   - "16.0"
   - "300.0"
   - "8"
+  :next_node: :what_is_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_is_overtime_pay_per_hour?
   :responses: 
@@ -4560,6 +4972,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -4571,6 +4984,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -4582,6 +4996,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -4594,6 +5009,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -4605,6 +5021,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -4617,6 +5034,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -4630,6 +5048,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -4642,6 +5061,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -4655,12 +5075,14 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :how_often_do_you_get_paid?
   :responses: 
   - current_payment
   - apprentice_over_19_first_year
   - "31"
+  :next_node: :how_many_hours_do_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_do_you_work?
   :responses: 
@@ -4668,6 +5090,7 @@
   - apprentice_over_19_first_year
   - "31"
   - "0"
+  :next_node: :how_much_are_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_are_you_paid_during_pay_period?
   :responses: 
@@ -4676,6 +5099,7 @@
   - "31"
   - "0.0"
   - "100"
+  :next_node: :how_many_hours_overtime_do_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -4685,6 +5109,7 @@
   - "0.0"
   - "100.0"
   - "0"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -4695,6 +5120,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -4705,6 +5131,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -4716,6 +5143,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -4726,6 +5154,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -4737,6 +5166,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -4749,6 +5179,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -4760,6 +5191,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -4772,6 +5204,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -4781,6 +5214,7 @@
   - "0.0"
   - "100.0"
   - "8"
+  :next_node: :what_is_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_is_overtime_pay_per_hour?
   :responses: 
@@ -4791,6 +5225,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -4802,6 +5237,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -4813,6 +5249,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -4825,6 +5262,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -4836,6 +5274,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -4848,6 +5287,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -4861,6 +5301,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -4873,6 +5314,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -4886,6 +5328,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_much_are_you_paid_during_pay_period?
   :responses: 
@@ -4894,6 +5337,7 @@
   - "31"
   - "0.0"
   - "300"
+  :next_node: :how_many_hours_overtime_do_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -4903,6 +5347,7 @@
   - "0.0"
   - "300.0"
   - "0"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -4913,6 +5358,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -4923,6 +5369,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -4934,6 +5381,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -4944,6 +5392,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -4955,6 +5404,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -4967,6 +5417,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -4978,6 +5429,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -4990,6 +5442,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -4999,6 +5452,7 @@
   - "0.0"
   - "300.0"
   - "8"
+  :next_node: :what_is_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_is_overtime_pay_per_hour?
   :responses: 
@@ -5009,6 +5463,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -5020,6 +5475,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -5031,6 +5487,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -5043,6 +5500,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -5054,6 +5512,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -5066,6 +5525,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -5079,6 +5539,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -5091,6 +5552,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -5104,6 +5566,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_do_you_work?
   :responses: 
@@ -5111,6 +5574,7 @@
   - apprentice_over_19_first_year
   - "31"
   - "16"
+  :next_node: :how_much_are_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_are_you_paid_during_pay_period?
   :responses: 
@@ -5119,6 +5583,7 @@
   - "31"
   - "16.0"
   - "100"
+  :next_node: :how_many_hours_overtime_do_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -5128,6 +5593,7 @@
   - "16.0"
   - "100.0"
   - "0"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -5138,6 +5604,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -5148,6 +5615,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -5159,6 +5627,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -5169,6 +5638,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -5180,6 +5650,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -5192,6 +5663,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -5203,6 +5675,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -5215,6 +5688,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -5224,6 +5698,7 @@
   - "16.0"
   - "100.0"
   - "8"
+  :next_node: :what_is_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_is_overtime_pay_per_hour?
   :responses: 
@@ -5234,6 +5709,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -5245,6 +5721,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -5256,6 +5733,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -5268,6 +5746,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -5279,6 +5758,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -5291,6 +5771,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -5304,6 +5785,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -5316,6 +5798,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -5329,6 +5812,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_much_are_you_paid_during_pay_period?
   :responses: 
@@ -5337,6 +5821,7 @@
   - "31"
   - "16.0"
   - "300"
+  :next_node: :how_many_hours_overtime_do_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -5346,6 +5831,7 @@
   - "16.0"
   - "300.0"
   - "0"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -5356,6 +5842,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -5366,6 +5853,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -5377,6 +5865,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -5387,6 +5876,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -5398,6 +5888,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -5410,6 +5901,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -5421,6 +5913,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -5433,6 +5926,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -5442,6 +5936,7 @@
   - "16.0"
   - "300.0"
   - "8"
+  :next_node: :what_is_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_is_overtime_pay_per_hour?
   :responses: 
@@ -5452,6 +5947,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -5463,6 +5959,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -5474,6 +5971,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -5486,6 +5984,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -5497,6 +5996,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -5509,6 +6009,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -5522,6 +6023,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -5534,6 +6036,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -5547,23 +6050,27 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :are_you_an_apprentice?
   :responses: 
   - current_payment
   - apprentice_over_19_second_year_onwards
+  :next_node: :how_old_are_you?
   :outcome_node: false
 - :current_node: :how_old_are_you?
   :responses: 
   - current_payment
   - apprentice_over_19_second_year_onwards
   - "15"
+  :next_node: :under_school_leaving_age
   :outcome_node: true
 - :current_node: :how_old_are_you?
   :responses: 
   - current_payment
   - apprentice_over_19_second_year_onwards
   - "25"
+  :next_node: :how_often_do_you_get_paid?
   :outcome_node: false
 - :current_node: :how_often_do_you_get_paid?
   :responses: 
@@ -5571,6 +6078,7 @@
   - apprentice_over_19_second_year_onwards
   - "25"
   - "1"
+  :next_node: :how_many_hours_do_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_do_you_work?
   :responses: 
@@ -5579,6 +6087,7 @@
   - "25"
   - "1"
   - "0"
+  :next_node: :how_much_are_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_are_you_paid_during_pay_period?
   :responses: 
@@ -5588,6 +6097,7 @@
   - "1"
   - "0.0"
   - "100"
+  :next_node: :how_many_hours_overtime_do_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -5598,6 +6108,7 @@
   - "0.0"
   - "100.0"
   - "0"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -5609,6 +6120,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -5620,6 +6132,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -5632,6 +6145,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -5643,6 +6157,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -5655,6 +6170,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -5668,6 +6184,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -5680,6 +6197,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -5693,6 +6211,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -5703,6 +6222,7 @@
   - "0.0"
   - "100.0"
   - "8"
+  :next_node: :what_is_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_is_overtime_pay_per_hour?
   :responses: 
@@ -5714,6 +6234,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -5726,6 +6247,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -5738,6 +6260,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -5751,6 +6274,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -5763,6 +6287,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -5776,6 +6301,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -5790,6 +6316,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -5803,6 +6330,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -5817,6 +6345,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_much_are_you_paid_during_pay_period?
   :responses: 
@@ -5826,6 +6355,7 @@
   - "1"
   - "0.0"
   - "300"
+  :next_node: :how_many_hours_overtime_do_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -5836,6 +6366,7 @@
   - "0.0"
   - "300.0"
   - "0"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -5847,6 +6378,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -5858,6 +6390,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -5870,6 +6403,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -5881,6 +6415,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -5893,6 +6428,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -5906,6 +6442,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -5918,6 +6455,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -5931,6 +6469,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -5941,6 +6480,7 @@
   - "0.0"
   - "300.0"
   - "8"
+  :next_node: :what_is_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_is_overtime_pay_per_hour?
   :responses: 
@@ -5952,6 +6492,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -5964,6 +6505,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -5976,6 +6518,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -5989,6 +6532,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -6001,6 +6545,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -6014,6 +6559,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -6028,6 +6574,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -6041,6 +6588,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -6055,6 +6603,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_do_you_work?
   :responses: 
@@ -6063,6 +6612,7 @@
   - "25"
   - "1"
   - "16"
+  :next_node: :how_much_are_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_are_you_paid_during_pay_period?
   :responses: 
@@ -6072,6 +6622,7 @@
   - "1"
   - "16.0"
   - "100"
+  :next_node: :how_many_hours_overtime_do_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -6082,6 +6633,7 @@
   - "16.0"
   - "100.0"
   - "0"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -6093,6 +6645,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -6104,6 +6657,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -6116,6 +6670,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -6127,6 +6682,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -6139,6 +6695,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -6152,6 +6709,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -6164,6 +6722,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -6177,6 +6736,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -6187,6 +6747,7 @@
   - "16.0"
   - "100.0"
   - "8"
+  :next_node: :what_is_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_is_overtime_pay_per_hour?
   :responses: 
@@ -6198,6 +6759,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -6210,6 +6772,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -6222,6 +6785,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -6235,6 +6799,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -6247,6 +6812,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -6260,6 +6826,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -6274,6 +6841,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -6287,6 +6855,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -6301,6 +6870,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_much_are_you_paid_during_pay_period?
   :responses: 
@@ -6310,6 +6880,7 @@
   - "1"
   - "16.0"
   - "300"
+  :next_node: :how_many_hours_overtime_do_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -6320,6 +6891,7 @@
   - "16.0"
   - "300.0"
   - "0"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -6331,6 +6903,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -6342,6 +6915,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -6354,6 +6928,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -6365,6 +6940,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -6377,6 +6953,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -6390,6 +6967,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -6402,6 +6980,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -6415,6 +6994,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -6425,6 +7005,7 @@
   - "16.0"
   - "300.0"
   - "8"
+  :next_node: :what_is_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_is_overtime_pay_per_hour?
   :responses: 
@@ -6436,6 +7017,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -6448,6 +7030,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -6460,6 +7043,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -6473,6 +7057,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -6485,6 +7070,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -6498,6 +7084,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -6512,6 +7099,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -6525,6 +7113,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -6539,6 +7128,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :how_often_do_you_get_paid?
   :responses: 
@@ -6546,6 +7136,7 @@
   - apprentice_over_19_second_year_onwards
   - "25"
   - "31"
+  :next_node: :how_many_hours_do_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_do_you_work?
   :responses: 
@@ -6554,6 +7145,7 @@
   - "25"
   - "31"
   - "0"
+  :next_node: :how_much_are_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_are_you_paid_during_pay_period?
   :responses: 
@@ -6563,6 +7155,7 @@
   - "31"
   - "0.0"
   - "100"
+  :next_node: :how_many_hours_overtime_do_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -6573,6 +7166,7 @@
   - "0.0"
   - "100.0"
   - "0"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -6584,6 +7178,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -6595,6 +7190,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -6607,6 +7203,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -6618,6 +7215,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -6630,6 +7228,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -6643,6 +7242,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -6655,6 +7255,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -6668,6 +7269,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -6678,6 +7280,7 @@
   - "0.0"
   - "100.0"
   - "8"
+  :next_node: :what_is_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_is_overtime_pay_per_hour?
   :responses: 
@@ -6689,6 +7292,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -6701,6 +7305,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -6713,6 +7318,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -6726,6 +7332,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -6738,6 +7345,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -6751,6 +7359,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -6765,6 +7374,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -6778,6 +7388,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -6792,6 +7403,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_much_are_you_paid_during_pay_period?
   :responses: 
@@ -6801,6 +7413,7 @@
   - "31"
   - "0.0"
   - "300"
+  :next_node: :how_many_hours_overtime_do_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -6811,6 +7424,7 @@
   - "0.0"
   - "300.0"
   - "0"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -6822,6 +7436,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -6833,6 +7448,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -6845,6 +7461,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -6856,6 +7473,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -6868,6 +7486,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -6881,6 +7500,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -6893,6 +7513,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -6906,6 +7527,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -6916,6 +7538,7 @@
   - "0.0"
   - "300.0"
   - "8"
+  :next_node: :what_is_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_is_overtime_pay_per_hour?
   :responses: 
@@ -6927,6 +7550,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -6939,6 +7563,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -6951,6 +7576,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -6964,6 +7590,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -6976,6 +7603,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -6989,6 +7617,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -7003,6 +7632,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -7016,6 +7646,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -7030,6 +7661,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_do_you_work?
   :responses: 
@@ -7038,6 +7670,7 @@
   - "25"
   - "31"
   - "16"
+  :next_node: :how_much_are_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_are_you_paid_during_pay_period?
   :responses: 
@@ -7047,6 +7680,7 @@
   - "31"
   - "16.0"
   - "100"
+  :next_node: :how_many_hours_overtime_do_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -7057,6 +7691,7 @@
   - "16.0"
   - "100.0"
   - "0"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -7068,6 +7703,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -7079,6 +7715,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -7091,6 +7728,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -7102,6 +7740,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -7114,6 +7753,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -7127,6 +7767,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -7139,6 +7780,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -7152,6 +7794,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -7162,6 +7805,7 @@
   - "16.0"
   - "100.0"
   - "8"
+  :next_node: :what_is_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_is_overtime_pay_per_hour?
   :responses: 
@@ -7173,6 +7817,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -7185,6 +7830,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -7197,6 +7843,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -7210,6 +7857,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -7222,6 +7870,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -7235,6 +7884,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -7249,6 +7899,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -7262,6 +7913,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -7276,6 +7928,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_much_are_you_paid_during_pay_period?
   :responses: 
@@ -7285,6 +7938,7 @@
   - "31"
   - "16.0"
   - "300"
+  :next_node: :how_many_hours_overtime_do_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -7295,6 +7949,7 @@
   - "16.0"
   - "300.0"
   - "0"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -7306,6 +7961,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -7317,6 +7973,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -7329,6 +7986,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -7340,6 +7998,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -7352,6 +8011,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -7365,6 +8025,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -7377,6 +8038,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -7390,6 +8052,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_do_you_work?
   :responses: 
@@ -7400,6 +8063,7 @@
   - "16.0"
   - "300.0"
   - "8"
+  :next_node: :what_is_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_is_overtime_pay_per_hour?
   :responses: 
@@ -7411,6 +8075,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :is_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -7423,6 +8088,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -7435,6 +8101,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -7448,6 +8115,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :is_provided_with_accommodation?
   :responses: 
@@ -7460,6 +8128,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :current_accommodation_charge?
   :outcome_node: false
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -7473,6 +8142,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -7487,6 +8157,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :current_payment_above
   :outcome_node: true
 - :current_node: :current_accommodation_charge?
   :responses: 
@@ -7500,6 +8171,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :current_accommodation_usage?
   :outcome_node: false
 - :current_node: :current_accommodation_usage?
   :responses: 
@@ -7514,21 +8186,25 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :current_payment_below
   :outcome_node: true
 - :current_node: :what_would_you_like_to_check?
   :responses: 
   - past_payment
+  :next_node: :past_payment_date?
   :outcome_node: false
 - :current_node: :past_payment_date?
   :responses: 
   - past_payment
   - "2013-10-01"
+  :next_node: :were_you_an_apprentice?
   :outcome_node: false
 - :current_node: :were_you_an_apprentice?
   :responses: 
   - past_payment
   - "2013-10-01"
   - "no"
+  :next_node: :how_old_were_you?
   :outcome_node: false
 - :current_node: :how_old_were_you?
   :responses: 
@@ -7536,6 +8212,7 @@
   - "2013-10-01"
   - "no"
   - "15"
+  :next_node: :under_school_leaving_age_past
   :outcome_node: true
 - :current_node: :how_old_were_you?
   :responses: 
@@ -7543,6 +8220,7 @@
   - "2013-10-01"
   - "no"
   - "25"
+  :next_node: :how_often_did_you_get_paid?
   :outcome_node: false
 - :current_node: :how_often_did_you_get_paid?
   :responses: 
@@ -7551,6 +8229,7 @@
   - "no"
   - "25"
   - "1"
+  :next_node: :how_many_hours_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -7560,6 +8239,7 @@
   - "25"
   - "1"
   - "0"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -7570,6 +8250,7 @@
   - "1"
   - "0.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -7581,6 +8262,7 @@
   - "0.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -7593,6 +8275,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -7605,6 +8288,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -7618,6 +8302,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -7630,6 +8315,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -7643,6 +8329,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -7657,6 +8344,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -7670,6 +8358,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -7684,6 +8373,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -7695,6 +8385,7 @@
   - "0.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -7707,6 +8398,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -7720,6 +8412,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -7733,6 +8426,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -7747,6 +8441,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -7760,6 +8455,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -7774,6 +8470,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -7789,6 +8486,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -7803,6 +8501,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -7818,6 +8517,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -7828,6 +8528,7 @@
   - "1"
   - "0.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -7839,6 +8540,7 @@
   - "0.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -7851,6 +8553,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -7863,6 +8566,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -7876,6 +8580,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -7888,6 +8593,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -7901,6 +8607,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -7915,6 +8622,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -7928,6 +8636,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -7942,6 +8651,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -7953,6 +8663,7 @@
   - "0.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -7965,6 +8676,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -7978,6 +8690,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -7991,6 +8704,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -8005,6 +8719,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -8018,6 +8733,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -8032,6 +8748,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -8047,6 +8764,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -8061,6 +8779,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -8076,6 +8795,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -8085,6 +8805,7 @@
   - "25"
   - "1"
   - "16"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -8095,6 +8816,7 @@
   - "1"
   - "16.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -8106,6 +8828,7 @@
   - "16.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -8118,6 +8841,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -8130,6 +8854,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -8143,6 +8868,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -8155,6 +8881,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -8168,6 +8895,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -8182,6 +8910,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -8195,6 +8924,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -8209,6 +8939,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -8220,6 +8951,7 @@
   - "16.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -8232,6 +8964,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -8245,6 +8978,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -8258,6 +8992,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -8272,6 +9007,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -8285,6 +9021,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -8299,6 +9036,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -8314,6 +9052,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -8328,6 +9067,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -8343,6 +9083,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -8353,6 +9094,7 @@
   - "1"
   - "16.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -8364,6 +9106,7 @@
   - "16.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -8376,6 +9119,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -8388,6 +9132,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -8401,6 +9146,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -8413,6 +9159,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -8426,6 +9173,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -8440,6 +9188,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -8453,6 +9202,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -8467,6 +9217,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -8478,6 +9229,7 @@
   - "16.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -8490,6 +9242,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -8503,6 +9256,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -8516,6 +9270,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -8530,6 +9285,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -8543,6 +9299,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -8557,6 +9314,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -8572,6 +9330,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -8586,6 +9345,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -8601,6 +9361,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_often_did_you_get_paid?
   :responses: 
@@ -8609,6 +9370,7 @@
   - "no"
   - "25"
   - "31"
+  :next_node: :how_many_hours_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -8618,6 +9380,7 @@
   - "25"
   - "31"
   - "0"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -8628,6 +9391,7 @@
   - "31"
   - "0.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -8639,6 +9403,7 @@
   - "0.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -8651,6 +9416,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -8663,6 +9429,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -8676,6 +9443,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -8688,6 +9456,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -8701,6 +9470,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -8715,6 +9485,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -8728,6 +9499,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -8742,6 +9514,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -8753,6 +9526,7 @@
   - "0.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -8765,6 +9539,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -8778,6 +9553,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -8791,6 +9567,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -8805,6 +9582,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -8818,6 +9596,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -8832,6 +9611,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -8847,6 +9627,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -8861,6 +9642,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -8876,6 +9658,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -8886,6 +9669,7 @@
   - "31"
   - "0.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -8897,6 +9681,7 @@
   - "0.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -8909,6 +9694,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -8921,6 +9707,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -8934,6 +9721,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -8946,6 +9734,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -8959,6 +9748,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -8973,6 +9763,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -8986,6 +9777,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -9000,6 +9792,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -9011,6 +9804,7 @@
   - "0.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -9023,6 +9817,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -9036,6 +9831,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -9049,6 +9845,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -9063,6 +9860,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -9076,6 +9874,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -9090,6 +9889,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -9105,6 +9905,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -9119,6 +9920,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -9134,6 +9936,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -9143,6 +9946,7 @@
   - "25"
   - "31"
   - "16"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -9153,6 +9957,7 @@
   - "31"
   - "16.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -9164,6 +9969,7 @@
   - "16.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -9176,6 +9982,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -9188,6 +9995,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -9201,6 +10009,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -9213,6 +10022,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -9226,6 +10036,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -9240,6 +10051,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -9253,6 +10065,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -9267,6 +10080,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -9278,6 +10092,7 @@
   - "16.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -9290,6 +10105,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -9303,6 +10119,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -9316,6 +10133,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -9330,6 +10148,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -9343,6 +10162,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -9357,6 +10177,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -9372,6 +10193,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -9386,6 +10208,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -9401,6 +10224,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -9411,6 +10235,7 @@
   - "31"
   - "16.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -9422,6 +10247,7 @@
   - "16.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -9434,6 +10260,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -9446,6 +10273,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -9459,6 +10287,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -9471,6 +10300,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -9484,6 +10314,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -9498,6 +10329,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -9511,6 +10343,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -9525,6 +10358,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -9536,6 +10370,7 @@
   - "16.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -9548,6 +10383,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -9561,6 +10397,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -9574,6 +10411,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -9588,6 +10426,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -9601,6 +10440,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -9615,6 +10455,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -9630,6 +10471,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -9644,6 +10486,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -9659,12 +10502,14 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :were_you_an_apprentice?
   :responses: 
   - past_payment
   - "2013-10-01"
   - apprentice_under_19
+  :next_node: :how_often_did_you_get_paid?
   :outcome_node: false
 - :current_node: :how_often_did_you_get_paid?
   :responses: 
@@ -9672,6 +10517,7 @@
   - "2013-10-01"
   - apprentice_under_19
   - "1"
+  :next_node: :how_many_hours_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -9680,6 +10526,7 @@
   - apprentice_under_19
   - "1"
   - "0"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -9689,6 +10536,7 @@
   - "1"
   - "0.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -9699,6 +10547,7 @@
   - "0.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -9710,6 +10559,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -9721,6 +10571,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -9733,6 +10584,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -9744,6 +10596,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -9756,6 +10609,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -9769,6 +10623,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -9781,6 +10636,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -9794,6 +10650,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -9804,6 +10661,7 @@
   - "0.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -9815,6 +10673,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -9827,6 +10686,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -9839,6 +10699,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -9852,6 +10713,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -9864,6 +10726,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -9877,6 +10740,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -9891,6 +10755,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -9904,6 +10769,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -9918,6 +10784,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -9927,6 +10794,7 @@
   - "1"
   - "0.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -9937,6 +10805,7 @@
   - "0.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -9948,6 +10817,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -9959,6 +10829,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -9971,6 +10842,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -9982,6 +10854,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -9994,6 +10867,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -10007,6 +10881,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -10019,6 +10894,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -10032,6 +10908,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -10042,6 +10919,7 @@
   - "0.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -10053,6 +10931,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -10065,6 +10944,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -10077,6 +10957,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -10090,6 +10971,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -10102,6 +10984,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -10115,6 +10998,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -10129,6 +11013,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -10142,6 +11027,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -10156,6 +11042,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -10164,6 +11051,7 @@
   - apprentice_under_19
   - "1"
   - "16"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -10173,6 +11061,7 @@
   - "1"
   - "16.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -10183,6 +11072,7 @@
   - "16.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -10194,6 +11084,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -10205,6 +11096,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -10217,6 +11109,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -10228,6 +11121,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -10240,6 +11134,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -10253,6 +11148,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -10265,6 +11161,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -10278,6 +11175,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -10288,6 +11186,7 @@
   - "16.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -10299,6 +11198,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -10311,6 +11211,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -10323,6 +11224,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -10336,6 +11238,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -10348,6 +11251,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -10361,6 +11265,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -10375,6 +11280,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -10388,6 +11294,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -10402,6 +11309,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -10411,6 +11319,7 @@
   - "1"
   - "16.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -10421,6 +11330,7 @@
   - "16.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -10432,6 +11342,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -10443,6 +11354,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -10455,6 +11367,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -10466,6 +11379,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -10478,6 +11392,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -10491,6 +11406,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -10503,6 +11419,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -10516,6 +11433,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -10526,6 +11444,7 @@
   - "16.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -10537,6 +11456,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -10549,6 +11469,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -10561,6 +11482,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -10574,6 +11496,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -10586,6 +11509,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -10599,6 +11523,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -10613,6 +11538,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -10626,6 +11552,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -10640,6 +11567,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_often_did_you_get_paid?
   :responses: 
@@ -10647,6 +11575,7 @@
   - "2013-10-01"
   - apprentice_under_19
   - "31"
+  :next_node: :how_many_hours_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -10655,6 +11584,7 @@
   - apprentice_under_19
   - "31"
   - "0"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -10664,6 +11594,7 @@
   - "31"
   - "0.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -10674,6 +11605,7 @@
   - "0.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -10685,6 +11617,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -10696,6 +11629,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -10708,6 +11642,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -10719,6 +11654,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -10731,6 +11667,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -10744,6 +11681,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -10756,6 +11694,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -10769,6 +11708,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -10779,6 +11719,7 @@
   - "0.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -10790,6 +11731,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -10802,6 +11744,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -10814,6 +11757,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -10827,6 +11771,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -10839,6 +11784,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -10852,6 +11798,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -10866,6 +11813,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -10879,6 +11827,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -10893,6 +11842,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -10902,6 +11852,7 @@
   - "31"
   - "0.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -10912,6 +11863,7 @@
   - "0.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -10923,6 +11875,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -10934,6 +11887,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -10946,6 +11900,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -10957,6 +11912,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -10969,6 +11925,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -10982,6 +11939,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -10994,6 +11952,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -11007,6 +11966,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -11017,6 +11977,7 @@
   - "0.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -11028,6 +11989,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -11040,6 +12002,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -11052,6 +12015,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -11065,6 +12029,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -11077,6 +12042,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -11090,6 +12056,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -11104,6 +12071,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -11117,6 +12085,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -11131,6 +12100,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -11139,6 +12109,7 @@
   - apprentice_under_19
   - "31"
   - "16"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -11148,6 +12119,7 @@
   - "31"
   - "16.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -11158,6 +12130,7 @@
   - "16.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -11169,6 +12142,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -11180,6 +12154,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -11192,6 +12167,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -11203,6 +12179,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -11215,6 +12192,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -11228,6 +12206,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -11240,6 +12219,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -11253,6 +12233,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -11263,6 +12244,7 @@
   - "16.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -11274,6 +12256,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -11286,6 +12269,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -11298,6 +12282,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -11311,6 +12296,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -11323,6 +12309,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -11336,6 +12323,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -11350,6 +12338,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -11363,6 +12352,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -11377,6 +12367,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -11386,6 +12377,7 @@
   - "31"
   - "16.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -11396,6 +12388,7 @@
   - "16.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -11407,6 +12400,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -11418,6 +12412,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -11430,6 +12425,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -11441,6 +12437,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -11453,6 +12450,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -11466,6 +12464,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -11478,6 +12477,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -11491,6 +12491,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -11501,6 +12502,7 @@
   - "16.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -11512,6 +12514,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -11524,6 +12527,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -11536,6 +12540,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -11549,6 +12554,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -11561,6 +12567,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -11574,6 +12581,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -11588,6 +12596,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -11601,6 +12610,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -11615,12 +12625,14 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :were_you_an_apprentice?
   :responses: 
   - past_payment
   - "2013-10-01"
   - apprentice_over_19
+  :next_node: :how_often_did_you_get_paid?
   :outcome_node: false
 - :current_node: :how_often_did_you_get_paid?
   :responses: 
@@ -11628,6 +12640,7 @@
   - "2013-10-01"
   - apprentice_over_19
   - "1"
+  :next_node: :how_many_hours_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -11636,6 +12649,7 @@
   - apprentice_over_19
   - "1"
   - "0"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -11645,6 +12659,7 @@
   - "1"
   - "0.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -11655,6 +12670,7 @@
   - "0.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -11666,6 +12682,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -11677,6 +12694,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -11689,6 +12707,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -11700,6 +12719,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -11712,6 +12732,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -11725,6 +12746,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -11737,6 +12759,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -11750,6 +12773,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -11760,6 +12784,7 @@
   - "0.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -11771,6 +12796,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -11783,6 +12809,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -11795,6 +12822,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -11808,6 +12836,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -11820,6 +12849,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -11833,6 +12863,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -11847,6 +12878,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -11860,6 +12892,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -11874,6 +12907,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -11883,6 +12917,7 @@
   - "1"
   - "0.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -11893,6 +12928,7 @@
   - "0.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -11904,6 +12940,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -11915,6 +12952,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -11927,6 +12965,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -11938,6 +12977,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -11950,6 +12990,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -11963,6 +13004,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -11975,6 +13017,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -11988,6 +13031,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -11998,6 +13042,7 @@
   - "0.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -12009,6 +13054,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -12021,6 +13067,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -12033,6 +13080,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -12046,6 +13094,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -12058,6 +13107,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -12071,6 +13121,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -12085,6 +13136,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -12098,6 +13150,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -12112,6 +13165,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -12120,6 +13174,7 @@
   - apprentice_over_19
   - "1"
   - "16"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -12129,6 +13184,7 @@
   - "1"
   - "16.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -12139,6 +13195,7 @@
   - "16.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -12150,6 +13207,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -12161,6 +13219,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -12173,6 +13232,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -12184,6 +13244,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -12196,6 +13257,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -12209,6 +13271,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -12221,6 +13284,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -12234,6 +13298,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -12244,6 +13309,7 @@
   - "16.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -12255,6 +13321,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -12267,6 +13334,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -12279,6 +13347,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -12292,6 +13361,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -12304,6 +13374,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -12317,6 +13388,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -12331,6 +13403,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -12344,6 +13417,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -12358,6 +13432,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -12367,6 +13442,7 @@
   - "1"
   - "16.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -12377,6 +13453,7 @@
   - "16.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -12388,6 +13465,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -12399,6 +13477,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -12411,6 +13490,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -12422,6 +13502,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -12434,6 +13515,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -12447,6 +13529,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -12459,6 +13542,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -12472,6 +13556,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -12482,6 +13567,7 @@
   - "16.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -12493,6 +13579,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -12505,6 +13592,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -12517,6 +13605,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -12530,6 +13619,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -12542,6 +13632,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -12555,6 +13646,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -12569,6 +13661,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -12582,6 +13675,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -12596,6 +13690,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_often_did_you_get_paid?
   :responses: 
@@ -12603,6 +13698,7 @@
   - "2013-10-01"
   - apprentice_over_19
   - "31"
+  :next_node: :how_many_hours_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -12611,6 +13707,7 @@
   - apprentice_over_19
   - "31"
   - "0"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -12620,6 +13717,7 @@
   - "31"
   - "0.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -12630,6 +13728,7 @@
   - "0.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -12641,6 +13740,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -12652,6 +13752,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -12664,6 +13765,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -12675,6 +13777,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -12687,6 +13790,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -12700,6 +13804,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -12712,6 +13817,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -12725,6 +13831,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -12735,6 +13842,7 @@
   - "0.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -12746,6 +13854,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -12758,6 +13867,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -12770,6 +13880,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -12783,6 +13894,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -12795,6 +13907,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -12808,6 +13921,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -12822,6 +13936,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -12835,6 +13950,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -12849,6 +13965,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -12858,6 +13975,7 @@
   - "31"
   - "0.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -12868,6 +13986,7 @@
   - "0.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -12879,6 +13998,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -12890,6 +14010,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -12902,6 +14023,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -12913,6 +14035,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -12925,6 +14048,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -12938,6 +14062,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -12950,6 +14075,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -12963,6 +14089,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -12973,6 +14100,7 @@
   - "0.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -12984,6 +14112,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -12996,6 +14125,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -13008,6 +14138,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -13021,6 +14152,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -13033,6 +14165,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -13046,6 +14179,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -13060,6 +14194,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -13073,6 +14208,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -13087,6 +14223,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -13095,6 +14232,7 @@
   - apprentice_over_19
   - "31"
   - "16"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -13104,6 +14242,7 @@
   - "31"
   - "16.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -13114,6 +14253,7 @@
   - "16.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -13125,6 +14265,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -13136,6 +14277,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -13148,6 +14290,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -13159,6 +14302,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -13171,6 +14315,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -13184,6 +14329,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -13196,6 +14342,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -13209,6 +14356,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -13219,6 +14367,7 @@
   - "16.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -13230,6 +14379,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -13242,6 +14392,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -13254,6 +14405,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -13267,6 +14419,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -13279,6 +14432,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -13292,6 +14446,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -13306,6 +14461,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -13319,6 +14475,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -13333,6 +14490,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -13342,6 +14500,7 @@
   - "31"
   - "16.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -13352,6 +14511,7 @@
   - "16.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -13363,6 +14523,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -13374,6 +14535,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -13386,6 +14548,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -13397,6 +14560,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -13409,6 +14573,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -13422,6 +14587,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -13434,6 +14600,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -13447,6 +14614,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -13457,6 +14625,7 @@
   - "16.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -13468,6 +14637,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -13480,6 +14650,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -13492,6 +14663,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -13505,6 +14677,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -13517,6 +14690,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -13530,6 +14704,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -13544,6 +14719,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -13557,6 +14733,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -13571,17 +14748,20 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_payment_date?
   :responses: 
   - past_payment
   - "2012-10-01"
+  :next_node: :were_you_an_apprentice?
   :outcome_node: false
 - :current_node: :were_you_an_apprentice?
   :responses: 
   - past_payment
   - "2012-10-01"
   - "no"
+  :next_node: :how_old_were_you?
   :outcome_node: false
 - :current_node: :how_old_were_you?
   :responses: 
@@ -13589,6 +14769,7 @@
   - "2012-10-01"
   - "no"
   - "15"
+  :next_node: :under_school_leaving_age_past
   :outcome_node: true
 - :current_node: :how_old_were_you?
   :responses: 
@@ -13596,6 +14777,7 @@
   - "2012-10-01"
   - "no"
   - "25"
+  :next_node: :how_often_did_you_get_paid?
   :outcome_node: false
 - :current_node: :how_often_did_you_get_paid?
   :responses: 
@@ -13604,6 +14786,7 @@
   - "no"
   - "25"
   - "1"
+  :next_node: :how_many_hours_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -13613,6 +14796,7 @@
   - "25"
   - "1"
   - "0"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -13623,6 +14807,7 @@
   - "1"
   - "0.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -13634,6 +14819,7 @@
   - "0.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -13646,6 +14832,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -13658,6 +14845,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -13671,6 +14859,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -13683,6 +14872,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -13696,6 +14886,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -13710,6 +14901,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -13723,6 +14915,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -13737,6 +14930,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -13748,6 +14942,7 @@
   - "0.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -13760,6 +14955,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -13773,6 +14969,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -13786,6 +14983,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -13800,6 +14998,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -13813,6 +15012,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -13827,6 +15027,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -13842,6 +15043,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -13856,6 +15058,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -13871,6 +15074,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -13881,6 +15085,7 @@
   - "1"
   - "0.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -13892,6 +15097,7 @@
   - "0.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -13904,6 +15110,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -13916,6 +15123,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -13929,6 +15137,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -13941,6 +15150,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -13954,6 +15164,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -13968,6 +15179,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -13981,6 +15193,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -13995,6 +15208,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -14006,6 +15220,7 @@
   - "0.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -14018,6 +15233,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -14031,6 +15247,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -14044,6 +15261,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -14058,6 +15276,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -14071,6 +15290,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -14085,6 +15305,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -14100,6 +15321,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -14114,6 +15336,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -14129,6 +15352,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -14138,6 +15362,7 @@
   - "25"
   - "1"
   - "16"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -14148,6 +15373,7 @@
   - "1"
   - "16.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -14159,6 +15385,7 @@
   - "16.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -14171,6 +15398,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -14183,6 +15411,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -14196,6 +15425,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -14208,6 +15438,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -14221,6 +15452,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -14235,6 +15467,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -14248,6 +15481,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -14262,6 +15496,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -14273,6 +15508,7 @@
   - "16.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -14285,6 +15521,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -14298,6 +15535,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -14311,6 +15549,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -14325,6 +15564,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -14338,6 +15578,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -14352,6 +15593,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -14367,6 +15609,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -14381,6 +15624,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -14396,6 +15640,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -14406,6 +15651,7 @@
   - "1"
   - "16.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -14417,6 +15663,7 @@
   - "16.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -14429,6 +15676,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -14441,6 +15689,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -14454,6 +15703,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -14466,6 +15716,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -14479,6 +15730,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -14493,6 +15745,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -14506,6 +15759,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -14520,6 +15774,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -14531,6 +15786,7 @@
   - "16.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -14543,6 +15799,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -14556,6 +15813,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -14569,6 +15827,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -14583,6 +15842,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -14596,6 +15856,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -14610,6 +15871,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -14625,6 +15887,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -14639,6 +15902,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -14654,6 +15918,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_often_did_you_get_paid?
   :responses: 
@@ -14662,6 +15927,7 @@
   - "no"
   - "25"
   - "31"
+  :next_node: :how_many_hours_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -14671,6 +15937,7 @@
   - "25"
   - "31"
   - "0"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -14681,6 +15948,7 @@
   - "31"
   - "0.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -14692,6 +15960,7 @@
   - "0.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -14704,6 +15973,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -14716,6 +15986,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -14729,6 +16000,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -14741,6 +16013,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -14754,6 +16027,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -14768,6 +16042,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -14781,6 +16056,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -14795,6 +16071,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -14806,6 +16083,7 @@
   - "0.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -14818,6 +16096,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -14831,6 +16110,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -14844,6 +16124,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -14858,6 +16139,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -14871,6 +16153,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -14885,6 +16168,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -14900,6 +16184,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -14914,6 +16199,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -14929,6 +16215,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -14939,6 +16226,7 @@
   - "31"
   - "0.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -14950,6 +16238,7 @@
   - "0.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -14962,6 +16251,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -14974,6 +16264,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -14987,6 +16278,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -14999,6 +16291,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -15012,6 +16305,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -15026,6 +16320,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -15039,6 +16334,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -15053,6 +16349,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -15064,6 +16361,7 @@
   - "0.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -15076,6 +16374,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -15089,6 +16388,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -15102,6 +16402,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -15116,6 +16417,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -15129,6 +16431,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -15143,6 +16446,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -15158,6 +16462,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -15172,6 +16477,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -15187,6 +16493,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -15196,6 +16503,7 @@
   - "25"
   - "31"
   - "16"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -15206,6 +16514,7 @@
   - "31"
   - "16.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -15217,6 +16526,7 @@
   - "16.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -15229,6 +16539,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -15241,6 +16552,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -15254,6 +16566,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -15266,6 +16579,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -15279,6 +16593,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -15293,6 +16608,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -15306,6 +16622,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -15320,6 +16637,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -15331,6 +16649,7 @@
   - "16.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -15343,6 +16662,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -15356,6 +16676,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -15369,6 +16690,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -15383,6 +16705,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -15396,6 +16719,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -15410,6 +16734,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -15425,6 +16750,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -15439,6 +16765,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -15454,6 +16781,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -15464,6 +16792,7 @@
   - "31"
   - "16.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -15475,6 +16804,7 @@
   - "16.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -15487,6 +16817,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -15499,6 +16830,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -15512,6 +16844,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -15524,6 +16857,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -15537,6 +16871,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -15551,6 +16886,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -15564,6 +16900,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -15578,6 +16915,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -15589,6 +16927,7 @@
   - "16.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -15601,6 +16940,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -15614,6 +16954,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -15627,6 +16968,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -15641,6 +16983,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -15654,6 +16997,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -15668,6 +17012,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -15683,6 +17028,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -15697,6 +17043,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -15712,12 +17059,14 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :were_you_an_apprentice?
   :responses: 
   - past_payment
   - "2012-10-01"
   - apprentice_under_19
+  :next_node: :how_often_did_you_get_paid?
   :outcome_node: false
 - :current_node: :how_often_did_you_get_paid?
   :responses: 
@@ -15725,6 +17074,7 @@
   - "2012-10-01"
   - apprentice_under_19
   - "1"
+  :next_node: :how_many_hours_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -15733,6 +17083,7 @@
   - apprentice_under_19
   - "1"
   - "0"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -15742,6 +17093,7 @@
   - "1"
   - "0.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -15752,6 +17104,7 @@
   - "0.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -15763,6 +17116,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -15774,6 +17128,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -15786,6 +17141,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -15797,6 +17153,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -15809,6 +17166,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -15822,6 +17180,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -15834,6 +17193,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -15847,6 +17207,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -15857,6 +17218,7 @@
   - "0.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -15868,6 +17230,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -15880,6 +17243,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -15892,6 +17256,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -15905,6 +17270,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -15917,6 +17283,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -15930,6 +17297,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -15944,6 +17312,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -15957,6 +17326,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -15971,6 +17341,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -15980,6 +17351,7 @@
   - "1"
   - "0.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -15990,6 +17362,7 @@
   - "0.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -16001,6 +17374,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -16012,6 +17386,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -16024,6 +17399,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -16035,6 +17411,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -16047,6 +17424,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -16060,6 +17438,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -16072,6 +17451,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -16085,6 +17465,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -16095,6 +17476,7 @@
   - "0.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -16106,6 +17488,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -16118,6 +17501,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -16130,6 +17514,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -16143,6 +17528,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -16155,6 +17541,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -16168,6 +17555,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -16182,6 +17570,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -16195,6 +17584,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -16209,6 +17599,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -16217,6 +17608,7 @@
   - apprentice_under_19
   - "1"
   - "16"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -16226,6 +17618,7 @@
   - "1"
   - "16.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -16236,6 +17629,7 @@
   - "16.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -16247,6 +17641,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -16258,6 +17653,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -16270,6 +17666,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -16281,6 +17678,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -16293,6 +17691,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -16306,6 +17705,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -16318,6 +17718,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -16331,6 +17732,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -16341,6 +17743,7 @@
   - "16.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -16352,6 +17755,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -16364,6 +17768,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -16376,6 +17781,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -16389,6 +17795,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -16401,6 +17808,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -16414,6 +17822,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -16428,6 +17837,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -16441,6 +17851,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -16455,6 +17866,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -16464,6 +17876,7 @@
   - "1"
   - "16.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -16474,6 +17887,7 @@
   - "16.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -16485,6 +17899,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -16496,6 +17911,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -16508,6 +17924,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -16519,6 +17936,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -16531,6 +17949,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -16544,6 +17963,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -16556,6 +17976,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -16569,6 +17990,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -16579,6 +18001,7 @@
   - "16.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -16590,6 +18013,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -16602,6 +18026,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -16614,6 +18039,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -16627,6 +18053,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -16639,6 +18066,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -16652,6 +18080,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -16666,6 +18095,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -16679,6 +18109,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -16693,6 +18124,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_often_did_you_get_paid?
   :responses: 
@@ -16700,6 +18132,7 @@
   - "2012-10-01"
   - apprentice_under_19
   - "31"
+  :next_node: :how_many_hours_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -16708,6 +18141,7 @@
   - apprentice_under_19
   - "31"
   - "0"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -16717,6 +18151,7 @@
   - "31"
   - "0.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -16727,6 +18162,7 @@
   - "0.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -16738,6 +18174,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -16749,6 +18186,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -16761,6 +18199,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -16772,6 +18211,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -16784,6 +18224,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -16797,6 +18238,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -16809,6 +18251,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -16822,6 +18265,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -16832,6 +18276,7 @@
   - "0.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -16843,6 +18288,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -16855,6 +18301,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -16867,6 +18314,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -16880,6 +18328,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -16892,6 +18341,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -16905,6 +18355,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -16919,6 +18370,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -16932,6 +18384,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -16946,6 +18399,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -16955,6 +18409,7 @@
   - "31"
   - "0.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -16965,6 +18420,7 @@
   - "0.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -16976,6 +18432,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -16987,6 +18444,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -16999,6 +18457,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -17010,6 +18469,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -17022,6 +18482,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -17035,6 +18496,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -17047,6 +18509,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -17060,6 +18523,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -17070,6 +18534,7 @@
   - "0.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -17081,6 +18546,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -17093,6 +18559,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -17105,6 +18572,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -17118,6 +18586,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -17130,6 +18599,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -17143,6 +18613,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -17157,6 +18628,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -17170,6 +18642,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -17184,6 +18657,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -17192,6 +18666,7 @@
   - apprentice_under_19
   - "31"
   - "16"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -17201,6 +18676,7 @@
   - "31"
   - "16.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -17211,6 +18687,7 @@
   - "16.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -17222,6 +18699,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -17233,6 +18711,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -17245,6 +18724,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -17256,6 +18736,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -17268,6 +18749,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -17281,6 +18763,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -17293,6 +18776,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -17306,6 +18790,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -17316,6 +18801,7 @@
   - "16.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -17327,6 +18813,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -17339,6 +18826,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -17351,6 +18839,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -17364,6 +18853,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -17376,6 +18866,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -17389,6 +18880,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -17403,6 +18895,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -17416,6 +18909,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -17430,6 +18924,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -17439,6 +18934,7 @@
   - "31"
   - "16.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -17449,6 +18945,7 @@
   - "16.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -17460,6 +18957,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -17471,6 +18969,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -17483,6 +18982,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -17494,6 +18994,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -17506,6 +19007,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -17519,6 +19021,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -17531,6 +19034,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -17544,6 +19048,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -17554,6 +19059,7 @@
   - "16.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -17565,6 +19071,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -17577,6 +19084,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -17589,6 +19097,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -17602,6 +19111,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -17614,6 +19124,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -17627,6 +19138,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -17641,6 +19153,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -17654,6 +19167,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -17668,12 +19182,14 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :were_you_an_apprentice?
   :responses: 
   - past_payment
   - "2012-10-01"
   - apprentice_over_19
+  :next_node: :how_often_did_you_get_paid?
   :outcome_node: false
 - :current_node: :how_often_did_you_get_paid?
   :responses: 
@@ -17681,6 +19197,7 @@
   - "2012-10-01"
   - apprentice_over_19
   - "1"
+  :next_node: :how_many_hours_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -17689,6 +19206,7 @@
   - apprentice_over_19
   - "1"
   - "0"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -17698,6 +19216,7 @@
   - "1"
   - "0.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -17708,6 +19227,7 @@
   - "0.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -17719,6 +19239,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -17730,6 +19251,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -17742,6 +19264,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -17753,6 +19276,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -17765,6 +19289,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -17778,6 +19303,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -17790,6 +19316,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -17803,6 +19330,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -17813,6 +19341,7 @@
   - "0.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -17824,6 +19353,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -17836,6 +19366,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -17848,6 +19379,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -17861,6 +19393,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -17873,6 +19406,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -17886,6 +19420,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -17900,6 +19435,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -17913,6 +19449,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -17927,6 +19464,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -17936,6 +19474,7 @@
   - "1"
   - "0.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -17946,6 +19485,7 @@
   - "0.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -17957,6 +19497,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -17968,6 +19509,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -17980,6 +19522,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -17991,6 +19534,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -18003,6 +19547,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -18016,6 +19561,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -18028,6 +19574,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -18041,6 +19588,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -18051,6 +19599,7 @@
   - "0.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -18062,6 +19611,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -18074,6 +19624,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -18086,6 +19637,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -18099,6 +19651,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -18111,6 +19664,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -18124,6 +19678,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -18138,6 +19693,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -18151,6 +19707,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -18165,6 +19722,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -18173,6 +19731,7 @@
   - apprentice_over_19
   - "1"
   - "16"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -18182,6 +19741,7 @@
   - "1"
   - "16.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -18192,6 +19752,7 @@
   - "16.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -18203,6 +19764,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -18214,6 +19776,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -18226,6 +19789,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -18237,6 +19801,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -18249,6 +19814,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -18262,6 +19828,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -18274,6 +19841,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -18287,6 +19855,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -18297,6 +19866,7 @@
   - "16.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -18308,6 +19878,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -18320,6 +19891,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -18332,6 +19904,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -18345,6 +19918,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -18357,6 +19931,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -18370,6 +19945,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -18384,6 +19960,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -18397,6 +19974,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -18411,6 +19989,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -18420,6 +19999,7 @@
   - "1"
   - "16.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -18430,6 +20010,7 @@
   - "16.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -18441,6 +20022,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -18452,6 +20034,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -18464,6 +20047,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -18475,6 +20059,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -18487,6 +20072,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -18500,6 +20086,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -18512,6 +20099,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -18525,6 +20113,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -18535,6 +20124,7 @@
   - "16.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -18546,6 +20136,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -18558,6 +20149,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -18570,6 +20162,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -18583,6 +20176,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -18595,6 +20189,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -18608,6 +20203,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -18622,6 +20218,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -18635,6 +20232,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -18649,6 +20247,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_often_did_you_get_paid?
   :responses: 
@@ -18656,6 +20255,7 @@
   - "2012-10-01"
   - apprentice_over_19
   - "31"
+  :next_node: :how_many_hours_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -18664,6 +20264,7 @@
   - apprentice_over_19
   - "31"
   - "0"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -18673,6 +20274,7 @@
   - "31"
   - "0.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -18683,6 +20285,7 @@
   - "0.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -18694,6 +20297,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -18705,6 +20309,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -18717,6 +20322,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -18728,6 +20334,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -18740,6 +20347,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -18753,6 +20361,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -18765,6 +20374,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -18778,6 +20388,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -18788,6 +20399,7 @@
   - "0.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -18799,6 +20411,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -18811,6 +20424,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -18823,6 +20437,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -18836,6 +20451,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -18848,6 +20464,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -18861,6 +20478,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -18875,6 +20493,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -18888,6 +20507,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -18902,6 +20522,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -18911,6 +20532,7 @@
   - "31"
   - "0.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -18921,6 +20543,7 @@
   - "0.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -18932,6 +20555,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -18943,6 +20567,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -18955,6 +20580,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -18966,6 +20592,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -18978,6 +20605,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -18991,6 +20619,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -19003,6 +20632,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -19016,6 +20646,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -19026,6 +20657,7 @@
   - "0.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -19037,6 +20669,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -19049,6 +20682,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -19061,6 +20695,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -19074,6 +20709,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -19086,6 +20722,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -19099,6 +20736,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -19113,6 +20751,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -19126,6 +20765,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -19140,6 +20780,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -19148,6 +20789,7 @@
   - apprentice_over_19
   - "31"
   - "16"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -19157,6 +20799,7 @@
   - "31"
   - "16.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -19167,6 +20810,7 @@
   - "16.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -19178,6 +20822,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -19189,6 +20834,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -19201,6 +20847,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -19212,6 +20859,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -19224,6 +20872,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -19237,6 +20886,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -19249,6 +20899,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -19262,6 +20913,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -19272,6 +20924,7 @@
   - "16.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -19283,6 +20936,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -19295,6 +20949,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -19307,6 +20962,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -19320,6 +20976,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -19332,6 +20989,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -19345,6 +21003,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -19359,6 +21018,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -19372,6 +21032,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -19386,6 +21047,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -19395,6 +21057,7 @@
   - "31"
   - "16.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -19405,6 +21068,7 @@
   - "16.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -19416,6 +21080,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -19427,6 +21092,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -19439,6 +21105,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -19450,6 +21117,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -19462,6 +21130,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -19475,6 +21144,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -19487,6 +21157,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -19500,6 +21171,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -19510,6 +21182,7 @@
   - "16.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -19521,6 +21194,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -19533,6 +21207,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -19545,6 +21220,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -19558,6 +21234,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -19570,6 +21247,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -19583,6 +21261,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -19597,6 +21276,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -19610,6 +21290,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -19624,17 +21305,20 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_payment_date?
   :responses: 
   - past_payment
   - "2011-10-01"
+  :next_node: :were_you_an_apprentice?
   :outcome_node: false
 - :current_node: :were_you_an_apprentice?
   :responses: 
   - past_payment
   - "2011-10-01"
   - "no"
+  :next_node: :how_old_were_you?
   :outcome_node: false
 - :current_node: :how_old_were_you?
   :responses: 
@@ -19642,6 +21326,7 @@
   - "2011-10-01"
   - "no"
   - "15"
+  :next_node: :under_school_leaving_age_past
   :outcome_node: true
 - :current_node: :how_old_were_you?
   :responses: 
@@ -19649,6 +21334,7 @@
   - "2011-10-01"
   - "no"
   - "25"
+  :next_node: :how_often_did_you_get_paid?
   :outcome_node: false
 - :current_node: :how_often_did_you_get_paid?
   :responses: 
@@ -19657,6 +21343,7 @@
   - "no"
   - "25"
   - "1"
+  :next_node: :how_many_hours_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -19666,6 +21353,7 @@
   - "25"
   - "1"
   - "0"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -19676,6 +21364,7 @@
   - "1"
   - "0.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -19687,6 +21376,7 @@
   - "0.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -19699,6 +21389,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -19711,6 +21402,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -19724,6 +21416,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -19736,6 +21429,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -19749,6 +21443,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -19763,6 +21458,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -19776,6 +21472,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -19790,6 +21487,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -19801,6 +21499,7 @@
   - "0.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -19813,6 +21512,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -19826,6 +21526,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -19839,6 +21540,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -19853,6 +21555,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -19866,6 +21569,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -19880,6 +21584,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -19895,6 +21600,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -19909,6 +21615,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -19924,6 +21631,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -19934,6 +21642,7 @@
   - "1"
   - "0.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -19945,6 +21654,7 @@
   - "0.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -19957,6 +21667,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -19969,6 +21680,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -19982,6 +21694,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -19994,6 +21707,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -20007,6 +21721,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -20021,6 +21736,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -20034,6 +21750,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -20048,6 +21765,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -20059,6 +21777,7 @@
   - "0.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -20071,6 +21790,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -20084,6 +21804,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -20097,6 +21818,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -20111,6 +21833,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -20124,6 +21847,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -20138,6 +21862,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -20153,6 +21878,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -20167,6 +21893,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -20182,6 +21909,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -20191,6 +21919,7 @@
   - "25"
   - "1"
   - "16"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -20201,6 +21930,7 @@
   - "1"
   - "16.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -20212,6 +21942,7 @@
   - "16.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -20224,6 +21955,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -20236,6 +21968,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -20249,6 +21982,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -20261,6 +21995,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -20274,6 +22009,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -20288,6 +22024,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -20301,6 +22038,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -20315,6 +22053,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -20326,6 +22065,7 @@
   - "16.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -20338,6 +22078,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -20351,6 +22092,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -20364,6 +22106,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -20378,6 +22121,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -20391,6 +22135,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -20405,6 +22150,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -20420,6 +22166,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -20434,6 +22181,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -20449,6 +22197,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -20459,6 +22208,7 @@
   - "1"
   - "16.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -20470,6 +22220,7 @@
   - "16.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -20482,6 +22233,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -20494,6 +22246,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -20507,6 +22260,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -20519,6 +22273,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -20532,6 +22287,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -20546,6 +22302,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -20559,6 +22316,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -20573,6 +22331,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -20584,6 +22343,7 @@
   - "16.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -20596,6 +22356,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -20609,6 +22370,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -20622,6 +22384,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -20636,6 +22399,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -20649,6 +22413,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -20663,6 +22428,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -20678,6 +22444,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -20692,6 +22459,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -20707,6 +22475,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_often_did_you_get_paid?
   :responses: 
@@ -20715,6 +22484,7 @@
   - "no"
   - "25"
   - "31"
+  :next_node: :how_many_hours_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -20724,6 +22494,7 @@
   - "25"
   - "31"
   - "0"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -20734,6 +22505,7 @@
   - "31"
   - "0.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -20745,6 +22517,7 @@
   - "0.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -20757,6 +22530,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -20769,6 +22543,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -20782,6 +22557,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -20794,6 +22570,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -20807,6 +22584,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -20821,6 +22599,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -20834,6 +22613,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -20848,6 +22628,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -20859,6 +22640,7 @@
   - "0.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -20871,6 +22653,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -20884,6 +22667,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -20897,6 +22681,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -20911,6 +22696,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -20924,6 +22710,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -20938,6 +22725,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -20953,6 +22741,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -20967,6 +22756,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -20982,6 +22772,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -20992,6 +22783,7 @@
   - "31"
   - "0.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -21003,6 +22795,7 @@
   - "0.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -21015,6 +22808,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -21027,6 +22821,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -21040,6 +22835,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -21052,6 +22848,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -21065,6 +22862,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -21079,6 +22877,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -21092,6 +22891,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -21106,6 +22906,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -21117,6 +22918,7 @@
   - "0.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -21129,6 +22931,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -21142,6 +22945,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -21155,6 +22959,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -21169,6 +22974,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -21182,6 +22988,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -21196,6 +23003,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -21211,6 +23019,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -21225,6 +23034,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -21240,6 +23050,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -21249,6 +23060,7 @@
   - "25"
   - "31"
   - "16"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -21259,6 +23071,7 @@
   - "31"
   - "16.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -21270,6 +23083,7 @@
   - "16.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -21282,6 +23096,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -21294,6 +23109,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -21307,6 +23123,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -21319,6 +23136,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -21332,6 +23150,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -21346,6 +23165,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -21359,6 +23179,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -21373,6 +23194,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -21384,6 +23206,7 @@
   - "16.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -21396,6 +23219,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -21409,6 +23233,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -21422,6 +23247,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -21436,6 +23262,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -21449,6 +23276,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -21463,6 +23291,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -21478,6 +23307,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -21492,6 +23322,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -21507,6 +23338,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -21517,6 +23349,7 @@
   - "31"
   - "16.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -21528,6 +23361,7 @@
   - "16.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -21540,6 +23374,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -21552,6 +23387,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -21565,6 +23401,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -21577,6 +23414,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -21590,6 +23428,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -21604,6 +23443,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -21617,6 +23457,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -21631,6 +23472,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -21642,6 +23484,7 @@
   - "16.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -21654,6 +23497,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -21667,6 +23511,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -21680,6 +23525,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -21694,6 +23540,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -21707,6 +23554,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -21721,6 +23569,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -21736,6 +23585,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -21750,6 +23600,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -21765,12 +23616,14 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :were_you_an_apprentice?
   :responses: 
   - past_payment
   - "2011-10-01"
   - apprentice_under_19
+  :next_node: :how_often_did_you_get_paid?
   :outcome_node: false
 - :current_node: :how_often_did_you_get_paid?
   :responses: 
@@ -21778,6 +23631,7 @@
   - "2011-10-01"
   - apprentice_under_19
   - "1"
+  :next_node: :how_many_hours_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -21786,6 +23640,7 @@
   - apprentice_under_19
   - "1"
   - "0"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -21795,6 +23650,7 @@
   - "1"
   - "0.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -21805,6 +23661,7 @@
   - "0.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -21816,6 +23673,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -21827,6 +23685,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -21839,6 +23698,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -21850,6 +23710,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -21862,6 +23723,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -21875,6 +23737,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -21887,6 +23750,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -21900,6 +23764,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -21910,6 +23775,7 @@
   - "0.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -21921,6 +23787,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -21933,6 +23800,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -21945,6 +23813,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -21958,6 +23827,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -21970,6 +23840,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -21983,6 +23854,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -21997,6 +23869,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -22010,6 +23883,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -22024,6 +23898,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -22033,6 +23908,7 @@
   - "1"
   - "0.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -22043,6 +23919,7 @@
   - "0.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -22054,6 +23931,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -22065,6 +23943,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -22077,6 +23956,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -22088,6 +23968,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -22100,6 +23981,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -22113,6 +23995,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -22125,6 +24008,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -22138,6 +24022,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -22148,6 +24033,7 @@
   - "0.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -22159,6 +24045,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -22171,6 +24058,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -22183,6 +24071,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -22196,6 +24085,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -22208,6 +24098,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -22221,6 +24112,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -22235,6 +24127,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -22248,6 +24141,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -22262,6 +24156,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -22270,6 +24165,7 @@
   - apprentice_under_19
   - "1"
   - "16"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -22279,6 +24175,7 @@
   - "1"
   - "16.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -22289,6 +24186,7 @@
   - "16.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -22300,6 +24198,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -22311,6 +24210,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -22323,6 +24223,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -22334,6 +24235,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -22346,6 +24248,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -22359,6 +24262,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -22371,6 +24275,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -22384,6 +24289,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -22394,6 +24300,7 @@
   - "16.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -22405,6 +24312,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -22417,6 +24325,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -22429,6 +24338,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -22442,6 +24352,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -22454,6 +24365,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -22467,6 +24379,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -22481,6 +24394,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -22494,6 +24408,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -22508,6 +24423,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -22517,6 +24433,7 @@
   - "1"
   - "16.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -22527,6 +24444,7 @@
   - "16.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -22538,6 +24456,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -22549,6 +24468,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -22561,6 +24481,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -22572,6 +24493,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -22584,6 +24506,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -22597,6 +24520,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -22609,6 +24533,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -22622,6 +24547,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -22632,6 +24558,7 @@
   - "16.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -22643,6 +24570,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -22655,6 +24583,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -22667,6 +24596,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -22680,6 +24610,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -22692,6 +24623,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -22705,6 +24637,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -22719,6 +24652,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -22732,6 +24666,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -22746,6 +24681,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_often_did_you_get_paid?
   :responses: 
@@ -22753,6 +24689,7 @@
   - "2011-10-01"
   - apprentice_under_19
   - "31"
+  :next_node: :how_many_hours_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -22761,6 +24698,7 @@
   - apprentice_under_19
   - "31"
   - "0"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -22770,6 +24708,7 @@
   - "31"
   - "0.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -22780,6 +24719,7 @@
   - "0.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -22791,6 +24731,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -22802,6 +24743,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -22814,6 +24756,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -22825,6 +24768,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -22837,6 +24781,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -22850,6 +24795,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -22862,6 +24808,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -22875,6 +24822,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -22885,6 +24833,7 @@
   - "0.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -22896,6 +24845,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -22908,6 +24858,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -22920,6 +24871,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -22933,6 +24885,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -22945,6 +24898,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -22958,6 +24912,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -22972,6 +24927,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -22985,6 +24941,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -22999,6 +24956,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -23008,6 +24966,7 @@
   - "31"
   - "0.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -23018,6 +24977,7 @@
   - "0.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -23029,6 +24989,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -23040,6 +25001,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -23052,6 +25014,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -23063,6 +25026,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -23075,6 +25039,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -23088,6 +25053,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -23100,6 +25066,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -23113,6 +25080,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -23123,6 +25091,7 @@
   - "0.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -23134,6 +25103,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -23146,6 +25116,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -23158,6 +25129,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -23171,6 +25143,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -23183,6 +25156,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -23196,6 +25170,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -23210,6 +25185,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -23223,6 +25199,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -23237,6 +25214,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -23245,6 +25223,7 @@
   - apprentice_under_19
   - "31"
   - "16"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -23254,6 +25233,7 @@
   - "31"
   - "16.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -23264,6 +25244,7 @@
   - "16.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -23275,6 +25256,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -23286,6 +25268,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -23298,6 +25281,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -23309,6 +25293,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -23321,6 +25306,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -23334,6 +25320,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -23346,6 +25333,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -23359,6 +25347,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -23369,6 +25358,7 @@
   - "16.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -23380,6 +25370,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -23392,6 +25383,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -23404,6 +25396,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -23417,6 +25410,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -23429,6 +25423,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -23442,6 +25437,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -23456,6 +25452,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -23469,6 +25466,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -23483,6 +25481,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -23492,6 +25491,7 @@
   - "31"
   - "16.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -23502,6 +25502,7 @@
   - "16.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -23513,6 +25514,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -23524,6 +25526,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -23536,6 +25539,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -23547,6 +25551,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -23559,6 +25564,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -23572,6 +25578,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -23584,6 +25591,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -23597,6 +25605,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -23607,6 +25616,7 @@
   - "16.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -23618,6 +25628,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -23630,6 +25641,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -23642,6 +25654,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -23655,6 +25668,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -23667,6 +25681,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -23680,6 +25695,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -23694,6 +25710,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -23707,6 +25724,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -23721,12 +25739,14 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :were_you_an_apprentice?
   :responses: 
   - past_payment
   - "2011-10-01"
   - apprentice_over_19
+  :next_node: :how_often_did_you_get_paid?
   :outcome_node: false
 - :current_node: :how_often_did_you_get_paid?
   :responses: 
@@ -23734,6 +25754,7 @@
   - "2011-10-01"
   - apprentice_over_19
   - "1"
+  :next_node: :how_many_hours_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -23742,6 +25763,7 @@
   - apprentice_over_19
   - "1"
   - "0"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -23751,6 +25773,7 @@
   - "1"
   - "0.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -23761,6 +25784,7 @@
   - "0.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -23772,6 +25796,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -23783,6 +25808,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -23795,6 +25821,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -23806,6 +25833,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -23818,6 +25846,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -23831,6 +25860,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -23843,6 +25873,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -23856,6 +25887,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -23866,6 +25898,7 @@
   - "0.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -23877,6 +25910,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -23889,6 +25923,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -23901,6 +25936,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -23914,6 +25950,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -23926,6 +25963,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -23939,6 +25977,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -23953,6 +25992,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -23966,6 +26006,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -23980,6 +26021,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -23989,6 +26031,7 @@
   - "1"
   - "0.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -23999,6 +26042,7 @@
   - "0.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -24010,6 +26054,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -24021,6 +26066,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -24033,6 +26079,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -24044,6 +26091,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -24056,6 +26104,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -24069,6 +26118,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -24081,6 +26131,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -24094,6 +26145,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -24104,6 +26156,7 @@
   - "0.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -24115,6 +26168,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -24127,6 +26181,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -24139,6 +26194,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -24152,6 +26208,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -24164,6 +26221,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -24177,6 +26235,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -24191,6 +26250,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -24204,6 +26264,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -24218,6 +26279,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -24226,6 +26288,7 @@
   - apprentice_over_19
   - "1"
   - "16"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -24235,6 +26298,7 @@
   - "1"
   - "16.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -24245,6 +26309,7 @@
   - "16.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -24256,6 +26321,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -24267,6 +26333,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -24279,6 +26346,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -24290,6 +26358,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -24302,6 +26371,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -24315,6 +26385,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -24327,6 +26398,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -24340,6 +26412,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -24350,6 +26423,7 @@
   - "16.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -24361,6 +26435,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -24373,6 +26448,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -24385,6 +26461,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -24398,6 +26475,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -24410,6 +26488,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -24423,6 +26502,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -24437,6 +26517,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -24450,6 +26531,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -24464,6 +26546,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -24473,6 +26556,7 @@
   - "1"
   - "16.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -24483,6 +26567,7 @@
   - "16.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -24494,6 +26579,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -24505,6 +26591,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -24517,6 +26604,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -24528,6 +26616,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -24540,6 +26629,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -24553,6 +26643,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -24565,6 +26656,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -24578,6 +26670,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -24588,6 +26681,7 @@
   - "16.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -24599,6 +26693,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -24611,6 +26706,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -24623,6 +26719,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -24636,6 +26733,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -24648,6 +26746,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -24661,6 +26760,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -24675,6 +26775,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -24688,6 +26789,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -24702,6 +26804,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_often_did_you_get_paid?
   :responses: 
@@ -24709,6 +26812,7 @@
   - "2011-10-01"
   - apprentice_over_19
   - "31"
+  :next_node: :how_many_hours_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -24717,6 +26821,7 @@
   - apprentice_over_19
   - "31"
   - "0"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -24726,6 +26831,7 @@
   - "31"
   - "0.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -24736,6 +26842,7 @@
   - "0.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -24747,6 +26854,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -24758,6 +26866,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -24770,6 +26879,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -24781,6 +26891,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -24793,6 +26904,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -24806,6 +26918,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -24818,6 +26931,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -24831,6 +26945,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -24841,6 +26956,7 @@
   - "0.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -24852,6 +26968,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -24864,6 +26981,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -24876,6 +26994,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -24889,6 +27008,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -24901,6 +27021,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -24914,6 +27035,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -24928,6 +27050,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -24941,6 +27064,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -24955,6 +27079,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -24964,6 +27089,7 @@
   - "31"
   - "0.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -24974,6 +27100,7 @@
   - "0.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -24985,6 +27112,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -24996,6 +27124,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -25008,6 +27137,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -25019,6 +27149,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -25031,6 +27162,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -25044,6 +27176,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -25056,6 +27189,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -25069,6 +27203,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -25079,6 +27214,7 @@
   - "0.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -25090,6 +27226,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -25102,6 +27239,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -25114,6 +27252,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -25127,6 +27266,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -25139,6 +27279,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -25152,6 +27293,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -25166,6 +27308,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -25179,6 +27322,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -25193,6 +27337,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -25201,6 +27346,7 @@
   - apprentice_over_19
   - "31"
   - "16"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -25210,6 +27356,7 @@
   - "31"
   - "16.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -25220,6 +27367,7 @@
   - "16.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -25231,6 +27379,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -25242,6 +27391,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -25254,6 +27404,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -25265,6 +27416,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -25277,6 +27429,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -25290,6 +27443,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -25302,6 +27456,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -25315,6 +27470,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -25325,6 +27481,7 @@
   - "16.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -25336,6 +27493,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -25348,6 +27506,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -25360,6 +27519,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -25373,6 +27533,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -25385,6 +27546,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -25398,6 +27560,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -25412,6 +27575,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -25425,6 +27589,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -25439,6 +27604,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -25448,6 +27614,7 @@
   - "31"
   - "16.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -25458,6 +27625,7 @@
   - "16.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -25469,6 +27637,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -25480,6 +27649,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -25492,6 +27662,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -25503,6 +27674,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -25515,6 +27687,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -25528,6 +27701,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -25540,6 +27714,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -25553,6 +27728,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -25563,6 +27739,7 @@
   - "16.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -25574,6 +27751,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -25586,6 +27764,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -25598,6 +27777,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -25611,6 +27791,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -25623,6 +27804,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -25636,6 +27818,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -25650,6 +27833,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -25663,6 +27847,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -25677,17 +27862,20 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_payment_date?
   :responses: 
   - past_payment
   - "2010-10-01"
+  :next_node: :were_you_an_apprentice?
   :outcome_node: false
 - :current_node: :were_you_an_apprentice?
   :responses: 
   - past_payment
   - "2010-10-01"
   - "no"
+  :next_node: :how_old_were_you?
   :outcome_node: false
 - :current_node: :how_old_were_you?
   :responses: 
@@ -25695,6 +27883,7 @@
   - "2010-10-01"
   - "no"
   - "15"
+  :next_node: :under_school_leaving_age_past
   :outcome_node: true
 - :current_node: :how_old_were_you?
   :responses: 
@@ -25702,6 +27891,7 @@
   - "2010-10-01"
   - "no"
   - "25"
+  :next_node: :how_often_did_you_get_paid?
   :outcome_node: false
 - :current_node: :how_often_did_you_get_paid?
   :responses: 
@@ -25710,6 +27900,7 @@
   - "no"
   - "25"
   - "1"
+  :next_node: :how_many_hours_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -25719,6 +27910,7 @@
   - "25"
   - "1"
   - "0"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -25729,6 +27921,7 @@
   - "1"
   - "0.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -25740,6 +27933,7 @@
   - "0.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -25752,6 +27946,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -25764,6 +27959,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -25777,6 +27973,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -25789,6 +27986,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -25802,6 +28000,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -25816,6 +28015,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -25829,6 +28029,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -25843,6 +28044,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -25854,6 +28056,7 @@
   - "0.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -25866,6 +28069,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -25879,6 +28083,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -25892,6 +28097,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -25906,6 +28112,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -25919,6 +28126,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -25933,6 +28141,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -25948,6 +28157,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -25962,6 +28172,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -25977,6 +28188,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -25987,6 +28199,7 @@
   - "1"
   - "0.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -25998,6 +28211,7 @@
   - "0.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -26010,6 +28224,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -26022,6 +28237,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -26035,6 +28251,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -26047,6 +28264,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -26060,6 +28278,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -26074,6 +28293,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -26087,6 +28307,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -26101,6 +28322,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -26112,6 +28334,7 @@
   - "0.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -26124,6 +28347,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -26137,6 +28361,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -26150,6 +28375,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -26164,6 +28390,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -26177,6 +28404,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -26191,6 +28419,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -26206,6 +28435,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -26220,6 +28450,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -26235,6 +28466,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -26244,6 +28476,7 @@
   - "25"
   - "1"
   - "16"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -26254,6 +28487,7 @@
   - "1"
   - "16.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -26265,6 +28499,7 @@
   - "16.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -26277,6 +28512,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -26289,6 +28525,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -26302,6 +28539,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -26314,6 +28552,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -26327,6 +28566,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -26341,6 +28581,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -26354,6 +28595,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -26368,6 +28610,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -26379,6 +28622,7 @@
   - "16.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -26391,6 +28635,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -26404,6 +28649,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -26417,6 +28663,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -26431,6 +28678,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -26444,6 +28692,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -26458,6 +28707,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -26473,6 +28723,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -26487,6 +28738,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -26502,6 +28754,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -26512,6 +28765,7 @@
   - "1"
   - "16.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -26523,6 +28777,7 @@
   - "16.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -26535,6 +28790,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -26547,6 +28803,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -26560,6 +28817,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -26572,6 +28830,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -26585,6 +28844,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -26599,6 +28859,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -26612,6 +28873,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -26626,6 +28888,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -26637,6 +28900,7 @@
   - "16.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -26649,6 +28913,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -26662,6 +28927,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -26675,6 +28941,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -26689,6 +28956,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -26702,6 +28970,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -26716,6 +28985,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -26731,6 +29001,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -26745,6 +29016,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -26760,6 +29032,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_often_did_you_get_paid?
   :responses: 
@@ -26768,6 +29041,7 @@
   - "no"
   - "25"
   - "31"
+  :next_node: :how_many_hours_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -26777,6 +29051,7 @@
   - "25"
   - "31"
   - "0"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -26787,6 +29062,7 @@
   - "31"
   - "0.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -26798,6 +29074,7 @@
   - "0.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -26810,6 +29087,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -26822,6 +29100,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -26835,6 +29114,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -26847,6 +29127,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -26860,6 +29141,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -26874,6 +29156,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -26887,6 +29170,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -26901,6 +29185,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -26912,6 +29197,7 @@
   - "0.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -26924,6 +29210,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -26937,6 +29224,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -26950,6 +29238,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -26964,6 +29253,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -26977,6 +29267,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -26991,6 +29282,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -27006,6 +29298,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -27020,6 +29313,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -27035,6 +29329,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -27045,6 +29340,7 @@
   - "31"
   - "0.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -27056,6 +29352,7 @@
   - "0.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -27068,6 +29365,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -27080,6 +29378,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -27093,6 +29392,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -27105,6 +29405,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -27118,6 +29419,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -27132,6 +29434,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -27145,6 +29448,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -27159,6 +29463,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -27170,6 +29475,7 @@
   - "0.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -27182,6 +29488,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -27195,6 +29502,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -27208,6 +29516,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -27222,6 +29531,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -27235,6 +29545,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -27249,6 +29560,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -27264,6 +29576,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -27278,6 +29591,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -27293,6 +29607,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -27302,6 +29617,7 @@
   - "25"
   - "31"
   - "16"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -27312,6 +29628,7 @@
   - "31"
   - "16.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -27323,6 +29640,7 @@
   - "16.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -27335,6 +29653,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -27347,6 +29666,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -27360,6 +29680,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -27372,6 +29693,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -27385,6 +29707,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -27399,6 +29722,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -27412,6 +29736,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -27426,6 +29751,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -27437,6 +29763,7 @@
   - "16.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -27449,6 +29776,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -27462,6 +29790,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -27475,6 +29804,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -27489,6 +29819,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -27502,6 +29833,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -27516,6 +29848,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -27531,6 +29864,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -27545,6 +29879,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -27560,6 +29895,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -27570,6 +29906,7 @@
   - "31"
   - "16.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -27581,6 +29918,7 @@
   - "16.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -27593,6 +29931,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -27605,6 +29944,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -27618,6 +29958,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -27630,6 +29971,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -27643,6 +29985,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -27657,6 +30000,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -27670,6 +30014,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -27684,6 +30029,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -27695,6 +30041,7 @@
   - "16.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -27707,6 +30054,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -27720,6 +30068,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -27733,6 +30082,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -27747,6 +30097,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -27760,6 +30111,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -27774,6 +30126,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -27789,6 +30142,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -27803,6 +30157,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -27818,12 +30173,14 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :were_you_an_apprentice?
   :responses: 
   - past_payment
   - "2010-10-01"
   - apprentice_under_19
+  :next_node: :how_often_did_you_get_paid?
   :outcome_node: false
 - :current_node: :how_often_did_you_get_paid?
   :responses: 
@@ -27831,6 +30188,7 @@
   - "2010-10-01"
   - apprentice_under_19
   - "1"
+  :next_node: :how_many_hours_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -27839,6 +30197,7 @@
   - apprentice_under_19
   - "1"
   - "0"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -27848,6 +30207,7 @@
   - "1"
   - "0.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -27858,6 +30218,7 @@
   - "0.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -27869,6 +30230,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -27880,6 +30242,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -27892,6 +30255,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -27903,6 +30267,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -27915,6 +30280,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -27928,6 +30294,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -27940,6 +30307,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -27953,6 +30321,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -27963,6 +30332,7 @@
   - "0.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -27974,6 +30344,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -27986,6 +30357,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -27998,6 +30370,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -28011,6 +30384,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -28023,6 +30397,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -28036,6 +30411,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -28050,6 +30426,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -28063,6 +30440,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -28077,6 +30455,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -28086,6 +30465,7 @@
   - "1"
   - "0.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -28096,6 +30476,7 @@
   - "0.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -28107,6 +30488,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -28118,6 +30500,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -28130,6 +30513,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -28141,6 +30525,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -28153,6 +30538,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -28166,6 +30552,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -28178,6 +30565,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -28191,6 +30579,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -28201,6 +30590,7 @@
   - "0.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -28212,6 +30602,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -28224,6 +30615,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -28236,6 +30628,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -28249,6 +30642,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -28261,6 +30655,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -28274,6 +30669,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -28288,6 +30684,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -28301,6 +30698,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -28315,6 +30713,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -28323,6 +30722,7 @@
   - apprentice_under_19
   - "1"
   - "16"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -28332,6 +30732,7 @@
   - "1"
   - "16.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -28342,6 +30743,7 @@
   - "16.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -28353,6 +30755,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -28364,6 +30767,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -28376,6 +30780,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -28387,6 +30792,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -28399,6 +30805,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -28412,6 +30819,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -28424,6 +30832,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -28437,6 +30846,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -28447,6 +30857,7 @@
   - "16.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -28458,6 +30869,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -28470,6 +30882,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -28482,6 +30895,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -28495,6 +30909,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -28507,6 +30922,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -28520,6 +30936,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -28534,6 +30951,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -28547,6 +30965,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -28561,6 +30980,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -28570,6 +30990,7 @@
   - "1"
   - "16.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -28580,6 +31001,7 @@
   - "16.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -28591,6 +31013,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -28602,6 +31025,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -28614,6 +31038,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -28625,6 +31050,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -28637,6 +31063,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -28650,6 +31077,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -28662,6 +31090,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -28675,6 +31104,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -28685,6 +31115,7 @@
   - "16.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -28696,6 +31127,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -28708,6 +31140,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -28720,6 +31153,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -28733,6 +31167,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -28745,6 +31180,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -28758,6 +31194,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -28772,6 +31209,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -28785,6 +31223,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -28799,6 +31238,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_often_did_you_get_paid?
   :responses: 
@@ -28806,6 +31246,7 @@
   - "2010-10-01"
   - apprentice_under_19
   - "31"
+  :next_node: :how_many_hours_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -28814,6 +31255,7 @@
   - apprentice_under_19
   - "31"
   - "0"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -28823,6 +31265,7 @@
   - "31"
   - "0.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -28833,6 +31276,7 @@
   - "0.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -28844,6 +31288,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -28855,6 +31300,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -28867,6 +31313,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -28878,6 +31325,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -28890,6 +31338,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -28903,6 +31352,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -28915,6 +31365,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -28928,6 +31379,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -28938,6 +31390,7 @@
   - "0.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -28949,6 +31402,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -28961,6 +31415,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -28973,6 +31428,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -28986,6 +31442,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -28998,6 +31455,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -29011,6 +31469,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -29025,6 +31484,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -29038,6 +31498,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -29052,6 +31513,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -29061,6 +31523,7 @@
   - "31"
   - "0.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -29071,6 +31534,7 @@
   - "0.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -29082,6 +31546,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -29093,6 +31558,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -29105,6 +31571,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -29116,6 +31583,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -29128,6 +31596,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -29141,6 +31610,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -29153,6 +31623,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -29166,6 +31637,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -29176,6 +31648,7 @@
   - "0.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -29187,6 +31660,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -29199,6 +31673,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -29211,6 +31686,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -29224,6 +31700,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -29236,6 +31713,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -29249,6 +31727,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -29263,6 +31742,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -29276,6 +31756,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -29290,6 +31771,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -29298,6 +31780,7 @@
   - apprentice_under_19
   - "31"
   - "16"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -29307,6 +31790,7 @@
   - "31"
   - "16.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -29317,6 +31801,7 @@
   - "16.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -29328,6 +31813,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -29339,6 +31825,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -29351,6 +31838,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -29362,6 +31850,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -29374,6 +31863,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -29387,6 +31877,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -29399,6 +31890,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -29412,6 +31904,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -29422,6 +31915,7 @@
   - "16.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -29433,6 +31927,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -29445,6 +31940,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -29457,6 +31953,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -29470,6 +31967,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -29482,6 +31980,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -29495,6 +31994,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -29509,6 +32009,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -29522,6 +32023,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -29536,6 +32038,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -29545,6 +32048,7 @@
   - "31"
   - "16.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -29555,6 +32059,7 @@
   - "16.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -29566,6 +32071,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -29577,6 +32083,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -29589,6 +32096,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -29600,6 +32108,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -29612,6 +32121,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -29625,6 +32135,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -29637,6 +32148,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -29650,6 +32162,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -29660,6 +32173,7 @@
   - "16.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -29671,6 +32185,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -29683,6 +32198,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -29695,6 +32211,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -29708,6 +32225,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -29720,6 +32238,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -29733,6 +32252,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -29747,6 +32267,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -29760,6 +32281,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -29774,12 +32296,14 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :were_you_an_apprentice?
   :responses: 
   - past_payment
   - "2010-10-01"
   - apprentice_over_19
+  :next_node: :how_often_did_you_get_paid?
   :outcome_node: false
 - :current_node: :how_often_did_you_get_paid?
   :responses: 
@@ -29787,6 +32311,7 @@
   - "2010-10-01"
   - apprentice_over_19
   - "1"
+  :next_node: :how_many_hours_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -29795,6 +32320,7 @@
   - apprentice_over_19
   - "1"
   - "0"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -29804,6 +32330,7 @@
   - "1"
   - "0.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -29814,6 +32341,7 @@
   - "0.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -29825,6 +32353,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -29836,6 +32365,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -29848,6 +32378,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -29859,6 +32390,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -29871,6 +32403,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -29884,6 +32417,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -29896,6 +32430,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -29909,6 +32444,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -29919,6 +32455,7 @@
   - "0.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -29930,6 +32467,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -29942,6 +32480,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -29954,6 +32493,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -29967,6 +32507,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -29979,6 +32520,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -29992,6 +32534,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -30006,6 +32549,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -30019,6 +32563,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -30033,6 +32578,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -30042,6 +32588,7 @@
   - "1"
   - "0.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -30052,6 +32599,7 @@
   - "0.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -30063,6 +32611,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -30074,6 +32623,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -30086,6 +32636,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -30097,6 +32648,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -30109,6 +32661,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -30122,6 +32675,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -30134,6 +32688,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -30147,6 +32702,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -30157,6 +32713,7 @@
   - "0.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -30168,6 +32725,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -30180,6 +32738,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -30192,6 +32751,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -30205,6 +32765,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -30217,6 +32778,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -30230,6 +32792,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -30244,6 +32807,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -30257,6 +32821,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -30271,6 +32836,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -30279,6 +32845,7 @@
   - apprentice_over_19
   - "1"
   - "16"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -30288,6 +32855,7 @@
   - "1"
   - "16.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -30298,6 +32866,7 @@
   - "16.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -30309,6 +32878,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -30320,6 +32890,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -30332,6 +32903,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -30343,6 +32915,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -30355,6 +32928,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -30368,6 +32942,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -30380,6 +32955,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -30393,6 +32969,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -30403,6 +32980,7 @@
   - "16.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -30414,6 +32992,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -30426,6 +33005,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -30438,6 +33018,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -30451,6 +33032,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -30463,6 +33045,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -30476,6 +33059,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -30490,6 +33074,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -30503,6 +33088,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -30517,6 +33103,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -30526,6 +33113,7 @@
   - "1"
   - "16.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -30536,6 +33124,7 @@
   - "16.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -30547,6 +33136,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -30558,6 +33148,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -30570,6 +33161,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -30581,6 +33173,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -30593,6 +33186,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -30606,6 +33200,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -30618,6 +33213,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -30631,6 +33227,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -30641,6 +33238,7 @@
   - "16.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -30652,6 +33250,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -30664,6 +33263,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -30676,6 +33276,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -30689,6 +33290,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -30701,6 +33303,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -30714,6 +33317,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -30728,6 +33332,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -30741,6 +33346,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -30755,6 +33361,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_often_did_you_get_paid?
   :responses: 
@@ -30762,6 +33369,7 @@
   - "2010-10-01"
   - apprentice_over_19
   - "31"
+  :next_node: :how_many_hours_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -30770,6 +33378,7 @@
   - apprentice_over_19
   - "31"
   - "0"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -30779,6 +33388,7 @@
   - "31"
   - "0.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -30789,6 +33399,7 @@
   - "0.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -30800,6 +33411,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -30811,6 +33423,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -30823,6 +33436,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -30834,6 +33448,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -30846,6 +33461,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -30859,6 +33475,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -30871,6 +33488,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -30884,6 +33502,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -30894,6 +33513,7 @@
   - "0.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -30905,6 +33525,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -30917,6 +33538,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -30929,6 +33551,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -30942,6 +33565,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -30954,6 +33578,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -30967,6 +33592,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -30981,6 +33607,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -30994,6 +33621,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -31008,6 +33636,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -31017,6 +33646,7 @@
   - "31"
   - "0.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -31027,6 +33657,7 @@
   - "0.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -31038,6 +33669,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -31049,6 +33681,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -31061,6 +33694,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -31072,6 +33706,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -31084,6 +33719,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -31097,6 +33733,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -31109,6 +33746,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -31122,6 +33760,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -31132,6 +33771,7 @@
   - "0.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -31143,6 +33783,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -31155,6 +33796,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -31167,6 +33809,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -31180,6 +33823,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -31192,6 +33836,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -31205,6 +33850,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -31219,6 +33865,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -31232,6 +33879,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -31246,6 +33894,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -31254,6 +33903,7 @@
   - apprentice_over_19
   - "31"
   - "16"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -31263,6 +33913,7 @@
   - "31"
   - "16.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -31273,6 +33924,7 @@
   - "16.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -31284,6 +33936,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -31295,6 +33948,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -31307,6 +33961,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -31318,6 +33973,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -31330,6 +33986,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -31343,6 +34000,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -31355,6 +34013,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -31368,6 +34027,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -31378,6 +34038,7 @@
   - "16.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -31389,6 +34050,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -31401,6 +34063,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -31413,6 +34076,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -31426,6 +34090,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -31438,6 +34103,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -31451,6 +34117,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -31465,6 +34132,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -31478,6 +34146,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -31492,6 +34161,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -31501,6 +34171,7 @@
   - "31"
   - "16.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -31511,6 +34182,7 @@
   - "16.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -31522,6 +34194,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -31533,6 +34206,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -31545,6 +34219,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -31556,6 +34231,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -31568,6 +34244,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -31581,6 +34258,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -31593,6 +34271,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -31606,6 +34285,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -31616,6 +34296,7 @@
   - "16.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -31627,6 +34308,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -31639,6 +34321,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -31651,6 +34334,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -31664,6 +34348,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -31676,6 +34361,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -31689,6 +34375,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -31703,6 +34390,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -31716,6 +34404,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -31730,17 +34419,20 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_payment_date?
   :responses: 
   - past_payment
   - "2009-10-01"
+  :next_node: :were_you_an_apprentice?
   :outcome_node: false
 - :current_node: :were_you_an_apprentice?
   :responses: 
   - past_payment
   - "2009-10-01"
   - "no"
+  :next_node: :how_old_were_you?
   :outcome_node: false
 - :current_node: :how_old_were_you?
   :responses: 
@@ -31748,6 +34440,7 @@
   - "2009-10-01"
   - "no"
   - "15"
+  :next_node: :under_school_leaving_age_past
   :outcome_node: true
 - :current_node: :how_old_were_you?
   :responses: 
@@ -31755,6 +34448,7 @@
   - "2009-10-01"
   - "no"
   - "25"
+  :next_node: :how_often_did_you_get_paid?
   :outcome_node: false
 - :current_node: :how_often_did_you_get_paid?
   :responses: 
@@ -31763,6 +34457,7 @@
   - "no"
   - "25"
   - "1"
+  :next_node: :how_many_hours_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -31772,6 +34467,7 @@
   - "25"
   - "1"
   - "0"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -31782,6 +34478,7 @@
   - "1"
   - "0.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -31793,6 +34490,7 @@
   - "0.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -31805,6 +34503,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -31817,6 +34516,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -31830,6 +34530,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -31842,6 +34543,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -31855,6 +34557,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -31869,6 +34572,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -31882,6 +34586,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -31896,6 +34601,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -31907,6 +34613,7 @@
   - "0.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -31919,6 +34626,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -31932,6 +34640,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -31945,6 +34654,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -31959,6 +34669,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -31972,6 +34683,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -31986,6 +34698,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -32001,6 +34714,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -32015,6 +34729,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -32030,6 +34745,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -32040,6 +34756,7 @@
   - "1"
   - "0.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -32051,6 +34768,7 @@
   - "0.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -32063,6 +34781,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -32075,6 +34794,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -32088,6 +34808,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -32100,6 +34821,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -32113,6 +34835,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -32127,6 +34850,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -32140,6 +34864,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -32154,6 +34879,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -32165,6 +34891,7 @@
   - "0.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -32177,6 +34904,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -32190,6 +34918,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -32203,6 +34932,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -32217,6 +34947,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -32230,6 +34961,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -32244,6 +34976,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -32259,6 +34992,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -32273,6 +35007,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -32288,6 +35023,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -32297,6 +35033,7 @@
   - "25"
   - "1"
   - "16"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -32307,6 +35044,7 @@
   - "1"
   - "16.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -32318,6 +35056,7 @@
   - "16.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -32330,6 +35069,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -32342,6 +35082,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -32355,6 +35096,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -32367,6 +35109,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -32380,6 +35123,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -32394,6 +35138,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -32407,6 +35152,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -32421,6 +35167,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -32432,6 +35179,7 @@
   - "16.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -32444,6 +35192,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -32457,6 +35206,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -32470,6 +35220,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -32484,6 +35235,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -32497,6 +35249,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -32511,6 +35264,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -32526,6 +35280,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -32540,6 +35295,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -32555,6 +35311,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -32565,6 +35322,7 @@
   - "1"
   - "16.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -32576,6 +35334,7 @@
   - "16.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -32588,6 +35347,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -32600,6 +35360,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -32613,6 +35374,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -32625,6 +35387,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -32638,6 +35401,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -32652,6 +35416,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -32665,6 +35430,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -32679,6 +35445,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -32690,6 +35457,7 @@
   - "16.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -32702,6 +35470,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -32715,6 +35484,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -32728,6 +35498,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -32742,6 +35513,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -32755,6 +35527,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -32769,6 +35542,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -32784,6 +35558,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -32798,6 +35573,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -32813,6 +35589,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_often_did_you_get_paid?
   :responses: 
@@ -32821,6 +35598,7 @@
   - "no"
   - "25"
   - "31"
+  :next_node: :how_many_hours_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -32830,6 +35608,7 @@
   - "25"
   - "31"
   - "0"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -32840,6 +35619,7 @@
   - "31"
   - "0.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -32851,6 +35631,7 @@
   - "0.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -32863,6 +35644,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -32875,6 +35657,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -32888,6 +35671,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -32900,6 +35684,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -32913,6 +35698,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -32927,6 +35713,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -32940,6 +35727,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -32954,6 +35742,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -32965,6 +35754,7 @@
   - "0.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -32977,6 +35767,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -32990,6 +35781,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -33003,6 +35795,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -33017,6 +35810,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -33030,6 +35824,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -33044,6 +35839,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -33059,6 +35855,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -33073,6 +35870,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -33088,6 +35886,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -33098,6 +35897,7 @@
   - "31"
   - "0.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -33109,6 +35909,7 @@
   - "0.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -33121,6 +35922,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -33133,6 +35935,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -33146,6 +35949,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -33158,6 +35962,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -33171,6 +35976,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -33185,6 +35991,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -33198,6 +36005,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -33212,6 +36020,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -33223,6 +36032,7 @@
   - "0.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -33235,6 +36045,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -33248,6 +36059,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -33261,6 +36073,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -33275,6 +36088,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -33288,6 +36102,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -33302,6 +36117,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -33317,6 +36133,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -33331,6 +36148,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -33346,6 +36164,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -33355,6 +36174,7 @@
   - "25"
   - "31"
   - "16"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -33365,6 +36185,7 @@
   - "31"
   - "16.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -33376,6 +36197,7 @@
   - "16.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -33388,6 +36210,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -33400,6 +36223,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -33413,6 +36237,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -33425,6 +36250,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -33438,6 +36264,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -33452,6 +36279,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -33465,6 +36293,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -33479,6 +36308,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -33490,6 +36320,7 @@
   - "16.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -33502,6 +36333,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -33515,6 +36347,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -33528,6 +36361,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -33542,6 +36376,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -33555,6 +36390,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -33569,6 +36405,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -33584,6 +36421,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -33598,6 +36436,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -33613,6 +36452,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -33623,6 +36463,7 @@
   - "31"
   - "16.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -33634,6 +36475,7 @@
   - "16.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -33646,6 +36488,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -33658,6 +36501,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -33671,6 +36515,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -33683,6 +36528,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -33696,6 +36542,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -33710,6 +36557,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -33723,6 +36571,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -33737,6 +36586,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -33748,6 +36598,7 @@
   - "16.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -33760,6 +36611,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -33773,6 +36625,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -33786,6 +36639,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -33800,6 +36654,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -33813,6 +36668,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -33827,6 +36683,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -33842,6 +36699,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -33856,6 +36714,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -33871,29 +36730,34 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :were_you_an_apprentice?
   :responses: 
   - past_payment
   - "2009-10-01"
   - apprentice_under_19
+  :next_node: :does_not_apply_to_historical_apprentices
   :outcome_node: true
 - :current_node: :were_you_an_apprentice?
   :responses: 
   - past_payment
   - "2009-10-01"
   - apprentice_over_19
+  :next_node: :does_not_apply_to_historical_apprentices
   :outcome_node: true
 - :current_node: :past_payment_date?
   :responses: 
   - past_payment
   - "2008-10-01"
+  :next_node: :were_you_an_apprentice?
   :outcome_node: false
 - :current_node: :were_you_an_apprentice?
   :responses: 
   - past_payment
   - "2008-10-01"
   - "no"
+  :next_node: :how_old_were_you?
   :outcome_node: false
 - :current_node: :how_old_were_you?
   :responses: 
@@ -33901,6 +36765,7 @@
   - "2008-10-01"
   - "no"
   - "15"
+  :next_node: :under_school_leaving_age_past
   :outcome_node: true
 - :current_node: :how_old_were_you?
   :responses: 
@@ -33908,6 +36773,7 @@
   - "2008-10-01"
   - "no"
   - "25"
+  :next_node: :how_often_did_you_get_paid?
   :outcome_node: false
 - :current_node: :how_often_did_you_get_paid?
   :responses: 
@@ -33916,6 +36782,7 @@
   - "no"
   - "25"
   - "1"
+  :next_node: :how_many_hours_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -33925,6 +36792,7 @@
   - "25"
   - "1"
   - "0"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -33935,6 +36803,7 @@
   - "1"
   - "0.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -33946,6 +36815,7 @@
   - "0.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -33958,6 +36828,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -33970,6 +36841,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -33983,6 +36855,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -33995,6 +36868,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -34008,6 +36882,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -34022,6 +36897,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -34035,6 +36911,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -34049,6 +36926,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -34060,6 +36938,7 @@
   - "0.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -34072,6 +36951,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -34085,6 +36965,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -34098,6 +36979,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -34112,6 +36994,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -34125,6 +37008,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -34139,6 +37023,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -34154,6 +37039,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -34168,6 +37054,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -34183,6 +37070,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -34193,6 +37081,7 @@
   - "1"
   - "0.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -34204,6 +37093,7 @@
   - "0.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -34216,6 +37106,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -34228,6 +37119,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -34241,6 +37133,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -34253,6 +37146,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -34266,6 +37160,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -34280,6 +37175,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -34293,6 +37189,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -34307,6 +37204,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -34318,6 +37216,7 @@
   - "0.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -34330,6 +37229,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -34343,6 +37243,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -34356,6 +37257,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -34370,6 +37272,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -34383,6 +37286,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -34397,6 +37301,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -34412,6 +37317,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -34426,6 +37332,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -34441,6 +37348,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -34450,6 +37358,7 @@
   - "25"
   - "1"
   - "16"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -34460,6 +37369,7 @@
   - "1"
   - "16.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -34471,6 +37381,7 @@
   - "16.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -34483,6 +37394,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -34495,6 +37407,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -34508,6 +37421,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -34520,6 +37434,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -34533,6 +37448,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -34547,6 +37463,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -34560,6 +37477,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -34574,6 +37492,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -34585,6 +37504,7 @@
   - "16.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -34597,6 +37517,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -34610,6 +37531,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -34623,6 +37545,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -34637,6 +37560,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -34650,6 +37574,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -34664,6 +37589,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -34679,6 +37605,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -34693,6 +37620,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -34708,6 +37636,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -34718,6 +37647,7 @@
   - "1"
   - "16.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -34729,6 +37659,7 @@
   - "16.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -34741,6 +37672,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -34753,6 +37685,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -34766,6 +37699,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -34778,6 +37712,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -34791,6 +37726,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -34805,6 +37741,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -34818,6 +37755,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -34832,6 +37770,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -34843,6 +37782,7 @@
   - "16.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -34855,6 +37795,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -34868,6 +37809,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -34881,6 +37823,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -34895,6 +37838,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -34908,6 +37852,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -34922,6 +37867,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -34937,6 +37883,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -34951,6 +37898,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -34966,6 +37914,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :how_often_did_you_get_paid?
   :responses: 
@@ -34974,6 +37923,7 @@
   - "no"
   - "25"
   - "31"
+  :next_node: :how_many_hours_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -34983,6 +37933,7 @@
   - "25"
   - "31"
   - "0"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -34993,6 +37944,7 @@
   - "31"
   - "0.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -35004,6 +37956,7 @@
   - "0.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -35016,6 +37969,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -35028,6 +37982,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -35041,6 +37996,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -35053,6 +38009,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -35066,6 +38023,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -35080,6 +38038,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -35093,6 +38052,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -35107,6 +38067,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -35118,6 +38079,7 @@
   - "0.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -35130,6 +38092,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -35143,6 +38106,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -35156,6 +38120,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -35170,6 +38135,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -35183,6 +38149,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -35197,6 +38164,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -35212,6 +38180,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -35226,6 +38195,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -35241,6 +38211,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -35251,6 +38222,7 @@
   - "31"
   - "0.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -35262,6 +38234,7 @@
   - "0.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -35274,6 +38247,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -35286,6 +38260,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -35299,6 +38274,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -35311,6 +38287,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -35324,6 +38301,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -35338,6 +38316,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -35351,6 +38330,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -35365,6 +38345,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -35376,6 +38357,7 @@
   - "0.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -35388,6 +38370,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -35401,6 +38384,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -35414,6 +38398,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -35428,6 +38413,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -35441,6 +38427,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -35455,6 +38442,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -35470,6 +38458,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -35484,6 +38473,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -35499,6 +38489,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_did_you_work?
   :responses: 
@@ -35508,6 +38499,7 @@
   - "25"
   - "31"
   - "16"
+  :next_node: :how_much_were_you_paid_during_pay_period?
   :outcome_node: false
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -35518,6 +38510,7 @@
   - "31"
   - "16.0"
   - "100"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -35529,6 +38522,7 @@
   - "16.0"
   - "100.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -35541,6 +38535,7 @@
   - "100.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -35553,6 +38548,7 @@
   - "100.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -35566,6 +38562,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -35578,6 +38575,7 @@
   - "100.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -35591,6 +38589,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -35605,6 +38604,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -35618,6 +38618,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -35632,6 +38633,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -35643,6 +38645,7 @@
   - "16.0"
   - "100.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -35655,6 +38658,7 @@
   - "100.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -35668,6 +38672,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -35681,6 +38686,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -35695,6 +38701,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -35708,6 +38715,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -35722,6 +38730,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -35737,6 +38746,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -35751,6 +38761,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -35766,6 +38777,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_much_were_you_paid_during_pay_period?
   :responses: 
@@ -35776,6 +38788,7 @@
   - "31"
   - "16.0"
   - "300"
+  :next_node: :how_many_hours_overtime_did_you_work?
   :outcome_node: false
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -35787,6 +38800,7 @@
   - "16.0"
   - "300.0"
   - "0"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -35799,6 +38813,7 @@
   - "300.0"
   - "0.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -35811,6 +38826,7 @@
   - "300.0"
   - "0.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -35824,6 +38840,7 @@
   - "0.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -35836,6 +38853,7 @@
   - "300.0"
   - "0.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -35849,6 +38867,7 @@
   - "0.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -35863,6 +38882,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -35876,6 +38896,7 @@
   - "0.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -35890,6 +38911,7 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :how_many_hours_overtime_did_you_work?
   :responses: 
@@ -35901,6 +38923,7 @@
   - "16.0"
   - "300.0"
   - "8"
+  :next_node: :what_was_overtime_pay_per_hour?
   :outcome_node: false
 - :current_node: :what_was_overtime_pay_per_hour?
   :responses: 
@@ -35913,6 +38936,7 @@
   - "300.0"
   - "8.0"
   - "10"
+  :next_node: :was_provided_with_accommodation?
   :outcome_node: false
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -35926,6 +38950,7 @@
   - "8.0"
   - "10.0"
   - "no"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -35939,6 +38964,7 @@
   - "8.0"
   - "10.0"
   - yes_free
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -35953,6 +38979,7 @@
   - "10.0"
   - yes_free
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :was_provided_with_accommodation?
   :responses: 
@@ -35966,6 +38993,7 @@
   - "8.0"
   - "10.0"
   - yes_charged
+  :next_node: :past_accommodation_charge?
   :outcome_node: false
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -35980,6 +39008,7 @@
   - "10.0"
   - yes_charged
   - "5"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -35995,6 +39024,7 @@
   - yes_charged
   - "5.0"
   - "5"
+  :next_node: :past_payment_above
   :outcome_node: true
 - :current_node: :past_accommodation_charge?
   :responses: 
@@ -36009,6 +39039,7 @@
   - "10.0"
   - yes_charged
   - "50"
+  :next_node: :past_accommodation_usage?
   :outcome_node: false
 - :current_node: :past_accommodation_usage?
   :responses: 
@@ -36024,16 +39055,19 @@
   - yes_charged
   - "50.0"
   - "5"
+  :next_node: :past_payment_below
   :outcome_node: true
 - :current_node: :were_you_an_apprentice?
   :responses: 
   - past_payment
   - "2008-10-01"
   - apprentice_under_19
+  :next_node: :does_not_apply_to_historical_apprentices
   :outcome_node: true
 - :current_node: :were_you_an_apprentice?
   :responses: 
   - past_payment
   - "2008-10-01"
   - apprentice_over_19
+  :next_node: :does_not_apply_to_historical_apprentices
   :outcome_node: true

--- a/test/data/apply-tier-4-visa-files.yml
+++ b/test/data/apply-tier-4-visa-files.yml
@@ -2,5 +2,5 @@
 lib/smart_answer_flows/apply-tier-4-visa.rb: 9883575c2342dd95963da6bc4d06c5f0
 lib/smart_answer_flows/locales/en/apply-tier-4-visa.yml: 54401da7ebae8a1c9e00864bbce54e4c
 test/data/apply-tier-4-visa-questions-and-responses.yml: fe87a99e4337e45586806181742f0b8f
-test/data/apply-tier-4-visa-responses-and-expected-results.yml: 0a4f632cf6eee9a243f896392cd2ea24
+test/data/apply-tier-4-visa-responses-and-expected-results.yml: 339690f2a3125ef29d63f29a79ae1cba
 lib/data/apply_tier_4_visa_data.yml: 671371971f6024d6d8b95f422e7985f6

--- a/test/data/apply-tier-4-visa-responses-and-expected-results.yml
+++ b/test/data/apply-tier-4-visa-responses-and-expected-results.yml
@@ -2,76 +2,92 @@
 - :current_node: :extending_or_switching?
   :responses: 
   - extend_general
+  :next_node: :sponsor_id?
   :outcome_node: false
 - :current_node: :sponsor_id?
   :responses: 
   - extend_general
   - V6G1G9F62
+  :next_node: :outcome
   :outcome_node: true
 - :current_node: :sponsor_id?
   :responses: 
   - extend_general
   - QNCPTDW26
+  :next_node: :outcome
   :outcome_node: true
 - :current_node: :sponsor_id?
   :responses: 
   - extend_general
   - made-up-sponsor-id
+  :next_node: :sponsor_id?
   :outcome_node: false
 - :current_node: :extending_or_switching?
   :responses: 
   - switch_general
+  :next_node: :sponsor_id?
   :outcome_node: false
 - :current_node: :sponsor_id?
   :responses: 
   - switch_general
   - V6G1G9F62
+  :next_node: :outcome
   :outcome_node: true
 - :current_node: :sponsor_id?
   :responses: 
   - switch_general
   - QNCPTDW26
+  :next_node: :outcome
   :outcome_node: true
 - :current_node: :sponsor_id?
   :responses: 
   - switch_general
   - made-up-sponsor-id
+  :next_node: :sponsor_id?
   :outcome_node: false
 - :current_node: :extending_or_switching?
   :responses: 
   - extend_child
+  :next_node: :sponsor_id?
   :outcome_node: false
 - :current_node: :sponsor_id?
   :responses: 
   - extend_child
   - V6G1G9F62
+  :next_node: :outcome
   :outcome_node: true
 - :current_node: :sponsor_id?
   :responses: 
   - extend_child
   - QNCPTDW26
+  :next_node: :outcome
   :outcome_node: true
 - :current_node: :sponsor_id?
   :responses: 
   - extend_child
   - made-up-sponsor-id
+  :next_node: :sponsor_id?
   :outcome_node: false
 - :current_node: :extending_or_switching?
   :responses: 
   - switch_child
+  :next_node: :sponsor_id?
   :outcome_node: false
 - :current_node: :sponsor_id?
   :responses: 
   - switch_child
   - V6G1G9F62
+  :next_node: :outcome
   :outcome_node: true
 - :current_node: :sponsor_id?
   :responses: 
   - switch_child
   - QNCPTDW26
+  :next_node: :outcome
   :outcome_node: true
 - :current_node: :sponsor_id?
   :responses: 
   - switch_child
   - made-up-sponsor-id
+  :next_node: :sponsor_id?
   :outcome_node: false

--- a/test/data/state-pension-through-partner-files.yml
+++ b/test/data/state-pension-through-partner-files.yml
@@ -2,5 +2,5 @@
 lib/smart_answer_flows/state-pension-through-partner.rb: fde6fc823fc6f523af9ffa6be793f0cc
 lib/smart_answer_flows/locales/en/state-pension-through-partner.yml: 741b1a6be2aeed88b3745e9351020ff0
 test/data/state-pension-through-partner-questions-and-responses.yml: 34f2b5f7ac286bb3eea690564339051b
-test/data/state-pension-through-partner-responses-and-expected-results.yml: 5cf58a9a4d447c348f9821d5d61468eb
+test/data/state-pension-through-partner-responses-and-expected-results.yml: 40dfc8e1e81b26debb660cf64ca8ea15
 lib/data/rates/state_pension.yml: 7e97e88500fb698038c49332b48b82bf

--- a/test/data/state-pension-through-partner-responses-and-expected-results.yml
+++ b/test/data/state-pension-through-partner-responses-and-expected-results.yml
@@ -2,34 +2,40 @@
 - :current_node: :what_is_your_marital_status?
   :responses: 
   - married
+  :next_node: :when_will_you_reach_pension_age?
   :outcome_node: false
 - :current_node: :when_will_you_reach_pension_age?
   :responses: 
   - married
   - your_pension_age_before_specific_date
+  :next_node: :when_will_your_partner_reach_pension_age?
   :outcome_node: false
 - :current_node: :when_will_your_partner_reach_pension_age?
   :responses: 
   - married
   - your_pension_age_before_specific_date
   - partner_pension_age_before_specific_date
+  :next_node: :final_outcome
   :outcome_node: true
 - :current_node: :when_will_your_partner_reach_pension_age?
   :responses: 
   - married
   - your_pension_age_before_specific_date
   - partner_pension_age_after_specific_date
+  :next_node: :final_outcome
   :outcome_node: true
 - :current_node: :when_will_you_reach_pension_age?
   :responses: 
   - married
   - your_pension_age_after_specific_date
+  :next_node: :when_will_your_partner_reach_pension_age?
   :outcome_node: false
 - :current_node: :when_will_your_partner_reach_pension_age?
   :responses: 
   - married
   - your_pension_age_after_specific_date
   - partner_pension_age_before_specific_date
+  :next_node: :what_is_your_gender?
   :outcome_node: false
 - :current_node: :what_is_your_gender?
   :responses: 
@@ -37,6 +43,7 @@
   - your_pension_age_after_specific_date
   - partner_pension_age_before_specific_date
   - male_gender
+  :next_node: :final_outcome
   :outcome_node: true
 - :current_node: :what_is_your_gender?
   :responses: 
@@ -44,12 +51,14 @@
   - your_pension_age_after_specific_date
   - partner_pension_age_before_specific_date
   - female_gender
+  :next_node: :final_outcome
   :outcome_node: true
 - :current_node: :when_will_your_partner_reach_pension_age?
   :responses: 
   - married
   - your_pension_age_after_specific_date
   - partner_pension_age_after_specific_date
+  :next_node: :what_is_your_gender?
   :outcome_node: false
 - :current_node: :what_is_your_gender?
   :responses: 
@@ -57,6 +66,7 @@
   - your_pension_age_after_specific_date
   - partner_pension_age_after_specific_date
   - male_gender
+  :next_node: :final_outcome
   :outcome_node: true
 - :current_node: :what_is_your_gender?
   :responses: 
@@ -64,38 +74,45 @@
   - your_pension_age_after_specific_date
   - partner_pension_age_after_specific_date
   - female_gender
+  :next_node: :final_outcome
   :outcome_node: true
 - :current_node: :what_is_your_marital_status?
   :responses: 
   - will_marry_before_specific_date
+  :next_node: :when_will_you_reach_pension_age?
   :outcome_node: false
 - :current_node: :when_will_you_reach_pension_age?
   :responses: 
   - will_marry_before_specific_date
   - your_pension_age_before_specific_date
+  :next_node: :when_will_your_partner_reach_pension_age?
   :outcome_node: false
 - :current_node: :when_will_your_partner_reach_pension_age?
   :responses: 
   - will_marry_before_specific_date
   - your_pension_age_before_specific_date
   - partner_pension_age_before_specific_date
+  :next_node: :final_outcome
   :outcome_node: true
 - :current_node: :when_will_your_partner_reach_pension_age?
   :responses: 
   - will_marry_before_specific_date
   - your_pension_age_before_specific_date
   - partner_pension_age_after_specific_date
+  :next_node: :final_outcome
   :outcome_node: true
 - :current_node: :when_will_you_reach_pension_age?
   :responses: 
   - will_marry_before_specific_date
   - your_pension_age_after_specific_date
+  :next_node: :when_will_your_partner_reach_pension_age?
   :outcome_node: false
 - :current_node: :when_will_your_partner_reach_pension_age?
   :responses: 
   - will_marry_before_specific_date
   - your_pension_age_after_specific_date
   - partner_pension_age_before_specific_date
+  :next_node: :what_is_your_gender?
   :outcome_node: false
 - :current_node: :what_is_your_gender?
   :responses: 
@@ -103,6 +120,7 @@
   - your_pension_age_after_specific_date
   - partner_pension_age_before_specific_date
   - male_gender
+  :next_node: :final_outcome
   :outcome_node: true
 - :current_node: :what_is_your_gender?
   :responses: 
@@ -110,12 +128,14 @@
   - your_pension_age_after_specific_date
   - partner_pension_age_before_specific_date
   - female_gender
+  :next_node: :final_outcome
   :outcome_node: true
 - :current_node: :when_will_your_partner_reach_pension_age?
   :responses: 
   - will_marry_before_specific_date
   - your_pension_age_after_specific_date
   - partner_pension_age_after_specific_date
+  :next_node: :what_is_your_gender?
   :outcome_node: false
 - :current_node: :what_is_your_gender?
   :responses: 
@@ -123,6 +143,7 @@
   - your_pension_age_after_specific_date
   - partner_pension_age_after_specific_date
   - male_gender
+  :next_node: :final_outcome
   :outcome_node: true
 - :current_node: :what_is_your_gender?
   :responses: 
@@ -130,38 +151,45 @@
   - your_pension_age_after_specific_date
   - partner_pension_age_after_specific_date
   - female_gender
+  :next_node: :final_outcome
   :outcome_node: true
 - :current_node: :what_is_your_marital_status?
   :responses: 
   - will_marry_on_or_after_specific_date
+  :next_node: :when_will_you_reach_pension_age?
   :outcome_node: false
 - :current_node: :when_will_you_reach_pension_age?
   :responses: 
   - will_marry_on_or_after_specific_date
   - your_pension_age_before_specific_date
+  :next_node: :when_will_your_partner_reach_pension_age?
   :outcome_node: false
 - :current_node: :when_will_your_partner_reach_pension_age?
   :responses: 
   - will_marry_on_or_after_specific_date
   - your_pension_age_before_specific_date
   - partner_pension_age_before_specific_date
+  :next_node: :final_outcome
   :outcome_node: true
 - :current_node: :when_will_your_partner_reach_pension_age?
   :responses: 
   - will_marry_on_or_after_specific_date
   - your_pension_age_before_specific_date
   - partner_pension_age_after_specific_date
+  :next_node: :final_outcome
   :outcome_node: true
 - :current_node: :when_will_you_reach_pension_age?
   :responses: 
   - will_marry_on_or_after_specific_date
   - your_pension_age_after_specific_date
+  :next_node: :when_will_your_partner_reach_pension_age?
   :outcome_node: false
 - :current_node: :when_will_your_partner_reach_pension_age?
   :responses: 
   - will_marry_on_or_after_specific_date
   - your_pension_age_after_specific_date
   - partner_pension_age_before_specific_date
+  :next_node: :what_is_your_gender?
   :outcome_node: false
 - :current_node: :what_is_your_gender?
   :responses: 
@@ -169,6 +197,7 @@
   - your_pension_age_after_specific_date
   - partner_pension_age_before_specific_date
   - male_gender
+  :next_node: :final_outcome
   :outcome_node: true
 - :current_node: :what_is_your_gender?
   :responses: 
@@ -176,12 +205,14 @@
   - your_pension_age_after_specific_date
   - partner_pension_age_before_specific_date
   - female_gender
+  :next_node: :final_outcome
   :outcome_node: true
 - :current_node: :when_will_your_partner_reach_pension_age?
   :responses: 
   - will_marry_on_or_after_specific_date
   - your_pension_age_after_specific_date
   - partner_pension_age_after_specific_date
+  :next_node: :what_is_your_gender?
   :outcome_node: false
 - :current_node: :what_is_your_gender?
   :responses: 
@@ -189,6 +220,7 @@
   - your_pension_age_after_specific_date
   - partner_pension_age_after_specific_date
   - male_gender
+  :next_node: :final_outcome
   :outcome_node: true
 - :current_node: :what_is_your_gender?
   :responses: 
@@ -196,44 +228,53 @@
   - your_pension_age_after_specific_date
   - partner_pension_age_after_specific_date
   - female_gender
+  :next_node: :final_outcome
   :outcome_node: true
 - :current_node: :what_is_your_marital_status?
   :responses: 
   - widowed
+  :next_node: :when_will_you_reach_pension_age?
   :outcome_node: false
 - :current_node: :when_will_you_reach_pension_age?
   :responses: 
   - widowed
   - your_pension_age_before_specific_date
+  :next_node: :final_outcome
   :outcome_node: true
 - :current_node: :when_will_you_reach_pension_age?
   :responses: 
   - widowed
   - your_pension_age_after_specific_date
+  :next_node: :what_is_your_gender?
   :outcome_node: false
 - :current_node: :what_is_your_gender?
   :responses: 
   - widowed
   - your_pension_age_after_specific_date
   - male_gender
+  :next_node: :final_outcome
   :outcome_node: true
 - :current_node: :what_is_your_gender?
   :responses: 
   - widowed
   - your_pension_age_after_specific_date
   - female_gender
+  :next_node: :final_outcome
   :outcome_node: true
 - :current_node: :what_is_your_marital_status?
   :responses: 
   - divorced
+  :next_node: :what_is_your_gender?
   :outcome_node: false
 - :current_node: :what_is_your_gender?
   :responses: 
   - divorced
   - male_gender
+  :next_node: :final_outcome
   :outcome_node: true
 - :current_node: :what_is_your_gender?
   :responses: 
   - divorced
   - female_gender
+  :next_node: :final_outcome
   :outcome_node: true

--- a/test/data/state-pension-topup-files.yml
+++ b/test/data/state-pension-topup-files.yml
@@ -2,7 +2,7 @@
 lib/smart_answer_flows/state-pension-topup.rb: 005abed8a3e630d74fc5cd14bf12ea75
 lib/smart_answer_flows/locales/en/state-pension-topup.yml: 1c97f6d53c415cd376e99a0ed812d811
 test/data/state-pension-topup-questions-and-responses.yml: d3997e715e206c38ea8a0783b07b2350
-test/data/state-pension-topup-responses-and-expected-results.yml: ff3557145d39c5b2d10c31b599ee493f
+test/data/state-pension-topup-responses-and-expected-results.yml: caa7a2bc7d84f16cf78583a97192e29b
 lib/smart_answer/calculators/state_pension_topup_calculator.rb: 2481f46c212f185572def0aa2c3f3e0a
 lib/smart_answer/calculators/state_pension_topup_data_query.rb: 9a87f13dd72f0d0518b7261e2dafe32f
 lib/data/pension_top_up_data.yml: 9059d16c14713405d406e5aefa81ea46

--- a/test/data/state-pension-topup-responses-and-expected-results.yml
+++ b/test/data/state-pension-topup-responses-and-expected-results.yml
@@ -2,136 +2,162 @@
 - :current_node: :dob_age?
   :responses: 
   - "1914-10-12"
+  :next_node: :outcome_age_limit_reached_birth
   :outcome_node: true
 - :current_node: :dob_age?
   :responses: 
   - "1914-10-13"
+  :next_node: :gender?
   :outcome_node: false
 - :current_node: :gender?
   :responses: 
   - "1914-10-13"
   - male
+  :next_node: :how_much_extra_per_week?
   :outcome_node: false
 - :current_node: :how_much_extra_per_week?
   :responses: 
   - "1914-10-13"
   - male
   - "7"
+  :next_node: :outcome_topup_calculations
   :outcome_node: true
 - :current_node: :how_much_extra_per_week?
   :responses: 
   - "1914-10-13"
   - male
   - "20"
+  :next_node: :outcome_topup_calculations
   :outcome_node: true
 - :current_node: :gender?
   :responses: 
   - "1914-10-13"
   - female
+  :next_node: :how_much_extra_per_week?
   :outcome_node: false
 - :current_node: :how_much_extra_per_week?
   :responses: 
   - "1914-10-13"
   - female
   - "7"
+  :next_node: :outcome_topup_calculations
   :outcome_node: true
 - :current_node: :how_much_extra_per_week?
   :responses: 
   - "1914-10-13"
   - female
   - "20"
+  :next_node: :outcome_topup_calculations
   :outcome_node: true
 - :current_node: :dob_age?
   :responses: 
   - "1951-04-05"
+  :next_node: :gender?
   :outcome_node: false
 - :current_node: :gender?
   :responses: 
   - "1951-04-05"
   - male
+  :next_node: :how_much_extra_per_week?
   :outcome_node: false
 - :current_node: :how_much_extra_per_week?
   :responses: 
   - "1951-04-05"
   - male
   - "7"
+  :next_node: :outcome_topup_calculations
   :outcome_node: true
 - :current_node: :how_much_extra_per_week?
   :responses: 
   - "1951-04-05"
   - male
   - "20"
+  :next_node: :outcome_topup_calculations
   :outcome_node: true
 - :current_node: :gender?
   :responses: 
   - "1951-04-05"
   - female
+  :next_node: :how_much_extra_per_week?
   :outcome_node: false
 - :current_node: :how_much_extra_per_week?
   :responses: 
   - "1951-04-05"
   - female
   - "7"
+  :next_node: :outcome_topup_calculations
   :outcome_node: true
 - :current_node: :how_much_extra_per_week?
   :responses: 
   - "1951-04-05"
   - female
   - "20"
+  :next_node: :outcome_topup_calculations
   :outcome_node: true
 - :current_node: :dob_age?
   :responses: 
   - "1951-04-06"
+  :next_node: :gender?
   :outcome_node: false
 - :current_node: :gender?
   :responses: 
   - "1951-04-06"
   - male
+  :next_node: :outcome_pension_age_not_reached
   :outcome_node: true
 - :current_node: :gender?
   :responses: 
   - "1951-04-06"
   - female
+  :next_node: :how_much_extra_per_week?
   :outcome_node: false
 - :current_node: :how_much_extra_per_week?
   :responses: 
   - "1951-04-06"
   - female
   - "7"
+  :next_node: :outcome_topup_calculations
   :outcome_node: true
 - :current_node: :how_much_extra_per_week?
   :responses: 
   - "1951-04-06"
   - female
   - "20"
+  :next_node: :outcome_topup_calculations
   :outcome_node: true
 - :current_node: :dob_age?
   :responses: 
   - "1953-04-05"
+  :next_node: :gender?
   :outcome_node: false
 - :current_node: :gender?
   :responses: 
   - "1953-04-05"
   - male
+  :next_node: :outcome_pension_age_not_reached
   :outcome_node: true
 - :current_node: :gender?
   :responses: 
   - "1953-04-05"
   - female
+  :next_node: :how_much_extra_per_week?
   :outcome_node: false
 - :current_node: :how_much_extra_per_week?
   :responses: 
   - "1953-04-05"
   - female
   - "7"
+  :next_node: :outcome_topup_calculations
   :outcome_node: true
 - :current_node: :how_much_extra_per_week?
   :responses: 
   - "1953-04-05"
   - female
   - "20"
+  :next_node: :outcome_topup_calculations
   :outcome_node: true
 - :current_node: :dob_age?
   :responses: 
   - "1953-04-06"
+  :next_node: :outcome_pension_age_not_reached
   :outcome_node: true

--- a/test/data/student-finance-calculator-files.yml
+++ b/test/data/student-finance-calculator-files.yml
@@ -2,7 +2,7 @@
 lib/smart_answer_flows/student-finance-calculator.rb: 11a0a54f5635c6a438ee55e7206c7091
 lib/smart_answer_flows/locales/en/student-finance-calculator.yml: 6100f316b4a031ee1a3c46ff377c6ab6
 test/data/student-finance-calculator-questions-and-responses.yml: 7f7a6293dd5c37756c89ea6b075ffd45
-test/data/student-finance-calculator-responses-and-expected-results.yml: 7680ed7e0f6205784af3c766bbdcf23e
+test/data/student-finance-calculator-responses-and-expected-results.yml: f4588ab6828397faa8f1fc4dce005398
 lib/smart_answer_flows/student-finance-calculator/outcome_eu_students_body.govspeak.erb: 09baaca179dba1dc7fd0415800775503
 lib/smart_answer_flows/student-finance-calculator/outcome_uk_all_students_body.govspeak.erb: 9a2911d77e4e1fc153584d1d1a99af81
 lib/smart_answer_flows/student-finance-calculator/outcome_uk_full_time_students_body.govspeak.erb: 3ccbc53c77f0c94f1fef64048f56496e

--- a/test/data/student-finance-calculator-responses-and-expected-results.yml
+++ b/test/data/student-finance-calculator-responses-and-expected-results.yml
@@ -2,17 +2,20 @@
 - :current_node: :when_does_your_course_start?
   :responses: 
   - 2014-2015
+  :next_node: :what_type_of_student_are_you?
   :outcome_node: false
 - :current_node: :what_type_of_student_are_you?
   :responses: 
   - 2014-2015
   - uk-full-time
+  :next_node: :how_much_are_your_tuition_fees_per_year?
   :outcome_node: false
 - :current_node: :how_much_are_your_tuition_fees_per_year?
   :responses: 
   - 2014-2015
   - uk-full-time
   - "6000"
+  :next_node: :where_will_you_live_while_studying?
   :outcome_node: false
 - :current_node: :where_will_you_live_while_studying?
   :responses: 
@@ -20,6 +23,7 @@
   - uk-full-time
   - "6000.0"
   - at-home
+  :next_node: :whats_your_household_income?
   :outcome_node: false
 - :current_node: :whats_your_household_income?
   :responses: 
@@ -28,6 +32,7 @@
   - "6000.0"
   - at-home
   - "100000"
+  :next_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :outcome_node: false
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -37,6 +42,7 @@
   - at-home
   - "100000.0"
   - children-under-17,dependant-adult,has-disability,low-income
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -47,6 +53,7 @@
   - "100000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -57,6 +64,7 @@
   - "100000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -67,6 +75,7 @@
   - "100000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -77,6 +86,7 @@
   - "100000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -86,6 +96,7 @@
   - at-home
   - "100000.0"
   - "no"
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -96,6 +107,7 @@
   - "100000.0"
   - "no"
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -106,6 +118,7 @@
   - "100000.0"
   - "no"
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -116,6 +129,7 @@
   - "100000.0"
   - "no"
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -126,6 +140,7 @@
   - "100000.0"
   - "no"
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :whats_your_household_income?
   :responses: 
@@ -134,6 +149,7 @@
   - "6000.0"
   - at-home
   - "43875"
+  :next_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :outcome_node: false
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -143,6 +159,7 @@
   - at-home
   - "43875.0"
   - children-under-17,dependant-adult,has-disability,low-income
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -153,6 +170,7 @@
   - "43875.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -163,6 +181,7 @@
   - "43875.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -173,6 +192,7 @@
   - "43875.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -183,6 +203,7 @@
   - "43875.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -192,6 +213,7 @@
   - at-home
   - "43875.0"
   - "no"
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -202,6 +224,7 @@
   - "43875.0"
   - "no"
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -212,6 +235,7 @@
   - "43875.0"
   - "no"
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -222,6 +246,7 @@
   - "43875.0"
   - "no"
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -232,6 +257,7 @@
   - "43875.0"
   - "no"
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :whats_your_household_income?
   :responses: 
@@ -240,6 +266,7 @@
   - "6000.0"
   - at-home
   - "35000"
+  :next_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :outcome_node: false
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -249,6 +276,7 @@
   - at-home
   - "35000.0"
   - children-under-17,dependant-adult,has-disability,low-income
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -259,6 +287,7 @@
   - "35000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -269,6 +298,7 @@
   - "35000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -279,6 +309,7 @@
   - "35000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -289,6 +320,7 @@
   - "35000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -298,6 +330,7 @@
   - at-home
   - "35000.0"
   - "no"
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -308,6 +341,7 @@
   - "35000.0"
   - "no"
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -318,6 +352,7 @@
   - "35000.0"
   - "no"
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -328,6 +363,7 @@
   - "35000.0"
   - "no"
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -338,6 +374,7 @@
   - "35000.0"
   - "no"
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :whats_your_household_income?
   :responses: 
@@ -346,6 +383,7 @@
   - "6000.0"
   - at-home
   - "24500"
+  :next_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :outcome_node: false
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -355,6 +393,7 @@
   - at-home
   - "24500.0"
   - children-under-17,dependant-adult,has-disability,low-income
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -365,6 +404,7 @@
   - "24500.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -375,6 +415,7 @@
   - "24500.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -385,6 +426,7 @@
   - "24500.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -395,6 +437,7 @@
   - "24500.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -404,6 +447,7 @@
   - at-home
   - "24500.0"
   - "no"
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -414,6 +458,7 @@
   - "24500.0"
   - "no"
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -424,6 +469,7 @@
   - "24500.0"
   - "no"
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -434,6 +480,7 @@
   - "24500.0"
   - "no"
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -444,6 +491,7 @@
   - "24500.0"
   - "no"
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :where_will_you_live_while_studying?
   :responses: 
@@ -451,6 +499,7 @@
   - uk-full-time
   - "6000.0"
   - away-outside-london
+  :next_node: :whats_your_household_income?
   :outcome_node: false
 - :current_node: :whats_your_household_income?
   :responses: 
@@ -459,6 +508,7 @@
   - "6000.0"
   - away-outside-london
   - "100000"
+  :next_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :outcome_node: false
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -468,6 +518,7 @@
   - away-outside-london
   - "100000.0"
   - children-under-17,dependant-adult,has-disability,low-income
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -478,6 +529,7 @@
   - "100000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -488,6 +540,7 @@
   - "100000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -498,6 +551,7 @@
   - "100000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -508,6 +562,7 @@
   - "100000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -517,6 +572,7 @@
   - away-outside-london
   - "100000.0"
   - "no"
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -527,6 +583,7 @@
   - "100000.0"
   - "no"
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -537,6 +594,7 @@
   - "100000.0"
   - "no"
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -547,6 +605,7 @@
   - "100000.0"
   - "no"
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -557,6 +616,7 @@
   - "100000.0"
   - "no"
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :whats_your_household_income?
   :responses: 
@@ -565,6 +625,7 @@
   - "6000.0"
   - away-outside-london
   - "43875"
+  :next_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :outcome_node: false
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -574,6 +635,7 @@
   - away-outside-london
   - "43875.0"
   - children-under-17,dependant-adult,has-disability,low-income
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -584,6 +646,7 @@
   - "43875.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -594,6 +657,7 @@
   - "43875.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -604,6 +668,7 @@
   - "43875.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -614,6 +679,7 @@
   - "43875.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -623,6 +689,7 @@
   - away-outside-london
   - "43875.0"
   - "no"
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -633,6 +700,7 @@
   - "43875.0"
   - "no"
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -643,6 +711,7 @@
   - "43875.0"
   - "no"
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -653,6 +722,7 @@
   - "43875.0"
   - "no"
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -663,6 +733,7 @@
   - "43875.0"
   - "no"
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :whats_your_household_income?
   :responses: 
@@ -671,6 +742,7 @@
   - "6000.0"
   - away-outside-london
   - "35000"
+  :next_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :outcome_node: false
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -680,6 +752,7 @@
   - away-outside-london
   - "35000.0"
   - children-under-17,dependant-adult,has-disability,low-income
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -690,6 +763,7 @@
   - "35000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -700,6 +774,7 @@
   - "35000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -710,6 +785,7 @@
   - "35000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -720,6 +796,7 @@
   - "35000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -729,6 +806,7 @@
   - away-outside-london
   - "35000.0"
   - "no"
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -739,6 +817,7 @@
   - "35000.0"
   - "no"
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -749,6 +828,7 @@
   - "35000.0"
   - "no"
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -759,6 +839,7 @@
   - "35000.0"
   - "no"
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -769,6 +850,7 @@
   - "35000.0"
   - "no"
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :whats_your_household_income?
   :responses: 
@@ -777,6 +859,7 @@
   - "6000.0"
   - away-outside-london
   - "24500"
+  :next_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :outcome_node: false
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -786,6 +869,7 @@
   - away-outside-london
   - "24500.0"
   - children-under-17,dependant-adult,has-disability,low-income
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -796,6 +880,7 @@
   - "24500.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -806,6 +891,7 @@
   - "24500.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -816,6 +902,7 @@
   - "24500.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -826,6 +913,7 @@
   - "24500.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -835,6 +923,7 @@
   - away-outside-london
   - "24500.0"
   - "no"
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -845,6 +934,7 @@
   - "24500.0"
   - "no"
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -855,6 +945,7 @@
   - "24500.0"
   - "no"
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -865,6 +956,7 @@
   - "24500.0"
   - "no"
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -875,6 +967,7 @@
   - "24500.0"
   - "no"
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :where_will_you_live_while_studying?
   :responses: 
@@ -882,6 +975,7 @@
   - uk-full-time
   - "6000.0"
   - away-in-london
+  :next_node: :whats_your_household_income?
   :outcome_node: false
 - :current_node: :whats_your_household_income?
   :responses: 
@@ -890,6 +984,7 @@
   - "6000.0"
   - away-in-london
   - "100000"
+  :next_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :outcome_node: false
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -899,6 +994,7 @@
   - away-in-london
   - "100000.0"
   - children-under-17,dependant-adult,has-disability,low-income
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -909,6 +1005,7 @@
   - "100000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -919,6 +1016,7 @@
   - "100000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -929,6 +1027,7 @@
   - "100000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -939,6 +1038,7 @@
   - "100000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -948,6 +1048,7 @@
   - away-in-london
   - "100000.0"
   - "no"
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -958,6 +1059,7 @@
   - "100000.0"
   - "no"
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -968,6 +1070,7 @@
   - "100000.0"
   - "no"
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -978,6 +1081,7 @@
   - "100000.0"
   - "no"
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -988,6 +1092,7 @@
   - "100000.0"
   - "no"
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :whats_your_household_income?
   :responses: 
@@ -996,6 +1101,7 @@
   - "6000.0"
   - away-in-london
   - "43875"
+  :next_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :outcome_node: false
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -1005,6 +1111,7 @@
   - away-in-london
   - "43875.0"
   - children-under-17,dependant-adult,has-disability,low-income
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1015,6 +1122,7 @@
   - "43875.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1025,6 +1133,7 @@
   - "43875.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1035,6 +1144,7 @@
   - "43875.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1045,6 +1155,7 @@
   - "43875.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -1054,6 +1165,7 @@
   - away-in-london
   - "43875.0"
   - "no"
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1064,6 +1176,7 @@
   - "43875.0"
   - "no"
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1074,6 +1187,7 @@
   - "43875.0"
   - "no"
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1084,6 +1198,7 @@
   - "43875.0"
   - "no"
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1094,6 +1209,7 @@
   - "43875.0"
   - "no"
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :whats_your_household_income?
   :responses: 
@@ -1102,6 +1218,7 @@
   - "6000.0"
   - away-in-london
   - "35000"
+  :next_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :outcome_node: false
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -1111,6 +1228,7 @@
   - away-in-london
   - "35000.0"
   - children-under-17,dependant-adult,has-disability,low-income
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1121,6 +1239,7 @@
   - "35000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1131,6 +1250,7 @@
   - "35000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1141,6 +1261,7 @@
   - "35000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1151,6 +1272,7 @@
   - "35000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -1160,6 +1282,7 @@
   - away-in-london
   - "35000.0"
   - "no"
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1170,6 +1293,7 @@
   - "35000.0"
   - "no"
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1180,6 +1304,7 @@
   - "35000.0"
   - "no"
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1190,6 +1315,7 @@
   - "35000.0"
   - "no"
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1200,6 +1326,7 @@
   - "35000.0"
   - "no"
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :whats_your_household_income?
   :responses: 
@@ -1208,6 +1335,7 @@
   - "6000.0"
   - away-in-london
   - "24500"
+  :next_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :outcome_node: false
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -1217,6 +1345,7 @@
   - away-in-london
   - "24500.0"
   - children-under-17,dependant-adult,has-disability,low-income
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1227,6 +1356,7 @@
   - "24500.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1237,6 +1367,7 @@
   - "24500.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1247,6 +1378,7 @@
   - "24500.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1257,6 +1389,7 @@
   - "24500.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -1266,6 +1399,7 @@
   - away-in-london
   - "24500.0"
   - "no"
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1276,6 +1410,7 @@
   - "24500.0"
   - "no"
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1286,6 +1421,7 @@
   - "24500.0"
   - "no"
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1296,6 +1432,7 @@
   - "24500.0"
   - "no"
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1306,17 +1443,20 @@
   - "24500.0"
   - "no"
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_type_of_student_are_you?
   :responses: 
   - 2014-2015
   - uk-part-time
+  :next_node: :how_much_are_your_tuition_fees_per_year?
   :outcome_node: false
 - :current_node: :how_much_are_your_tuition_fees_per_year?
   :responses: 
   - 2014-2015
   - uk-part-time
   - "6000"
+  :next_node: :do_any_of_the_following_apply_all_uk_students?
   :outcome_node: false
 - :current_node: :do_any_of_the_following_apply_all_uk_students?
   :responses: 
@@ -1324,6 +1464,7 @@
   - uk-part-time
   - "6000.0"
   - has-disability,low-income
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1332,6 +1473,7 @@
   - "6000.0"
   - has-disability,low-income
   - teacher-training
+  :next_node: :outcome_uk_all_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1340,6 +1482,7 @@
   - "6000.0"
   - has-disability,low-income
   - dental-medical-healthcare
+  :next_node: :outcome_uk_all_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1348,6 +1491,7 @@
   - "6000.0"
   - has-disability,low-income
   - social-work
+  :next_node: :outcome_uk_all_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1356,6 +1500,7 @@
   - "6000.0"
   - has-disability,low-income
   - none-of-the-above
+  :next_node: :outcome_uk_all_students
   :outcome_node: true
 - :current_node: :do_any_of_the_following_apply_all_uk_students?
   :responses: 
@@ -1363,6 +1508,7 @@
   - uk-part-time
   - "6000.0"
   - "no"
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1371,6 +1517,7 @@
   - "6000.0"
   - "no"
   - teacher-training
+  :next_node: :outcome_uk_all_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1379,6 +1526,7 @@
   - "6000.0"
   - "no"
   - dental-medical-healthcare
+  :next_node: :outcome_uk_all_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1387,6 +1535,7 @@
   - "6000.0"
   - "no"
   - social-work
+  :next_node: :outcome_uk_all_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1395,43 +1544,51 @@
   - "6000.0"
   - "no"
   - none-of-the-above
+  :next_node: :outcome_uk_all_students
   :outcome_node: true
 - :current_node: :what_type_of_student_are_you?
   :responses: 
   - 2014-2015
   - eu-full-time
+  :next_node: :how_much_are_your_tuition_fees_per_year?
   :outcome_node: false
 - :current_node: :how_much_are_your_tuition_fees_per_year?
   :responses: 
   - 2014-2015
   - eu-full-time
   - "6000"
+  :next_node: :outcome_eu_students
   :outcome_node: true
 - :current_node: :what_type_of_student_are_you?
   :responses: 
   - 2014-2015
   - eu-part-time
+  :next_node: :how_much_are_your_tuition_fees_per_year?
   :outcome_node: false
 - :current_node: :how_much_are_your_tuition_fees_per_year?
   :responses: 
   - 2014-2015
   - eu-part-time
   - "6000"
+  :next_node: :outcome_eu_students
   :outcome_node: true
 - :current_node: :when_does_your_course_start?
   :responses: 
   - 2015-2016
+  :next_node: :what_type_of_student_are_you?
   :outcome_node: false
 - :current_node: :what_type_of_student_are_you?
   :responses: 
   - 2015-2016
   - uk-full-time
+  :next_node: :how_much_are_your_tuition_fees_per_year?
   :outcome_node: false
 - :current_node: :how_much_are_your_tuition_fees_per_year?
   :responses: 
   - 2015-2016
   - uk-full-time
   - "6000"
+  :next_node: :where_will_you_live_while_studying?
   :outcome_node: false
 - :current_node: :where_will_you_live_while_studying?
   :responses: 
@@ -1439,6 +1596,7 @@
   - uk-full-time
   - "6000.0"
   - at-home
+  :next_node: :whats_your_household_income?
   :outcome_node: false
 - :current_node: :whats_your_household_income?
   :responses: 
@@ -1447,6 +1605,7 @@
   - "6000.0"
   - at-home
   - "100000"
+  :next_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :outcome_node: false
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -1456,6 +1615,7 @@
   - at-home
   - "100000.0"
   - children-under-17,dependant-adult,has-disability,low-income
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1466,6 +1626,7 @@
   - "100000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1476,6 +1637,7 @@
   - "100000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1486,6 +1648,7 @@
   - "100000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1496,6 +1659,7 @@
   - "100000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -1505,6 +1669,7 @@
   - at-home
   - "100000.0"
   - "no"
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1515,6 +1680,7 @@
   - "100000.0"
   - "no"
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1525,6 +1691,7 @@
   - "100000.0"
   - "no"
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1535,6 +1702,7 @@
   - "100000.0"
   - "no"
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1545,6 +1713,7 @@
   - "100000.0"
   - "no"
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :whats_your_household_income?
   :responses: 
@@ -1553,6 +1722,7 @@
   - "6000.0"
   - at-home
   - "43875"
+  :next_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :outcome_node: false
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -1562,6 +1732,7 @@
   - at-home
   - "43875.0"
   - children-under-17,dependant-adult,has-disability,low-income
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1572,6 +1743,7 @@
   - "43875.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1582,6 +1754,7 @@
   - "43875.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1592,6 +1765,7 @@
   - "43875.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1602,6 +1776,7 @@
   - "43875.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -1611,6 +1786,7 @@
   - at-home
   - "43875.0"
   - "no"
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1621,6 +1797,7 @@
   - "43875.0"
   - "no"
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1631,6 +1808,7 @@
   - "43875.0"
   - "no"
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1641,6 +1819,7 @@
   - "43875.0"
   - "no"
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1651,6 +1830,7 @@
   - "43875.0"
   - "no"
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :whats_your_household_income?
   :responses: 
@@ -1659,6 +1839,7 @@
   - "6000.0"
   - at-home
   - "35000"
+  :next_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :outcome_node: false
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -1668,6 +1849,7 @@
   - at-home
   - "35000.0"
   - children-under-17,dependant-adult,has-disability,low-income
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1678,6 +1860,7 @@
   - "35000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1688,6 +1871,7 @@
   - "35000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1698,6 +1882,7 @@
   - "35000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1708,6 +1893,7 @@
   - "35000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -1717,6 +1903,7 @@
   - at-home
   - "35000.0"
   - "no"
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1727,6 +1914,7 @@
   - "35000.0"
   - "no"
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1737,6 +1925,7 @@
   - "35000.0"
   - "no"
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1747,6 +1936,7 @@
   - "35000.0"
   - "no"
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1757,6 +1947,7 @@
   - "35000.0"
   - "no"
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :whats_your_household_income?
   :responses: 
@@ -1765,6 +1956,7 @@
   - "6000.0"
   - at-home
   - "24500"
+  :next_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :outcome_node: false
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -1774,6 +1966,7 @@
   - at-home
   - "24500.0"
   - children-under-17,dependant-adult,has-disability,low-income
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1784,6 +1977,7 @@
   - "24500.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1794,6 +1988,7 @@
   - "24500.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1804,6 +1999,7 @@
   - "24500.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1814,6 +2010,7 @@
   - "24500.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -1823,6 +2020,7 @@
   - at-home
   - "24500.0"
   - "no"
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1833,6 +2031,7 @@
   - "24500.0"
   - "no"
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1843,6 +2042,7 @@
   - "24500.0"
   - "no"
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1853,6 +2053,7 @@
   - "24500.0"
   - "no"
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1863,6 +2064,7 @@
   - "24500.0"
   - "no"
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :where_will_you_live_while_studying?
   :responses: 
@@ -1870,6 +2072,7 @@
   - uk-full-time
   - "6000.0"
   - away-outside-london
+  :next_node: :whats_your_household_income?
   :outcome_node: false
 - :current_node: :whats_your_household_income?
   :responses: 
@@ -1878,6 +2081,7 @@
   - "6000.0"
   - away-outside-london
   - "100000"
+  :next_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :outcome_node: false
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -1887,6 +2091,7 @@
   - away-outside-london
   - "100000.0"
   - children-under-17,dependant-adult,has-disability,low-income
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1897,6 +2102,7 @@
   - "100000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1907,6 +2113,7 @@
   - "100000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1917,6 +2124,7 @@
   - "100000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1927,6 +2135,7 @@
   - "100000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -1936,6 +2145,7 @@
   - away-outside-london
   - "100000.0"
   - "no"
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1946,6 +2156,7 @@
   - "100000.0"
   - "no"
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1956,6 +2167,7 @@
   - "100000.0"
   - "no"
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1966,6 +2178,7 @@
   - "100000.0"
   - "no"
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -1976,6 +2189,7 @@
   - "100000.0"
   - "no"
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :whats_your_household_income?
   :responses: 
@@ -1984,6 +2198,7 @@
   - "6000.0"
   - away-outside-london
   - "43875"
+  :next_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :outcome_node: false
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -1993,6 +2208,7 @@
   - away-outside-london
   - "43875.0"
   - children-under-17,dependant-adult,has-disability,low-income
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2003,6 +2219,7 @@
   - "43875.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2013,6 +2230,7 @@
   - "43875.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2023,6 +2241,7 @@
   - "43875.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2033,6 +2252,7 @@
   - "43875.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -2042,6 +2262,7 @@
   - away-outside-london
   - "43875.0"
   - "no"
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2052,6 +2273,7 @@
   - "43875.0"
   - "no"
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2062,6 +2284,7 @@
   - "43875.0"
   - "no"
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2072,6 +2295,7 @@
   - "43875.0"
   - "no"
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2082,6 +2306,7 @@
   - "43875.0"
   - "no"
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :whats_your_household_income?
   :responses: 
@@ -2090,6 +2315,7 @@
   - "6000.0"
   - away-outside-london
   - "35000"
+  :next_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :outcome_node: false
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -2099,6 +2325,7 @@
   - away-outside-london
   - "35000.0"
   - children-under-17,dependant-adult,has-disability,low-income
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2109,6 +2336,7 @@
   - "35000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2119,6 +2347,7 @@
   - "35000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2129,6 +2358,7 @@
   - "35000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2139,6 +2369,7 @@
   - "35000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -2148,6 +2379,7 @@
   - away-outside-london
   - "35000.0"
   - "no"
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2158,6 +2390,7 @@
   - "35000.0"
   - "no"
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2168,6 +2401,7 @@
   - "35000.0"
   - "no"
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2178,6 +2412,7 @@
   - "35000.0"
   - "no"
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2188,6 +2423,7 @@
   - "35000.0"
   - "no"
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :whats_your_household_income?
   :responses: 
@@ -2196,6 +2432,7 @@
   - "6000.0"
   - away-outside-london
   - "24500"
+  :next_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :outcome_node: false
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -2205,6 +2442,7 @@
   - away-outside-london
   - "24500.0"
   - children-under-17,dependant-adult,has-disability,low-income
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2215,6 +2453,7 @@
   - "24500.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2225,6 +2464,7 @@
   - "24500.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2235,6 +2475,7 @@
   - "24500.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2245,6 +2486,7 @@
   - "24500.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -2254,6 +2496,7 @@
   - away-outside-london
   - "24500.0"
   - "no"
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2264,6 +2507,7 @@
   - "24500.0"
   - "no"
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2274,6 +2518,7 @@
   - "24500.0"
   - "no"
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2284,6 +2529,7 @@
   - "24500.0"
   - "no"
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2294,6 +2540,7 @@
   - "24500.0"
   - "no"
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :where_will_you_live_while_studying?
   :responses: 
@@ -2301,6 +2548,7 @@
   - uk-full-time
   - "6000.0"
   - away-in-london
+  :next_node: :whats_your_household_income?
   :outcome_node: false
 - :current_node: :whats_your_household_income?
   :responses: 
@@ -2309,6 +2557,7 @@
   - "6000.0"
   - away-in-london
   - "100000"
+  :next_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :outcome_node: false
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -2318,6 +2567,7 @@
   - away-in-london
   - "100000.0"
   - children-under-17,dependant-adult,has-disability,low-income
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2328,6 +2578,7 @@
   - "100000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2338,6 +2589,7 @@
   - "100000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2348,6 +2600,7 @@
   - "100000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2358,6 +2611,7 @@
   - "100000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -2367,6 +2621,7 @@
   - away-in-london
   - "100000.0"
   - "no"
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2377,6 +2632,7 @@
   - "100000.0"
   - "no"
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2387,6 +2643,7 @@
   - "100000.0"
   - "no"
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2397,6 +2654,7 @@
   - "100000.0"
   - "no"
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2407,6 +2665,7 @@
   - "100000.0"
   - "no"
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :whats_your_household_income?
   :responses: 
@@ -2415,6 +2674,7 @@
   - "6000.0"
   - away-in-london
   - "43875"
+  :next_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :outcome_node: false
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -2424,6 +2684,7 @@
   - away-in-london
   - "43875.0"
   - children-under-17,dependant-adult,has-disability,low-income
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2434,6 +2695,7 @@
   - "43875.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2444,6 +2706,7 @@
   - "43875.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2454,6 +2717,7 @@
   - "43875.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2464,6 +2728,7 @@
   - "43875.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -2473,6 +2738,7 @@
   - away-in-london
   - "43875.0"
   - "no"
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2483,6 +2749,7 @@
   - "43875.0"
   - "no"
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2493,6 +2760,7 @@
   - "43875.0"
   - "no"
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2503,6 +2771,7 @@
   - "43875.0"
   - "no"
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2513,6 +2782,7 @@
   - "43875.0"
   - "no"
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :whats_your_household_income?
   :responses: 
@@ -2521,6 +2791,7 @@
   - "6000.0"
   - away-in-london
   - "35000"
+  :next_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :outcome_node: false
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -2530,6 +2801,7 @@
   - away-in-london
   - "35000.0"
   - children-under-17,dependant-adult,has-disability,low-income
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2540,6 +2812,7 @@
   - "35000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2550,6 +2823,7 @@
   - "35000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2560,6 +2834,7 @@
   - "35000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2570,6 +2845,7 @@
   - "35000.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -2579,6 +2855,7 @@
   - away-in-london
   - "35000.0"
   - "no"
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2589,6 +2866,7 @@
   - "35000.0"
   - "no"
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2599,6 +2877,7 @@
   - "35000.0"
   - "no"
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2609,6 +2888,7 @@
   - "35000.0"
   - "no"
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2619,6 +2899,7 @@
   - "35000.0"
   - "no"
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :whats_your_household_income?
   :responses: 
@@ -2627,6 +2908,7 @@
   - "6000.0"
   - away-in-london
   - "24500"
+  :next_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :outcome_node: false
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -2636,6 +2918,7 @@
   - away-in-london
   - "24500.0"
   - children-under-17,dependant-adult,has-disability,low-income
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2646,6 +2929,7 @@
   - "24500.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2656,6 +2940,7 @@
   - "24500.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2666,6 +2951,7 @@
   - "24500.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2676,6 +2962,7 @@
   - "24500.0"
   - children-under-17,dependant-adult,has-disability,low-income
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :do_any_of_the_following_apply_uk_full_time_students_only?
   :responses: 
@@ -2685,6 +2972,7 @@
   - away-in-london
   - "24500.0"
   - "no"
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2695,6 +2983,7 @@
   - "24500.0"
   - "no"
   - teacher-training
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2705,6 +2994,7 @@
   - "24500.0"
   - "no"
   - dental-medical-healthcare
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2715,6 +3005,7 @@
   - "24500.0"
   - "no"
   - social-work
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2725,17 +3016,20 @@
   - "24500.0"
   - "no"
   - none-of-the-above
+  :next_node: :outcome_uk_full_time_students
   :outcome_node: true
 - :current_node: :what_type_of_student_are_you?
   :responses: 
   - 2015-2016
   - uk-part-time
+  :next_node: :how_much_are_your_tuition_fees_per_year?
   :outcome_node: false
 - :current_node: :how_much_are_your_tuition_fees_per_year?
   :responses: 
   - 2015-2016
   - uk-part-time
   - "6000"
+  :next_node: :do_any_of_the_following_apply_all_uk_students?
   :outcome_node: false
 - :current_node: :do_any_of_the_following_apply_all_uk_students?
   :responses: 
@@ -2743,6 +3037,7 @@
   - uk-part-time
   - "6000.0"
   - has-disability,low-income
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2751,6 +3046,7 @@
   - "6000.0"
   - has-disability,low-income
   - teacher-training
+  :next_node: :outcome_uk_all_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2759,6 +3055,7 @@
   - "6000.0"
   - has-disability,low-income
   - dental-medical-healthcare
+  :next_node: :outcome_uk_all_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2767,6 +3064,7 @@
   - "6000.0"
   - has-disability,low-income
   - social-work
+  :next_node: :outcome_uk_all_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2775,6 +3073,7 @@
   - "6000.0"
   - has-disability,low-income
   - none-of-the-above
+  :next_node: :outcome_uk_all_students
   :outcome_node: true
 - :current_node: :do_any_of_the_following_apply_all_uk_students?
   :responses: 
@@ -2782,6 +3081,7 @@
   - uk-part-time
   - "6000.0"
   - "no"
+  :next_node: :what_course_are_you_studying?
   :outcome_node: false
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2790,6 +3090,7 @@
   - "6000.0"
   - "no"
   - teacher-training
+  :next_node: :outcome_uk_all_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2798,6 +3099,7 @@
   - "6000.0"
   - "no"
   - dental-medical-healthcare
+  :next_node: :outcome_uk_all_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2806,6 +3108,7 @@
   - "6000.0"
   - "no"
   - social-work
+  :next_node: :outcome_uk_all_students
   :outcome_node: true
 - :current_node: :what_course_are_you_studying?
   :responses: 
@@ -2814,26 +3117,31 @@
   - "6000.0"
   - "no"
   - none-of-the-above
+  :next_node: :outcome_uk_all_students
   :outcome_node: true
 - :current_node: :what_type_of_student_are_you?
   :responses: 
   - 2015-2016
   - eu-full-time
+  :next_node: :how_much_are_your_tuition_fees_per_year?
   :outcome_node: false
 - :current_node: :how_much_are_your_tuition_fees_per_year?
   :responses: 
   - 2015-2016
   - eu-full-time
   - "6000"
+  :next_node: :outcome_eu_students
   :outcome_node: true
 - :current_node: :what_type_of_student_are_you?
   :responses: 
   - 2015-2016
   - eu-part-time
+  :next_node: :how_much_are_your_tuition_fees_per_year?
   :outcome_node: false
 - :current_node: :how_much_are_your_tuition_fees_per_year?
   :responses: 
   - 2015-2016
   - eu-part-time
   - "6000"
+  :next_node: :outcome_eu_students
   :outcome_node: true

--- a/test/data/towing-rules-files.yml
+++ b/test/data/towing-rules-files.yml
@@ -2,4 +2,4 @@
 lib/smart_answer_flows/towing-rules.rb: 76c99d0ebe9a26d686563ce4b9512a54
 lib/smart_answer_flows/locales/en/towing-rules.yml: 65c5f6133bc15d0c77db3ee4bc30de28
 test/data/towing-rules-questions-and-responses.yml: 09c8f43d5353fa6248658a27982ea5a2
-test/data/towing-rules-responses-and-expected-results.yml: 943926704f214c45404673391ed47bc8
+test/data/towing-rules-responses-and-expected-results.yml: ab907e6d438f7f2f6fc76bb1b219e6d7

--- a/test/data/towing-rules-responses-and-expected-results.yml
+++ b/test/data/towing-rules-responses-and-expected-results.yml
@@ -2,78 +2,92 @@
 - :current_node: :towing_vehicle_type?
   :responses: 
   - car-or-light-vehicle
+  :next_node: :existing_towing_entitlements?
   :outcome_node: false
 - :current_node: :existing_towing_entitlements?
   :responses: 
   - car-or-light-vehicle
   - "yes"
+  :next_node: :how_long_entitlements?
   :outcome_node: false
 - :current_node: :how_long_entitlements?
   :responses: 
   - car-or-light-vehicle
   - "yes"
   - before-19-Jan-2013
+  :next_node: :car_light_vehicle_entitlement
   :outcome_node: true
 - :current_node: :how_long_entitlements?
   :responses: 
   - car-or-light-vehicle
   - "yes"
   - after-19-Jan-2013
+  :next_node: :full_entitlement
   :outcome_node: true
 - :current_node: :existing_towing_entitlements?
   :responses: 
   - car-or-light-vehicle
   - "no"
+  :next_node: :date_licence_was_issued?
   :outcome_node: false
 - :current_node: :date_licence_was_issued?
   :responses: 
   - car-or-light-vehicle
   - "no"
   - licence-issued-before-19-Jan-2013
+  :next_node: :limited_trailer_entitlement
   :outcome_node: true
 - :current_node: :date_licence_was_issued?
   :responses: 
   - car-or-light-vehicle
   - "no"
   - licence-issued-after-19-Jan-2013
+  :next_node: :limited_trailer_entitlement_2013
   :outcome_node: true
 - :current_node: :towing_vehicle_type?
   :responses: 
   - medium-sized-vehicle
+  :next_node: :medium_sized_vehicle_licenceholder?
   :outcome_node: false
 - :current_node: :medium_sized_vehicle_licenceholder?
   :responses: 
   - medium-sized-vehicle
   - "yes"
+  :next_node: :how_old_are_you_msv?
   :outcome_node: false
 - :current_node: :how_old_are_you_msv?
   :responses: 
   - medium-sized-vehicle
   - "yes"
   - under-21
+  :next_node: :limited_conditional_trailer_entitlement_msv
   :outcome_node: true
 - :current_node: :how_old_are_you_msv?
   :responses: 
   - medium-sized-vehicle
   - "yes"
   - 21-or-over
+  :next_node: :limited_trailer_entitlement_msv
   :outcome_node: true
 - :current_node: :medium_sized_vehicle_licenceholder?
   :responses: 
   - medium-sized-vehicle
   - "no"
+  :next_node: :existing_large_vehicle_towing_entitlements?
   :outcome_node: false
 - :current_node: :existing_large_vehicle_towing_entitlements?
   :responses: 
   - medium-sized-vehicle
   - "no"
   - "yes"
+  :next_node: :included_entitlement_msv
   :outcome_node: true
 - :current_node: :existing_large_vehicle_towing_entitlements?
   :responses: 
   - medium-sized-vehicle
   - "no"
   - "no"
+  :next_node: :date_licence_was_issued_msv?
   :outcome_node: false
 - :current_node: :date_licence_was_issued_msv?
   :responses: 
@@ -81,6 +95,7 @@
   - "no"
   - "no"
   - before-jan-1997
+  :next_node: :full_entitlement_msv
   :outcome_node: true
 - :current_node: :date_licence_was_issued_msv?
   :responses: 
@@ -88,6 +103,7 @@
   - "no"
   - "no"
   - from-jan-1997
+  :next_node: :how_old_are_you_msv_2?
   :outcome_node: false
 - :current_node: :how_old_are_you_msv_2?
   :responses: 
@@ -96,6 +112,7 @@
   - "no"
   - from-jan-1997
   - under-18
+  :next_node: :too_young_msv
   :outcome_node: true
 - :current_node: :how_old_are_you_msv_2?
   :responses: 
@@ -104,6 +121,7 @@
   - "no"
   - from-jan-1997
   - under-21
+  :next_node: :apply_for_provisional_with_exceptions_msv
   :outcome_node: true
 - :current_node: :how_old_are_you_msv_2?
   :responses: 
@@ -112,58 +130,69 @@
   - "no"
   - from-jan-1997
   - 21-or-over
+  :next_node: :apply_for_provisional_msv
   :outcome_node: true
 - :current_node: :towing_vehicle_type?
   :responses: 
   - large-vehicle
+  :next_node: :existing_large_vehicle_licence?
   :outcome_node: false
 - :current_node: :existing_large_vehicle_licence?
   :responses: 
   - large-vehicle
   - "yes"
+  :next_node: :full_cat_c_entitlement
   :outcome_node: true
 - :current_node: :existing_large_vehicle_licence?
   :responses: 
   - large-vehicle
   - "no"
+  :next_node: :how_old_are_you_lv?
   :outcome_node: false
 - :current_node: :how_old_are_you_lv?
   :responses: 
   - large-vehicle
   - "no"
   - under-21
+  :next_node: :not_old_enough_lv
   :outcome_node: true
 - :current_node: :how_old_are_you_lv?
   :responses: 
   - large-vehicle
   - "no"
   - 21-or-over
+  :next_node: :apply_for_provisional_lv
   :outcome_node: true
 - :current_node: :towing_vehicle_type?
   :responses: 
   - minibus
+  :next_node: :car_licence_before_jan_1997?
   :outcome_node: false
 - :current_node: :car_licence_before_jan_1997?
   :responses: 
   - minibus
   - "yes"
+  :next_node: :full_entitlement_minibus
   :outcome_node: true
 - :current_node: :car_licence_before_jan_1997?
   :responses: 
   - minibus
   - "no"
+  :next_node: :do_you_have_lv_or_bus_towing_entitlement?
   :outcome_node: false
 - :current_node: :do_you_have_lv_or_bus_towing_entitlement?
   :responses: 
   - minibus
   - "no"
   - "yes"
+  :next_node: :included_entitlement_minibus
   :outcome_node: true
 - :current_node: :do_you_have_lv_or_bus_towing_entitlement?
   :responses: 
   - minibus
   - "no"
   - "no"
+  :next_node: :full_minibus_licence?
   :outcome_node: false
 - :current_node: :full_minibus_licence?
   :responses: 
@@ -171,6 +200,7 @@
   - "no"
   - "no"
   - "yes"
+  :next_node: :limited_towing_entitlement_minibus
   :outcome_node: true
 - :current_node: :full_minibus_licence?
   :responses: 
@@ -178,6 +208,7 @@
   - "no"
   - "no"
   - "no"
+  :next_node: :how_old_are_you_minibus?
   :outcome_node: false
 - :current_node: :how_old_are_you_minibus?
   :responses: 
@@ -186,6 +217,7 @@
   - "no"
   - "no"
   - under-21
+  :next_node: :not_old_enough_minibus
   :outcome_node: true
 - :current_node: :how_old_are_you_minibus?
   :responses: 
@@ -194,30 +226,36 @@
   - "no"
   - "no"
   - 21-or-over
+  :next_node: :limited_overall_entitlement_minibus
   :outcome_node: true
 - :current_node: :towing_vehicle_type?
   :responses: 
   - bus
+  :next_node: :bus_licenceholder?
   :outcome_node: false
 - :current_node: :bus_licenceholder?
   :responses: 
   - bus
   - "yes"
+  :next_node: :full_entitlement_bus
   :outcome_node: true
 - :current_node: :bus_licenceholder?
   :responses: 
   - bus
   - "no"
+  :next_node: :how_old_are_you_bus?
   :outcome_node: false
 - :current_node: :how_old_are_you_bus?
   :responses: 
   - bus
   - "no"
   - under-21
+  :next_node: :not_old_enough_bus
   :outcome_node: true
 - :current_node: :how_old_are_you_bus?
   :responses: 
   - bus
   - "no"
   - 21-or-over
+  :next_node: :apply_for_provisional_bus
   :outcome_node: true

--- a/test/data/vat-payment-deadlines-files.yml
+++ b/test/data/vat-payment-deadlines-files.yml
@@ -2,7 +2,7 @@
 lib/smart_answer_flows/vat-payment-deadlines.rb: 0b42593ff72d99cc3fb1c31d4851c5bb
 lib/smart_answer_flows/locales/en/vat-payment-deadlines.yml: 96a0aaa62f2db7169db4ed5f1caeff06
 test/data/vat-payment-deadlines-questions-and-responses.yml: a9c89cff2686881257fe52b750032268
-test/data/vat-payment-deadlines-responses-and-expected-results.yml: 929c9a22dbd6775ad15330e52e860b65
+test/data/vat-payment-deadlines-responses-and-expected-results.yml: 88f5a54e78f8b5006265a8005cdd15fe
 lib/smart_answer_flows/vat-payment-deadlines/result_bacs_direct_credit_body.govspeak.erb: 9995803d5fee6c5eea80b26e2b92d0ec
 lib/smart_answer_flows/vat-payment-deadlines/result_bacs_direct_credit_title.txt.erb: 961e10029948fddff8ac69bedccc82e7
 lib/smart_answer_flows/vat-payment-deadlines/result_bank_giro_body.govspeak.erb: d8289868c853367534a7213cd385ac95

--- a/test/data/vat-payment-deadlines-responses-and-expected-results.yml
+++ b/test/data/vat-payment-deadlines-responses-and-expected-results.yml
@@ -2,39 +2,47 @@
 - :current_node: :when_does_your_vat_accounting_period_end?
   :responses: 
   - "2015-01-31"
+  :next_node: :how_do_you_want_to_pay?
   :outcome_node: false
 - :current_node: :how_do_you_want_to_pay?
   :responses: 
   - "2015-01-31"
   - direct-debit
+  :next_node: :result_direct_debit
   :outcome_node: true
 - :current_node: :how_do_you_want_to_pay?
   :responses: 
   - "2015-01-31"
   - online-telephone-banking
+  :next_node: :result_online_telephone_banking
   :outcome_node: true
 - :current_node: :how_do_you_want_to_pay?
   :responses: 
   - "2015-01-31"
   - online-debit-credit-card
+  :next_node: :result_online_debit_credit_card
   :outcome_node: true
 - :current_node: :how_do_you_want_to_pay?
   :responses: 
   - "2015-01-31"
   - bacs-direct-credit
+  :next_node: :result_bacs_direct_credit
   :outcome_node: true
 - :current_node: :how_do_you_want_to_pay?
   :responses: 
   - "2015-01-31"
   - bank-giro
+  :next_node: :result_bank_giro
   :outcome_node: true
 - :current_node: :how_do_you_want_to_pay?
   :responses: 
   - "2015-01-31"
   - chaps
+  :next_node: :result_chaps
   :outcome_node: true
 - :current_node: :how_do_you_want_to_pay?
   :responses: 
   - "2015-01-31"
   - cheque
+  :next_node: :result_cheque
   :outcome_node: true

--- a/test/regression/smart_answers_regression_test.rb
+++ b/test/regression/smart_answers_regression_test.rb
@@ -45,6 +45,20 @@ class SmartAnswerResponsesAndExpectedResultsTest < ActionController::TestCase
         assert_equal false, smart_answer_helper.files_checksum_data_needs_updating?, message.join('. ')
       end
 
+      should "ensure all nodes are being exercised" do
+        flow = SmartAnswer::FlowRegistry.instance.find(flow_name)
+
+        nodes_exercised_in_test = responses_and_expected_results.inject([]) do |array, responses_and_expected_results|
+          current_node = responses_and_expected_results[:current_node]
+          next_node    = responses_and_expected_results[:next_node]
+          array << current_node unless array.include?(current_node)
+          array << next_node unless array.include?(next_node)
+          array
+        end
+
+        assert_equal nodes_exercised_in_test.sort, flow.nodes.map(&:name).sort
+      end
+
       responses_and_expected_results.each do |responses_and_expected_node|
         responses    = responses_and_expected_node[:responses]
         outcome_node = responses_and_expected_node[:outcome_node]


### PR DESCRIPTION
By storing both the `current_node` and `next_node` in the responses-and-expected-results YAML file, we can compare the nodes that have been exercised with all the nodes in the Flow. I'd added a test that fails if the two sets of nodes don't match.

This is the test that @floehopper mentioned in 53e67d850500421fc26c226a004c13d02429cee8.
