### PR TITLE
Validate date ranges

### DIFF
--- a/lib/smart_answer/question/date.rb
+++ b/lib/smart_answer/question/date.rb
@@ -7,6 +7,10 @@ module SmartAnswer
         super
       end
 
+      def validate_in_range
+        @validate_in_range = true
+      end
+
       def from(from = nil, &block)
         if block_given?
           @from_func = block
@@ -105,6 +109,7 @@ module SmartAnswer
           else
            raise InvalidResponse, "Bad date", caller
           end
+        validate_input(date) if @validate_in_range
         date
       rescue
         raise InvalidResponse, "Bad date: #{input.inspect}", caller
@@ -119,6 +124,17 @@ module SmartAnswer
         }
       rescue
         nil
+      end
+
+    private
+
+      def validate_input(date)
+        return unless range
+
+        min, max = [range.begin, range.end].sort
+        if date < min || date > max
+          raise InvalidResponse, "Provided date is out of range: #{date}", caller
+        end
       end
     end
   end

--- a/lib/smart_answer/question/date.rb
+++ b/lib/smart_answer/question/date.rb
@@ -126,6 +126,12 @@ module SmartAnswer
         nil
       end
 
+      def date_of_birth_defaults
+        from { 122.years.ago.beginning_of_year.to_date }
+        to { ::Date.today.end_of_year }
+        validate_in_range
+      end
+
     private
 
       def validate_input(date)

--- a/lib/smart_answer_flows/appeal-a-benefits-decision.rb
+++ b/lib/smart_answer_flows/appeal-a-benefits-decision.rb
@@ -23,7 +23,7 @@ module SmartAnswer
       # Q3
       date_question :date_of_decision_letter? do
         from { 5.years.ago }
-        to { Date.today }
+        to { Date.today.end_of_year }
         save_input_as :decision_letter_date
 
         next_node do |response|
@@ -79,7 +79,7 @@ module SmartAnswer
       # Q5
       date_question :when_did_you_ask_for_it? do
         from { 5.years.ago }
-        to { Date.today }
+        to { Date.today.end_of_year }
         calculate :written_explanation_request_date do |response|
           response
         end
@@ -91,7 +91,7 @@ module SmartAnswer
 
         save_input_as :written_explanation_received_date
         from { 5.years.ago }
-        to { Date.today }
+        to { Date.today.end_of_year }
 
         validate do |response|
           response >= written_explanation_request_date

--- a/lib/smart_answer_flows/calculate-married-couples-allowance.rb
+++ b/lib/smart_answer_flows/calculate-married-couples-allowance.rb
@@ -39,8 +39,8 @@ module SmartAnswer
       end
 
       date_question :whats_the_husbands_date_of_birth? do
+        from { Date.today.end_of_year }
         to { Date.parse('1 Jan 1896') }
-        from { Date.today }
 
         save_input_as :birth_date
         next_node :whats_the_husbands_income?
@@ -48,7 +48,7 @@ module SmartAnswer
 
       date_question :whats_the_highest_earners_date_of_birth? do
         to { Date.parse('1 Jan 1896') }
-        from { Date.today }
+        from { Date.today.end_of_year }
 
         save_input_as :birth_date
         next_node :whats_the_highest_earners_income?

--- a/lib/smart_answer_flows/calculate-state-pension.rb
+++ b/lib/smart_answer_flows/calculate-state-pension.rb
@@ -42,8 +42,8 @@ module SmartAnswer
 
       # Q3:Age
       date_question :dob_age? do
-        from { 100.years.ago }
-        to { Date.today.end_of_year  }
+        from { 122.years.ago.beginning_of_year }
+        to { Date.today.end_of_year }
         validate_in_range
 
         save_input_as :dob
@@ -129,7 +129,7 @@ module SmartAnswer
 
       # Q3:Amount
       date_question :dob_amount? do
-        from { 100.years.ago }
+        from { 122.years.ago.beginning_of_year }
         to { Date.today.end_of_year }
         validate_in_range
 

