### PR TITLE
Use ActionView instead of Erubis to render outcome templates

### DIFF
--- a/app/presenters/outcome_presenter.rb
+++ b/app/presenters/outcome_presenter.rb
@@ -2,12 +2,12 @@ class OutcomePresenter < NodePresenter
   def initialize(i18n_prefix, node, state = nil, options = {})
     @options = options
     super(i18n_prefix, node, state)
-    @view = ActionView::Base.new(["/"])
+    @view = ActionView::Base.new([template_directory])
   end
 
   def title
     if use_template? && title_erb_template_exists?
-      title = @view.render(template: title_erb_template_path, locals: @state.to_hash)
+      title = @view.render(template: title_erb_template_name, locals: @state.to_hash)
       title.chomp
     else
       translate!('title')
@@ -27,7 +27,7 @@ class OutcomePresenter < NodePresenter
 
   def body
     if use_template? && body_erb_template_exists?
-      govspeak = @view.render(template: body_erb_template_path, locals: @state.to_hash)
+      govspeak = @view.render(template: body_erb_template_name, locals: @state.to_hash)
       GovspeakPresenter.new(govspeak.to_str).html
     else
       super()
@@ -35,25 +35,33 @@ class OutcomePresenter < NodePresenter
   end
 
   def title_erb_template_path
-    @options[:title_erb_template_path] || default_title_erb_template_path
+    template_directory.join(title_erb_template_name)
   end
 
-  def default_title_erb_template_path
-    template_directory.join("#{name}_title.txt.erb")
+  def title_erb_template_name
+    @options[:title_erb_template_name] || default_title_erb_template_name
+  end
+
+  def default_title_erb_template_name
+    "#{name}_title.txt.erb"
   end
 
   def body_erb_template_path
-    @options[:body_erb_template_path] || default_body_erb_template_path
+    template_directory.join(body_erb_template_name)
   end
 
-  def default_body_erb_template_path
-    template_directory.join("#{name}_body.govspeak.erb")
+  def body_erb_template_name
+    @options[:body_erb_template_name] || default_body_erb_template_name
+  end
+
+  def default_body_erb_template_name
+    "#{name}_body.govspeak.erb"
   end
 
   private
 
   def template_directory
-    @node.template_directory
+    @options[:erb_template_directory] || @node.template_directory
   end
 
   def title_erb_template_exists?

--- a/app/presenters/outcome_presenter.rb
+++ b/app/presenters/outcome_presenter.rb
@@ -2,12 +2,12 @@ class OutcomePresenter < NodePresenter
   def initialize(i18n_prefix, node, state = nil, options = {})
     @options = options
     super(i18n_prefix, node, state)
+    @view = ActionView::Base.new(["/"])
   end
 
   def title
     if use_template? && title_erb_template_exists?
-      view = ActionView::Base.new(["/"])
-      title = view.render(template: title_erb_template_path, locals: @state.to_hash)
+      title = @view.render(template: title_erb_template_path, locals: @state.to_hash)
       title.chomp
     else
       translate!('title')
@@ -27,8 +27,7 @@ class OutcomePresenter < NodePresenter
 
   def body
     if use_template? && body_erb_template_exists?
-      view = ActionView::Base.new(["/"])
-      govspeak = view.render(template: body_erb_template_path, locals: @state.to_hash)
+      govspeak = @view.render(template: body_erb_template_path, locals: @state.to_hash)
       GovspeakPresenter.new(govspeak.to_str).html
     else
       super()

--- a/app/presenters/outcome_presenter.rb
+++ b/app/presenters/outcome_presenter.rb
@@ -1,32 +1,4 @@
 class OutcomePresenter < NodePresenter
-  class ViewContext
-    def initialize(state)
-      @state = state
-    end
-
-    def method_missing(method, *args, &block)
-      if method_can_be_delegated_to_state?(method)
-        @state.send(method, *args, &block)
-      else
-        super
-      end
-    end
-
-    def respond_to_missing?(method, include_private = false)
-      method_can_be_delegated_to_state?(method)
-    end
-
-    def get_binding
-      binding
-    end
-
-    private
-
-    def method_can_be_delegated_to_state?(method)
-      @state.respond_to?(method) && !method.to_s.end_with?('=')
-    end
-  end
-
   def initialize(i18n_prefix, node, state = nil, options = {})
     @options = options
     super(i18n_prefix, node, state)
@@ -34,8 +6,8 @@ class OutcomePresenter < NodePresenter
 
   def title
     if use_template? && title_erb_template_exists?
-      view_context = ViewContext.new(@state)
-      title = render_erb_template(title_erb_template_from_file, view_context)
+      view = ActionView::Base.new(["/"])
+      title = view.render(template: title_erb_template_path, locals: @state.to_hash)
       title.chomp
     else
       translate!('title')
@@ -55,17 +27,12 @@ class OutcomePresenter < NodePresenter
 
   def body
     if use_template? && body_erb_template_exists?
-      view_context = ViewContext.new(@state)
-      view_context.extend(ActionView::Helpers::NumberHelper)
-      govspeak = render_erb_template(body_erb_template_from_file, view_context)
-      GovspeakPresenter.new(govspeak).html
+      view = ActionView::Base.new(["/"])
+      govspeak = view.render(template: body_erb_template_path, locals: @state.to_hash)
+      GovspeakPresenter.new(govspeak.to_str).html
     else
       super()
     end
-  end
-
-  def title_erb_template_from_file
-    File.read(title_erb_template_path)
   end
 
   def title_erb_template_path
@@ -74,10 +41,6 @@ class OutcomePresenter < NodePresenter
 
   def default_title_erb_template_path
     template_directory.join("#{name}_title.txt.erb")
-  end
-
-  def body_erb_template_from_file
-    File.read(body_erb_template_path)
   end
 
   def body_erb_template_path
@@ -92,10 +55,6 @@ class OutcomePresenter < NodePresenter
 
   def template_directory
     @node.template_directory
-  end
-
-  def render_erb_template(template, view_context)
-    Erubis::Eruby.new(template).result(view_context.get_binding)
   end
 
   def title_erb_template_exists?

--- a/app/presenters/outcome_presenter.rb
+++ b/app/presenters/outcome_presenter.rb
@@ -39,10 +39,6 @@ class OutcomePresenter < NodePresenter
   end
 
   def title_erb_template_name
-    @options[:title_erb_template_name] || default_title_erb_template_name
-  end
-
-  def default_title_erb_template_name
     "#{name}_title.txt.erb"
   end
 
@@ -51,10 +47,6 @@ class OutcomePresenter < NodePresenter
   end
 
   def body_erb_template_name
-    @options[:body_erb_template_name] || default_body_erb_template_name
-  end
-
-  def default_body_erb_template_name
     "#{name}_body.govspeak.erb"
   end
 

--- a/lib/smart_answer_flows/additional-commodity-code.rb
+++ b/lib/smart_answer_flows/additional-commodity-code.rb
@@ -177,7 +177,7 @@ module SmartAnswer
           calculator.commodity_code
         end
 
-        precalculate :has_commodity_code? do
+        precalculate :has_commodity_code do
           commodity_code != 'X'
         end
       end

