### PR TITLE
Remove unused code from energy grants calculator

### DIFF
--- a/lib/smart_answer_flows/energy-grants-calculator.rb
+++ b/lib/smart_answer_flows/energy-grants-calculator.rb
@@ -46,20 +46,12 @@ module SmartAnswer
           []
         end
 
-        define_predicate(:measure?) {
-          %w(help_energy_efficiency help_boiler_measure).include?(which_help)
-        }
-
         validate(:error_perm_prop_house) { |r| ! r.include?('permission,property,social_housing') }
         validate(:error_prop_house) { |r| ! r.include?('property,social_housing') }
         validate(:error_perm_prop) { |r| ! r.include?('permission,property') }
         validate(:error_perm_house) { |r| ! r.include?('permission,social_housing')}
 
-        next_node_if(:date_of_birth?) { bills_help || both_help } # Q3
-        on_condition(measure?) do
-          next_node_if(:which_benefits?, responded_with("benefits"))
-          next_node :when_property_built?
-        end
+        next_node(:date_of_birth?) # Q3
       end
 
       # Q2A

--- a/lib/smart_answer_flows/energy-grants-calculator.rb
+++ b/lib/smart_answer_flows/energy-grants-calculator.rb
@@ -373,39 +373,6 @@ module SmartAnswer
         end
       end
 
-      outcome :outcome_measures_help_and_eco_eligible do
-        precalculate :title_end do
-          if (measure_help && both_help) || measure_help && (circumstances & %w(property permission)).any? and ((benefits_claimed & %w(child_tax_credit esa pension_credit)).any? or incomesupp_jobseekers_1 or incomesupp_jobseekers_2)
-            PhraseList.new(:title_energy_supplier)
-          else
-            PhraseList.new(:title_under_green_deal)
-          end
-        end
-        precalculate :eligibilities do
-          phrases = PhraseList.new
-          phrases << :header_boilers_and_insulation
-          if measure_help || both_help
-            if (circumstances & %w(property permission)).any? and ((benefits_claimed & %w(child_tax_credit esa pension_credit)).any? or incomesupp_jobseekers_1 or incomesupp_jobseekers_2)
-              phrases << :opt_condensing_boiler unless (features & %w(modern_boiler)).any?
-              phrases << :opt_cavity_wall_insulation unless (features & %w(cavity_wall_insulation mains_gas)).any?
-              unless (features & %w(mains_gas solid_wall_insulation)).any? or ((features & %w(loft)).any? and (features & %w(cavity_wall_insulation solid_wall_insulation)).any?)
-                phrases << :opt_solid_wall_insulation
-              end
-              phrases << :opt_draught_proofing unless (features & %w(draught_proofing mains_gas)).any?
-              phrases << :opt_loft_roof_insulation unless (features & %w(loft_insulation loft_attic_conversion)).any? || property_type == 'flat'
-              phrases << :opt_room_roof_insulation if (features & %w(loft_attic_conversion)).any? || property_type == 'flat' || flat_type != "top_floor"
-              phrases << :opt_under_floor_insulation unless modern || flat_type != "top_floor"
-              phrases << :opt_eco_affordable_warmth << :opt_eco_help << :header_heating << :opt_better_heating_controls
-              (phrases << :opt_heat_pump << :opt_biomass_boilers_heaters << :opt_solar_water_heating) unless (features & %w(mains_gas)).any?
-              (phrases << :header_windows_and_doors << :opt_replacement_glazing) unless (features & %w(modern_double_glazing)).any?
-              phrases << :opt_renewal_heat
-            end
-          end
-          phrases << :help_and_advice << :help_and_advice_body
-          phrases
-        end
-      end
-
       outcome :outcome_measures_help_green_deal do
         precalculate :title_end do
           if measure_help

--- a/lib/smart_answer_flows/energy-grants-calculator.rb
+++ b/lib/smart_answer_flows/energy-grants-calculator.rb
@@ -424,18 +424,13 @@ module SmartAnswer
         precalculate :eligibilities_bills do
           phrases = PhraseList.new
           if both_help