--- a/lib/smart_answer_flows/calculate-state-pension.rb
+++ b/lib/smart_answer_flows/calculate-state-pension.rb
@@ -42,9 +42,7 @@ module SmartAnswer
 
       # Q3:Age
       date_question :dob_age? do
-        from { 122.years.ago.beginning_of_year }
-        to { Date.today.end_of_year }
-        validate_in_range
+        date_of_birth_defaults
 
         save_input_as :dob
 
@@ -129,9 +127,7 @@ module SmartAnswer
 
       # Q3:Amount
       date_question :dob_amount? do
-        from { 122.years.ago.beginning_of_year }
-        to { Date.today.end_of_year }
-        validate_in_range
+        date_of_birth_defaults
 
         save_input_as :dob
 

--- a/lib/smart_answer_flows/calculate-state-pension.rb
+++ b/lib/smart_answer_flows/calculate-state-pension.rb
@@ -43,7 +43,7 @@ module SmartAnswer
       # Q3:Age
       date_question :dob_age? do
         from { 100.years.ago }
-        to { Date.today }
+        to { Date.today.end_of_year }
 
         save_input_as :dob
 
@@ -129,7 +129,7 @@ module SmartAnswer
       # Q3:Amount
       date_question :dob_amount? do
         from { 100.years.ago }
-        to { Date.today }
+        to { Date.today.end_of_year }
 
         save_input_as :dob
 

--- a/lib/smart_answer_flows/calculate-state-pension.rb
+++ b/lib/smart_answer_flows/calculate-state-pension.rb
@@ -43,7 +43,8 @@ module SmartAnswer
       # Q3:Age
       date_question :dob_age? do
         from { 100.years.ago }
-        to { Date.today.end_of_year }
+        to { Date.today.end_of_year  }
+        validate_in_range
 
         save_input_as :dob
 
@@ -130,6 +131,7 @@ module SmartAnswer
       date_question :dob_amount? do
         from { 100.years.ago }
         to { Date.today.end_of_year }
+        validate_in_range
 
         save_input_as :dob
 

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -42,7 +42,8 @@ end
 # Question 4
 date_question :first_sick_day? do
   from { Date.new(2011, 1, 1) }
-  to { Date.today }
+  to { Date.today.end_of_year }
+
   calculate :sick_start_date do |response|
     response
   end
@@ -54,7 +55,8 @@ end
 # Question 5
 date_question :last_sick_day? do
   from { Date.new(2011, 1, 1) }
-  to { Date.today }
+  to { Date.today.end_of_year }
+
   calculate :sick_end_date do |response|
     response
   end
@@ -95,7 +97,7 @@ end
 # Question 6
 date_question :last_payday_before_sickness? do
   from { Date.new(2010, 1, 1) }
-  to { Date.today }
+  to { Date.today.end_of_year }
 
   calculate :relevant_period_to do |response|
     response
@@ -118,7 +120,7 @@ end
 # Question 6.1
 date_question :last_payday_before_offset? do
   from { Date.new(2010, 1, 1) }
-  to { Date.today }
+  to { Date.today.end_of_year }
 
   # You must enter a date on or before [pay_day_offset]
   validate { |payday| payday <= pay_day_offset }
@@ -202,7 +204,7 @@ end
 # Question 11.1
 date_question :linked_sickness_start_date? do
   from { Date.new(2010, 1, 1) }
-  to { Date.today }
+  to { Date.today.end_of_year }
 
   next_node_if(:not_earned_enough) do |response|
     employee_average_weekly_earnings < Calculators::StatutorySickPayCalculator.lower_earning_limit_on(response)

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -43,6 +43,7 @@ end
 date_question :first_sick_day? do
   from { Date.new(2011, 1, 1) }
   to { Date.today.end_of_year }
+  validate_in_range
 
   calculate :sick_start_date do |response|
     response
@@ -56,6 +57,7 @@ end
 date_question :last_sick_day? do
   from { Date.new(2011, 1, 1) }
   to { Date.today.end_of_year }
+  validate_in_range
 
   calculate :sick_end_date do |response|
     response
@@ -98,6 +100,7 @@ end
 date_question :last_payday_before_sickness? do
   from { Date.new(2010, 1, 1) }
   to { Date.today.end_of_year }