--- a/lib/smart_answer_flows/additional-commodity-code/commodity_code_result_body.govspeak.erb
+++ b/lib/smart_answer_flows/additional-commodity-code/commodity_code_result_body.govspeak.erb
@@ -1,3 +1,3 @@
-<% if has_commodity_code? %>
+<% if has_commodity_code %>
 Use these four digits together with the ten-digit commodity code from Trade Tariff.
 <% end %>

--- a/lib/smart_answer_flows/additional-commodity-code/commodity_code_result_title.txt.erb
+++ b/lib/smart_answer_flows/additional-commodity-code/commodity_code_result_title.txt.erb
@@ -1,4 +1,4 @@
-<% unless has_commodity_code? %>
+<% unless has_commodity_code %>
 The product composition you indicated is not possible.
 <% else %>
 The Meursing code for a product with this composition is 7<%= commodity_code %>.

--- a/test/data/additional-commodity-code-files.yml
+++ b/test/data/additional-commodity-code-files.yml
@@ -1,9 +1,9 @@
 --- 
-lib/smart_answer_flows/additional-commodity-code.rb: d7f38b15cd1c6e000f0cdc5f562f3912
+lib/smart_answer_flows/additional-commodity-code.rb: 125986c8bc137e3dbd101748864f2fde
 lib/smart_answer_flows/locales/en/additional-commodity-code.yml: 1bd6a7da656f81f10992dcbae147f9b5
 test/data/additional-commodity-code-questions-and-responses.yml: f2149cbfa6ec8c5ead572f0a89542a79
 test/data/additional-commodity-code-responses-and-expected-results.yml: 6ca51c22f472dbe159ac81f31006a7b1
-lib/smart_answer_flows/additional-commodity-code/commodity_code_result_body.govspeak.erb: 26838a35d94dd1cb7b51f336d248eb39
-lib/smart_answer_flows/additional-commodity-code/commodity_code_result_title.txt.erb: d4473d12d01d9812e9167496a51f5a8e
+lib/smart_answer_flows/additional-commodity-code/commodity_code_result_body.govspeak.erb: 7aaaf7596cbd9ee5306f16953cb7b5d8
+lib/smart_answer_flows/additional-commodity-code/commodity_code_result_title.txt.erb: 756420d2f5dcf6ff675eebe7c7b2d149
 lib/smart_answer/calculators/commodity_code_calculator.rb: e0aba9021dacb17e95d60337bdbed247
 lib/data/commodity_codes_data.yml: e18434a8a7b02f644e69ebe45f518772

--- a/test/fixtures/smart_answer_flows/locales/en/value-sample.yml
+++ b/test/fixtures/smart_answer_flows/locales/en/value-sample.yml
@@ -1,0 +1,7 @@
+en-GB:
+  flow:
+    value-sample:
+      user_input?:
+        label: "User input:"
+      outcome_with_template:
+        title: "Outcome with template"

--- a/test/fixtures/smart_answer_flows/value-sample.rb
+++ b/test/fixtures/smart_answer_flows/value-sample.rb
@@ -1,0 +1,10 @@
+status :draft
+name "value-sample"
+
+value_question :user_input? do
+  save_input_as :user_input
+
+  next_node :outcome_with_template
+end
+
+outcome :outcome_with_template, use_outcome_templates: true

--- a/test/fixtures/smart_answer_flows/value-sample/outcome_with_template_body.govspeak.erb
+++ b/test/fixtures/smart_answer_flows/value-sample/outcome_with_template_body.govspeak.erb
@@ -1,0 +1,1 @@
+<%= user_input %>

--- a/test/integration/engine/html_escaping_user_input_test.rb
+++ b/test/integration/engine/html_escaping_user_input_test.rb
@@ -1,0 +1,22 @@
+require_relative 'engine_test_helper'
+
+class HtmlEscapingUserInputTest < EngineIntegrationTest
+  setup do
+    visit "/value-sample"
+    click_on "Start now"
+  end
+
+  context "when user input contains unsafe HTML" do
+    setup do
+      @javascript = "doSomethingNaughty();"
+      unsafe_html = "<script id='naughty'>#{@javascript}"
+      fill_in "User input", with: unsafe_html
+      click_on "Next step"
+    end
+
+    should "escape user input interpolated into outcome ERB template" do
+      assert page.has_css?("h2", text: "Outcome with template"), "Not on outcome page"
+      refute page.has_css?("script#naughty", text: @javascript, visible: false), "Includes unsafe HTML"
+    end
+  end
+end

--- a/test/unit/outcome_presenter_test.rb
+++ b/test/unit/outcome_presenter_test.rb
@@ -14,9 +14,8 @@ module SmartAnswer
     test '#body_erb_template_path returns the erb template path supplied in the options' do
       outcome = Outcome.new('outcome-name')
 
-      state = nil
       options = { erb_template_directory: Pathname.new('/erb-template-directory'), body_erb_template_name: 'template.erb' }
-      presenter = OutcomePresenter.new('i18n-prefix', outcome, state, options)
+      presenter = OutcomePresenter.new('i18n-prefix', outcome, state = nil, options)
 
       expected_path = Pathname.new('/erb-template-directory').join('template.erb')
       assert_equal expected_path, presenter.body_erb_template_path
@@ -26,9 +25,8 @@ module SmartAnswer
       options = { use_outcome_templates: true }
       outcome = Outcome.new('outcome-name', options)
 
-      state = nil
       options = { erb_template_directory: Pathname.new('/path/to/non-existent'), body_erb_template_name: 'template.erb' }
-      presenter = OutcomePresenter.new('i18n-prefix', outcome, state, options)
+      presenter = OutcomePresenter.new('i18n-prefix', outcome, state = nil, options)
 
       assert_equal nil, presenter.body
     end
@@ -43,8 +41,7 @@ Hello world
         options = { use_outcome_templates: true }
         outcome = Outcome.new('outcome-name', options)
 
-        state = nil
-        presenter = OutcomePresenter.new('i18n-prefix', outcome, state, presenter_options)
+        presenter = OutcomePresenter.new('i18n-prefix', outcome, state = nil, presenter_options)
 
         assert_equal "<p>Hello world</p>\n", presenter.body
       end
@@ -88,8 +85,7 @@ Hello world
         options = { use_outcome_templates: true }
         outcome = Outcome.new('outcome-name', options)
 
-        state = nil
-        presenter = OutcomePresenter.new('i18n-prefix', outcome, state, presenter_options)
+        presenter = OutcomePresenter.new('i18n-prefix', outcome, state = nil, presenter_options)
 
         assert_match '123,456,789', presenter.body
       end
@@ -102,8 +98,7 @@ Hello world
         options = { use_outcome_templates: true }
         outcome = Outcome.new('outcome-name', options)
 
-        state = nil
-        presenter = OutcomePresenter.new('i18n-prefix', outcome, state, presenter_options)
+        presenter = OutcomePresenter.new('i18n-prefix', outcome, state = nil, presenter_options)
 
         nodes = Capybara.string(presenter.body)
         assert nodes.has_css?(".application-notice", text: "information"), "Does not have information callout"
@@ -131,9 +126,8 @@ Hello world
     test '#title_erb_template_path returns the erb template path supplied in the options' do
       outcome = Outcome.new('outcome-name')
 
