### PR TITLE
Add appointment booking links for some Affirmation countries

### DIFF
--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -1527,6 +1527,8 @@ en-GB:
               [Make an appointment at the embassy in Vientiane.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-kinshasa/notice-of-marriage-or-civil-partnership/slot_picker)
             latvia: |
               [Make an appointment at the embassy in Riga.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-riga/notice-of-marriage-or-civil-partnership/slot_picker)
+            lebanon: |
+              [Make an appointment at the embassy in Beirut.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beirut/oaths-affirmations-and-affidavits/slot_picker)
             lithuania: |
               [Make an appointment at the embassy in Vilnius.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-vilnius/notice-of-marriage-or-civil-partnership/slot_picker)
             luxembourg: |
@@ -1539,12 +1541,18 @@ en-GB:
               [Make an appointment at the embassy in Manila.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-manila/oaths-affirmations-and-affidavits/slot_picker)
             montenegro: |
               [Make an appointment at the embassy in Podgorica.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-podgorica/notice-of-marriage-or-civil-partnership/slot_picker)
+            morocco: |
+              [Make an appointment at the embassy in Rabat.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rabat/oaths-affirmations-and-affidavits/slot_picker)
             nepal: |
               [Make an appointment at the embassy in Kathmandu.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-kathmandu/notice-of-marriage-or-civil-partnership/slot_picker)
             norway: |
               [Make an appointment at the embassy in Oslo.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker)
             panama: |
               [Make an appointment at the embassy in Panama City.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-panama-city/notice-of-marriage-or-civil-partnership/slot_picker)
+            philippines: |
+              [Make an appointment at the embassy in Manila.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-manila/oaths-affirmations-and-affidavits/slot_picker)
+            peru: |
+              [Make an appointment at the embassy in Lima.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/oaths-affirmations-and-affidavits/slot_picker)
             poland: |
               [Make an appointment at the embassy in Warsaw.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-warsaw/notice-of-marriage-or-civil-partnership/slot_picker)
             romania: |
@@ -1559,8 +1567,18 @@ en-GB:
               [Make an appointment at the embassy in Khartoum.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-khartoum/notice-of-marriage-or-civil-partnership/slot_picker)
             tajikistan: |
               [Make an appointment at the embassy in Dushanbe.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-dushanbe/notice-of-marriage-or-civil-partnership/slot_picker)
+            thailand: |
+              [Make an appointment at the embassy in Bangkok.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bangkok/oaths-affirmations-and-affidavits/slot_picker)
             tunisia: |
               [Make an appointment at the embassy in Tunis.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/notice-of-marriage-or-civil-partnership/slot_picker)