+  validate_in_range
 
   calculate :relevant_period_to do |response|
     response
@@ -121,6 +124,7 @@ end
 date_question :last_payday_before_offset? do
   from { Date.new(2010, 1, 1) }
   to { Date.today.end_of_year }
+  validate_in_range
 
   # You must enter a date on or before [pay_day_offset]
   validate { |payday| payday <= pay_day_offset }
@@ -205,6 +209,7 @@ end
 date_question :linked_sickness_start_date? do
   from { Date.new(2010, 1, 1) }
   to { Date.today.end_of_year }
+  validate_in_range
 
   next_node_if(:not_earned_enough) do |response|
     employee_average_weekly_earnings < Calculators::StatutorySickPayCalculator.lower_earning_limit_on(response)

--- a/lib/smart_answer_flows/energy-grants-calculator.rb
+++ b/lib/smart_answer_flows/energy-grants-calculator.rb
@@ -95,9 +95,7 @@ module SmartAnswer
 
       # Q3
       date_question :date_of_birth? do
-        from { 122.years.ago.beginning_of_year }
-        to { Date.today.end_of_year }
-        validate_in_range
+        date_of_birth_defaults
 
         calculate :age_variant do |response|
           dob = response

--- a/lib/smart_answer_flows/energy-grants-calculator.rb
+++ b/lib/smart_answer_flows/energy-grants-calculator.rb
@@ -97,6 +97,7 @@ module SmartAnswer
       date_question :date_of_birth? do
         from { 100.years.ago }
         to { Date.today.end_of_year }
+        validate_in_range
 
         calculate :age_variant do |response|
           dob = response

--- a/lib/smart_answer_flows/energy-grants-calculator.rb
+++ b/lib/smart_answer_flows/energy-grants-calculator.rb
@@ -96,7 +96,7 @@ module SmartAnswer
       # Q3
       date_question :date_of_birth? do
         from { 100.years.ago }
-        to { Date.today }
+        to { Date.today.end_of_year }
 
         calculate :age_variant do |response|
           dob = response

--- a/lib/smart_answer_flows/energy-grants-calculator.rb
+++ b/lib/smart_answer_flows/energy-grants-calculator.rb
@@ -95,7 +95,7 @@ module SmartAnswer
 
       # Q3
       date_question :date_of_birth? do
-        from { 100.years.ago }
+        from { 122.years.ago.beginning_of_year }
         to { Date.today.end_of_year }
         validate_in_range
 

--- a/lib/smart_answer_flows/pip-checker.rb
+++ b/lib/smart_answer_flows/pip-checker.rb
@@ -27,7 +27,7 @@ module SmartAnswer
       ## Q2
       date_question :what_is_your_dob? do
         from { Date.today - 100.years }
-        to { Date.today }
+        to { Date.today.end_of_year }
         next_node do |response|
           calculator.dob = response
           if getting_dla

--- a/lib/smart_answer_flows/pip-checker.rb
+++ b/lib/smart_answer_flows/pip-checker.rb
@@ -28,6 +28,8 @@ module SmartAnswer
       date_question :what_is_your_dob? do
         from { Date.today - 100.years }
         to { Date.today.end_of_year }
+        validate_in_range
+
         next_node do |response|
           calculator.dob = response
           if getting_dla

--- a/lib/smart_answer_flows/pip-checker.rb
+++ b/lib/smart_answer_flows/pip-checker.rb
@@ -26,9 +26,7 @@ module SmartAnswer
 
       ## Q2
       date_question :what_is_your_dob? do
-        from { 122.years.ago.beginning_of_year }
-        to { Date.today.end_of_year }
-        validate_in_range
+        date_of_birth_defaults
 
         next_node do |response|
           calculator.dob = response

--- a/lib/smart_answer_flows/pip-checker.rb
+++ b/lib/smart_answer_flows/pip-checker.rb
@@ -26,7 +26,7 @@ module SmartAnswer
 
       ## Q2
       date_question :what_is_your_dob? do
