### PR TITLE
Customise Kuwait outcomes for local residents

### DIFF
--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -146,6 +146,8 @@ en-GB:
 # payment methods
         payment_methods_japan: |
           You can pay by credit card, but not by personal cheque. The embassy in Tokyo will also accept cash.
+        pay_by_card_no_amex_no_cheque: |
+          You can pay by cash or credit card (except American Express), but not by personal cheque.
         pay_by_cash_or_credit_card_no_cheque: |
           You can pay by cash or credit card, but not by personal cheque.
         pay_by_cash_or_us_dollars_only: |
@@ -295,6 +297,8 @@ en-GB:
           Your partner will probably need to get an equivalent document from their national authorities.
         partner_declaration: |
           ^Your partner will need to make a declaration as well.^
+        check_with_notary_public_if_you_need_cni: |
+          You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry. Contact the local notary public to check if you need a CNI.
         what_to_do_croatia: |
           You may be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
 

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -648,6 +648,8 @@ module SmartAnswer
 
           if ceremony_and_residency_in_croatia
             phrases << :what_to_do_croatia
+          elsif ceremony_country == 'kuwait' && resident_of != 'uk'
+            phrases << :check_with_notary_public_if_you_need_cni
           elsif ceremony_country == 'jordan'
             phrases << :consular_cni_os_foreign_resident_21_days_jordan
           elsif data_query.os_21_days_residency_required_countries?(ceremony_country)
@@ -874,7 +876,9 @@ module SmartAnswer
               phrases << :consular_cni_os_fees_russia
             elsif ceremony_country == 'finland'
               phrases << :pay_in_euros_or_visa_electron
-            elsif !%w(cote-d-ivoire burundi).include? ceremony_country
+            elsif ceremony_country == 'kuwait'
+              phrases << :pay_by_card_no_amex_no_cheque
+            elsif %w(cote-d-ivoire burundi).exclude?(ceremony_country)
               phrases << :pay_by_cash_or_credit_card_no_cheque
             end
           end

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -1,7 +1,7 @@
 --- 
-lib/smart_answer_flows/marriage-abroad.rb: 6e4cad3fb44e8db0aea936e4d4cbc4b5
-lib/smart_answer_flows/locales/en/marriage-abroad.yml: ee9f5714b02a019a13a2acb9719a93f5
-test/data/marriage-abroad-questions-and-responses.yml: 587c31f6050c0bdc1ca5b51eb8aaefb9
+lib/smart_answer_flows/marriage-abroad.rb: 9202c3fdd8e4edff60054f8192732244
+lib/smart_answer_flows/locales/en/marriage-abroad.yml: ac88980dfc897149f7d6ccd3d81765cf
+test/data/marriage-abroad-questions-and-responses.yml: 202693ceb110a9851b8d269c6bf77c1f
 test/data/marriage-abroad-responses-and-expected-results.yml: 9f3ca67c58dae770c65e174899f5d80b
 lib/smart_answer/calculators/marriage_abroad_data_query.rb: 4ed1f9632c270531ef76fe8bb00b7942
 lib/smart_answer/calculators/country_name_formatter.rb: 0cb274748f0daf3965451b6230c183fd

--- a/test/data/marriage-abroad-questions-and-responses.yml
+++ b/test/data/marriage-abroad-questions-and-responses.yml
@@ -47,6 +47,7 @@
 - jordan
 - kazakhstan
 - kosovo
+- kuwait
 - laos
 - latvia
 - lebanon


### PR DESCRIPTION
1) American express cards are not accepted for payments
2) Users must check with Notary public if they need a CNI (not an embassy)