### PR TITLE
Use ActionView instead of Erubis to render outcome templates

### DIFF
--- a/app/presenters/outcome_presenter.rb
+++ b/app/presenters/outcome_presenter.rb
@@ -2,12 +2,12 @@ class OutcomePresenter < NodePresenter
   def initialize(i18n_prefix, node, state = nil, options = {})
     @options = options
     super(i18n_prefix, node, state)
+    @view = ActionView::Base.new(["/"])
   end
 
   def title
     if use_template? && title_erb_template_exists?
-      view = ActionView::Base.new(["/"])
-      title = view.render(template: title_erb_template_path, locals: @state.to_hash)
+      title = @view.render(template: title_erb_template_path, locals: @state.to_hash)
       title.chomp
     else
       translate!('title')
@@ -27,8 +27,7 @@ class OutcomePresenter < NodePresenter
 
   def body
     if use_template? && body_erb_template_exists?
-      view = ActionView::Base.new(["/"])
-      govspeak = view.render(template: body_erb_template_path, locals: @state.to_hash)
+      govspeak = @view.render(template: body_erb_template_path, locals: @state.to_hash)
       GovspeakPresenter.new(govspeak).html
     else
       super()

--- a/app/presenters/outcome_presenter.rb
+++ b/app/presenters/outcome_presenter.rb
@@ -1,32 +1,4 @@
 class OutcomePresenter < NodePresenter
-  class ViewContext
-    def initialize(state)
-      @state = state
-    end
-
-    def method_missing(method, *args, &block)
-      if method_can_be_delegated_to_state?(method)
-        @state.send(method, *args, &block)
-      else
-        super
-      end
-    end
-
-    def respond_to_missing?(method, include_private = false)
-      method_can_be_delegated_to_state?(method)
-    end
-
-    def get_binding
-      binding
-    end
-
-    private
-
-    def method_can_be_delegated_to_state?(method)
-      @state.respond_to?(method) && !method.to_s.end_with?('=')
-    end
-  end
-
   def initialize(i18n_prefix, node, state = nil, options = {})
     @options = options
     super(i18n_prefix, node, state)
@@ -34,8 +6,8 @@ class OutcomePresenter < NodePresenter
 
   def title
     if use_template? && title_erb_template_exists?
-      view_context = ViewContext.new(@state)
-      title = render_erb_template(title_erb_template_from_file, view_context)
+      view = ActionView::Base.new(["/"])
+      title = view.render(template: title_erb_template_path, locals: @state.to_hash)
       title.chomp
     else
       translate!('title')
@@ -55,17 +27,12 @@ class OutcomePresenter < NodePresenter
 
   def body
     if use_template? && body_erb_template_exists?
-      view_context = ViewContext.new(@state)
-      view_context.extend(ActionView::Helpers::NumberHelper)
-      govspeak = render_erb_template(body_erb_template_from_file, view_context)
+      view = ActionView::Base.new(["/"])
+      govspeak = view.render(template: body_erb_template_path, locals: @state.to_hash)
       GovspeakPresenter.new(govspeak).html
     else
       super()
     end
-  end
-
-  def title_erb_template_from_file
-    File.read(title_erb_template_path)
   end
 
   def title_erb_template_path
@@ -74,10 +41,6 @@ class OutcomePresenter < NodePresenter
 
   def default_title_erb_template_path
     template_directory.join("#{name}_title.txt.erb")
-  end
-
-  def body_erb_template_from_file
-    File.read(body_erb_template_path)
   end
 
   def body_erb_template_path
@@ -92,10 +55,6 @@ class OutcomePresenter < NodePresenter
 
   def template_directory
     @node.template_directory
-  end
-
-  def render_erb_template(template, view_context)
-    Erubis::Eruby.new(template).result(view_context.get_binding)
   end
 
   def title_erb_template_exists?

--- a/test/fixtures/smart_answer_flows/locales/en/value-sample.yml
+++ b/test/fixtures/smart_answer_flows/locales/en/value-sample.yml
@@ -1,0 +1,7 @@
+en-GB:
+  flow:
+    value-sample:
+      user_input?:
+        label: "User input:"
+      outcome_with_template:
+        title: "Outcome with template"

--- a/test/fixtures/smart_answer_flows/value-sample.rb
+++ b/test/fixtures/smart_answer_flows/value-sample.rb
@@ -1,0 +1,10 @@
+status :draft
+name "value-sample"
+
+value_question :user_input? do
+  save_input_as :user_input
+
+  next_node :outcome_with_template
+end
+
+outcome :outcome_with_template, use_outcome_templates: true

--- a/test/fixtures/smart_answer_flows/value-sample/outcome_with_template_body.govspeak.erb
+++ b/test/fixtures/smart_answer_flows/value-sample/outcome_with_template_body.govspeak.erb
@@ -1,0 +1,1 @@
+<%= user_input %>

--- a/test/integration/engine/html_escaping_user_input_test.rb
+++ b/test/integration/engine/html_escaping_user_input_test.rb
@@ -1,0 +1,33 @@
+require_relative 'engine_test_helper'
+
+class HtmlEscapingUserInputTest < EngineIntegrationTest
+  setup do
+    visit "/value-sample"
+    click_on "Start now"
+  end
+
+  context "when user input contains unsafe HTML" do
+    setup do
+      @javascript = "doSomethingNaughty();"
+      unsafe_html = "<script id='naughty'>#{@javascript}"
+      fill_in "User input", with: unsafe_html
+      click_on "Next step"
+    end
+
+    should "escape user input interpolated into outcome ERB template" do
+      assert page.has_css?("h2", text: "Outcome with template"), "Not on outcome page"
+      including_hidden_elements do
+        refute page.has_css?("script#naughty", text: @javascript), "Includes unsafe HTML"
+      end
+    end
+  end
+
+  private
+
+  def including_hidden_elements
+    original_value = Capybara.ignore_hidden_elements
+    Capybara.ignore_hidden_elements = false
+    yield if block_given?
+    Capybara.ignore_hidden_elements = original_value
+  end
+end


### PR DESCRIPTION
In general this moves us closer to being a standard Rails app which is one of
our longer-term goals. More specifically:

* By supplying the state in the `locals` Hash, we don't have to worry about the
view modifying the state via writer methods.
* Strings marked as HTML-unsafe (e.g. user input) are automatically escaped.
I've added an integration test to demonstrate this.
* We don't have to do mess about with a binding object.
* Note that `ActionView` uses Erubis in its implementation which is what we
were using previously, so this reduces the scope of the change.
* A different exception is raised if a non-existent state variable is accessed:
`ActionView::Template::Error` instead of `NoMethodError`.
* It should now be much easier to introduce "partial" templates for sharing
content between outcome templates.