### PR TITLE
Remove unreachable outcome from overseas-passports flow

### DIFF
--- a/lib/smart_answer/calculators/passport_and_embassy_data_query.rb
+++ b/lib/smart_answer/calculators/passport_and_embassy_data_query.rb
@@ -16,10 +16,6 @@ module SmartAnswer::Calculators
         "IPS")
     end
 
-    def fco_application?
-      SmartAnswer::Predicate::VariableMatches.new(:application_type, %w{pretoria_south_africa})
-    end
-
     include ActionView::Helpers::NumberHelper
 
     ALT_EMBASSIES = {

--- a/lib/smart_answer_flows/locales/en/overseas-passports.yml
+++ b/lib/smart_answer_flows/locales/en/overseas-passports.yml
@@ -1492,54 +1492,6 @@ en-GB:
             Textphone: +44 1750 725 368
           $C
 
-      fco_result:
-        body: |
-          ## How long it takes
-          %{how_long_it_takes}
-
-          Your application may take longer if:
-
-          - you don’t send the right supporting documents or payment
-          - the photographs you send are rejected
-
-          Don’t book travel until you have a valid passport. If you need to travel more urgently, you may be able to apply for an [Emergency Travel Document.](/emergency-travel-document)
-
-          ## Cost
-          %{cost}
-
-          ## How to apply
-
-          1. Download the application form and guidance notes that help you fill it in.
-
-          2. Include 2 identical new photos of you (or your child, if it’s a child passport application). [Follow the rules about passport photos](/photos-for-passports "Passport photo requirements") or your application may be delayed.
-
-          3. Check the guidance notes to find out which supporting documents you must send with your application. You must get documents that aren’t in English fully translated by a professional translator.
-
-          %{how_to_apply_supplement}
-
-          %{hurricane_warning}
-
-          %{fco_forms}
-
-          %{supporting_documents}
-
-          ## Submit your application
-
-          %{send_your_application}
-
-          ## Getting your passport
-
-          %{getting_your_passport}
-
-
-          ## If your passport hasn't arrived
-
-          If you haven’t received your passport within the expected timescale, you can check your application’s progress by phone. You will be charged for the call.
-
-          Don’t use this service any earlier - information won’t be available but you will still be charged for the call.
-
-          %{helpline}
-
       ips_application_result_online:
         body: |
           ## How long it takes

--- a/lib/smart_answer_flows/overseas-passports.rb
+++ b/lib/smart_answer_flows/overseas-passports.rb
@@ -137,7 +137,6 @@ module SmartAnswer
           next_node_if(:ips_application_result_online, variable_matches(:ips_result_type, :ips_application_result_online))
           next_node(:ips_application_result)
         end
-        next_node_if(:fco_result, data_query.fco_application?)
         next_node(:result)
       end
 
@@ -161,7 +160,6 @@ module SmartAnswer
           next_node_if(:ips_application_result_online, variable_matches(:ips_result_type, :ips_application_result_online))
           next_node(:ips_application_result)
         end
-        next_node_if(:fco_result, data_query.fco_application?)
         next_node(:result)
       end
 
@@ -404,79 +402,6 @@ module SmartAnswer
         end
         precalculate :contact_passport_adviceline do
           PhraseList.new(:contact_passport_adviceline)
-        end
-      end
-
-      ## FCO Result
-      outcome :fco_result do
-        precalculate :how_long_it_takes do
-          phrases = PhraseList.new
-          phrases << :"how_long_#{waiting_time}"
-          phrases << :you_may_have_to_attend_an_interview if %w(renewing_old applying).include?(application_action)
-          phrases << :report_loss_or_theft if application_action == "replacing"
-          phrases
-        end
-
-        precalculate :cost do
-          cost_type = application_type
-          payment_methods = :"passport_costs_#{application_type}"
-
-          phrases = PhraseList.new(:"passport_courier_costs_#{cost_type}",
-                                   :"#{child_or_adult}_passport_costs_#{cost_type}",
-                                   payment_methods)
-
-          phrases
-        end
-
-        precalculate :how_to_apply_supplement do
-          if general_action == 'renewing' and data_query.retain_passport?(current_location)
-            PhraseList.new(:how_to_apply_retain_passport)
-          else
-            ''
-          end
-        end
-
-        precalculate :hurricane_warning do
-          if general_action == 'renewing' and data_query.retain_passport_hurricanes?(current_location)
-            PhraseList.new(:how_to_apply_retain_passport_hurricane)
-          else
-            ''
-          end
-        end
-
-        precalculate :supporting_documents do
-          if application_action == 'applying' and current_location == 'jordan'
-            PhraseList.new(:supporting_documents_jordan_applying)
-          elsif current_location == 'south-africa' and general_action == 'applying'
-            PhraseList.new(:supporting_documents_south_africa_applying)
-          else
-            ''
-          end
-        end
-
-        precalculate :send_your_application do
-          phrases = PhraseList.new
-          if %(south-africa).include?(current_location)
-            phrases << :"send_application_#{current_location}"
-          elsif current_location == 'indonesia'
-            if application_action == 'applying' or application_action == 'replacing'
-              phrases << :send_application_indonesia_applying
-            else
-              phrases << :send_application_fco_preamble << :"send_application_#{application_type}"
-            end
-          else
-            phrases << :send_application_fco_preamble
-            phrases << :"send_application_#{application_type}"
-          end
-          phrases
-        end
-        precalculate :getting_your_passport do
-          location = 'fco'
-          location = current_location if %(cambodia congo nepal).include?(current_location)
-          PhraseList.new(:"getting_your_passport_#{location}")
-        end
-        precalculate :helpline do
-          PhraseList.new(:"helpline_#{application_type}", :helpline_fco_webchat)
         end
       end
 


### PR DESCRIPTION
The `SmartAnswer::Calculators::PassportAndEmbassyDataQuery#fco_application?`
predicate never returns `true`, because none of the entries in
`lib/data/passport_data.yml` have `type: pretoria_south_africa`.

The history of the latter file is a bit confusing, but it appears as if most
of the occurrences of `type: pretoria_south_africa` were removed in
[this commit][1] and the last occurence in [this commit][2].

[1]: f26262ffeae2558d1e36042b638eed9099340fc4
[2]: 3a86b8ecd1c4686885dcbd9466da43f504999df9