-            if circumstances.include?('benefits')
-              phrases << :winter_fuel_payments if age_variant == :winter_fuel_payment
-              if (benefits_claimed & %w(esa pension_credit)).any? || incomesupp_jobseekers_1
-                phrases << :warm_home_discount if benefits_claimed.include?('pension_credit')
-                phrases << :cold_weather_payment
-              end
-              if (benefits_claimed & %w(esa child_tax_credit pension_credit)).any? || incomesupp_jobseekers_1 || incomesupp_jobseekers_2 || benefits_claimed.include?('working_tax_credit') && age_variant == :over_60
-                phrases << :energy_company_obligation
-              end
-            else
-              (phrases << :winter_fuel_payments << :cold_weather_payment) if age_variant == :winter_fuel_payment
-              phrases << :smartmeters
+            phrases << :winter_fuel_payments if age_variant == :winter_fuel_payment
+            if (benefits_claimed & %w(esa pension_credit)).any? || incomesupp_jobseekers_1
+              phrases << :warm_home_discount if benefits_claimed.include?('pension_credit')
+              phrases << :cold_weather_payment
+            end
+            if (benefits_claimed & %w(esa child_tax_credit pension_credit)).any? || incomesupp_jobseekers_1 || incomesupp_jobseekers_2 || benefits_claimed.include?('working_tax_credit') && age_variant == :over_60
+              phrases << :energy_company_obligation
             end
           end
           phrases

--- a/lib/smart_answer_flows/energy-grants-calculator.rb
+++ b/lib/smart_answer_flows/energy-grants-calculator.rb
@@ -468,18 +468,13 @@ module SmartAnswer
         precalculate :eligibilities_bills do
           phrases = PhraseList.new
           if both_help
-            if circumstances.include?('benefits')
-              phrases << :winter_fuel_payments if age_variant == :winter_fuel_payment
-              if (benefits_claimed & %w(esa pension_credit)).any? || incomesupp_jobseekers_1
-                phrases << :warm_home_discount if benefits_claimed.include?('pension_credit')
-                phrases << :cold_weather_payment
-              end
-              if (benefits_claimed & %w(esa child_tax_credit pension_credit)).any? || incomesupp_jobseekers_1 || incomesupp_jobseekers_2 || benefits_claimed.include?('working_tax_credit') && age_variant == :over_60
-                phrases << :energy_company_obligation
-              end
-            else
-              (phrases << :winter_fuel_payments << :cold_weather_payment) if age_variant == :winter_fuel_payment
-              phrases << :smartmeters
+            phrases << :winter_fuel_payments if age_variant == :winter_fuel_payment
+            if (benefits_claimed & %w(esa pension_credit)).any? || incomesupp_jobseekers_1
+              phrases << :warm_home_discount if benefits_claimed.include?('pension_credit')
+              phrases << :cold_weather_payment
+            end
+            if (benefits_claimed & %w(esa child_tax_credit pension_credit)).any? || incomesupp_jobseekers_1 || incomesupp_jobseekers_2 || benefits_claimed.include?('working_tax_credit') && age_variant == :over_60
+              phrases << :energy_company_obligation
             end
           end
           phrases

--- a/lib/smart_answer_flows/energy-grants-calculator.rb
+++ b/lib/smart_answer_flows/energy-grants-calculator.rb
@@ -232,10 +232,6 @@ module SmartAnswer
           measure_help && (circumstances & %w(property permission)).any?
         end
 
-        define_predicate(:benefits_or_income_support?) do
-          (benefits_claimed & %w(child_tax_credit esa pension_credit)).any? or incomesupp_jobseekers_1 or incomesupp_jobseekers_2
-        end
-
         define_predicate(:no_benefits?) { circumstances.exclude?('benefits') }
 
         define_predicate(:property_permission_circumstance_and_benefits?) do
@@ -244,7 +240,6 @@ module SmartAnswer
 
         next_node_if(:outcome_no_green_deal_no_energy_measures, modern_and_gas_and_electric_heating?)
         on_condition(measure_help_and_property_permission_circumstance?) do