-        from { Date.today - 100.years }
+        from { 122.years.ago.beginning_of_year }
         to { Date.today.end_of_year }
         validate_in_range
 

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -61,7 +61,7 @@ module SmartAnswer
 
       # Q4
       date_question :childs_date_of_birth? do
-        from { Date.today }
+        from { Date.today.end_of_year }
         to { 50.years.ago(Date.today) }
 
         before_july_2006 = SmartAnswer::Predicate::Callable.new("before 1 July 2006") do |response|

--- a/lib/smart_answer_flows/shared_logic/redundancy_pay.rb
+++ b/lib/smart_answer_flows/shared_logic/redundancy_pay.rb
@@ -1,6 +1,7 @@
 date_question :date_of_redundancy? do
   from { Date.civil(2012, 1, 1) }
   to { Date.today.end_of_year }
+  validate_in_range
 
   calculate :rates do |response|
     Calculators::RedundancyCalculator.redundancy_rates(response)

--- a/lib/smart_answer_flows/shared_logic/redundancy_pay.rb
+++ b/lib/smart_answer_flows/shared_logic/redundancy_pay.rb
@@ -1,6 +1,7 @@
 date_question :date_of_redundancy? do
   from { Date.civil(2012, 1, 1) }
-  to { Date.today }
+  to { Date.today.end_of_year }
+
   calculate :rates do |response|
     Calculators::RedundancyCalculator.redundancy_rates(response)
   end

--- a/lib/smart_answer_flows/state-pension-topup.rb
+++ b/lib/smart_answer_flows/state-pension-topup.rb
@@ -9,7 +9,7 @@ module SmartAnswer
 
       #Q1
       date_question :dob_age? do
-        from { 110.years.ago }
+        from { 122.years.ago.beginning_of_year }
         to { Date.today - 18.years }
         validate_in_range
 

--- a/lib/smart_answer_flows/state-pension-topup.rb
+++ b/lib/smart_answer_flows/state-pension-topup.rb
@@ -9,9 +9,7 @@ module SmartAnswer
 
       #Q1
       date_question :dob_age? do
-        from { 122.years.ago.beginning_of_year }
-        to { Date.today - 18.years }
-        validate_in_range
+        date_of_birth_defaults
 
         save_input_as :date_of_birth
 

--- a/lib/smart_answer_flows/state-pension-topup.rb
+++ b/lib/smart_answer_flows/state-pension-topup.rb
@@ -11,6 +11,7 @@ module SmartAnswer
       date_question :dob_age? do
         from { 110.years.ago }
         to { Date.today - 18.years }
+        validate_in_range
 
         save_input_as :date_of_birth
 

--- a/test/data/calculate-married-couples-allowance-files.yml
+++ b/test/data/calculate-married-couples-allowance-files.yml
@@ -1,5 +1,5 @@
 --- 
-lib/smart_answer_flows/calculate-married-couples-allowance.rb: 23b9c0558efe30347c7f03fc7b64eabf
+lib/smart_answer_flows/calculate-married-couples-allowance.rb: c7e93d8d17bfa0f57793048c6a100ff0
 lib/smart_answer_flows/locales/en/calculate-married-couples-allowance.yml: 443009d73289059eff85152dc2226def
 test/data/calculate-married-couples-allowance-questions-and-responses.yml: 1bbef5f2f30d470433bbb63f029881cd
 test/data/calculate-married-couples-allowance-responses-and-expected-results.yml: 3bb53e4211718b8b1b7dacfaa52f3f49

--- a/test/data/calculate-state-pension-files.yml
+++ b/test/data/calculate-state-pension-files.yml
@@ -1,5 +1,5 @@
 --- 
-lib/smart_answer_flows/calculate-state-pension.rb: 001a9384399a1d5837e665e44f52439a
+lib/smart_answer_flows/calculate-state-pension.rb: 617f76058f43433872d2021befb7368e
 lib/smart_answer_flows/locales/en/calculate-state-pension.yml: 6ffe7b3949aa19db1f87a3eafe2f835d
 test/data/calculate-state-pension-questions-and-responses.yml: 4767e955eba84fd456636a4f6ec19284
 test/data/calculate-state-pension-responses-and-expected-results.yml: 5eabfd4e1c8d35cdcd28d61952fac4d9