-      state = nil
       options = { erb_template_directory: Pathname.new('/erb-template-directory'), title_erb_template_name: 'template.erb' }
-      presenter = OutcomePresenter.new('i18n-prefix', outcome, state, options)
+      presenter = OutcomePresenter.new('i18n-prefix', outcome, state = nil, options)
 
       expected_path = Pathname.new('/erb-template-directory').join('template.erb')
       assert_equal expected_path, presenter.title_erb_template_path
@@ -143,9 +137,8 @@ Hello world
       options = { use_outcome_templates: true }
       outcome = Outcome.new('outcome-name', options)
 
-      state = nil
       options = { erb_template_directory: Pathname.new('/path/to/non-existent'), title_erb_template_name: 'template.erb' }
-      presenter = OutcomePresenter.new('i18n-prefix', outcome, state, options)
+      presenter = OutcomePresenter.new('i18n-prefix', outcome, state = nil, options)
 
       assert_equal nil, presenter.title
     end
@@ -157,8 +150,7 @@ Hello world
         options = { use_outcome_templates: true }
         outcome = Outcome.new('outcome-name', options)
 
-        state = nil
-        presenter = OutcomePresenter.new('i18n-prefix', outcome, state, presenter_options)
+        presenter = OutcomePresenter.new('i18n-prefix', outcome, state = nil, presenter_options)
 
         assert_equal "title-text\n", presenter.title
       end

--- a/test/unit/outcome_presenter_test.rb
+++ b/test/unit/outcome_presenter_test.rb
@@ -37,8 +37,8 @@ Hello world
 <% end %>
 '
 
-      with_body_erb_template_file("outcome-name", erb_template) do |presenter_options|
-        presenter = OutcomePresenter.new('i18n-prefix', outcome, state = nil, presenter_options)
+      with_body_erb_template_file("outcome-name", erb_template) do |erb_template_directory|
+        presenter = OutcomePresenter.new('i18n-prefix', outcome, state = nil, erb_template_directory: erb_template_directory)
 
         assert_equal "<p>Hello world</p>\n", presenter.body
       end
@@ -49,9 +49,9 @@ Hello world
 
       erb_template = '<%= state_variable %>'
 
-      with_body_erb_template_file("outcome-name", erb_template) do |presenter_options|
+      with_body_erb_template_file("outcome-name", erb_template) do |erb_template_directory|
         state = stub(to_hash: { state_variable: 'state-variable' })
-        presenter = OutcomePresenter.new('i18n-prefix', outcome, state, presenter_options)
+        presenter = OutcomePresenter.new('i18n-prefix', outcome, state, erb_template_directory: erb_template_directory)
 
         assert_match 'state-variable', presenter.body
       end
@@ -62,9 +62,9 @@ Hello world
 
       erb_template = '<%= non_existent_state_variable %>'
 
-      with_body_erb_template_file("outcome-name", erb_template) do |presenter_options|
+      with_body_erb_template_file("outcome-name", erb_template) do |erb_template_directory|
         state = stub(to_hash: {})
-        presenter = OutcomePresenter.new('i18n-prefix', outcome, state, presenter_options)
+        presenter = OutcomePresenter.new('i18n-prefix', outcome, state, erb_template_directory: erb_template_directory)
 
         e = assert_raises(ActionView::Template::Error) do
           presenter.body
@@ -78,8 +78,8 @@ Hello world
 
       erb_template = '<%= number_with_delimiter(123456789) %>'
 
-      with_body_erb_template_file("outcome-name", erb_template) do |presenter_options|
-        presenter = OutcomePresenter.new('i18n-prefix', outcome, state = nil, presenter_options)
+      with_body_erb_template_file("outcome-name", erb_template) do |erb_template_directory|
+        presenter = OutcomePresenter.new('i18n-prefix', outcome, state = nil, erb_template_directory: erb_template_directory)
 
         assert_match '123,456,789', presenter.body
       end
@@ -90,8 +90,8 @@ Hello world
 
       erb_template = '^information^'
 
-      with_body_erb_template_file("outcome-name", erb_template) do |presenter_options|
-        presenter = OutcomePresenter.new('i18n-prefix', outcome, state = nil, presenter_options)
+      with_body_erb_template_file("outcome-name", erb_template) do |erb_template_directory|
+        presenter = OutcomePresenter.new('i18n-prefix', outcome, state = nil, erb_template_directory: erb_template_directory)
 
         nodes = Capybara.string(presenter.body)
         assert nodes.has_css?(".application-notice", text: "information"), "Does not have information callout"
@@ -139,8 +139,8 @@ Hello world
 
       erb_template = "title-text\n\n"
 
-      with_title_erb_template_file("outcome-name", erb_template) do |presenter_options|
-        presenter = OutcomePresenter.new('i18n-prefix', outcome, state = nil, presenter_options)
+      with_title_erb_template_file("outcome-name", erb_template) do |erb_template_directory|
+        presenter = OutcomePresenter.new('i18n-prefix', outcome, state = nil, erb_template_directory: erb_template_directory)
 
         assert_equal "title-text\n", presenter.title
       end
@@ -151,9 +151,9 @@ Hello world
 
       erb_template = '<%= state_variable %>'
 
-      with_title_erb_template_file("outcome-name", erb_template) do |presenter_options|
+      with_title_erb_template_file("outcome-name", erb_template) do |erb_template_directory|
         state = stub(to_hash: { state_variable: 'state-variable' })
-        presenter = OutcomePresenter.new('i18n-prefix', outcome, state, presenter_options)
+        presenter = OutcomePresenter.new('i18n-prefix', outcome, state, erb_template_directory: erb_template_directory)
 
         assert_match 'state-variable', presenter.title
       end
@@ -164,9 +164,9 @@ Hello world
 
       erb_template = '<%= non_existent_state_variable %>'
 
-      with_title_erb_template_file("outcome-name", erb_template) do |presenter_options|
+      with_title_erb_template_file("outcome-name", erb_template) do |erb_template_directory|
         state = stub(to_hash: {})
-        presenter = OutcomePresenter.new('i18n-prefix', outcome, state, presenter_options)
+        presenter = OutcomePresenter.new('i18n-prefix', outcome, state, erb_template_directory: erb_template_directory)
 
         e = assert_raises(ActionView::Template::Error) do
           presenter.title
@@ -201,11 +201,7 @@ Hello world
           erb_template_file.write(erb_template)
           erb_template_file.rewind
 
-          options = {
-            :erb_template_directory => erb_template_directory,
-          }
-
-          yield options
+          yield erb_template_directory
         end
       end
     end

--- a/test/unit/outcome_presenter_test.rb
+++ b/test/unit/outcome_presenter_test.rb
@@ -46,13 +46,12 @@ Hello world
 <% end %>
 '
 
-      with_erb_template_file("body", erb_template) do |erb_template_file|
+      with_erb_template_file("body", erb_template) do |presenter_options|
         options = { use_outcome_templates: true }
         outcome = Outcome.new('outcome-name', options)
 
         state = nil
-        options = { body_erb_template_path: erb_template_file.path }
-        presenter = OutcomePresenter.new('i18n-prefix', outcome, state, options)
+        presenter = OutcomePresenter.new('i18n-prefix', outcome, state, presenter_options)
 
         assert_equal "<p>Hello world</p>\n", presenter.body
       end
