### PR TITLE
Customise Montenegro outcomes

### DIFF
--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -1526,6 +1526,8 @@ en-GB:
               [Make an appointment at the embassy in Chisinau.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-chisinau/notice-of-marriage-or-civil-partnership/slot_picker)
             mongolia: |
               [Make an appointment at the embassy in Manila.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-manila/oaths-affirmations-and-affidavits/slot_picker)
+            montenegro: |
+              [Make an appointment at the embassy in Podgorica.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-podgorica/notice-of-marriage-or-civil-partnership/slot_picker)
             nepal: |
               [Make an appointment at the embassy in Kathmandu.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-kathmandu/notice-of-marriage-or-civil-partnership/slot_picker)
             norway: |
@@ -1573,9 +1575,11 @@ en-GB:
               [Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
             colombia: |
               [Make an appointment at the British embassy in Colombia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/notice-of-marriage-or-civil-partnership/slot_picker)
+            montenegro: |
+              [Make an appointment at the embassy in Podgorica.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-podgorica/notice-of-marriage-or-civil-partnership/slot_picker)
             norway: |
               [Make an appointment at the embassy in Oslo.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker)
-
+            
 # Q1
       country_of_ceremony?:
         title: Where do you want to get married?

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -651,7 +651,7 @@ module SmartAnswer
 
           if ceremony_and_residency_in_croatia
             phrases << :what_to_do_croatia
-          elsif ceremony_country == 'kuwait' && resident_of != 'uk'
+          elsif %w(montenegro kuwait).include?(ceremony_country) && resident_of != 'uk'
             phrases << :check_with_notary_public_if_you_need_cni
           elsif ceremony_country == 'jordan'
             phrases << :consular_cni_os_foreign_resident_21_days_jordan

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -1,6 +1,6 @@
 --- 
-lib/smart_answer_flows/marriage-abroad.rb: c6f5049b36441fd6d9a09309437657e8
-lib/smart_answer_flows/locales/en/marriage-abroad.yml: 4799733908d0b9d0ce97e94f9b03e041
+lib/smart_answer_flows/marriage-abroad.rb: cc615b317856ea5af3d9b0b7dc768251
+lib/smart_answer_flows/locales/en/marriage-abroad.yml: a879b5dff5cb671e4a7afb0c6aca69b6
 test/data/marriage-abroad-questions-and-responses.yml: 202693ceb110a9851b8d269c6bf77c1f
 test/data/marriage-abroad-responses-and-expected-results.yml: 9f3ca67c58dae770c65e174899f5d80b
 lib/smart_answer/calculators/marriage_abroad_data_query.rb: 4ed1f9632c270531ef76fe8bb00b7942

--- a/test/integration/smart_answer_flows/marriage_abroad_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_test.rb
@@ -2494,6 +2494,26 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
   end
 
+  context "Montenegro" do
+    setup do
+      worldwide_api_has_organisations_for_location('montenegro', read_fixture_file('worldwide/montenegro_organisations.json'))
+      add_response 'montenegro'
+      add_response 'ceremony_country'
+    end
+
+    should "lead to outcome_ss_marriage when both partners are same sex british" do
+      add_response 'partner_british'
+      add_response 'same_sex'
+      assert_current_node :outcome_ss_marriage
+    end
+
+    should "lead to outcome_ss_marriage_not_possible when both partners are same sex not british" do
+      add_response 'partner_local'
+      add_response 'same_sex'
+      assert_current_node :outcome_ss_marriage_not_possible
+    end
+  end
+
   context "Saint-Barthélemy" do
     setup do
       worldwide_api_has_no_organisations_for_location('st-martin')
@@ -2564,7 +2584,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
         worldwide_api_has_no_organisations_for_location(country)
         add_response country
         add_response 'ceremony_country'
-        add_response 'partner_local'
+        add_response 'partner_british'
         add_response 'same_sex'
 
         assert current_state.current_node.to_s.include?('outcome'), "Expected to have reached an outcome node, but is at #{current_state.current_node}"


### PR DESCRIPTION
1) Advise users to check with Notary Public if they need a CNI.
   This is to avoid users contacting embassy, as they can't help
2) Add appointment booking link to OS outcomes
3) Add appointment booking link for SS outcomes where both partners
   are british