### PR TITLE
Fix a bug with answer changing in smartdown.

### DIFF
--- a/lib/smartdown_adapter/presenter.rb
+++ b/lib/smartdown_adapter/presenter.rb
@@ -126,21 +126,14 @@ module SmartdownAdapter
 
     def responses_from_query_params(request)
       responses = []
-      # get form submission request: one response
       if request[:response]
         responses << request[:response]
       end
 
-      #get form submission request: for multiple responses
       if request[:next]
         (@previous_smartdown_state.current_node.questions.count - responses.count).times do |index|
           responses << request.query_parameters["response_#{index+1}"] || nil
         end
-      elsif !request.query_parameters.select { |key| key.to_s.match(/^previous_response_\d+/) }.empty?
-        @previous_smartdown_state.current_node.questions.count.times do |index|
-          responses << request["previous_response_#{index+1}"] || nil
-        end
-        responses
       end
       responses
     end

--- a/test/fixtures/smartdown_flows/multiple-answer-question-flow/multiple-answer-question-flow.txt
+++ b/test/fixtures/smartdown_flows/multiple-answer-question-flow/multiple-answer-question-flow.txt
@@ -1,0 +1,9 @@
+---
+meta_description: Has a node with mulitple questions
+satisfies_need: 100999
+status: draft
+---
+
+# Multiple question nodes to follow
+
+[start: question_1]

--- a/test/fixtures/smartdown_flows/multiple-answer-question-flow/outcomes/the_outcome.txt
+++ b/test/fixtures/smartdown_flows/multiple-answer-question-flow/outcomes/the_outcome.txt
@@ -1,0 +1,3 @@
+# Conclusion
+
+It doesn't matter, just ship it!

--- a/test/fixtures/smartdown_flows/multiple-answer-question-flow/questions/question_1.txt
+++ b/test/fixtures/smartdown_flows/multiple-answer-question-flow/questions/question_1.txt
@@ -1,0 +1,18 @@
+# Colours and Quotes
+
+
+# Your colour preference
+
+How do you highlight instance vars in your editor?
+
+[choice: colour]
+* red: Red
+* green: Green
+
+# What looks better?
+
+[choice: syntax]
+* single: Single Quotes
+* double: Double Quotes
+
+* otherwise => question_2

--- a/test/fixtures/smartdown_flows/multiple-answer-question-flow/questions/question_2.txt
+++ b/test/fixtures/smartdown_flows/multiple-answer-question-flow/questions/question_2.txt
@@ -1,0 +1,9 @@
+# Indentation
+
+# How do you indent?
+
+[choice: indentation]
+* tabs: Tabs
+* spaces: Spaces
+
+* otherwise => the_outcome

--- a/test/integration/smartdown_flows/changing_the_answer.rb
+++ b/test/integration/smartdown_flows/changing_the_answer.rb
@@ -1,0 +1,32 @@
+require 'integration_test_helper'
+
+class ChangingTheAnswerTest < ActionDispatch::IntegrationTest
+  def setup
+    use_test_smartdown_flow_fixtures
+    stub_content_api_default_artefact
+
+    visit smart_answer_path(id: "multiple-answer-question-flow")
+    click_on "Start now"
+  end
+
+  def teardown
+    stop_using_test_smartdown_flow_fixtures
+  end
+
+  test "changing a multiple question node" do
+    assert page.has_content?("How do you highlight instance vars in your editor?")
+
+    choose "Green"
+    choose "Single Quotes"
+    click_on "Next step"
+
+    choose "Tabs"
+    click_on "Next step"
+
+    assert page.has_content?("ship it")
+
+    click_on 'Change answer to "Colours and Quotes"'
+    assert page.has_content?("How do you highlight instance vars in your editor?")
+  end
+end
+


### PR DESCRIPTION
## Problem as reported

Three issues with the Parental Leave & Pay calculator: two minor, one serious, all very likely related.

From the results page at:

https://www.gov.uk/pay-leave-for-parents/y/no/2015-6-8/employee/yes/yes/160-week/yes

* clicking [change] for mother's employment details.

has no effect - should return us to the correct form.

Similarly,

https://www.gov.uk/pay-leave-for-parents/y/yes/2015-5-5/employee/employee/yes/yes/200-week/yes/yes/yes/150-week/yes

* clicking [change] for partner's employment details

has no effect - as above

But

* clicking [change] for mother's employment details

does take us back to the correct form. If we then

* change the mother's earnings
* click [next_step]

we get back to the results page, but it's the *partner's* earnings that are updated,
not the mother's.

### Bug description

When a change link was opened, responses to the question that's being changed
(previous_response_* query params) were added to the current state, which is
incorrect. The current state is being calculated based purely on those answers,
therefore we were displaying the question that goes after the one that is being
changed.

This only affects smartdown answers.

[The commit](https://github.com/alphagov/smart-answers/commit/cafeee0e66d807b896a7eb161b79c2eeb551567b) that has introduced this code has no useful description nor tests. We have added an integration test and have done some manual testing, but it should still be reviewed thoroughly.
