### PR TITLE
Fix contact blocks in uk-benefits-abroad

### DIFF
--- a/lib/smart_answer_flows/locales/en/uk-benefits-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/uk-benefits-abroad.yml
@@ -78,20 +78,20 @@ en-GB:
         tax_credits_going_abroad_helpline: |
 
           $C
-          **Tax Credits Helpline**
-          Telephone: 0345 300 3900
-          Textphone: 0345 300 3909
-          Outside the UK call +44 2890 538 192
-          Monday to Friday, 8am to 8pm
-          Saturday, 8am to 4pm
+          **Tax Credits Helpline**\\
+          Telephone: 0345 300 3900\\
+          Textphone: 0345 300 3909\\
+          Outside the UK call +44 2890 538 192\\
+          Monday to Friday, 8am to 8pm\\
+          Saturday, 8am to 4pm\\
           Find out about [call charges](/call-charges)
           $C
         tax_credits_already_abroad_helpline: |
 
           $C
-          **Tax Credits Helpline**
-          From outside the UK: +44 2890 538 192
-          Monday to Friday, 8am to 8pm
+          **Tax Credits Helpline**\\
+          From outside the UK: +44 2890 538 192\\
+          Monday to Friday, 8am to 8pm\\
           Saturday, 8am to 4pm
           $C
 
@@ -572,11 +572,11 @@ en-GB:
 
 
           $C
-          **Tax Credits Helpline**
-          Telephone: 0345 300 3900
-          Textphone: 0345 300 3909
-          Outside the UK: +44 2890 538 192
-          Monday to Friday, 8am to 8pm
+          **Tax Credits Helpline**\\
+          Telephone: 0345 300 3900\\
+          Textphone: 0345 300 3909\\
+          Outside the UK: +44 2890 538 192\\
+          Monday to Friday, 8am to 8pm\\
           Saturday 8am to 4pm
           $C
 

--- a/lib/smart_answer_flows/locales/en/uk-benefits-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/uk-benefits-abroad.yml
@@ -81,7 +81,7 @@ en-GB:
           **Tax Credits Helpline**\\
           Telephone: 0345 300 3900\\
           Textphone: 0345 300 3909\\
-          Outside the UK call +44 2890 538 192\\
+          Outside the UK: +44 2890 538 192\\
           Monday to Friday, 8am to 8pm\\
           Saturday, 8am to 4pm\\
           Find out about [call charges](/call-charges)
@@ -577,7 +577,8 @@ en-GB:
           Textphone: 0345 300 3909\\
           Outside the UK: +44 2890 538 192\\
           Monday to Friday, 8am to 8pm\\
-          Saturday 8am to 4pm
+          Saturday 8am to 4pm\\
+          Find out about [call charges](/call-charges)
           $C
 
 # A23 already_abroad and A25 going_abroad

--- a/test/artefacts/uk-benefits-abroad/already_abroad/tax_credits/cross_border_worker.html
+++ b/test/artefacts/uk-benefits-abroad/already_abroad/tax_credits/cross_border_worker.html
@@ -59,9 +59,9 @@
 <p>Contact the Tax Credits Helpline to claim.</p>
 
 <div class="contact">
-<p><strong>Tax Credits Helpline</strong>
-From outside the UK: +44 2890 538 192
-Monday to Friday, 8am to 8pm
+<p><strong>Tax Credits Helpline</strong><br />
+From outside the UK: +44 2890 538 192<br />
+Monday to Friday, 8am to 8pm<br />
 Saturday, 8am to 4pm</p>
 </div>
 

--- a/test/artefacts/uk-benefits-abroad/already_abroad/tax_credits/crown_servant.html
+++ b/test/artefacts/uk-benefits-abroad/already_abroad/tax_credits/crown_servant.html
@@ -36,9 +36,9 @@
 <p>Contact the Tax Credits Helpline to claim.</p>
 
 <div class="contact">
