### PR TITLE
Improve "Next node undefined" error message

### DIFF
--- a/lib/smart_answer/question/base.rb
+++ b/lib/smart_answer/question/base.rb
@@ -41,7 +41,8 @@ module SmartAnswer
       def next_node_for(current_state, input)
         validate!(current_state, input)
         next_node = next_node_from_function_chain(current_state, input) || next_node_from_default_function(current_state, input)
-        raise "Next node undefined (#{current_state.current_node}(#{input}))" unless next_node
+        responses_and_input = current_state.responses + [input]
+        raise "Next node undefined. Node: #{current_state.current_node}. Responses: #{responses_and_input}" unless next_node
         next_node
       end
 

--- a/test/unit/question_base_test.rb
+++ b/test/unit/question_base_test.rb
@@ -229,13 +229,18 @@ class QuestionBaseTest < ActiveSupport::TestCase
   end
 
   test "error if no conditional transitions found and no fallback" do
-    q = SmartAnswer::Question::Base.new(:example) {
+    question_name = :example
+    responses = [:blue, :red]
+    q = SmartAnswer::Question::Base.new(question_name) {
       next_node_if(:skipped) { false }
     }
     initial_state = SmartAnswer::State.new(q.name)
-    assert_raises RuntimeError do
-      q.next_node_for(initial_state, :red)
+    initial_state.responses << responses[0]
+    error = assert_raises(RuntimeError) do
+      q.next_node_for(initial_state, responses[1])
     end
+    expected_message = "Next node undefined. Node: #{question_name}. Responses: #{responses}"
+    assert_equal expected_message, error.message
   end
 
   test "can define a predicate on a node" do


### PR DESCRIPTION
I ran into this error when testing the uk-visa-checker with st-martin selected
as my passport.

The previous error message was:

> Next node undefined (staying_for_how_long?(six_months_or_less))

This doesn't give enough information to recreate the error (i.e. it doesn't
contain all the responses).

The new message for the same error mentioned above is:

> Next node undefined. Node: staying_for_how_long?. Responses: ["st-martin",
"work", "six_months_or_less"]

While I'm sure the copy can be improved further, I think this is enough of an
improvement for now.