### PR TITLE
Disable session store

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,6 +1,6 @@
 # Be sure to restart your server when you modify this file.
 
-# SmartAnswers::Application.config.session_store :cookie_store, key: '_smart-answers_session'
+SmartAnswers::Application.config.session_store :disabled
 
 # Use the database for sessions instead of the cookie-based default,
 # which shouldn't be used to store highly confidential information

--- a/test/unit/session_store_test.rb
+++ b/test/unit/session_store_test.rb
@@ -1,0 +1,7 @@
+require_relative '../test_helper'
+
+class SessionStoreTest < ActiveSupport::TestCase
+  should 'be disabled' do
+    assert_nil SmartAnswers::Application.config.session_store
+  end
+end


### PR DESCRIPTION
As requested by @tekin as a precautionary measure for all "front-end" apps.

The Smart Answers app is designed to be stateless - this change makes
that explicit.

Apparently the Varnish cache strips session cookies on the way in and out
anyway, so cookies aren't currently making it through to users, but at some
point such filters may be relaxed in order to implement authentication.
This change ensures that cookies will never make it through to users.

Also our cookie policy doesn't describe any of the cookies we might set, so
we'd be breaking our own policy by enabling sessions.

c.f. alphagov/government-frontend#48

Although the configuration line was commented out in [this commit][1], this
isn't sufficient to disable session cookies; you need to actively set the session
store to `:disabled`.

Note that I was able to see the session cookie in the browser when the line was
just commented out, but only when I set a value in the session.

[1]: 84ba7be