### PR TITLE
Standardise birth registrations in Gibraltar

### DIFF
--- a/lib/data/registrations.yml
+++ b/lib/data/registrations.yml
@@ -23,7 +23,6 @@ registration_country:
   french-guiana: france
   french-polynesia: france
   gabon: cameroon
-  gibraltar: spain
   grenada: barbados
   guadeloupe: france
   guinea-bissau: senegal

--- a/test/data/register-a-birth-files.yml
+++ b/test/data/register-a-birth-files.yml
@@ -3,7 +3,7 @@ lib/smart_answer_flows/register-a-birth.rb: 8ebc915b17a2afc941c2517d24cdaf11
 lib/smart_answer_flows/locales/en/register-a-birth.yml: 7b865d215fad1348306d79b0ac954377
 test/data/register-a-birth-questions-and-responses.yml: b8656669a138a00d52afdd33cc9b4590
 test/data/register-a-birth-responses-and-expected-results.yml: 3c431cc901085e1e4c0fcc9fe50eef47
-lib/data/registrations.yml: 740ea2425dd262918b83dd8cee8a00c7
+lib/data/registrations.yml: f9c542793c73aa0a8abd6920e49be735
 lib/smart_answer/calculators/country_name_formatter.rb: 0cb274748f0daf3965451b6230c183fd
 lib/smart_answer/calculators/registrations_data_query.rb: 2755d76a53d867b350940f1af65fa5d1
 lib/smart_answer/calculators/translator_links.rb: 079592f6c5ede06d7c6ae4e8c5553127


### PR DESCRIPTION
Affected URL /register-a-birth/y/gibraltar

It use to refer to Spain for birth registrations in Gibraltar.
As per original ticket:

>the outcome for Gibraltar - https://www.gov.uk/register-a-birth/y/gibraltar - needs to be brought into line with the other 'Outcome Commonwealth' outcomes (like Australia, etc) This means that the 2 references to Spain just have to change to 'Gibraltar'.

As a side note, @floehopper, do you think we should add some countries [from this file](https://github.com/alphagov/smart-answers/blob/master/lib/data/registrations.yml) to the regression test answer list for this flow?