-          next_node_if(:outcome_measures_help_and_eco_eligible, benefits_or_income_support?)
           next_node(:outcome_measures_help_green_deal)
         end
         next_node_if(:outcome_bills_and_measures_no_benefits, no_benefits?)
@@ -271,10 +266,6 @@ module SmartAnswer
           measure_help && (circumstances & %w(property permission)).any?
         end
 
-        define_predicate(:benefits_or_income_support?) do
-          (benefits_claimed & %w(child_tax_credit esa pension_credit)).any? or incomesupp_jobseekers_1 or incomesupp_jobseekers_2
-        end
-
         define_predicate(:no_benefits?) { circumstances.exclude?('benefits') }
 
         define_predicate(:property_permission_circumstance_and_benefits?) do
@@ -282,7 +273,6 @@ module SmartAnswer
         end
 
         on_condition(measure_help_and_property_permission_circumstance?) do
-          next_node_if(:outcome_measures_help_and_eco_eligible, benefits_or_income_support?)
           next_node(:outcome_measures_help_green_deal)
         end
         next_node_if(:outcome_bills_and_measures_no_benefits, no_benefits?)
@@ -310,10 +300,6 @@ module SmartAnswer
           measure_help && (circumstances & %w(property permission)).any?
         end
 
-        define_predicate(:benefits_or_income_support?) do
-          (benefits_claimed & %w(child_tax_credit esa pension_credit)).any? or incomesupp_jobseekers_1 or incomesupp_jobseekers_2
-        end
-
         define_predicate(:no_benefits?) { circumstances.exclude?('benefits') }
 
         define_predicate(:property_permission_circumstance_and_benefits?) do
@@ -321,7 +307,6 @@ module SmartAnswer
         end
 
         on_condition(measure_help_and_property_permission_circumstance?) do
-          next_node_if(:outcome_measures_help_and_eco_eligible, benefits_or_income_support?)
           next_node(:outcome_measures_help_green_deal)
         end
         next_node_if(:outcome_bills_and_measures_no_benefits, no_benefits?)

--- a/lib/smart_answer_flows/energy-grants-calculator.rb
+++ b/lib/smart_answer_flows/energy-grants-calculator.rb
@@ -74,7 +74,7 @@ module SmartAnswer
           %w(help_energy_efficiency help_boiler_measure).include?(which_help)
         }
 
-        next_node_if(:date_of_birth?) { bills_help || both_help }
+        next_node_if(:date_of_birth?) { both_help }
         on_condition(measure?) do
           next_node_if(:which_benefits?, responded_with("benefits"))
           next_node :when_property_built?

--- a/lib/smart_answer_flows/energy-grants-calculator.rb
+++ b/lib/smart_answer_flows/energy-grants-calculator.rb
@@ -24,11 +24,7 @@ module SmartAnswer
         end
 
         calculate :warm_home_discount_amount do
-          if Date.today < Date.civil(2014, 4, 6)
-            135
-          else
-            ''
-          end
+          ''
         end
 
         next_node_if(:what_are_your_circumstances?, responded_with("help_with_fuel_bill")) # Q2

--- a/lib/smart_answer_flows/energy-grants-calculator.rb
+++ b/lib/smart_answer_flows/energy-grants-calculator.rb
@@ -386,19 +386,8 @@ module SmartAnswer
         precalculate :eligibilities_bills do
           phrases = PhraseList.new
           if both_help
-            if circumstances.include?('benefits')
-              phrases << :winter_fuel_payments if age_variant == :winter_fuel_payment
-              if (benefits_claimed & %w(esa pension_credit)).any? || incomesupp_jobseekers_1
-                phrases << :warm_home_discount if benefits_claimed.include?('pension_credit')
-                phrases << :cold_weather_payment
-              end
-              if (benefits_claimed & %w(esa child_tax_credit pension_credit)).any? || incomesupp_jobseekers_1 || incomesupp_jobseekers_2 || benefits_claimed.include?('working_tax_credit') && age_variant == :over_60
-                phrases << :energy_company_obligation
-              end
-            else
-              (phrases << :winter_fuel_payments << :cold_weather_payment) if age_variant == :winter_fuel_payment
-              phrases << :smartmeters
-            end
+            (phrases << :winter_fuel_payments << :cold_weather_payment) if age_variant == :winter_fuel_payment
+            phrases << :smartmeters
           end
           phrases
         end