@@ -61,13 +60,12 @@ Hello world
     test '#body makes the state variables available to the ERB template' do
       erb_template = '<%= state_variable %>'
 
-      with_erb_template_file("body", erb_template) do |erb_template_file|
+      with_erb_template_file("body", erb_template) do |presenter_options|
         options = { use_outcome_templates: true }
         outcome = Outcome.new('outcome-name', options)
 
         state = stub(to_hash: { state_variable: 'state-variable' })
-        options = { body_erb_template_path: erb_template_file.path }
-        presenter = OutcomePresenter.new('i18n-prefix', outcome, state, options)
+        presenter = OutcomePresenter.new('i18n-prefix', outcome, state, presenter_options)
 
         assert_match 'state-variable', presenter.body
       end
@@ -76,13 +74,12 @@ Hello world
     test "#body raises an exception if the ERB template references a non-existent state variable" do
       erb_template = '<%= non_existent_state_variable %>'
 
-      with_erb_template_file("body", erb_template) do |erb_template_file|
+      with_erb_template_file("body", erb_template) do |presenter_options|
         options = { use_outcome_templates: true }
         outcome = Outcome.new('outcome-name', options)
 
         state = stub(to_hash: {})
-        options = { body_erb_template_path: erb_template_file.path }
-        presenter = OutcomePresenter.new('i18n-prefix', outcome, state, options)
+        presenter = OutcomePresenter.new('i18n-prefix', outcome, state, presenter_options)
 
         e = assert_raises(ActionView::Template::Error) do
           presenter.body
@@ -94,13 +91,12 @@ Hello world
     test '#body makes the ActionView::Helpers::NumberHelper methods available to the ERB template' do
       erb_template = '<%= number_with_delimiter(123456789) %>'
 
-      with_erb_template_file("body", erb_template) do |erb_template_file|
+      with_erb_template_file("body", erb_template) do |presenter_options|
         options = { use_outcome_templates: true }
         outcome = Outcome.new('outcome-name', options)
 
         state = nil
-        options = { body_erb_template_path: erb_template_file.path }
-        presenter = OutcomePresenter.new('i18n-prefix', outcome, state, options)
+        presenter = OutcomePresenter.new('i18n-prefix', outcome, state, presenter_options)
 
         assert_match '123,456,789', presenter.body
       end
@@ -109,13 +105,12 @@ Hello world
     test '#body passes output of ERB template through Govspeak' do
       erb_template = '^information^'
 
-      with_erb_template_file("body", erb_template) do |erb_template_file|
+      with_erb_template_file("body", erb_template) do |presenter_options|
         options = { use_outcome_templates: true }
         outcome = Outcome.new('outcome-name', options)
 
         state = nil
-        options = { body_erb_template_path: erb_template_file.path }
-        presenter = OutcomePresenter.new('i18n-prefix', outcome, state, options)
+        presenter = OutcomePresenter.new('i18n-prefix', outcome, state, presenter_options)
 
         nodes = Capybara.string(presenter.body)
         assert nodes.has_css?(".application-notice", text: "information"), "Does not have information callout"
@@ -172,13 +167,12 @@ Hello world
     test '#title trims a single newline from the end of the string' do
       erb_template = "title-text\n\n"
 
-      with_erb_template_file("title", erb_template) do |erb_template_file|
+      with_erb_template_file("title", erb_template) do |presenter_options|
         options = { use_outcome_templates: true }
         outcome = Outcome.new('outcome-name', options)
 
         state = nil
-        options = { title_erb_template_path: erb_template_file.path }
-        presenter = OutcomePresenter.new('i18n-prefix', outcome, state, options)
+        presenter = OutcomePresenter.new('i18n-prefix', outcome, state, presenter_options)
 
         assert_equal "title-text\n", presenter.title
       end
@@ -187,13 +181,12 @@ Hello world
     test '#title makes the state variables available to the ERB template' do
       erb_template = '<%= state_variable %>'
 
-      with_erb_template_file("title", erb_template) do |erb_template_file|
+      with_erb_template_file("title", erb_template) do |presenter_options|
         options = { use_outcome_templates: true }
         outcome = Outcome.new('outcome-name', options)
 
         state = stub(to_hash: { state_variable: 'state-variable' })
-        options = { title_erb_template_path: erb_template_file.path }
-        presenter = OutcomePresenter.new('i18n-prefix', outcome, state, options)
+        presenter = OutcomePresenter.new('i18n-prefix', outcome, state, presenter_options)
 
         assert_match 'state-variable', presenter.title
       end
@@ -202,13 +195,12 @@ Hello world
     test "#title raises an exception if the ERB template references a non-existent state variable" do
       erb_template = '<%= non_existent_state_variable %>'
 
-      with_erb_template_file("title", erb_template) do |erb_template_file|
+      with_erb_template_file("title", erb_template) do |presenter_options|
         options = { use_outcome_templates: true }
         outcome = Outcome.new('outcome-name', options)
 
         state = stub(to_hash: {})
-        options = { title_erb_template_path: erb_template_file.path }
-        presenter = OutcomePresenter.new('i18n-prefix', outcome, state, options)
+        presenter = OutcomePresenter.new('i18n-prefix', outcome, state, presenter_options)
 
         e = assert_raises(ActionView::Template::Error) do
           presenter.title
@@ -233,7 +225,11 @@ Hello world
         erb_template_file.write(erb_template)
         erb_template_file.rewind
 
-        yield erb_template_file
+        options = {
+          :"#{suffix}_erb_template_path" => erb_template_file.path
+        }
+
+        yield options
       end
     end
   end

--- a/test/unit/outcome_presenter_test.rb
+++ b/test/unit/outcome_presenter_test.rb
@@ -46,7 +46,7 @@ Hello world
 <% end %>
 '
 
-      with_erb_template_file(erb_template) do |erb_template_file|
+      with_erb_template_file("body", erb_template) do |erb_template_file|
         options = { use_outcome_templates: true }
         outcome = Outcome.new('outcome-name', options)
 
@@ -61,7 +61,7 @@ Hello world
     test '#body makes the state variables available to the ERB template' do
       erb_template = '<%= state_variable %>'
 
-      with_erb_template_file(erb_template) do |erb_template_file|
+      with_erb_template_file("body", erb_template) do |erb_template_file|
         options = { use_outcome_templates: true }
         outcome = Outcome.new('outcome-name', options)
 
@@ -76,7 +76,7 @@ Hello world
     test "#body raises an exception if the ERB template references a non-existent state variable" do
       erb_template = '<%= non_existent_state_variable %>'
 
-      with_erb_template_file(erb_template) do |erb_template_file|
+      with_erb_template_file("body", erb_template) do |erb_template_file|
         options = { use_outcome_templates: true }
         outcome = Outcome.new('outcome-name', options)
 
@@ -94,7 +94,7 @@ Hello world
     test '#body makes the ActionView::Helpers::NumberHelper methods available to the ERB template' do
       erb_template = '<%= number_with_delimiter(123456789) %>'
 
-      with_erb_template_file(erb_template) do |erb_template_file|
+      with_erb_template_file("body", erb_template) do |erb_template_file|
         options = { use_outcome_templates: true }
         outcome = Outcome.new('outcome-name', options)
 
