### PR TITLE
Remove unused outcomes from inherits someone dies without will

### DIFF
--- a/lib/smart_answer_flows/inherits-someone-dies-without-will.rb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will.rb
@@ -167,10 +167,6 @@ module SmartAnswer
           end
         end
         on_condition(variable_matches(:region, 'northern-ireland')) do
-          on_condition(variable_matches(:partner, 'yes')) do
-            next_node_if(:outcome_64, responded_with('yes'))
-            next_node_if(:outcome_65, responded_with('no'))
-          end
           on_condition(variable_matches(:partner, 'no')) do
             next_node_if(:outcome_4, responded_with('yes'))
             next_node_if(:grandparents?, responded_with('no'))

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will.rb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will.rb
@@ -111,10 +111,6 @@ module SmartAnswer
         save_input_as :parents
 
         on_condition(variable_matches(:region, 'england-and-wales')) do
-          on_condition(variable_matches(:partner, 'yes')) do
-            next_node_if(:outcome_21, responded_with('yes'))
-            next_node_if(:siblings?, responded_with('no'))
-          end
           on_condition(variable_matches(:partner, 'no')) do
             next_node_if(:outcome_3, responded_with('yes'))
             next_node_if(:siblings?, responded_with('no'))
@@ -143,10 +139,6 @@ module SmartAnswer
         save_input_as :siblings
 
         on_condition(variable_matches(:region, 'england-and-wales')) do
-          on_condition(variable_matches(:partner, 'yes')) do
-            next_node_if(:outcome_22, responded_with('yes'))
-            next_node_if(:outcome_1, responded_with('no'))
-          end
           on_condition(variable_matches(:partner, 'no')) do
             next_node_if(:outcome_4, responded_with('yes'))
             next_node_if(:half_siblings?, responded_with('no'))
@@ -291,8 +283,6 @@ module SmartAnswer
       outcome :outcome_6
 
       outcome :outcome_20
-      outcome :outcome_21
-      outcome :outcome_22
       outcome :outcome_23
       outcome :outcome_24
 

--- a/lib/smart_answer_flows/locales/en/inherits-someone-dies-without-will.yml
+++ b/lib/smart_answer_flows/locales/en/inherits-someone-dies-without-will.yml
@@ -140,29 +140,6 @@ en-GB:
         next_steps: |
           %{next_step_links}
 
-      outcome_21:
-        title: The husband, wife or civil partner keeps all the assets (including property) up to £450,000, and all the personal possessions, whatever their value.
-        body: |
-          They also get half of the amount left over.
-
-          The remainder goes to the parent or parents.
-
-          If a son or daughter has already died, their children will inherit in their place.
-        next_steps: |
-          %{next_step_links}
-
-      outcome_22:
-        title: The husband, wife or civil partner keeps all the assets (including property) up to £450,000, and all the personal possessions, whatever their value.
-        body: |
-          They also get half the amount left over.
-
-          The remainder is divided between the surviving siblings.
-
-          If a brother or sister has already died, their children (nieces and nephews of the deceased) inherit in their place.
-
-        next_steps: |
-          %{next_step_links}
-
       outcome_23:
         title: The estate is shared equally between the half-brothers or half-sisters.
         body: |


### PR DESCRIPTION
I discovered this unused code when adding regression tests for inherits-someone-dies-without-will.

I need to remove these unused outcomes before I can merge the regression tests as I currently get a failing test because not all nodes are being exercised.
