### PR TITLE
Remove unreachable "result" outcome from overseas-passports (part 2)

### DIFF
--- a/lib/data/passport_data.yml
+++ b/lib/data/passport_data.yml
@@ -191,7 +191,6 @@ belize:
 benin:
   type: ips_application_1
   group: ips_documents_group_3
-  helpline: pretoria_south_africa
   app_form: hmpo_1_application_form
   address: durham
   renewing_new: 6_weeks
@@ -316,7 +315,6 @@ burma:
 burundi:
   type: ips_application_3
   group: ips_documents_group_3
-  helpline: pretoria_south_africa
   app_form: hmpo_1_application_form
   renewing_new: 6_weeks
   renewing_old: 10_weeks
@@ -333,7 +331,6 @@ cambodia:
 cameroon:
   type: ips_application_1
   group: ips_documents_group_3
-  helpline: pretoria_south_africa
   app_form: hmpo_1_application_form
   address: durham
   renewing_new: 6_weeks
@@ -576,7 +573,6 @@ equatorial-guinea:
 eritrea:
   type: ips_application_1
   group: ips_documents_group_3
-  helpline: pretoria_south_africa
   app_form: hmpo_1_application_form
   address: durham
   renewing_new: 6_weeks
@@ -595,7 +591,6 @@ estonia:
 ethiopia:
   type: ips_application_1
   group: ips_documents_group_3
-  helpline: pretoria_south_africa
   app_form: hmpo_1_application_form
   address: durham
   renewing_new: 8_weeks
@@ -667,7 +662,6 @@ gabon:
 gambia:
   type: ips_application_1
   group: ips_documents_group_3
-  helpline: pretoria_south_africa
   app_form: hmpo_1_application_form
   address: durham
   renewing_new: 6_weeks
@@ -694,7 +688,6 @@ georgia:
 germany:
   type: ips_application_1
   group: ips_documents_group_1
-  helpline: pretoria_south_africa
   app_form: hmpo_1_application_form
   online_application: true
   renewing_new: 6_weeks
@@ -704,7 +697,6 @@ germany:
 ghana:
   type: ips_application_1
   group: ips_documents_group_3
-  helpline: pretoria_south_africa
   app_form: hmpo_1_application_form
   address: durham
   renewing_new: 6_weeks
@@ -759,7 +751,6 @@ guatemala:
 guinea:
   type: ips_application_1
   group: ips_documents_group_3
-  helpline: pretoria_south_africa
   app_form: hmpo_1_application_form
   address: durham
   renewing_new: 6_weeks
@@ -939,7 +930,6 @@ kazakhstan:
 kenya:
   type: ips_application_1
   group: ips_documents_group_3
-  helpline: pretoria_south_africa
   app_form: hmpo_1_application_form
   address: durham
   renewing_new: 8_weeks
@@ -1336,7 +1326,6 @@ niger:
 nigeria:
   type: ips_application_1
   group: ips_documents_group_3
-  helpline: pretoria_south_africa
   app_form: hmpo_1_application_form
   address: durham
   renewing_new: 8_weeks
@@ -1570,7 +1559,6 @@ seychelles:
 sierra-leone:
   type: ips_application_1
   group: ips_documents_group_3
-  helpline: pretoria_south_africa
   app_form: hmpo_1_application_form
   address: durham
   renewing_new: 6_weeks
@@ -1616,7 +1604,6 @@ solomon-islands:
 somalia:
   type: ips_application_1
   group: ips_documents_group_3
-  helpline: pretoria_south_africa
   app_form: hmpo_1_application_form
   address: durham
   renewing_new: 6_weeks
@@ -1652,7 +1639,6 @@ south-korea:
 south-sudan:
   type: ips_application_1
   group: ips_documents_group_3
-  helpline: pretoria_south_africa
   app_form: hmpo_1_application_form
   address: durham
   renewing_new: 8_weeks
@@ -1977,7 +1963,6 @@ vanuatu:
 venezuela:
   type: ips_application_3
   group: ips_documents_group_3
-  helpline: washington_usa
   app_form: hmpo_2_application_form
   application_office: true
   renewing_new: 6_weeks
@@ -2014,7 +1999,6 @@ western-sahara:
 yemen:
   type: ips_application_1
   group: ips_documents_group_3
-  helpline: yemen
   app_form: hmpo_1_application_form
   address: durham
   renewing_new: 6_weeks
@@ -2024,7 +2008,6 @@ yemen:
 zambia:
   type: ips_application_1
   group: ips_documents_group_3
