### PR TITLE
Bump slimmer for new rendering app meta tag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem 'extlib', '0.9.16'
 if ENV['SLIMMER_DEV']
   gem 'slimmer', :path => '../slimmer'
 else
-  gem 'slimmer', '8.2.0'
+  gem 'slimmer', '8.2.1'
 end
 
 if ENV['GOVSPEAK_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -225,7 +225,7 @@ GEM
     simplecov-html (0.5.3)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    slimmer (8.2.0)
+    slimmer (8.2.1)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -308,7 +308,7 @@ DEPENDENCIES
   shoulda (~> 3.5.0)
   simplecov (~> 0.6.4)
   simplecov-rcov (~> 0.2.3)
-  slimmer (= 8.2.0)
+  slimmer (= 8.2.1)
   smartdown (~> 0.15.1)
   syck (= 1.0.5)
   therubyracer (~> 0.12.1)


### PR DESCRIPTION
This now uses the GOVUK_APP_NAME env variable rather than the
application class name so it can be cross referenced to other things in
the stack.

This contains https://github.com/alphagov/slimmer/pull/128