-<p><strong>Tax Credits Helpline</strong>
-From outside the UK: +44 2890 538 192
-Monday to Friday, 8am to 8pm
+<p><strong>Tax Credits Helpline</strong><br />
+From outside the UK: +44 2890 538 192<br />
+Monday to Friday, 8am to 8pm<br />
 Saturday, 8am to 4pm</p>
 </div>
 

--- a/test/artefacts/uk-benefits-abroad/already_abroad/tax_credits/none_of_the_above/tax_credits_more_than_a_year/yes/austria/yes.html
+++ b/test/artefacts/uk-benefits-abroad/already_abroad/tax_credits/none_of_the_above/tax_credits_more_than_a_year/yes/austria/yes.html
@@ -36,11 +36,11 @@
 <p>Contact the Tax Credits Helpline to claim.</p>
 
 <div class="contact">
-<p><strong>Tax Credits Helpline</strong>
-Telephone: 0345 300 3900
-Textphone: 0345 300 3909
-Outside the UK: +44 2890 538 192
-Monday to Friday, 8am to 8pm
+<p><strong>Tax Credits Helpline</strong><br />
+Telephone: 0345 300 3900<br />
+Textphone: 0345 300 3909<br />
+Outside the UK: +44 2890 538 192<br />
+Monday to Friday, 8am to 8pm<br />
 Saturday 8am to 4pm</p>
 </div>
 

--- a/test/artefacts/uk-benefits-abroad/already_abroad/tax_credits/none_of_the_above/tax_credits_more_than_a_year/yes/austria/yes.html
+++ b/test/artefacts/uk-benefits-abroad/already_abroad/tax_credits/none_of_the_above/tax_credits_more_than_a_year/yes/austria/yes.html
@@ -41,7 +41,8 @@ Telephone: 0345 300 3900<br />
 Textphone: 0345 300 3909<br />
 Outside the UK: +44 2890 538 192<br />
 Monday to Friday, 8am to 8pm<br />
-Saturday 8am to 4pm</p>
+Saturday 8am to 4pm<br />
+Find out about <a href="/call-charges">call charges</a></p>
 </div>
 
       </div>

--- a/test/artefacts/uk-benefits-abroad/already_abroad/tax_credits/none_of_the_above/tax_credits_up_to_a_year/tax_credits_death.html
+++ b/test/artefacts/uk-benefits-abroad/already_abroad/tax_credits/none_of_the_above/tax_credits_up_to_a_year/tax_credits_death.html
@@ -38,9 +38,9 @@
 <p>You can receive tax credits for longer in some circumstances. You can be fined £300 if you receive credits you shouldn&rsquo;t have.</p>
 
 <div class="contact">
-<p><strong>Tax Credits Helpline</strong>
-From outside the UK: +44 2890 538 192
-Monday to Friday, 8am to 8pm
+<p><strong>Tax Credits Helpline</strong><br />
+From outside the UK: +44 2890 538 192<br />
+Monday to Friday, 8am to 8pm<br />
 Saturday, 8am to 4pm</p>
 </div>
 

--- a/test/artefacts/uk-benefits-abroad/already_abroad/tax_credits/none_of_the_above/tax_credits_up_to_a_year/tax_credits_holiday.html
+++ b/test/artefacts/uk-benefits-abroad/already_abroad/tax_credits/none_of_the_above/tax_credits_up_to_a_year/tax_credits_holiday.html
@@ -38,9 +38,9 @@
 <p>You can receive tax credits for longer in some circumstances. You can be fined £300 if you receive credits you shouldn&rsquo;t have.</p>
 
 <div class="contact">
-<p><strong>Tax Credits Helpline</strong>
-From outside the UK: +44 2890 538 192
-Monday to Friday, 8am to 8pm
+<p><strong>Tax Credits Helpline</strong><br />
+From outside the UK: +44 2890 538 192<br />
+Monday to Friday, 8am to 8pm<br />
 Saturday, 8am to 4pm</p>
 </div>
 