@@ -109,7 +109,7 @@ Hello world
     test '#body passes output of ERB template through Govspeak' do
       erb_template = '^information^'
 
-      with_erb_template_file(erb_template) do |erb_template_file|
+      with_erb_template_file("body", erb_template) do |erb_template_file|
         options = { use_outcome_templates: true }
         outcome = Outcome.new('outcome-name', options)
 
@@ -172,7 +172,7 @@ Hello world
     test '#title trims a single newline from the end of the string' do
       erb_template = "title-text\n\n"
 
-      with_erb_template_file(erb_template) do |erb_template_file|
+      with_erb_template_file("title", erb_template) do |erb_template_file|
         options = { use_outcome_templates: true }
         outcome = Outcome.new('outcome-name', options)
 
@@ -187,7 +187,7 @@ Hello world
     test '#title makes the state variables available to the ERB template' do
       erb_template = '<%= state_variable %>'
 
-      with_erb_template_file(erb_template) do |erb_template_file|
+      with_erb_template_file("title", erb_template) do |erb_template_file|
         options = { use_outcome_templates: true }
         outcome = Outcome.new('outcome-name', options)
 
@@ -202,7 +202,7 @@ Hello world
     test "#title raises an exception if the ERB template references a non-existent state variable" do
       erb_template = '<%= non_existent_state_variable %>'
 
-      with_erb_template_file(erb_template) do |erb_template_file|
+      with_erb_template_file("title", erb_template) do |erb_template_file|
         options = { use_outcome_templates: true }
         outcome = Outcome.new('outcome-name', options)
 
@@ -228,8 +228,8 @@ Hello world
 
     private
 
-    def with_erb_template_file(erb_template)
-      Tempfile.open('template.txt.erb') do |erb_template_file|
+    def with_erb_template_file(suffix, erb_template)
+      Tempfile.open(["template_", "_#{suffix}.txt.erb"]) do |erb_template_file|
         erb_template_file.write(erb_template)
         erb_template_file.rewind
 

--- a/test/unit/outcome_presenter_test.rb
+++ b/test/unit/outcome_presenter_test.rb
@@ -207,16 +207,22 @@ Hello world
     private
 
     def with_erb_template_file(suffix, erb_template)
-      Tempfile.open(["template_", "_#{suffix}.txt.erb"]) do |erb_template_file|
-        erb_template_file.write(erb_template)
-        erb_template_file.rewind
+      erb_template_filename = "template_#{suffix}.txt.erb"
 
-        options = {
-          :erb_template_directory => Pathname.new(File.dirname(erb_template_file.path)),
-          :"#{suffix}_erb_template_name" => File.basename(erb_template_file.path)
-        }
+      Dir.mktmpdir do |directory|
+        erb_template_directory = Pathname.new(directory)
 
-        yield options
+        File.open(erb_template_directory.join(erb_template_filename), "w") do |erb_template_file|
+          erb_template_file.write(erb_template)
+          erb_template_file.rewind
+
+          options = {
+            :erb_template_directory => erb_template_directory,
+            :"#{suffix}_erb_template_name" => erb_template_filename
+          }
+
+          yield options
+        end
       end
     end
   end

--- a/test/unit/outcome_presenter_test.rb
+++ b/test/unit/outcome_presenter_test.rb
@@ -3,8 +3,7 @@ require_relative '../test_helper'
 module SmartAnswer
   class OutcomePresenterTest < ActiveSupport::TestCase
     test '#body_erb_template_path returns the default erb template path built using both the flow and outcome node name' do
-      options = { flow_name: 'flow-name' }
-      outcome = Outcome.new('outcome-name', options)
+      outcome = Outcome.new('outcome-name', flow_name: 'flow-name')
       presenter = OutcomePresenter.new('i18n-prefix', outcome)
 
       expected_path = Rails.root.join('lib', 'smart_answer_flows', 'flow-name', 'outcome-name_body.govspeak.erb')
@@ -22,8 +21,7 @@ module SmartAnswer
     end
 
     test "#body returns nil when the erb template doesn't exist" do
-      options = { use_outcome_templates: true }
-      outcome = Outcome.new('outcome-name', options)
+      outcome = Outcome.new('outcome-name', use_outcome_templates: true)
 
       options = { erb_template_directory: Pathname.new('/path/to/non-existent'), body_erb_template_name: 'template.erb' }
       presenter = OutcomePresenter.new('i18n-prefix', outcome, state = nil, options)
@@ -38,8 +36,7 @@ Hello world
 '
 
       with_erb_template_file("body", erb_template) do |presenter_options|
-        options = { use_outcome_templates: true }
-        outcome = Outcome.new('outcome-name', options)
+        outcome = Outcome.new('outcome-name', use_outcome_templates: true)
 
         presenter = OutcomePresenter.new('i18n-prefix', outcome, state = nil, presenter_options)
 
@@ -51,8 +48,7 @@ Hello world
       erb_template = '<%= state_variable %>'
 
       with_erb_template_file("body", erb_template) do |presenter_options|
-        options = { use_outcome_templates: true }
-        outcome = Outcome.new('outcome-name', options)
+        outcome = Outcome.new('outcome-name', use_outcome_templates: true)
 
         state = stub(to_hash: { state_variable: 'state-variable' })
         presenter = OutcomePresenter.new('i18n-prefix', outcome, state, presenter_options)
@@ -65,8 +61,7 @@ Hello world
       erb_template = '<%= non_existent_state_variable %>'
 
       with_erb_template_file("body", erb_template) do |presenter_options|
-        options = { use_outcome_templates: true }
-        outcome = Outcome.new('outcome-name', options)
+        outcome = Outcome.new('outcome-name', use_outcome_templates: true)
 
         state = stub(to_hash: {})
         presenter = OutcomePresenter.new('i18n-prefix', outcome, state, presenter_options)
@@ -82,8 +77,7 @@ Hello world
       erb_template = '<%= number_with_delimiter(123456789) %>'
 
       with_erb_template_file("body", erb_template) do |presenter_options|
-        options = { use_outcome_templates: true }
-        outcome = Outcome.new('outcome-name', options)
+        outcome = Outcome.new('outcome-name', use_outcome_templates: true)
 
         presenter = OutcomePresenter.new('i18n-prefix', outcome, state = nil, presenter_options)
 
@@ -95,8 +89,7 @@ Hello world
       erb_template = '^information^'
 
       with_erb_template_file("body", erb_template) do |presenter_options|
-        options = { use_outcome_templates: true }
-        outcome = Outcome.new('outcome-name', options)
+        outcome = Outcome.new('outcome-name', use_outcome_templates: true)
 
         presenter = OutcomePresenter.new('i18n-prefix', outcome, state = nil, presenter_options)
 
@@ -106,8 +99,7 @@ Hello world
     end
 
     test '#body delegates to NodePresenter when not using outcome templates' do
-      options = { use_outcome_templates: false }
-      outcome = Outcome.new('outcome-name', options)
+      outcome = Outcome.new('outcome-name', use_outcome_templates: false)
       presenter = OutcomePresenter.new('i18n-prefix', outcome)
 
       presenter.stubs(:translate_and_render).with('body').returns('node-presenter-body')