--- a/test/data/pip-checker-files.yml
+++ b/test/data/pip-checker-files.yml
@@ -1,5 +1,5 @@
 --- 
-lib/smart_answer_flows/pip-checker.rb: 36069a40041f933a47bab09ec63f4acb
+lib/smart_answer_flows/pip-checker.rb: bde45cd16c3846ab35eaa383df6791a1
 lib/smart_answer_flows/locales/en/pip-checker.yml: 4ae71296a013134cee5c9c95a2198204
 test/data/pip-checker-questions-and-responses.yml: b1d68ebfb76a9e2793705c55b82294f5
 test/data/pip-checker-responses-and-expected-results.yml: f0c8c243623cad06b9c65dbb504d5b4d

--- a/test/data/pip-checker-files.yml
+++ b/test/data/pip-checker-files.yml
@@ -1,5 +1,5 @@
 --- 
-lib/smart_answer_flows/pip-checker.rb: bde45cd16c3846ab35eaa383df6791a1
+lib/smart_answer_flows/pip-checker.rb: bdc2645cbb9d7582f6c8d0f2f0c3550d
 lib/smart_answer_flows/locales/en/pip-checker.yml: 4ae71296a013134cee5c9c95a2198204
 test/data/pip-checker-questions-and-responses.yml: b1d68ebfb76a9e2793705c55b82294f5
 test/data/pip-checker-responses-and-expected-results.yml: f0c8c243623cad06b9c65dbb504d5b4d

--- a/test/data/pip-checker-files.yml
+++ b/test/data/pip-checker-files.yml
@@ -1,5 +1,5 @@
 --- 
-lib/smart_answer_flows/pip-checker.rb: bdc2645cbb9d7582f6c8d0f2f0c3550d
+lib/smart_answer_flows/pip-checker.rb: 0e09d0bf53dfe2a921363f53be3e6cd4
 lib/smart_answer_flows/locales/en/pip-checker.yml: 4ae71296a013134cee5c9c95a2198204
 test/data/pip-checker-questions-and-responses.yml: b1d68ebfb76a9e2793705c55b82294f5
 test/data/pip-checker-responses-and-expected-results.yml: f0c8c243623cad06b9c65dbb504d5b4d

--- a/test/data/register-a-birth-files.yml
+++ b/test/data/register-a-birth-files.yml
@@ -1,5 +1,5 @@
 --- 
-lib/smart_answer_flows/register-a-birth.rb: 8ebc915b17a2afc941c2517d24cdaf11
+lib/smart_answer_flows/register-a-birth.rb: e652c29d97be2fee2d2349a63a9879d7
 lib/smart_answer_flows/locales/en/register-a-birth.yml: 7b865d215fad1348306d79b0ac954377
 test/data/register-a-birth-questions-and-responses.yml: b8656669a138a00d52afdd33cc9b4590
 test/data/register-a-birth-responses-and-expected-results.yml: 3c431cc901085e1e4c0fcc9fe50eef47

--- a/test/data/state-pension-topup-files.yml
+++ b/test/data/state-pension-topup-files.yml
@@ -1,6 +1,6 @@
 --- 
-lib/smart_answer_flows/state-pension-topup.rb: 6025ae044b120b8e72a4bc44609dec4a
-lib/smart_answer_flows/locales/en/state-pension-topup.yml: 1c97f6d53c415cd376e99a0ed812d811
+lib/smart_answer_flows/state-pension-topup.rb: fb9776e8733e17bc3753c77e457e3c58
+lib/smart_answer_flows/locales/en/state-pension-topup.yml: 8005a071aa395af1e92ecb5ea3b0f574
 test/data/state-pension-topup-questions-and-responses.yml: d3997e715e206c38ea8a0783b07b2350
 test/data/state-pension-topup-responses-and-expected-results.yml: caa7a2bc7d84f16cf78583a97192e29b
 lib/smart_answer/calculators/state_pension_topup_calculator.rb: 2481f46c212f185572def0aa2c3f3e0a