-  helpline: pretoria_south_africa
   app_form: hmpo_1_application_form
   address: durham
   renewing_new: 8_weeks
@@ -2034,7 +2017,6 @@ zambia:
 zimbabwe:
   type: ips_application_1
   group: ips_documents_group_3
-  helpline: pretoria_south_africa
   app_form: hmpo_1_application_form
   address: durham
   renewing_new: 8_weeks

--- a/lib/smart_answer/calculators/passport_and_embassy_data_query.rb
+++ b/lib/smart_answer/calculators/passport_and_embassy_data_query.rb
@@ -23,9 +23,6 @@ module SmartAnswer::Calculators
       'guinea' => 'ghana'
     }
 
-    RETAIN_PASSPORT_COUNTRIES = %w(angola brazil burundi cuba
-    egypt eritrea georgia iraq lebanon libya morocco rwanda sri-lanka sudan timor-leste tunisia uganda zambia)
-
     RETAIN_PASSPORT_COUNTRIES_HURRICANES = %w(anguilla antigua-and-barbuda bahamas bermuda bonaire-st-eustatius-saba british-virgin-islands cayman-islands curacao dominica dominican-republic french-guiana grenada guadeloupe guyana haiti martinique mexico montserrat st-maarten st-kitts-and-nevis st-lucia st-pierre-and-miquelon st-vincent-and-the-grenadines suriname trinidad-and-tobago turks-and-caicos-islands)
 
     PASSPORT_COSTS = {
@@ -48,10 +45,6 @@ module SmartAnswer::Calculators
 
     def find_passport_data(country_slug)
       passport_data[country_slug]
-    end
-
-    def retain_passport?(country_slug)
-      RETAIN_PASSPORT_COUNTRIES.include?(country_slug)
     end
 
     def retain_passport_hurricanes?(country_slug)

--- a/lib/smart_answer/calculators/passport_and_embassy_data_query.rb
+++ b/lib/smart_answer/calculators/passport_and_embassy_data_query.rb
@@ -23,8 +23,6 @@ module SmartAnswer::Calculators
       'guinea' => 'ghana'
     }
 