@@ -134,8 +126,7 @@ Hello world
     end
 
     test "#title returns nil when the erb template doesn't exist" do
-      options = { use_outcome_templates: true }
-      outcome = Outcome.new('outcome-name', options)
+      outcome = Outcome.new('outcome-name', use_outcome_templates: true)
 
       options = { erb_template_directory: Pathname.new('/path/to/non-existent'), title_erb_template_name: 'template.erb' }
       presenter = OutcomePresenter.new('i18n-prefix', outcome, state = nil, options)
@@ -147,8 +138,7 @@ Hello world
       erb_template = "title-text\n\n"
 
       with_erb_template_file("title", erb_template) do |presenter_options|
-        options = { use_outcome_templates: true }
-        outcome = Outcome.new('outcome-name', options)
+        outcome = Outcome.new('outcome-name', use_outcome_templates: true)
 
         presenter = OutcomePresenter.new('i18n-prefix', outcome, state = nil, presenter_options)
 
@@ -160,8 +150,7 @@ Hello world
       erb_template = '<%= state_variable %>'
 
       with_erb_template_file("title", erb_template) do |presenter_options|
-        options = { use_outcome_templates: true }
-        outcome = Outcome.new('outcome-name', options)
+        outcome = Outcome.new('outcome-name', use_outcome_templates: true)
 
         state = stub(to_hash: { state_variable: 'state-variable' })
         presenter = OutcomePresenter.new('i18n-prefix', outcome, state, presenter_options)
@@ -174,8 +163,7 @@ Hello world
       erb_template = '<%= non_existent_state_variable %>'
 
       with_erb_template_file("title", erb_template) do |presenter_options|
-        options = { use_outcome_templates: true }
-        outcome = Outcome.new('outcome-name', options)
+        outcome = Outcome.new('outcome-name', use_outcome_templates: true)
 
         state = stub(to_hash: {})
         presenter = OutcomePresenter.new('i18n-prefix', outcome, state, presenter_options)
@@ -188,8 +176,7 @@ Hello world
     end
 
     test '#title calls translate! to return the title when not using outcome templates' do
-      options = { use_outcome_templates: false }
-      outcome = Outcome.new('outcome-name', options)
+      outcome = Outcome.new('outcome-name', use_outcome_templates: false)
       presenter = OutcomePresenter.new('i18n-prefix', outcome)
 
       presenter.stubs(:translate!).with('title').returns('outcome-presenter-title')

--- a/test/unit/outcome_presenter_test.rb
+++ b/test/unit/outcome_presenter_test.rb
@@ -2,31 +2,24 @@ require_relative '../test_helper'
 
 module SmartAnswer
   class OutcomePresenterTest < ActiveSupport::TestCase
-    test '#default_body_erb_template_path returns the default erb template path built using both the flow and outcome node name' do
+    test '#body_erb_template_path returns the default erb template path built using both the flow and outcome node name' do
       options = { flow_name: 'flow-name' }
       outcome = Outcome.new('outcome-name', options)
       presenter = OutcomePresenter.new('i18n-prefix', outcome)
 
       expected_path = Rails.root.join('lib', 'smart_answer_flows', 'flow-name', 'outcome-name_body.govspeak.erb')
-      assert_equal expected_path, presenter.default_body_erb_template_path
-    end
-
-    test '#body_erb_template_path returns the default erb template path if not overridden in the options' do
-      outcome = Outcome.new('outcome-name')
-      presenter = OutcomePresenter.new('i18n-prefix', outcome)
-      presenter.stubs(default_body_erb_template_path: 'default-erb-template-path')
-
-      assert_equal 'default-erb-template-path', presenter.body_erb_template_path
+      assert_equal expected_path, presenter.body_erb_template_path
     end
 
     test '#body_erb_template_path returns the erb template path supplied in the options' do
       outcome = Outcome.new('outcome-name')
 
       state = nil
-      options = {body_erb_template_path: 'erb-template-path'}
+      options = { erb_template_directory: Pathname.new('/erb-template-directory'), body_erb_template_name: 'template.erb' }
       presenter = OutcomePresenter.new('i18n-prefix', outcome, state, options)
 
-      assert_equal 'erb-template-path', presenter.body_erb_template_path
+      expected_path = Pathname.new('/erb-template-directory').join('template.erb')
+      assert_equal expected_path, presenter.body_erb_template_path
     end
 
     test "#body returns nil when the erb template doesn't exist" do
@@ -34,7 +27,7 @@ module SmartAnswer
       outcome = Outcome.new('outcome-name', options)
 
       state = nil
-      options = { body_erb_template_path: '/path/to/non-existent/template.erb' }
+      options = { erb_template_directory: Pathname.new('/path/to/non-existent'), body_erb_template_name: 'template.erb' }
       presenter = OutcomePresenter.new('i18n-prefix', outcome, state, options)
 
       assert_equal nil, presenter.body
@@ -126,31 +119,24 @@ Hello world
       assert_equal 'node-presenter-body', presenter.body
     end
 
-    test '#default_title_erb_template_path returns the default erb template path built using both the flow and outcome node name' do
+    test '#title_erb_template_path returns the default erb template path built using both the flow and outcome node name' do
       options = { flow_name: 'flow-name' }
       outcome = Outcome.new('outcome-name', options)
       presenter = OutcomePresenter.new('i18n-prefix', outcome)
 
       expected_path = Rails.root.join('lib', 'smart_answer_flows', 'flow-name', 'outcome-name_title.txt.erb')
-      assert_equal expected_path, presenter.default_title_erb_template_path
-    end
-
-    test '#title_erb_template_path returns the default erb template path if not overridden in the options' do
-      outcome = Outcome.new('outcome-name')
-      presenter = OutcomePresenter.new('i18n-prefix', outcome)
-      presenter.stubs(default_title_erb_template_path: 'default-title-erb-template-path')
-
-      assert_equal 'default-title-erb-template-path', presenter.title_erb_template_path
+      assert_equal expected_path, presenter.title_erb_template_path
     end
 
     test '#title_erb_template_path returns the erb template path supplied in the options' do
       outcome = Outcome.new('outcome-name')
 
       state = nil
-      options = { title_erb_template_path: 'erb-template-path' }
+      options = { erb_template_directory: Pathname.new('/erb-template-directory'), title_erb_template_name: 'template.erb' }
       presenter = OutcomePresenter.new('i18n-prefix', outcome, state, options)
 
-      assert_equal 'erb-template-path', presenter.title_erb_template_path
+      expected_path = Pathname.new('/erb-template-directory').join('template.erb')
+      assert_equal expected_path, presenter.title_erb_template_path
     end
 
     test "#title returns nil when the erb template doesn't exist" do
@@ -158,7 +144,7 @@ Hello world
       outcome = Outcome.new('outcome-name', options)
 
       state = nil
-      options = { title_erb_template_path: '/path/to/non-existent/template.erb' }
+      options = { erb_template_directory: Pathname.new('/path/to/non-existent'), title_erb_template_name: 'template.erb' }
       presenter = OutcomePresenter.new('i18n-prefix', outcome, state, options)
 
       assert_equal nil, presenter.title
