### PR TITLE
Change payment method for Russia

### DIFF
--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -144,6 +144,8 @@ en-GB:
         embassies_data: |
           +[data_partial:overseas_passports_embassies:overseas_passports_embassies]
 # payment methods
+        pay_by_mastercard_or_visa: |
+          You can only by MasterCard and Visa credit cards.
         payment_methods_japan: |
           You can pay by credit card, but not by personal cheque. The embassy in Tokyo will also accept cash.
         pay_by_card_no_amex_no_cheque: |
@@ -917,10 +919,6 @@ en-GB:
           Issuing any other consular letter or certificate in any other language | £70
           Administering an oath or making a declaration | £55
 
-        consular_cni_os_fees_russia: |
-          You can pay by cash or credit card in Moscow, but not by personal cheque.
-
-          You can pay by credit card only in St Petersburg and Ekaterinburg.
 # France and French Overseas Territories phrases
         fot_os_rules_similar_to_france: |
           %{country_name_uppercase_prefix} is an overseas department or territory of France. The rules and requirements for getting married there are similar to France.
@@ -1608,7 +1606,7 @@ en-GB:
               [Make an appointment at the embassy in Podgorica.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-podgorica/notice-of-marriage-or-civil-partnership/slot_picker)
             norway: |
               [Make an appointment at the embassy in Oslo.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker)
-            
+
 # Q1
       country_of_ceremony?:
         title: Where do you want to get married?

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -880,7 +880,7 @@ module SmartAnswer
             elsif ceremony_country == 'luxembourg'
               phrases << :pay_in_cash_visa_or_mastercard
             elsif ceremony_country == 'russia'
-              phrases << :consular_cni_os_fees_russia
+              phrases << :pay_by_mastercard_or_visa
             elsif ceremony_country == 'finland'
               phrases << :pay_in_euros_or_visa_electron
             elsif ceremony_country == 'kuwait'

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -1,6 +1,6 @@
 --- 
-lib/smart_answer_flows/marriage-abroad.rb: 9d72a87e15f3b92a438030ed6488b26f
-lib/smart_answer_flows/locales/en/marriage-abroad.yml: db8340748784f728539442fe8c98fbd2
+lib/smart_answer_flows/marriage-abroad.rb: 9c519d8e20a804bddcb87a19bff02a54
+lib/smart_answer_flows/locales/en/marriage-abroad.yml: f4b1e686540dccf6131bedf635e5085a
 test/data/marriage-abroad-questions-and-responses.yml: 202693ceb110a9851b8d269c6bf77c1f
 test/data/marriage-abroad-responses-and-expected-results.yml: 9f3ca67c58dae770c65e174899f5d80b
 lib/smart_answer/calculators/marriage_abroad_data_query.rb: 4ed1f9632c270531ef76fe8bb00b7942

--- a/test/integration/smart_answer_flows/marriage_abroad_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_test.rb
@@ -1272,7 +1272,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     should "go to russia CNI outcome" do
       assert_current_node :outcome_os_consular_cni
       assert_phrase_list :consular_cni_os_start, [:contact_local_authorities_in_country_marriage, :get_legal_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :russia_os_local_resident, "appointment_links.opposite_sex.russia", :required_supporting_documents_notary_public, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :consular_cni_os_download_documents_notary_public, :consular_cni_os_foreign_resident_ceremony_notary_public]
-      assert_phrase_list :consular_cni_os_remainder, [:names_on_documents_must_match, :check_if_cni_needs_to_be_legalised, :partner_naturalisation_in_uk, :no_need_to_stay_after_posting_notice, :consular_cni_os_fees_not_italy_not_uk, :list_of_consular_fees, :consular_cni_os_fees_russia]
+      assert_phrase_list :consular_cni_os_remainder, [:names_on_documents_must_match, :check_if_cni_needs_to_be_legalised, :partner_naturalisation_in_uk, :no_need_to_stay_after_posting_notice, :consular_cni_os_fees_not_italy_not_uk, :list_of_consular_fees, :pay_by_mastercard_or_visa]
     end
   end
 


### PR DESCRIPTION
Users can pay only by MasterCard and Visa credit cards in both consulates