--- a/test/data/state-pension-topup-files.yml
+++ b/test/data/state-pension-topup-files.yml
@@ -1,6 +1,6 @@
 --- 
-lib/smart_answer_flows/state-pension-topup.rb: 005abed8a3e630d74fc5cd14bf12ea75
-lib/smart_answer_flows/locales/en/state-pension-topup.yml: 8005a071aa395af1e92ecb5ea3b0f574
+lib/smart_answer_flows/state-pension-topup.rb: 6025ae044b120b8e72a4bc44609dec4a
+lib/smart_answer_flows/locales/en/state-pension-topup.yml: 1c97f6d53c415cd376e99a0ed812d811
 test/data/state-pension-topup-questions-and-responses.yml: d3997e715e206c38ea8a0783b07b2350
 test/data/state-pension-topup-responses-and-expected-results.yml: caa7a2bc7d84f16cf78583a97192e29b
 lib/smart_answer/calculators/state_pension_topup_calculator.rb: 2481f46c212f185572def0aa2c3f3e0a

--- a/test/integration/smart_answer_flows/calculate_redundancy_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_redundancy_pay_test.rb
@@ -205,12 +205,24 @@ class CalculateRedundancyPayTest < ActiveSupport::TestCase
       end
     end # After Feb 2013
 
-    context "answer 05 April 2014" do
+    context "answer tomorrow" do
       setup do
-        add_response Date.parse("2014-04-05")
+        add_response (Date.today + 1.day).to_s
       end
       should "ask employee age" do
         assert_current_node :age_of_employee?
+      end
+    end
+
+    context "dates out of range" do
+      should "not allow dates before 2012" do
+        add_response Date.parse("2011-12-21")
+        assert_current_node_is_error
+      end
+
+      should "not allow dates next year" do
+        add_response (Date.today.end_of_year + 1.day).to_s
+        assert_current_node_is_error
       end
     end
   end

--- a/test/integration/smart_answer_flows/calculate_state_pension_test.rb
+++ b/test/integration/smart_answer_flows/calculate_state_pension_test.rb
@@ -33,11 +33,14 @@ class CalculateStatePensionTest < ActiveSupport::TestCase
         assert_current_node :dob_age?
       end
 
-      context "give a date in the future" do
-        should "raise an error" do
-          add_response (Date.today + 1).to_s
-          assert_current_node_is_error
-        end
+      should "prevent from providing future dates" do
+        add_response (Date.today + 1).to_s
+        assert_current_node_is_error
+      end
+
+      should "prevent from providing dates too far in the past" do
+        add_response (200.years.ago).to_s
+        assert_current_node_is_error
       end
 
       context "pension_credit_date check -- born 5th Dec 1953" do

--- a/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
@@ -63,6 +63,18 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
             assert_current_node :first_sick_day?
           end
 
+          context "dates out of range" do
+            should "not allow dates before 2011" do
+              add_response Date.parse("2010-12-31")
+              assert_current_node_is_error
+            end
+
+            should "not allow dates next year" do
+              add_response (Date.today.end_of_year + 1.day).to_s
+              assert_current_node_is_error
+            end
+          end
+
           context "answer 2 March 2014" do
             setup do
               add_response Date.parse('2 March 2014')
@@ -174,6 +186,18 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
               assert_current_node :last_sick_day? # Q5
             end
 
+            context "dates out of range" do
+              should "not allow dates before 2012" do
+                add_response Date.parse("2011-12-21")
+                assert_current_node_is_error
+              end
+
+              should "not allow dates next year" do
+                add_response (Date.today.end_of_year + 1.day).to_s
+                assert_current_node_is_error
+              end
+            end
+
             context "answering last sick day" do
               context "last sick day is less than 3 days after first" do
                 setup do
@@ -213,14 +237,39 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
                       assert_current_node :last_payday_before_sickness?
                       assert_state_variable :pay_pattern, 'weekly'
                     end