@@ -226,7 +212,8 @@ Hello world
         erb_template_file.rewind
 
         options = {
-          :"#{suffix}_erb_template_path" => erb_template_file.path
+          :erb_template_directory => Pathname.new(File.dirname(erb_template_file.path)),
+          :"#{suffix}_erb_template_name" => File.basename(erb_template_file.path)
         }
 
         yield options

--- a/test/unit/outcome_presenter_test.rb
+++ b/test/unit/outcome_presenter_test.rb
@@ -29,18 +29,6 @@ module SmartAnswer
       assert_equal 'erb-template-path', presenter.body_erb_template_path
     end
 
-    test '#body_erb_template_from_file returns the content of the erb template' do
-      with_erb_template_file('erb-template') do |erb_template_file|
-        outcome = Outcome.new('outcome-name')
-
-        state = nil
-        options = { body_erb_template_path: erb_template_file.path }
-        presenter = OutcomePresenter.new('i18n-prefix', outcome, state, options)
-
-        assert_equal 'erb-template', presenter.body_erb_template_from_file
-      end
-    end
-
     test "#body returns nil when the erb template doesn't exist" do
       options = { use_outcome_templates: true }
       outcome = Outcome.new('outcome-name', options)
@@ -50,24 +38,6 @@ module SmartAnswer
       presenter = OutcomePresenter.new('i18n-prefix', outcome, state, options)
 
       assert_equal nil, presenter.body
-    end
-
-    test '#body uses GovspeakPresenter to generate the html' do
-      erb_template = '# level-1-heading'
-
-      with_erb_template_file(erb_template) do |erb_template_file|
-        options = { use_outcome_templates: true }
-        outcome = Outcome.new('outcome-name', options)
-
-        state = nil
-        options = { body_erb_template_path: erb_template_file.path }
-        presenter = OutcomePresenter.new('i18n-prefix', outcome, state, options)
-
-        govspeak_presenter = stub(html: 'govspeak-output')
-        GovspeakPresenter.stubs(:new).with(erb_template).returns(govspeak_presenter)
-
-        assert_equal 'govspeak-output', presenter.body
-      end
     end
 
     test "#body trims newlines by default" do
@@ -89,17 +59,35 @@ Hello world
     end
 
     test '#body makes the state variables available to the ERB template' do
-      erb_template = '<%= method_on_state_object %>'
+      erb_template = '<%= state_variable %>'
 
       with_erb_template_file(erb_template) do |erb_template_file|
         options = { use_outcome_templates: true }
         outcome = Outcome.new('outcome-name', options)
 
-        state = stub(method_on_state_object: 'method-on-state-object')
+        state = stub(to_hash: { state_variable: 'state-variable' })
         options = { body_erb_template_path: erb_template_file.path }
         presenter = OutcomePresenter.new('i18n-prefix', outcome, state, options)
 
-        assert_match 'method-on-state-object', presenter.body
+        assert_match 'state-variable', presenter.body
+      end
+    end
+
+    test "#body raises an exception if the ERB template references a non-existent state variable" do
+      erb_template = '<%= non_existent_state_variable %>'
+
+      with_erb_template_file(erb_template) do |erb_template_file|
+        options = { use_outcome_templates: true }
+        outcome = Outcome.new('outcome-name', options)
+
+        state = stub(to_hash: {})
+        options = { body_erb_template_path: erb_template_file.path }
+        presenter = OutcomePresenter.new('i18n-prefix', outcome, state, options)
+
+        e = assert_raises(ActionView::Template::Error) do
+          presenter.body
+        end
+        assert_match "undefined local variable or method `non_existent_state_variable'", e.message
       end
     end
 
@@ -115,6 +103,22 @@ Hello world
         presenter = OutcomePresenter.new('i18n-prefix', outcome, state, options)
 
         assert_match '123,456,789', presenter.body
+      end
+    end
+
+    test '#body passes output of ERB template through Govspeak' do
+      erb_template = '^information^'
+
+      with_erb_template_file(erb_template) do |erb_template_file|
+        options = { use_outcome_templates: true }
+        outcome = Outcome.new('outcome-name', options)
+
+        state = nil
+        options = { body_erb_template_path: erb_template_file.path }
+        presenter = OutcomePresenter.new('i18n-prefix', outcome, state, options)
+
+        nodes = Capybara.string(presenter.body)
+        assert nodes.has_css?(".application-notice", text: "information"), "Does not have information callout"
       end
     end
 
@@ -154,18 +158,6 @@ Hello world
       assert_equal 'erb-template-path', presenter.title_erb_template_path
     end
 
-    test '#title_erb_template_from_file returns the content of the erb template' do
-      with_erb_template_file('erb-template') do |erb_template_file|
-        outcome = Outcome.new('outcome-name')
-
-        state = nil
-        options = { title_erb_template_path: erb_template_file.path }
-        presenter = OutcomePresenter.new('i18n-prefix', outcome, state, options)
-
-        assert_equal 'erb-template', presenter.title_erb_template_from_file
-      end
-    end
-
     test "#title returns nil when the erb template doesn't exist" do
       options = { use_outcome_templates: true }
       outcome = Outcome.new('outcome-name', options)
@@ -193,17 +185,35 @@ Hello world
     end
 
     test '#title makes the state variables available to the ERB template' do
-      erb_template = '<%= method_on_state_object %>'
+      erb_template = '<%= state_variable %>'
 
       with_erb_template_file(erb_template) do |erb_template_file|
         options = { use_outcome_templates: true }
         outcome = Outcome.new('outcome-name', options)
 
-        state = stub(method_on_state_object: 'method-on-state-object')
+        state = stub(to_hash: { state_variable: 'state-variable' })
         options = { title_erb_template_path: erb_template_file.path }
         presenter = OutcomePresenter.new('i18n-prefix', outcome, state, options)
 
-        assert_match 'method-on-state-object', presenter.title
+        assert_match 'state-variable', presenter.title
+      end
+    end
+
+    test "#title raises an exception if the ERB template references a non-existent state variable" do
+      erb_template = '<%= non_existent_state_variable %>'
+
+      with_erb_template_file(erb_template) do |erb_template_file|
+        options = { use_outcome_templates: true }
+        outcome = Outcome.new('outcome-name', options)
+
+        state = stub(to_hash: {})
+        options = { title_erb_template_path: erb_template_file.path }
+        presenter = OutcomePresenter.new('i18n-prefix', outcome, state, options)
+
+        e = assert_raises(ActionView::Template::Error) do
+          presenter.title
+        end
+        assert_match "undefined local variable or method `non_existent_state_variable'", e.message
       end
     end
 
@@ -224,68 +234,6 @@ Hello world
         erb_template_file.rewind
 
         yield erb_template_file
