### PR TITLE
Remove redundant code from pip-checker

### DIFF
--- a/lib/smart_answer_flows/locales/en/pip-checker.yml
+++ b/lib/smart_answer_flows/locales/en/pip-checker.yml
@@ -67,20 +67,6 @@ en-GB:
           - | - | -
           AB (Aberdeen), DD (Dundee), DG (Dumfries and Galloway), EH (Edinburgh), G (Glasgow, IV (Inverness), KA (Kilmarnock), KY (Kirkcaldy), ML (Motherwell), PH (Perth), TD (Galashiels), FK (Falkirk) | PA (Paisley)  | HS (Hebrides), KW (Kirkwall), ZE (Lerwick)
 
-        scheme_postcodes_pre_3rd_feb_2014: |
-          - DG (Dumfries and Galloway)
-          - EH (Edinburgh)
-          - TD (Galashiels)
-          - ML (Motherwell)
-
-          On 3 February 2014 the scheme will be expanded to include postcodes beginning with:
-
-          - CA (Carlisle)
-          - DL (Darlington)
-          - HG (Harrogate)
-          - LA (Lancaster)
-          - YO (York)
-
       ## Q1
       are_you_getting_dla?:
         title: "Are you getting Disability Living Allowance?"

--- a/lib/smart_answer_flows/pip-checker.rb
+++ b/lib/smart_answer_flows/pip-checker.rb
@@ -20,11 +20,7 @@ module SmartAnswer
         end
 
         calculate :postcodes do
-          if Date.today > Date.civil(2014, 02, 02)
-            PhraseList.new(:scheme_postcodes)
-          else
-            PhraseList.new(:scheme_postcodes_pre_3rd_feb_2014)
-          end
+          PhraseList.new(:scheme_postcodes)
         end
       end
 

--- a/test/data/pip-checker-files.yml
+++ b/test/data/pip-checker-files.yml
@@ -1,6 +1,6 @@
 --- 
-lib/smart_answer_flows/pip-checker.rb: 01a41276a49412bdfa9711e082c51393
-lib/smart_answer_flows/locales/en/pip-checker.yml: 4d650e8c004665dd98f1bce53bc2ad50
+lib/smart_answer_flows/pip-checker.rb: 36069a40041f933a47bab09ec63f4acb
+lib/smart_answer_flows/locales/en/pip-checker.yml: 4ae71296a013134cee5c9c95a2198204
 test/data/pip-checker-questions-and-responses.yml: b1d68ebfb76a9e2793705c55b82294f5
 test/data/pip-checker-responses-and-expected-results.yml: f0c8c243623cad06b9c65dbb504d5b4d
 lib/smart_answer/calculators/pip_dates.rb: 773342998eae28adbbc7403a24e9548c

--- a/test/integration/smart_answer_flows/pip_checker_test.rb
+++ b/test/integration/smart_answer_flows/pip_checker_test.rb
@@ -43,40 +43,6 @@ class PIPCheckerTest < ActiveSupport::TestCase
   context "getting DLA" do
     setup do
       add_response 'yes'
-      Timecop.travel('2013-06-07')
-    end
-
-    should "ask for your date of birth" do
-      assert_current_node :what_is_your_dob?
-    end
-
-    should "be result 6 if born on or before 08-04-1948" do
-      add_response "1948-04-08"
-      assert_current_node :result_6
-    end
-
-    should "be result 4 if born between 08-06-1997 and 06-10-1997" do
-      add_response '1997-06-08'
-      assert_current_node :result_4
-      assert_phrase_list :postcodes, [:scheme_postcodes_pre_3rd_feb_2014]
-    end
-
-    should "be result 5 if born on or after 07-10-1997" do
-      add_response '1997-10-07'
-      assert_current_node :result_5
-      assert_phrase_list :postcodes, [:scheme_postcodes_pre_3rd_feb_2014]
-    end
-
-    should "be result 7 if born between 09-04-1948 and 07-04-1997" do
-      add_response "1996-05-24"
-      assert_current_node :result_7
-      assert_phrase_list :postcodes, [:scheme_postcodes_pre_3rd_feb_2014]
-    end
-  end # getting DLA
-
-  context "getting DLA after 03 Feb 2014 (03/03/14)" do
-    setup do
-      add_response 'yes'
       Timecop.travel('2014-02-03')
     end
 


### PR DESCRIPTION
The changeover date of 3rd February, 2014 has long since passed, so this code
is only ever being executed in the integration test using `Timecop.travel` to
set the current date in the past.