### PR TITLE
Use arrays where data should be an array

### DIFF
--- a/lib/smart_answer/calculators/marriage_abroad_data_query.rb
+++ b/lib/smart_answer/calculators/marriage_abroad_data_query.rb
@@ -51,9 +51,9 @@ module SmartAnswer::Calculators
 
     SS_ALT_FEES_TABLE_OR_OUTCOME_GROUP_B = %w(azerbaijan chile dominican-republic kosovo latvia)
 
-    SS_21_DAYS_RESIDENCY_REQUIRED_COUNTRIES = %(albania australia azerbaijan bolivia cambodia chile china colombia costa-rica dominican-republic estonia germany hungary japan kosovo latvia lithuania mongolia montenegro nicaragua peru philippines russia san-marino serbia vietnam)
+    SS_21_DAYS_RESIDENCY_REQUIRED_COUNTRIES = %w(albania australia azerbaijan bolivia cambodia chile china colombia costa-rica dominican-republic estonia germany hungary japan kosovo latvia lithuania mongolia montenegro nicaragua peru philippines russia san-marino serbia vietnam)
 
-    OS_21_DAYS_RESIDENCY_REQUIRED_COUNTRIES = %(jordan oman qatar united-arab-emirates yemen)
+    OS_21_DAYS_RESIDENCY_REQUIRED_COUNTRIES = %w(jordan oman qatar united-arab-emirates yemen)
 
     SS_UNKNOWN_NO_EMBASSIES = %w(st-martin saint-barthelemy)
 

--- a/lib/smart_answer_flows/help-if-you-are-arrested-abroad.rb
+++ b/lib/smart_answer_flows/help-if-you-are-arrested-abroad.rb
@@ -94,7 +94,7 @@ module SmartAnswer
         end
 
         precalculate :generic_downloads do
-          transfers_back_to_uk_treaty_change_countries = %(austria belgium croatia denmark finland hungary italy latvia luxembourg malta netherlands slovakia)
+          transfers_back_to_uk_treaty_change_countries = %w(austria belgium croatia denmark finland hungary italy latvia luxembourg malta netherlands slovakia)
 
           phrases = PhraseList.new
           phrases << :common_downloads

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -869,7 +869,7 @@ outcome :outcome_os_consular_cni do
     if resident_of == 'other'
       if ceremony_country == 'italy' and resident_of == 'other'
         phrases << :consular_cni_os_other_resident_ceremony_italy
-      elsif %(germany spain).exclude?(ceremony_country)
+      elsif %w(germany spain).exclude?(ceremony_country)
         phrases << :consular_cni_os_other_resident_ceremony_not_germany_or_spain
       end
     end

--- a/lib/smart_answer_flows/overseas-passports.rb
+++ b/lib/smart_answer_flows/overseas-passports.rb
@@ -210,7 +210,7 @@ module SmartAnswer
 
         precalculate :cost do
           uk_visa_application_centre_countries = %w(algeria azerbaijan bangladesh belarus china georgia india indonesia kazakhstan kyrgyzstan laos lebanon mauritania morocco nepal pakistan russia thailand ukraine venezuela western-sahara)
-          pay_at_appointment_countries = %(venezuela)
+          pay_at_appointment_countries = %w(venezuela)
 
           if %w(st-helena-ascension-and-tristan-da-cunha).include?(current_location)
             PhraseList.new(:passport_costs_fee_only, :"#{child_or_adult}_passport_costs_only", :passport_cost_and_admin_fee)
@@ -347,7 +347,7 @@ module SmartAnswer
         precalculate :getting_your_passport do
           collect_in_person_countries = %w(angola benin cameroon chad congo eritrea ethiopia gambia ghana guinea jamaica kenya nigeria somalia south-sudan zambia zimbabwe)
           collect_in_person_variant_countries = %w(burundi india jordan pitcairn-island)
-          collect_in_person_renewing_new_variant_countries = %(burma nepal north-korea st-helena-ascension-and-tristan-da-cunha)
+          collect_in_person_renewing_new_variant_countries = %w(burma nepal north-korea st-helena-ascension-and-tristan-da-cunha)
           uk_visa_application_centre_countries = %w(algeria azerbaijan bangladesh belarus china georgia india indonesia kazakhstan kyrgyzstan lebanon mauritania morocco pakistan russia thailand ukraine venezuela western-sahara)
           uk_visa_application_centre_variant_countries = %w(cambodia egypt iraq libya rwanda sierra-leone tunisia uganda)
           collect_with_photo_id_countries = %w(cambodia egypt iraq libya rwanda sierra-leone tunisia uganda)


### PR DESCRIPTION
It looks like due to typos we had some data that was supposed to be
arrays of countries, but was a space separated string instead.

It kept working because active support's #include? matched a substring
provided. So this should not change any behaviour, just make things
more consistent and less surprising.