### PR TITLE
SPIKE: Add GA virtual pageview to outcome pages

### DIFF
--- a/app/views/smart_answers/_result.html.erb
+++ b/app/views/smart_answers/_result.html.erb
@@ -22,5 +22,7 @@
 </div>
 
 <script type="text/javascript">
-  GOVUK.analytics.trackPageview('/outcome' + window.location.pathname);
+  var flowName = '<%= @name %>';
+  var outcomeName = '<%= @presenter.current_node.name %>';
+  GOVUK.analytics.trackPageview('/' + flowName + '/outcome-reached/' + outcomeName);
 </script>

--- a/app/views/smart_answers/_result.html.erb
+++ b/app/views/smart_answers/_result.html.erb
@@ -20,3 +20,7 @@
     <% end %>
   </article>
 </div>
+
+<script type="text/javascript">
+  GOVUK.analytics.trackPageview('/outcome' + window.location.pathname);
+</script>


### PR DESCRIPTION
This results in us recording two page views for the outcome pages.

Assuming the following outcome URL:

/marriage-abroad/y/afghanistan/uk/uk_england/partner_british/opposite_sex

We'll record the following two page views in GA:

/marriage-abroad/y/afghanistan/uk/uk_england/partner_british/opposite_sex
/outcome/marriage-abroad/y/afghanistan/uk/uk_england/partner_british/opposite_sex

This commit is intended to be used to start a discussion about this approach.