+
+                    context "dates out of range" do
+                      should "not allow dates before 2010" do
+                        add_response Date.parse("2009-12-31")
+                        assert_current_node_is_error
+                      end
+
+                      should "not allow dates next year" do
+                        add_response (Date.today.end_of_year + 1.day).to_s
+                        assert_current_node_is_error
+                      end
+                    end
+
                     context "enter last payday before start of sickness" do
                       setup do
                         add_response '31/03/2013'
                       end
                       should "ask for last normal payday before payday offset" do # Q6.1
                         assert_current_node :last_payday_before_offset?
-
                       end
+
+                      context "dates out of range" do
+                        should "not allow dates before 2010" do
+                          add_response Date.parse("2009-12-31")
+                          assert_current_node_is_error
+                        end
+
+                        should "not allow dates next year" do
+                          add_response (Date.today.end_of_year + 1.day).to_s
+                          assert_current_node_is_error
+                        end
+                      end
+
                       context "enter last payday before offset" do
                         setup do
                           add_response '31/01/2013'
@@ -243,6 +292,19 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
                             should "ask for start date of linked period of sickness" do # Q11.1
                               assert_current_node :linked_sickness_start_date?
                             end
+
+                            context "dates out of range" do
+                              should "not allow dates before 2010" do
+                                add_response Date.parse("2009-12-31")
+                                assert_current_node_is_error
+                              end
+
+                              should "not allow dates next year" do
+                                add_response (Date.today.end_of_year + 1.day).to_s
+                                assert_current_node_is_error
+                              end
+                            end
+
                             context "enter previous sickness start date" do
                               setup do
                                 add_response ' 1/01/2013'

--- a/test/integration/smart_answer_flows/calculate_your_holiday_entitlement_test.rb
+++ b/test/integration/smart_answer_flows/calculate_your_holiday_entitlement_test.rb
@@ -339,16 +339,16 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
       should "ask for the employment end date" do
         assert_current_node :what_is_your_leaving_date?
       end
-      context "answer 2012-06-15" do
+      context "answer 06-15" do
         setup do
-          add_response '2012-06-15'
+          add_response "#{Date.today.year}-06-15"
         end
         should "ask when the leave year started" do
           assert_current_node :when_does_your_leave_year_start?
         end
-        context "answer 2012-01-01" do
+        context "answer 01-01" do
           setup do
-            add_response '2012-01-01'
+            add_response "#{Date.today.year}-01-01"
           end
           should "ask the number of hours worked per week" do
             assert_current_node :how_many_hours_per_week?
@@ -363,8 +363,8 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
                 with(
                   hours_per_week: 26.5,
                   start_date: nil,
-                  leaving_date: Date.parse("2012-06-15"),
-                  leave_year_start_date: Date.parse("2012-01-01")
+                  leaving_date: Date.parse("#{Date.today.year}-06-15"),
+                  leave_year_start_date: Date.parse("#{Date.today.year}-01-01")
                 ).
                 returns(@stubbed_calculator)
               @stubbed_calculator.expects(:full_time_part_time_hours).returns(19.75)

--- a/test/integration/smart_answer_flows/energy_grants_calculator_test.rb
+++ b/test/integration/smart_answer_flows/energy_grants_calculator_test.rb
@@ -31,6 +31,19 @@ class EnergyGrantsCalculatorTest < ActiveSupport::TestCase
         should "ask what's your date of birth" do
           assert_current_node :date_of_birth?
         end
+
+        context "dates out of range" do
+          should "not allow dates far in the past" do
+            add_response Date.parse("1850-12-21")
+            assert_current_node_is_error
+          end
+
+          should "not allow dates next year" do
+            add_response (Date.today.end_of_year + 1.day).to_s
+            assert_current_node_is_error
+          end
+        end
+
         context "answer before 5th July 1951" do
           setup do
             add_response ' 4/07/1951'

--- a/test/integration/smart_answer_flows/pip_checker_test.rb
+++ b/test/integration/smart_answer_flows/pip_checker_test.rb
@@ -24,6 +24,18 @@ class PIPCheckerTest < ActiveSupport::TestCase
       assert_current_node :what_is_your_dob?
     end
 