--- a/test/artefacts/uk-benefits-abroad/already_abroad/tax_credits/none_of_the_above/tax_credits_up_to_a_year/tax_credits_medical_treatment.html
+++ b/test/artefacts/uk-benefits-abroad/already_abroad/tax_credits/none_of_the_above/tax_credits_up_to_a_year/tax_credits_medical_treatment.html
@@ -38,9 +38,9 @@
 <p>You can receive tax credits for longer in some circumstances. You can be fined £300 if you receive credits you shouldn&rsquo;t have.</p>
 
 <div class="contact">
-<p><strong>Tax Credits Helpline</strong>
-From outside the UK: +44 2890 538 192
-Monday to Friday, 8am to 8pm
+<p><strong>Tax Credits Helpline</strong><br />
+From outside the UK: +44 2890 538 192<br />
+Monday to Friday, 8am to 8pm<br />
 Saturday, 8am to 4pm</p>
 </div>
 

--- a/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/cross_border_worker.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/cross_border_worker.html
@@ -59,12 +59,12 @@
 <p>Contact the Tax Credits Helpline to claim.</p>
 
 <div class="contact">
-<p><strong>Tax Credits Helpline</strong>
-Telephone: 0345 300 3900
-Textphone: 0345 300 3909
-Outside the UK call +44 2890 538 192
-Monday to Friday, 8am to 8pm
-Saturday, 8am to 4pm
+<p><strong>Tax Credits Helpline</strong><br />
+Telephone: 0345 300 3900<br />
+Textphone: 0345 300 3909<br />
+Outside the UK call +44 2890 538 192<br />
+Monday to Friday, 8am to 8pm<br />
+Saturday, 8am to 4pm<br />
 Find out about <a href="/call-charges">call charges</a></p>
 </div>
 

--- a/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/cross_border_worker.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/cross_border_worker.html
@@ -62,7 +62,7 @@
 <p><strong>Tax Credits Helpline</strong><br />
 Telephone: 0345 300 3900<br />
 Textphone: 0345 300 3909<br />
-Outside the UK call +44 2890 538 192<br />
+Outside the UK: +44 2890 538 192<br />
 Monday to Friday, 8am to 8pm<br />
 Saturday, 8am to 4pm<br />
 Find out about <a href="/call-charges">call charges</a></p>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/crown_servant.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/crown_servant.html
@@ -36,12 +36,12 @@
 <p>Contact the Tax Credits Helpline to claim.</p>
 
 <div class="contact">
-<p><strong>Tax Credits Helpline</strong>
-Telephone: 0345 300 3900
-Textphone: 0345 300 3909
-Outside the UK call +44 2890 538 192
-Monday to Friday, 8am to 8pm
-Saturday, 8am to 4pm
+<p><strong>Tax Credits Helpline</strong><br />
+Telephone: 0345 300 3900<br />
+Textphone: 0345 300 3909<br />
+Outside the UK call +44 2890 538 192<br />
+Monday to Friday, 8am to 8pm<br />
+Saturday, 8am to 4pm<br />
 Find out about <a href="/call-charges">call charges</a></p>
 </div>
 

--- a/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/crown_servant.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/crown_servant.html
@@ -39,7 +39,7 @@
 <p><strong>Tax Credits Helpline</strong><br />
 Telephone: 0345 300 3900<br />
 Textphone: 0345 300 3909<br />
-Outside the UK call +44 2890 538 192<br />
+Outside the UK: +44 2890 538 192<br />
 Monday to Friday, 8am to 8pm<br />
 Saturday, 8am to 4pm<br />
 Find out about <a href="/call-charges">call charges</a></p>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/none_of_the_above/tax_credits_more_than_a_year/yes/austria/yes.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/none_of_the_above/tax_credits_more_than_a_year/yes/austria/yes.html
@@ -36,11 +36,11 @@
 <p>Contact the Tax Credits Helpline to claim.</p>
 
 <div class="contact">