-    RETAIN_PASSPORT_COUNTRIES_HURRICANES = %w(anguilla antigua-and-barbuda bahamas bermuda bonaire-st-eustatius-saba british-virgin-islands cayman-islands curacao dominica dominican-republic french-guiana grenada guadeloupe guyana haiti martinique mexico montserrat st-maarten st-kitts-and-nevis st-lucia st-pierre-and-miquelon st-vincent-and-the-grenadines suriname trinidad-and-tobago turks-and-caicos-islands)
-
     PASSPORT_COSTS = {
       'Australian Dollars'  => [[282.21], [325.81], [205.81]],
       'Euros'               => [[161, 186],   [195, 220],   [103, 128]],
@@ -45,10 +43,6 @@ module SmartAnswer::Calculators
 
     def find_passport_data(country_slug)
       passport_data[country_slug]
-    end
-
-    def retain_passport_hurricanes?(country_slug)
-      RETAIN_PASSPORT_COUNTRIES_HURRICANES.include?(country_slug)
     end
 
     def cash_only_countries?(country_slug)

--- a/lib/smart_answer_flows/locales/en/overseas-passports.yml
+++ b/lib/smart_answer_flows/locales/en/overseas-passports.yml
@@ -68,11 +68,6 @@ en-GB:
           -|-|-
           Child passport | %{costs_euros_child}
 
-        how_to_apply_retain_passport: |
-          Send a photocopy of the pages of your existing passport that show your personal details, photograph and residence permit or visa.
-
-          Keep your existing passport for security and ID purposes - don’t send it with your application.
-
         how_to_apply_retain_passport_hurricane: |
           Don’t send your passport - keep it in case you have to to evacuate in the event of a hurricane.
 
@@ -121,51 +116,6 @@ en-GB:
 
         send_application_fco_preamble: |
           Send your application, photographs and supporting documents, ideally by courier.
-
-        helpline_yemen: |
-
-
-          $C
-            **Passport information - Yemen**
-
-            967 1308 114
-            8am to-3pm local time, Sunday to Thursday
-
-             +44 207 008 1500 at any other time
-
-          $C
-
-        helpline_intro: |
-          If you haven’t received your passport within the expected timescale, you can check your application’s progress by phone. You will be charged for the call.
-
-          Don’t use this service any earlier - information won’t be available but you will still be charged for the call.
-        helpline_exceptions: |
-          If you haven’t received your passport within the expected timescales, or need to change your travel plans urgently (eg a close relative has died), you can leave a message with the passport processing centre in Madrid.
-
-          They will only call you back if your passport has been delayed or you have a genuine emergency.
-
-          $C
-
-            **Passport processing centre, Madrid**
-
-            00 34 91 714 6314
-          $C
-        helpline_exception_yemen: |
-          If you haven’t received your passport within the expected timescale, you can check your application’s progress by phone. You’ll be charged for the call.
-
-          $C
-          **Passport information - Yemen**
-
-          +44 208 082 4729
-          Monday to Friday, 24 hours a day
-          $C
-        helpline_: ''
-        helpline_fco_webchat: |
-          ### Webchat service
-
-          A webchat service is available. It costs a flat rate of £4 - you must pay by credit card before you start. Once you’ve paid, you’ll be given a reference number to launch your webchat. You’ll receive an email transcript of your conversation when you finish.
-
-          [Use the webchat service](https://www.synthetix.info/fco/ "Use the webchat service to chat to an advisor")
 
         hmpo_1_application_form: |
           ^[Application form - applying for a British passport overseas](/government/publications/applying-for-a-passport-from-outside-the-uk-application-form)^
@@ -1480,18 +1430,6 @@ en-GB:
           Pretoria 0083
           South Africa
           $A
-        helpline_pretoria_south_africa: |
-
-          $C
-            __Passport Information Helpline__
-
-            +44 208 082 4743
-
-            Calls charged at £0.72 per minute plus VAT - you must pay by credit card when you call.
-
-            Textphone: +44 1750 725 368
-          $C
-
       ips_application_result_online:
         body: |
           ## How long it takes
@@ -1537,52 +1475,6 @@ en-GB:
           %{getting_your_passport}
 
           %{contact_passport_adviceline}
-
-      result:
-        body: |
-          ## How long it takes
-
-          %{how_long_it_takes}
-
-          Don't book travel until you have a valid passport. If you need to travel urgently, you may be able to apply for an [Emergency Travel Document](/emergency-travel-document).
-
-          If your passport has been lost or stolen and you haven't reported it yet, include [form LS01](/government/publications/lost-or-stolen-passport-notification--2) with your application.
-
-          ## Cost
-
-          %{cost}
-
-          ## How to apply
-
-          1. Download the application form and guidance notes that help you fill it in.
-
-          2. Include 2 identical new photos of you (or your child, if it’s a child passport application). [Follow the rules about passport photos](/photos-for-passports) or your application may be delayed.
-
-          3. Check the supporting documents you must send with your application. Non-English supporting documents must be translated into English by a professional translator.
-          %{how_to_apply}
-
-          %{incomplete_application_deadline}
-
-          %{fco_forms}
-
-          %{supporting_documents}
-
-          ## Making your application
-
-          %{making_application}
-
-
-          +[data_partial:overseas_passports_embassies:overseas_passports_embassies]
-
-          %{making_application_additional}
-
-          ## Getting your passport
-
-          %{getting_your_passport}
-
-          ## If your passport hasn’t arrived
-
-          %{helpline}
 
       cannot_apply:
         body: |

--- a/lib/smart_answer_flows/locales/en/overseas-passports.yml
+++ b/lib/smart_answer_flows/locales/en/overseas-passports.yml
@@ -68,13 +68,6 @@ en-GB:
           -|-|-
           Child passport | %{costs_euros_child}
 
-        how_to_apply_retain_passport_hurricane: |
-          Don’t send your passport - keep it in case you have to to evacuate in the event of a hurricane.
-
-          You’ll need to send a photocopy of your passport, and a letter to explain why you’ve not sent the original.
-
-          When you get your new passport, send your old one to the [nearest British Embassy, high commission or governors office](/government/world/organisations).
-
         how_to_apply_incomplete_application_deadline: |
 
           %You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%

--- a/lib/smart_answer_flows/overseas-passports.rb
+++ b/lib/smart_answer_flows/overseas-passports.rb
@@ -137,7 +137,6 @@ module SmartAnswer
           next_node_if(:ips_application_result_online, variable_matches(:ips_result_type, :ips_application_result_online))
           next_node(:ips_application_result)
         end
-        next_node(:result)
       end
 
       # Q4
@@ -160,7 +159,6 @@ module SmartAnswer
           next_node_if(:ips_application_result_online, variable_matches(:ips_result_type, :ips_application_result_online))
           next_node(:ips_application_result)
         end
-        next_node(:result)
       end
 
       ## Online IPS Application Result
@@ -402,49 +400,6 @@ module SmartAnswer
         end
         precalculate :contact_passport_adviceline do
           PhraseList.new(:contact_passport_adviceline)
-        end
-      end
-
-      ## Generic country outcome.
-      outcome :result do
-        precalculate :how_long_it_takes do
-          PhraseList.new(:"how_long_#{application_type}")
-        end
-        precalculate :cost do
-          PhraseList.new(:"cost_#{application_type}")
-        end
-        precalculate :how_to_apply do
-          phrases = PhraseList.new(:"how_to_apply_#{application_type}")
-          if general_action == 'renewing' and data_query.retain_passport?(current_location)
-            phrases << :how_to_apply_retain_passport
-          elsif general_action == 'renewing' and data_query.retain_passport_exception?(current_location)
-            phrases << :how_to_apply_retain_passport_exception
-          end
-          phrases
-        end
-        precalculate :making_application_additional do
-          ''
-        end
-        precalculate :supporting_documents do
-          phrase = ['supporting_documents', application_type]
-          phrase << general_action if %w(iraq zambia).include?(application_type)
-          PhraseList.new(phrase.join('_').to_sym)
-        end
-        precalculate :making_application do
-          PhraseList.new(:"making_application_#{application_type}")
-        end
-        precalculate :getting_your_passport do
-          PhraseList.new(:"getting_your_passport_#{application_type}")
-        end
-        precalculate :helpline do
-          phrases = PhraseList.new
-          if %w(cuba libya morocco tunisia).include?(current_location)
-            phrases << :helpline_exceptions
-          else
-            phrases << :helpline_intro << :"helpline_#{passport_data['helpline']}"
-          end
-          phrases << :helpline_fco_webchat
-          phrases
         end
       end
 

--- a/test/unit/calculators/passport_and_embassy_data_query_test.rb
+++ b/test/unit/calculators/passport_and_embassy_data_query_test.rb
@@ -21,13 +21,6 @@ module SmartAnswer::Calculators
         end
       end
 
-      context "retain_passport?" do
-        should "indicate whether to retain your passport when applying from the given country" do
-          assert @query.retain_passport?('angola')
-          refute @query.retain_passport?('france')
-        end
-      end
-
       context "passport_costs" do
         should "format passport costs" do
           %w(south_african_rand_adult_32 south_african_rand_adult_48 south_african_rand_child


### PR DESCRIPTION
There are only two questions from which it's theoretically possible to reach
the `:result` outcome:

* `:child_or_adult_passport?`
* `:country_of_birth?`

In both these questions there are a bunch of `next_node_if` statements and a
`next_node` statement inside an `on_condition` block, all followed by a final
`next_node` statement which points at the `:result` outcome.

In both cases the final `next_node` statement within the `on_condition` block
points at the `:ips_application_result` outcome i.e. not the `:result` outcome.

Thus the `:result` outcome is only reachable if the
`SmartAnswer::Calculators::PassportAndEmbassyDataQuery#ips_application?`
predicate returns `false`.

However since `st-helena-ascension-and-tristan-da-cunha` was switched to `type:
ips_application_3` in [this commit][1] the predicate only returns `false` when the
response to the `:which_country_are_you_in?` question is one of the following:

* `syria`
  * However, in this case the `PassportAndEmbassyDataQuery#ineligible_country?`
  predicate returns `true` for a response of "syria" and the user is taken
  immediately to the `:cannot_apply` outcome.
* `the-occupied-palestinian-territories`
  * However, in this case the user is subsequently asked to choose either
  `gaza` or `jerusalem-or-westbank` and either of these responses cause the
  `PassportAndEmbassyDataQuery#ips_application?` to return `true`.
* `united-kingdom`
  * However, in this case this response is not included in the
  `:which_country_are_you_in?` question's country select list (it is not
  included in such questions by default; only if the `:include_uk` option is
  set to `true`). So it wouldn't be possible for a user to give this response
  in production without hacking the URL.

Thus I'm pretty convinced the `:result` outcome is unreachable given the
current logic and data. Obviously if the data changed, it might be possible
for the outcome to become reachable again, but I don't think the overhead of
keeping all this code hanging around is justified.

I've elected to remove the two `next_node(:result)` statements which (although
perhaps slightly controversial) should mean we will see a `RuntimeError`
exception with the message "Next node undefined" if none of the other
conditions are satisfied by a response from the user.

I've also tried to remove as much code, content & data which the removal of
the outcome has rendered redundant.

[1]: 3a86b8ecd1c4686885dcbd9466da43f504999df9