--- a/lib/smart_answer_flows/energy-grants-calculator.rb
+++ b/lib/smart_answer_flows/energy-grants-calculator.rb
@@ -385,8 +385,6 @@ module SmartAnswer
         end
       end
 
-      outcome :outcome_social_housing
-
       outcome :outcome_measures_help_and_eco_eligible do
         precalculate :title_end do
           if (measure_help && both_help) || measure_help && (circumstances & %w(property permission)).any? and ((benefits_claimed & %w(child_tax_credit esa pension_credit)).any? or incomesupp_jobseekers_1 or incomesupp_jobseekers_2)

--- a/lib/smart_answer_flows/energy-grants-calculator.rb
+++ b/lib/smart_answer_flows/energy-grants-calculator.rb
@@ -360,11 +360,7 @@ module SmartAnswer
 
       outcome :outcome_measures_help_green_deal do
         precalculate :title_end do
-          if measure_help
-            PhraseList.new(:title_under_green_deal)
-          else
-            PhraseList.new(:title_energy_supplier)
-          end
+          PhraseList.new(:title_under_green_deal)
         end
         precalculate :eligibilities do
           phrases = PhraseList.new

--- a/lib/smart_answer_flows/locales/en/energy-grants-calculator.yml
+++ b/lib/smart_answer_flows/locales/en/energy-grants-calculator.yml
@@ -47,8 +47,6 @@ en-GB:
         opt_loft_roof_insulation: "- [Loft or roof insulation](http://www.energysavingtrust.org.uk/Insulation/Roof-and-loft-insulation)"
         opt_room_roof_insulation: "- Room in roof insulation"
         opt_under_floor_insulation: "- [Under-floor insulation](http://www.energysavingtrust.org.uk/Insulation/Floor-insulation)"
-        opt_eco_affordable_warmth: |
-          Find out more about [ECO Affordable Warmth](https://www.gov.uk/energy-company-obligation) or call the Energy Saving Advice Service on 0300 123 1234 to apply.
         opt_eco_help: |
           You may also be able to get some of the following improvements without having to pay all the costs up front through the Green Deal:
         opt_property_might_benefit: "Your property might also benefit from:"

--- a/lib/smart_answer_flows/locales/en/energy-grants-calculator.yml
+++ b/lib/smart_answer_flows/locales/en/energy-grants-calculator.yml
@@ -207,12 +207,6 @@ en-GB:
 
           For some of these schemes further eligibility criteria apply. These can differ depending on your supplier.
 
-# outcome 3a measures_help and eco_eligible
-      outcome_measures_help_and_eco_eligible:
-        title: %{title_end}
-        body: |
-          %{eligibilities}
-
 # outcome 3b measures_help and green_deal
       outcome_measures_help_green_deal:
         title: %{title_end}

--- a/lib/smart_answer_flows/locales/en/energy-grants-calculator.yml
+++ b/lib/smart_answer_flows/locales/en/energy-grants-calculator.yml
@@ -207,12 +207,6 @@ en-GB:
 
           For some of these schemes further eligibility criteria apply. These can differ depending on your supplier.
 
-# outcome 2 social housing
-      outcome_social_housing:
-        title: Unfortunately it doesn’t look like you qualify for support.
-        body: |
-          Contact your housing provider to discuss ways your home could be made more energy efficient.
-
 # outcome 3a measures_help and eco_eligible
       outcome_measures_help_and_eco_eligible:
         title: %{title_end}


### PR DESCRIPTION
I discovered this unused code while adding regression tests for this Smart Answer.

I wanted to remove the unused outcome nodes so that I could get the regression tests to pass, and I ended up removing the rest of the code where it was obvious that it wasn't reachable.