+    context "dates out of range" do
+      should "not allow dates far in the past" do
+        add_response Date.parse("1850-12-21")
+        assert_current_node_is_error
+      end
+
+      should "not allow dates next year" do
+        add_response (Date.today.end_of_year + 1.day).to_s
+        assert_current_node_is_error
+      end
+    end
+
     should "be result 1 if born on or after 08-06-1997" do
       add_response '1997-06-08'
       assert_current_node :result_1

--- a/test/unit/date_question_test.rb
+++ b/test/unit/date_question_test.rb
@@ -40,6 +40,40 @@ module SmartAnswer
       assert_equal ::Date.parse('2011-01-01')..::Date.parse('2011-01-03'), q.range
     end
 
+    test "a day before the allowed range is invalid" do
+      assert_raises(InvalidResponse) do
+        date_question_2011.transition(@initial_state, '2010-12-31')
+      end
+    end
+
+    test "a day after the allowed range is invalid" do
+      assert_raises(InvalidResponse) do
+        date_question_2011.transition(@initial_state, '2012-01-01')
+      end
+    end
+
+    test "the first day of the allowed range is valid" do
+      new_state = date_question_2011.transition(@initial_state, '2011-01-01')
+      assert @initial_state != new_state
+    end
+
+    test "the last day of the allowed range is valid" do
+      new_state = date_question_2011.transition(@initial_state, '2011-12-31')
+      assert @initial_state != new_state
+    end
+
+    test "do not complain when the input is within the allowed range when the dates are in descending order" do
+      q = Question::Date.new(:example) do
+        save_input_as :date
+        next_node :done
+        from { Date.parse('2011-01-03') }
+        to { Date.parse('2011-01-01') }
+        validate_in_range
+      end
+
+      q.transition(@initial_state, '2011-01-02')
+    end
+
     test "define default date" do
       q = Question::Date.new(:example) do
         default { Date.today }
@@ -91,6 +125,17 @@ module SmartAnswer
       incomplete_date = {year: "2013", month: "2", day: ""}
       new_state = q.transition(@initial_state, incomplete_date)
       assert_equal Date.parse('2013-02-28'), new_state.date
+    end
+
+  private
+    def date_question_2011
+      Question::Date.new(:example) do
+        save_input_as :date
+        next_node :done
+        from { Date.parse('2011-01-01') }
+        to { Date.parse('2011-12-31') }
+        validate_in_range
+      end
     end
   end
 end

--- a/test/unit/date_question_test.rb
+++ b/test/unit/date_question_test.rb
@@ -127,7 +127,25 @@ module SmartAnswer
       assert_equal Date.parse('2013-02-28'), new_state.date
     end
 
+    test "#date_of_birth_defaults prevent very old values" do
+      assert_raise SmartAnswer::InvalidResponse do
+        dob_question.transition(@initial_state, 125.years.ago.to_date.to_s)
+      end
+    end
+
+    test "#date_of_birth_defaults prevent next year dates" do
+      assert_raise SmartAnswer::InvalidResponse do
+        next_year_start = 1.year.from_now.beginning_of_year.to_date.to_s
+        dob_question.transition(@initial_state, next_year_start)
+      end
+    end
+
+    test "#date_of_birth_defaults accepts 120 years old values" do
+      dob_question.transition(@initial_state, 120.years.ago.to_date.to_s)
+    end
+
   private
+
     def date_question_2011
       Question::Date.new(:example) do
         save_input_as :date
@@ -135,6 +153,14 @@ module SmartAnswer
         from { Date.parse('2011-01-01') }
         to { Date.parse('2011-12-31') }
         validate_in_range
+      end
+    end
+
+    def dob_question
+      Question::Date.new(:example) do
+        date_of_birth_defaults
+        save_input_as :date
+        next_node :done
       end
     end
   end


### PR DESCRIPTION
It all started with a few errbit 500 errors where a user was tweaking the url to provide a date of birth that was out of the range of dates covered by logic. We decided that validating input in such cases is the best solution. Then I realised there are more questions affected.

This PR adds an optional `validate_in_range` behaviour, that makes sure user provided date input is within the allowed range defined by `#from` and `#to` methods.

It also adds some more years in DOB selectors to make sure people of all ages can use the tool.