-<p><strong>Tax Credits Helpline</strong>
-Telephone: 0345 300 3900
-Textphone: 0345 300 3909
-Outside the UK: +44 2890 538 192
-Monday to Friday, 8am to 8pm
+<p><strong>Tax Credits Helpline</strong><br />
+Telephone: 0345 300 3900<br />
+Textphone: 0345 300 3909<br />
+Outside the UK: +44 2890 538 192<br />
+Monday to Friday, 8am to 8pm<br />
 Saturday 8am to 4pm</p>
 </div>
 

--- a/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/none_of_the_above/tax_credits_more_than_a_year/yes/austria/yes.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/none_of_the_above/tax_credits_more_than_a_year/yes/austria/yes.html
@@ -41,7 +41,8 @@ Telephone: 0345 300 3900<br />
 Textphone: 0345 300 3909<br />
 Outside the UK: +44 2890 538 192<br />
 Monday to Friday, 8am to 8pm<br />
-Saturday 8am to 4pm</p>
+Saturday 8am to 4pm<br />
+Find out about <a href="/call-charges">call charges</a></p>
 </div>
 
       </div>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/none_of_the_above/tax_credits_up_to_a_year/tax_credits_death.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/none_of_the_above/tax_credits_up_to_a_year/tax_credits_death.html
@@ -38,12 +38,12 @@
 <p>You can receive tax credits for longer in some circumstances. You can be fined £300 if you receive credits you shouldn&rsquo;t have.</p>
 
 <div class="contact">
-<p><strong>Tax Credits Helpline</strong>
-Telephone: 0345 300 3900
-Textphone: 0345 300 3909
-Outside the UK call +44 2890 538 192
-Monday to Friday, 8am to 8pm
-Saturday, 8am to 4pm
+<p><strong>Tax Credits Helpline</strong><br />
+Telephone: 0345 300 3900<br />
+Textphone: 0345 300 3909<br />
+Outside the UK call +44 2890 538 192<br />
+Monday to Friday, 8am to 8pm<br />
+Saturday, 8am to 4pm<br />
 Find out about <a href="/call-charges">call charges</a></p>
 </div>
 

--- a/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/none_of_the_above/tax_credits_up_to_a_year/tax_credits_death.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/none_of_the_above/tax_credits_up_to_a_year/tax_credits_death.html
@@ -41,7 +41,7 @@
 <p><strong>Tax Credits Helpline</strong><br />
 Telephone: 0345 300 3900<br />
 Textphone: 0345 300 3909<br />
-Outside the UK call +44 2890 538 192<br />
+Outside the UK: +44 2890 538 192<br />
 Monday to Friday, 8am to 8pm<br />
 Saturday, 8am to 4pm<br />
 Find out about <a href="/call-charges">call charges</a></p>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/none_of_the_above/tax_credits_up_to_a_year/tax_credits_holiday.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/none_of_the_above/tax_credits_up_to_a_year/tax_credits_holiday.html
@@ -38,12 +38,12 @@
 <p>You can receive tax credits for longer in some circumstances. You can be fined £300 if you receive credits you shouldn&rsquo;t have.</p>
 
 <div class="contact">
-<p><strong>Tax Credits Helpline</strong>
-Telephone: 0345 300 3900
-Textphone: 0345 300 3909
-Outside the UK call +44 2890 538 192
-Monday to Friday, 8am to 8pm
-Saturday, 8am to 4pm
+<p><strong>Tax Credits Helpline</strong><br />
+Telephone: 0345 300 3900<br />
+Textphone: 0345 300 3909<br />
+Outside the UK call +44 2890 538 192<br />
+Monday to Friday, 8am to 8pm<br />
+Saturday, 8am to 4pm<br />
 Find out about <a href="/call-charges">call charges</a></p>
 </div>
 

--- a/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/none_of_the_above/tax_credits_up_to_a_year/tax_credits_holiday.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/none_of_the_above/tax_credits_up_to_a_year/tax_credits_holiday.html
@@ -41,7 +41,7 @@
 <p><strong>Tax Credits Helpline</strong><br />
 Telephone: 0345 300 3900<br />
 Textphone: 0345 300 3909<br />