-      end
-    end
-  end
-
-  class OutcomePresenterViewContextTest < ActiveSupport::TestCase
-    test 'delegates all methods to the state object' do
-      state = State.new(nil)
-      state.method_on_state_object = 'method-on-state-object'
-      view_context = OutcomePresenter::ViewContext.new(state)
-
-      assert_equal 'method-on-state-object', view_context.method_on_state_object
-    end
-
-    test "raises an exception if the state object doesn't respond to the method" do
-      state = State.new(nil)
-      view_context = OutcomePresenter::ViewContext.new(state)
-
-      assert_raises(NoMethodError) do
-        view_context.non_existent_method
-      end
-    end
-
-    test '#respond_to_missing? returns true if the state object responds to the method' do
-      state = State.new(nil)
-      state.method_on_state_object = 'method-on-state-object'
-      view_context = OutcomePresenter::ViewContext.new(state)
-
-      assert_equal true, view_context.respond_to?(:method_on_state_object)
-    end
-
-    test "#respond_to_missing? returns false if the state object doesn't responds to the method" do
-      state = State.new(nil)
-      view_context = OutcomePresenter::ViewContext.new(state)
-
-      assert_equal false, view_context.respond_to?(:non_existent_method)
-    end
-
-    test "#respond_to_missing? returns false if the state object responds to the method but the name implies it's a setter method" do
-      state = State.new(nil)
-      state.method_on_state_object = 'method-on-state-object'
-      view_context = OutcomePresenter::ViewContext.new(state)
-
-      assert_equal false, view_context.respond_to?(:method_on_state_object=)
-    end
-
-    test 'returns the binding that we can use as the context of code evaluation in our ERB templates' do
-      state = State.new(nil)
-      state.method_on_state_object = 'method-on-state-object'
-      view_context = OutcomePresenter::ViewContext.new(state)
-
-      binding = view_context.get_binding
-      assert_equal 'method-on-state-object', eval('method_on_state_object', binding)
-    end
-
-    test 'raises an exception if calling a writer method that has been defined on the state object' do
-      state = State.new(nil)
-      state.method_on_state_object = 'method-on-state-object'
-      view_context = OutcomePresenter::ViewContext.new(state)
-
-      assert_equal true, state.respond_to?(:method_on_state_object=)
-      assert_raises(NoMethodError) do
-        view_context.method_on_state_object = 'new-value'
       end
     end
   end

--- a/test/unit/outcome_presenter_test.rb
+++ b/test/unit/outcome_presenter_test.rb
@@ -30,13 +30,14 @@ module SmartAnswer
     end
 
     test "#body trims newlines by default" do
+      outcome = Outcome.new('outcome-name', use_outcome_templates: true)
+
       erb_template = '<% if true %>
 Hello world
 <% end %>
 '
 
       with_erb_template_file("body", erb_template) do |presenter_options|
-        outcome = Outcome.new('outcome-name', use_outcome_templates: true)
 
         presenter = OutcomePresenter.new('i18n-prefix', outcome, state = nil, presenter_options)
 
@@ -45,11 +46,11 @@ Hello world
     end
 
     test '#body makes the state variables available to the ERB template' do
+      outcome = Outcome.new('outcome-name', use_outcome_templates: true)
+
       erb_template = '<%= state_variable %>'
 
       with_erb_template_file("body", erb_template) do |presenter_options|
-        outcome = Outcome.new('outcome-name', use_outcome_templates: true)
-
         state = stub(to_hash: { state_variable: 'state-variable' })
         presenter = OutcomePresenter.new('i18n-prefix', outcome, state, presenter_options)
 
@@ -58,11 +59,11 @@ Hello world
     end
 
     test "#body raises an exception if the ERB template references a non-existent state variable" do
+      outcome = Outcome.new('outcome-name', use_outcome_templates: true)
+
       erb_template = '<%= non_existent_state_variable %>'
 
       with_erb_template_file("body", erb_template) do |presenter_options|
-        outcome = Outcome.new('outcome-name', use_outcome_templates: true)
-
         state = stub(to_hash: {})
         presenter = OutcomePresenter.new('i18n-prefix', outcome, state, presenter_options)
 
@@ -74,11 +75,11 @@ Hello world
     end
 
     test '#body makes the ActionView::Helpers::NumberHelper methods available to the ERB template' do
+      outcome = Outcome.new('outcome-name', use_outcome_templates: true)
+
       erb_template = '<%= number_with_delimiter(123456789) %>'
 
       with_erb_template_file("body", erb_template) do |presenter_options|
-        outcome = Outcome.new('outcome-name', use_outcome_templates: true)
-
         presenter = OutcomePresenter.new('i18n-prefix', outcome, state = nil, presenter_options)
 
         assert_match '123,456,789', presenter.body
@@ -86,11 +87,11 @@ Hello world
     end
 
     test '#body passes output of ERB template through Govspeak' do
+      outcome = Outcome.new('outcome-name', use_outcome_templates: true)
+
       erb_template = '^information^'
 
       with_erb_template_file("body", erb_template) do |presenter_options|
-        outcome = Outcome.new('outcome-name', use_outcome_templates: true)
-
         presenter = OutcomePresenter.new('i18n-prefix', outcome, state = nil, presenter_options)
 
         nodes = Capybara.string(presenter.body)
@@ -135,11 +136,11 @@ Hello world
     end
 
     test '#title trims a single newline from the end of the string' do
+      outcome = Outcome.new('outcome-name', use_outcome_templates: true)
+
       erb_template = "title-text\n\n"
 
       with_erb_template_file("title", erb_template) do |presenter_options|
-        outcome = Outcome.new('outcome-name', use_outcome_templates: true)
-
         presenter = OutcomePresenter.new('i18n-prefix', outcome, state = nil, presenter_options)
 
         assert_equal "title-text\n", presenter.title
@@ -147,11 +148,11 @@ Hello world
     end
 
     test '#title makes the state variables available to the ERB template' do
+      outcome = Outcome.new('outcome-name', use_outcome_templates: true)
+
       erb_template = '<%= state_variable %>'
 
       with_erb_template_file("title", erb_template) do |presenter_options|
-        outcome = Outcome.new('outcome-name', use_outcome_templates: true)
-
         state = stub(to_hash: { state_variable: 'state-variable' })
         presenter = OutcomePresenter.new('i18n-prefix', outcome, state, presenter_options)
 
@@ -160,11 +161,11 @@ Hello world
     end
 
     test "#title raises an exception if the ERB template references a non-existent state variable" do
+      outcome = Outcome.new('outcome-name', use_outcome_templates: true)
+
       erb_template = '<%= non_existent_state_variable %>'
 
       with_erb_template_file("title", erb_template) do |presenter_options|
-        outcome = Outcome.new('outcome-name', use_outcome_templates: true)
-
         state = stub(to_hash: {})
         presenter = OutcomePresenter.new('i18n-prefix', outcome, state, presenter_options)
 


### PR DESCRIPTION
In general this moves us closer to being a standard Rails app which is one of
our longer-term goals. More specifically:

* By supplying the state in the `locals` Hash, we don't have to worry about the
view modifying the state via writer methods.
* Strings marked as HTML-unsafe (e.g. user input) are automatically escaped.
I've added an integration test to demonstrate this.
* We don't have to do mess about with a binding object.
* ActionView helper modules (e.g. `ActionView::Helpers::NumberHelper`) are
automatically made available.

Notes:

* `ActionView` uses Erubis in its implementation which is what we
were using previously, so this reduces the scope of the change.
* A different exception is raised if a non-existent state variable is accessed:
`ActionView::Template::Error` instead of `NoMethodError`.
* It should now be much easier to introduce "partial" templates for sharing
content between outcome templates.

Supersedes #1686.