### PR TITLE
Remove unreachable outcome node

### DIFF
--- a/lib/smart_answer_flows/locales/en/calculate-redundancy-pay.yml
+++ b/lib/smart_answer_flows/locales/en/calculate-redundancy-pay.yml
@@ -64,9 +64,6 @@ en-GB:
 
         next_steps: |
           [Read the guide to Redundancy: your rights](https://www.gov.uk/redundant-your-rights)
-      no_result_possible_yet:
-        body: |
-          You can’t calculate redundancy rates after 5 April 2014 until the new rates are set on 6 April 2014.
 
     calculate-employee-redundancy-pay:
       title: "Calculate your employee's statutory redundancy pay"
@@ -133,6 +130,3 @@ en-GB:
         next_steps: |
           [Read the guide to Making staff redundant](https://www.gov.uk/staff-redundant)
 
-      no_result_possible_yet:
-        body: |
-          You can’t calculate redundancy rates after 5 April 2014 until the new rates are set on 6 April 2014.

--- a/lib/smart_answer_flows/shared_logic/redundancy_pay.rb
+++ b/lib/smart_answer_flows/shared_logic/redundancy_pay.rb
@@ -63,4 +63,3 @@ end
 
 outcome :done_no_statutory
 outcome :done
-outcome :no_result_possible_yet


### PR DESCRIPTION
This outcome was added on 13th Dec 2013[1] and was reachable from the
`:date_of_redundancy?` date question.

The `:date_of_redundancy?` question was updated on 7th Apr 2014[2] and this
outcome became unreachable.

[1]: 0112950a987a544ab1db91f2356827ad65af350d
[2]: 9c7081d230992cd7680451739c51c6b668a37816