-Outside the UK call +44 2890 538 192<br />
+Outside the UK: +44 2890 538 192<br />
 Monday to Friday, 8am to 8pm<br />
 Saturday, 8am to 4pm<br />
 Find out about <a href="/call-charges">call charges</a></p>

--- a/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/none_of_the_above/tax_credits_up_to_a_year/tax_credits_medical_treatment.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/none_of_the_above/tax_credits_up_to_a_year/tax_credits_medical_treatment.html
@@ -38,12 +38,12 @@
 <p>You can receive tax credits for longer in some circumstances. You can be fined £300 if you receive credits you shouldn&rsquo;t have.</p>
 
 <div class="contact">
-<p><strong>Tax Credits Helpline</strong>
-Telephone: 0345 300 3900
-Textphone: 0345 300 3909
-Outside the UK call +44 2890 538 192
-Monday to Friday, 8am to 8pm
-Saturday, 8am to 4pm
+<p><strong>Tax Credits Helpline</strong><br />
+Telephone: 0345 300 3900<br />
+Textphone: 0345 300 3909<br />
+Outside the UK call +44 2890 538 192<br />
+Monday to Friday, 8am to 8pm<br />
+Saturday, 8am to 4pm<br />
 Find out about <a href="/call-charges">call charges</a></p>
 </div>
 

--- a/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/none_of_the_above/tax_credits_up_to_a_year/tax_credits_medical_treatment.html
+++ b/test/artefacts/uk-benefits-abroad/going_abroad/tax_credits/none_of_the_above/tax_credits_up_to_a_year/tax_credits_medical_treatment.html
@@ -41,7 +41,7 @@
 <p><strong>Tax Credits Helpline</strong><br />
 Telephone: 0345 300 3900<br />
 Textphone: 0345 300 3909<br />
-Outside the UK call +44 2890 538 192<br />
+Outside the UK: +44 2890 538 192<br />
 Monday to Friday, 8am to 8pm<br />
 Saturday, 8am to 4pm<br />
 Find out about <a href="/call-charges">call charges</a></p>

--- a/test/data/uk-benefits-abroad-files.yml
+++ b/test/data/uk-benefits-abroad-files.yml
@@ -1,5 +1,5 @@
 --- 
 lib/smart_answer_flows/uk-benefits-abroad.rb: cd47cbb8d79265db30e4988bbf427d79
-lib/smart_answer_flows/locales/en/uk-benefits-abroad.yml: 76ba8b4c61bf7e746d01d7797d4c7fe3
+lib/smart_answer_flows/locales/en/uk-benefits-abroad.yml: 696845f2cd6015ca3bc2a54e1e13c862
 test/data/uk-benefits-abroad-questions-and-responses.yml: 17973c7c16f38d7988ff1a5b76d3261a
 test/data/uk-benefits-abroad-responses-and-expected-results.yml: 37bfb8e7982e15f0f907881bf1130ce3

--- a/test/data/uk-benefits-abroad-files.yml
+++ b/test/data/uk-benefits-abroad-files.yml
@@ -1,5 +1,5 @@
 --- 
 lib/smart_answer_flows/uk-benefits-abroad.rb: cd47cbb8d79265db30e4988bbf427d79
-lib/smart_answer_flows/locales/en/uk-benefits-abroad.yml: 696845f2cd6015ca3bc2a54e1e13c862
+lib/smart_answer_flows/locales/en/uk-benefits-abroad.yml: ea3b6ef38461960d511db660ea448be2
 test/data/uk-benefits-abroad-questions-and-responses.yml: 17973c7c16f38d7988ff1a5b76d3261a
 test/data/uk-benefits-abroad-responses-and-expected-results.yml: 37bfb8e7982e15f0f907881bf1130ce3


### PR DESCRIPTION
This PR address problems with the contact blocks in the
uk-benefits-abroad flow:

* Fix formatting of contacts. They've been missing HTML line-breaks since a [change][1] that was accidentally made about a month ago.
* Make contact blocks consistent as per an email conversation with @lutgendorff.

See individual commit notes for further details.

[1]: 1a96852a3186254d03767f22b15754e5830200ac