+            turkey: |
+              [Make an appointment at the British Consulate General in Istanbul](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-istanbul/oaths-affirmations-and-affidavits/slot_picker)
+
+              [Make an appointment at the embassy in Ankara](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ankara/oaths-affirmations-and-affidavits/slot_picker)
+
+              [Make an appointment at the consulate in Izmir](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-izmir/oaths-affirmations-and-affidavits/slot_picker)
+
+              [Make an appointment at the consulate in Antalya](https://www.consular-appointments.service.gov.uk/fco/#!/british-vice-consulate-antalya/oaths-affirmations-and-affidavits/slot_picker)
             turkmenistan: |
               [Make an appointment at the embassy in Ashgabat.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ashgabat/notice-of-marriage-or-civil-partnership/slot_picker)
             uzbekistan: |

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -1,6 +1,6 @@
 --- 
 lib/smart_answer_flows/marriage-abroad.rb: 9d72a87e15f3b92a438030ed6488b26f
-lib/smart_answer_flows/locales/en/marriage-abroad.yml: fa61c8fd4d4b66b252e43f1f4fdd725c
+lib/smart_answer_flows/locales/en/marriage-abroad.yml: db8340748784f728539442fe8c98fbd2
 test/data/marriage-abroad-questions-and-responses.yml: 202693ceb110a9851b8d269c6bf77c1f
 test/data/marriage-abroad-responses-and-expected-results.yml: 9f3ca67c58dae770c65e174899f5d80b
 lib/smart_answer/calculators/marriage_abroad_data_query.rb: 4ed1f9632c270531ef76fe8bb00b7942

--- a/test/integration/smart_answer_flows/marriage_abroad_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_test.rb
@@ -837,7 +837,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "go to os affirmation outcome" do
       assert_current_node :outcome_os_affirmation
-      assert_phrase_list :affirmation_os_outcome, [:contact_embassy_of_ceremony_country_in_uk_marriage, :get_legal_and_travel_advice, :what_you_need_to_do_affirmation, :appointment_for_affidavit, :embassies_data, :legalisation_and_translation, :affirmation_os_translation_in_local_language_text, :docs_decree_and_death_certificate, :divorced_or_widowed_evidences, :change_of_name_evidence, :callout_partner_equivalent_document, :partner_naturalisation_in_uk, :fee_table_affidavit_55, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+      assert_phrase_list :affirmation_os_outcome, [:contact_embassy_of_ceremony_country_in_uk_marriage, :get_legal_and_travel_advice, :what_you_need_to_do_affirmation, :appointment_for_affidavit, "appointment_links.opposite_sex.thailand", :legalisation_and_translation, :affirmation_os_translation_in_local_language_text, :docs_decree_and_death_certificate, :divorced_or_widowed_evidences, :change_of_name_evidence, :callout_partner_equivalent_document, :partner_naturalisation_in_uk, :fee_table_affidavit_55, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
     end
   end
 
@@ -880,7 +880,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "go to os affirmation outcome" do
       assert_current_node :outcome_os_affirmation
-      assert_phrase_list :affirmation_os_outcome, [:contact_local_authorities_in_country_marriage, :get_legal_and_travel_advice, :what_you_need_to_do_affirmation, :appointment_for_affidavit, :embassies_data, :legalisation_and_translation, :affirmation_os_translation_in_local_language_text, :docs_decree_and_death_certificate, :divorced_or_widowed_evidences, :change_of_name_evidence, :callout_partner_equivalent_document, :partner_naturalisation_in_uk, :affirmation_os_all_fees_45_70, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+      assert_phrase_list :affirmation_os_outcome, [:contact_local_authorities_in_country_marriage, :get_legal_and_travel_advice, :what_you_need_to_do_affirmation, :appointment_for_affidavit, "appointment_links.opposite_sex.lebanon", :legalisation_and_translation, :affirmation_os_translation_in_local_language_text, :docs_decree_and_death_certificate, :divorced_or_widowed_evidences, :change_of_name_evidence, :callout_partner_equivalent_document, :partner_naturalisation_in_uk, :affirmation_os_all_fees_45_70, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
     end
   end
 
@@ -937,7 +937,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "go to os affirmation outcome" do
       assert_current_node :outcome_os_affirmation
-      assert_phrase_list :affirmation_os_outcome, [:contact_local_authorities_in_country_marriage, :get_legal_advice, :what_you_need_to_do, :appointment_for_affidavit, :embassies_data, :complete_affidavit, :download_affidavit, :affirmation_os_legalised_in_turkey, :documents_for_divorced_or_widowed, :callout_partner_equivalent_document, :check_legalised_document, :fee_table_affidavit_55, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+      assert_phrase_list :affirmation_os_outcome, [:contact_local_authorities_in_country_marriage, :get_legal_advice, :what_you_need_to_do, :appointment_for_affidavit, "appointment_links.opposite_sex.turkey", :complete_affidavit, :download_affidavit, :affirmation_os_legalised_in_turkey, :documents_for_divorced_or_widowed, :callout_partner_equivalent_document, :check_legalised_document, :fee_table_affidavit_55, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
     end
   end
 
@@ -1855,7 +1855,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
       add_response 'opposite_sex'
     end
     should "go to os affirmation outcome" do
-      assert_phrase_list :affirmation_os_outcome, [:contact_embassy_of_ceremony_country_in_uk_marriage, :get_legal_and_travel_advice, :what_you_need_to_do_affirmation, :contact_for_affidavit, :embassies_data, :legalisation_and_translation, :affirmation_os_translation_in_local_language_text, :affirmation_os_download_affidavit_philippines, :docs_decree_and_death_certificate, :divorced_or_widowed_evidences, :change_of_name_evidence, :callout_partner_equivalent_document, :partner_naturalisation_in_uk, :fee_table_55_70, :list_of_consular_fees, :pay_in_cash_or_manager_cheque]
+      assert_phrase_list :affirmation_os_outcome, [:contact_embassy_of_ceremony_country_in_uk_marriage, :get_legal_and_travel_advice, :what_you_need_to_do_affirmation, :contact_for_affidavit, "appointment_links.opposite_sex.philippines", :legalisation_and_translation, :affirmation_os_translation_in_local_language_text, :affirmation_os_download_affidavit_philippines, :docs_decree_and_death_certificate, :divorced_or_widowed_evidences, :change_of_name_evidence, :callout_partner_equivalent_document, :partner_naturalisation_in_uk, :fee_table_55_70, :list_of_consular_fees, :pay_in_cash_or_manager_cheque]
     end
   end
 
@@ -2122,7 +2122,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "go to os affirmation outcome" do
       assert_current_node :outcome_os_affirmation
-      assert_phrase_list :affirmation_os_outcome, [:contact_embassy_of_ceremony_country_in_uk_marriage, :contact_laadoul, :get_legal_and_travel_advice, :what_you_need_to_do_affirmation, :appointment_for_affidavit, :embassies_data, :legalisation_and_translation, :affirmation_os_translation_in_local_language_text, :documents_for_divorced_or_widowed, :morocco_affidavit_length, :partner_equivalent_document, :fee_table_affirmation_55, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+      assert_phrase_list :affirmation_os_outcome, [:contact_embassy_of_ceremony_country_in_uk_marriage, :contact_laadoul, :get_legal_and_travel_advice, :what_you_need_to_do_affirmation, :appointment_for_affidavit, "appointment_links.opposite_sex.morocco", :legalisation_and_translation, :affirmation_os_translation_in_local_language_text, :documents_for_divorced_or_widowed, :morocco_affidavit_length, :partner_equivalent_document, :fee_table_affirmation_55, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
     end
   end
 
@@ -2136,7 +2136,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "go to os affirmation outcome" do
       assert_current_node :outcome_os_affirmation
-      assert_phrase_list :affirmation_os_outcome, [:contact_local_authorities_in_country_marriage, :contact_laadoul, :get_legal_and_travel_advice, :what_you_need_to_do_affirmation, :appointment_for_affidavit, :embassies_data, :legalisation_and_translation, :affirmation_os_translation_in_local_language_text, :documents_for_divorced_or_widowed, :morocco_affidavit_length, :partner_equivalent_document, :fee_table_affirmation_55, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+      assert_phrase_list :affirmation_os_outcome, [:contact_local_authorities_in_country_marriage, :contact_laadoul, :get_legal_and_travel_advice, :what_you_need_to_do_affirmation, :appointment_for_affidavit, "appointment_links.opposite_sex.morocco", :legalisation_and_translation, :affirmation_os_translation_in_local_language_text, :documents_for_divorced_or_widowed, :morocco_affidavit_length, :partner_equivalent_document, :fee_table_affirmation_55, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
     end
   end
 


### PR DESCRIPTION
Very much like with the CNI countries, appointment booking links
(where available) replace embassy addresses, thus reducing communication
overhead for people working there.

Alongside the modified existing tests, there is [this test](https://github.com/alphagov/smart-answers/blob/1932c3352f492a204900ff5ba468ec832a606b2d/test/integration/smart_answer_flows/marriage_abroad_test.rb#L2545-L2559) that makes sure all countries that have appointment links have them rendered in the outcome.