### PR TITLE
Convert calculate-married-couples-allowance to ERB

### DIFF
--- a/app/presenters/outcome_presenter.rb
+++ b/app/presenters/outcome_presenter.rb
@@ -37,6 +37,16 @@ class OutcomePresenter < NodePresenter
     end
   end
 
+  def next_steps
+    if use_template? && next_steps_erb_template_exists?
+      render_erb_template
+      govspeak = @view.content_for(:next_steps) || ''
+      GovspeakPresenter.new(govspeak.to_str).html
+    else
+      super
+    end
+  end
+
   def erb_template_path
     template_directory.join(erb_template_name)
   end
@@ -57,6 +67,10 @@ class OutcomePresenter < NodePresenter
 
   def body_erb_template_exists?
     erb_template_exists? && has_content_for_body?
+  end
+
+  def next_steps_erb_template_exists?
+    erb_template_exists? && has_content_for_next_steps?
   end
 
   def erb_template_exists?
@@ -87,5 +101,9 @@ class OutcomePresenter < NodePresenter
 
   def has_content_for_title?
     File.read(erb_template_path) =~ /content_for :title/
+  end
+
+  def has_content_for_next_steps?
+    File.read(erb_template_path) =~ /content_for :next_steps/
   end
 end

--- a/app/presenters/outcome_presenter.rb
+++ b/app/presenters/outcome_presenter.rb
@@ -3,6 +3,7 @@ class OutcomePresenter < NodePresenter
     @options = options
     super(i18n_prefix, node, state)
     @view = ActionView::Base.new([template_directory])
+    @view.extend(SmartAnswer::OutcomeHelper)
     @rendered_erb_template = false
   end
 

--- a/lib/smart_answer/outcome_helper.rb
+++ b/lib/smart_answer/outcome_helper.rb
@@ -1,0 +1,7 @@
+module SmartAnswer
+  module OutcomeHelper
+    def format_money(amount)
+      number_to_currency(amount, precision: ((amount.to_f == amount.to_f.round) ? 0 : 2))
+    end
+  end
+end

--- a/lib/smart_answer_flows/calculate-married-couples-allowance.rb
+++ b/lib/smart_answer_flows/calculate-married-couples-allowance.rb
@@ -115,19 +115,21 @@ module SmartAnswer
         end
       end
 
-      outcome :husband_done, use_outcome_templates: true do
+      use_outcome_templates
+
+      outcome :husband_done do
         precalculate :allowance do
           age_related_allowance = age_related_allowance_chooser.get_age_related_allowance(birth_date)
           calculator.calculate_allowance(age_related_allowance, income)
         end
       end
-      outcome :highest_earner_done, use_outcome_templates: true do
+      outcome :highest_earner_done do
         precalculate :allowance do
           age_related_allowance = age_related_allowance_chooser.get_age_related_allowance(birth_date)
           calculator.calculate_allowance(age_related_allowance, income)
         end
       end
-      outcome :sorry, use_outcome_templates: true
+      outcome :sorry
     end
   end
 end

--- a/lib/smart_answer_flows/calculate-married-couples-allowance.rb
+++ b/lib/smart_answer_flows/calculate-married-couples-allowance.rb
@@ -121,7 +121,7 @@ module SmartAnswer
           calculator.calculate_allowance(age_related_allowance, income)
         end
       end
-      outcome :highest_earner_done do
+      outcome :highest_earner_done, use_outcome_templates: true do
         precalculate :allowance do
           age_related_allowance = age_related_allowance_chooser.get_age_related_allowance(birth_date)
           calculator.calculate_allowance(age_related_allowance, income)

--- a/lib/smart_answer_flows/calculate-married-couples-allowance.rb
+++ b/lib/smart_answer_flows/calculate-married-couples-allowance.rb
@@ -127,7 +127,7 @@ module SmartAnswer
           calculator.calculate_allowance(age_related_allowance, income)
         end
       end
-      outcome :sorry
+      outcome :sorry, use_outcome_templates: true
     end
   end
 end

--- a/lib/smart_answer_flows/calculate-married-couples-allowance.rb
+++ b/lib/smart_answer_flows/calculate-married-couples-allowance.rb
@@ -115,7 +115,7 @@ module SmartAnswer
         end
       end
 
-      outcome :husband_done do
+      outcome :husband_done, use_outcome_templates: true do
         precalculate :allowance do
           age_related_allowance = age_related_allowance_chooser.get_age_related_allowance(birth_date)
           calculator.calculate_allowance(age_related_allowance, income)

--- a/lib/smart_answer_flows/calculate-married-couples-allowance/_done_body.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-married-couples-allowance/_done_body.govspeak.erb
@@ -1,0 +1,12 @@
+Contact HM Revenue & Customs to claim.
+
+
+$C
+**HM Revenue & Customs**\\
+**Telephone** 0300 200 3300\\
+**Textphone** 0300 200 3319\\
+[Find out about call charges](/call-charges)
+$C
+
+
+%This result is an estimate based on your answers.%

--- a/lib/smart_answer_flows/calculate-married-couples-allowance/_done_next_steps.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-married-couples-allowance/_done_next_steps.govspeak.erb
@@ -1,0 +1,4 @@
+Read the [guide to Married Couple's Allowance](/married-couples-allowance) to:
+
+- learn more about what you'll get and how to claim
+- find out how to transfer your Married Couple's Allowance to your  partner

--- a/lib/smart_answer_flows/calculate-married-couples-allowance/highest_earner_done.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-married-couples-allowance/highest_earner_done.govspeak.erb
@@ -1,0 +1,25 @@
+<% content_for :title do %>
+The highest earner qualifies for Married Couple's Allowance - they'll get <%= number_to_currency(allowance, precision: ((allowance.to_f == allowance.to_f.round) ? 0 : 2)) %> off their tax bill.
+<% end %>
+
+<% content_for :body do %>
+Contact HM Revenue & Customs to claim.
+
+
+$C
+**HM Revenue & Customs**\\
+**Telephone** 0300 200 3300\\
+**Textphone** 0300 200 3319\\
+[Find out about call charges](/call-charges)
+$C
+
+
+%This result is an estimate based on your answers.%
+<% end %>
+
+<% content_for :next_steps do %>
+Read the [guide to Married Couple's Allowance](/married-couples-allowance) to:
+
+- learn more about what you'll get and how to claim
+- find out how to transfer your Married Couple's Allowance to your  partner
+<% end %>

--- a/lib/smart_answer_flows/calculate-married-couples-allowance/highest_earner_done.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-married-couples-allowance/highest_earner_done.govspeak.erb
@@ -7,5 +7,5 @@ The highest earner qualifies for Married Couple's Allowance - they'll get <%= nu
 <% end %>
 
 <% content_for :next_steps do %>
-<%= render partial: 'done_next_steps.govspeak.erb' -%>
+  <%= render partial: 'done_next_steps.govspeak.erb' -%>
 <% end %>

--- a/lib/smart_answer_flows/calculate-married-couples-allowance/highest_earner_done.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-married-couples-allowance/highest_earner_done.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :title do %>
-The highest earner qualifies for Married Couple's Allowance - they'll get <%= number_to_currency(allowance, precision: ((allowance.to_f == allowance.to_f.round) ? 0 : 2)) %> off their tax bill.
+The highest earner qualifies for Married Couple's Allowance - they'll get <%= format_money(allowance) %> off their tax bill.
 <% end %>
 
 <% content_for :body do %>

--- a/lib/smart_answer_flows/calculate-married-couples-allowance/highest_earner_done.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-married-couples-allowance/highest_earner_done.govspeak.erb
@@ -3,18 +3,7 @@ The highest earner qualifies for Married Couple's Allowance - they'll get <%= nu
 <% end %>
 
 <% content_for :body do %>
-Contact HM Revenue & Customs to claim.
-
-
-$C
-**HM Revenue & Customs**\\
-**Telephone** 0300 200 3300\\
-**Textphone** 0300 200 3319\\
-[Find out about call charges](/call-charges)
-$C
-
-
-%This result is an estimate based on your answers.%
+<%= render partial: 'done_body.govspeak.erb' -%>
 <% end %>
 
 <% content_for :next_steps do %>

--- a/lib/smart_answer_flows/calculate-married-couples-allowance/highest_earner_done.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-married-couples-allowance/highest_earner_done.govspeak.erb
@@ -7,8 +7,5 @@ The highest earner qualifies for Married Couple's Allowance - they'll get <%= nu
 <% end %>
 
 <% content_for :next_steps do %>
-Read the [guide to Married Couple's Allowance](/married-couples-allowance) to:
-
-- learn more about what you'll get and how to claim
-- find out how to transfer your Married Couple's Allowance to your  partner
+<%= render partial: 'done_next_steps.govspeak.erb' -%>
 <% end %>

--- a/lib/smart_answer_flows/calculate-married-couples-allowance/highest_earner_done.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-married-couples-allowance/highest_earner_done.govspeak.erb
@@ -3,7 +3,7 @@ The highest earner qualifies for Married Couple's Allowance - they'll get <%= nu
 <% end %>
 
 <% content_for :body do %>
-<%= render partial: 'done_body.govspeak.erb' -%>
+  <%= render partial: 'done_body.govspeak.erb' -%>
 <% end %>
 
 <% content_for :next_steps do %>

--- a/lib/smart_answer_flows/calculate-married-couples-allowance/husband_done.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-married-couples-allowance/husband_done.govspeak.erb
@@ -1,0 +1,25 @@
+<% content_for :title do %>
+The husband qualifies for Married Couple's Allowance - he'll get <%= number_to_currency(allowance, precision: ((allowance.to_f == allowance.to_f.round) ? 0 : 2)) %> off his tax bill.
+<% end %>
+
+<% content_for :body do %>
+Contact HM Revenue & Customs to claim.
+
+
+$C
+**HM Revenue & Customs**\\
+**Telephone** 0300 200 3300\\
+**Textphone** 0300 200 3319\\
+[Find out about call charges](/call-charges)
+$C
+
+
+%This result is an estimate based on your answers.%
+<% end %>
+
+<% content_for :next_steps do %>
+Read the [guide to Married Couple's Allowance](/married-couples-allowance) to:
+
+- learn more about what you'll get and how to claim
+- find out how to transfer your Married Couple's Allowance to your  partner
+<% end %>

--- a/lib/smart_answer_flows/calculate-married-couples-allowance/husband_done.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-married-couples-allowance/husband_done.govspeak.erb
@@ -7,5 +7,5 @@ The husband qualifies for Married Couple's Allowance - he'll get <%= number_to_c
 <% end %>
 
 <% content_for :next_steps do %>
-<%= render partial: 'done_next_steps.govspeak.erb' -%>
+  <%= render partial: 'done_next_steps.govspeak.erb' -%>
 <% end %>

--- a/lib/smart_answer_flows/calculate-married-couples-allowance/husband_done.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-married-couples-allowance/husband_done.govspeak.erb
@@ -7,8 +7,5 @@ The husband qualifies for Married Couple's Allowance - he'll get <%= number_to_c
 <% end %>
 
 <% content_for :next_steps do %>
-Read the [guide to Married Couple's Allowance](/married-couples-allowance) to:
-
-- learn more about what you'll get and how to claim
-- find out how to transfer your Married Couple's Allowance to your  partner
+<%= render partial: 'done_next_steps.govspeak.erb' -%>
 <% end %>

--- a/lib/smart_answer_flows/calculate-married-couples-allowance/husband_done.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-married-couples-allowance/husband_done.govspeak.erb
@@ -3,18 +3,7 @@ The husband qualifies for Married Couple's Allowance - he'll get <%= number_to_c
 <% end %>
 
 <% content_for :body do %>
-Contact HM Revenue & Customs to claim.
-
-
-$C
-**HM Revenue & Customs**\\
-**Telephone** 0300 200 3300\\
-**Textphone** 0300 200 3319\\
-[Find out about call charges](/call-charges)
-$C
-
-
-%This result is an estimate based on your answers.%
+<%= render partial: 'done_body.govspeak.erb' -%>
 <% end %>
 
 <% content_for :next_steps do %>

--- a/lib/smart_answer_flows/calculate-married-couples-allowance/husband_done.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-married-couples-allowance/husband_done.govspeak.erb
@@ -3,7 +3,7 @@ The husband qualifies for Married Couple's Allowance - he'll get <%= number_to_c
 <% end %>
 
 <% content_for :body do %>
-<%= render partial: 'done_body.govspeak.erb' -%>
+  <%= render partial: 'done_body.govspeak.erb' -%>
 <% end %>
 
 <% content_for :next_steps do %>

--- a/lib/smart_answer_flows/calculate-married-couples-allowance/husband_done.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-married-couples-allowance/husband_done.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :title do %>
-The husband qualifies for Married Couple's Allowance - he'll get <%= number_to_currency(allowance, precision: ((allowance.to_f == allowance.to_f.round) ? 0 : 2)) %> off his tax bill.
+The husband qualifies for Married Couple's Allowance - he'll get <%= format_money(allowance) %> off his tax bill.
 <% end %>
 
 <% content_for :body do %>

--- a/lib/smart_answer_flows/calculate-married-couples-allowance/sorry.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-married-couples-allowance/sorry.govspeak.erb
@@ -1,0 +1,9 @@
+<% content_for :title do %>
+You don't qualify for Married Couple's Allowance.
+<% end %>
+
+<% content_for :body do %>
+You or your partner had to be born before 6 April 1935 to be [eligible for Married Couple's Allowance](/married-couples-allowance/eligibility).
+
+If you and your partner were born on or after 6 April 1935, you may be able to claim [Marriage Allowance](/marriage-allowance) instead.
+<% end %>

--- a/lib/smart_answer_flows/locales/en/calculate-married-couples-allowance.yml
+++ b/lib/smart_answer_flows/locales/en/calculate-married-couples-allowance.yml
@@ -71,7 +71,7 @@ en-GB:
         title: You don't qualify for Married Couple's Allowance.
         body: |
           You or your partner had to be born before 6 April 1935 to be [eligible for Married Couple's Allowance](/married-couples-allowance/eligibility).
-          
+
           If you and your partner were born on or after 6 April 1935, you may be able to claim [Marriage Allowance](/marriage-allowance) instead.
 
       highest_earner_done:
@@ -81,9 +81,9 @@ en-GB:
 
 
           $C
-          **HM Revenue & Customs**  
-          **Telephone** 0300 200 3300  
-          **Textphone** 0300 200 3319  
+          **HM Revenue & Customs**\\
+          **Telephone** 0300 200 3300\\
+          **Textphone** 0300 200 3319\\
           [Find out about call charges](/call-charges)
           $C
 
@@ -102,9 +102,9 @@ en-GB:
 
 
           $C
-          **HM Revenue & Customs**  
-          **Telephone** 0300 200 3300  
-          **Textphone** 0300 200 3319  
+          **HM Revenue & Customs**\\
+          **Telephone** 0300 200 3300\\
+          **Textphone** 0300 200 3319\\
           [Find out about call charges](/call-charges)
           $C
 

--- a/lib/smart_answer_flows/locales/en/calculate-married-couples-allowance.yml
+++ b/lib/smart_answer_flows/locales/en/calculate-married-couples-allowance.yml
@@ -67,13 +67,6 @@ en-GB:
         error_message: Please use numbers only, eg 9000
 
 #outcomes
-      sorry:
-        title: You don't qualify for Married Couple's Allowance.
-        body: |
-          You or your partner had to be born before 6 April 1935 to be [eligible for Married Couple's Allowance](/married-couples-allowance/eligibility).
-
-          If you and your partner were born on or after 6 April 1935, you may be able to claim [Marriage Allowance](/marriage-allowance) instead.
-
       highest_earner_done:
         title: The highest earner qualifies for Married Couple's Allowance - they'll get %{allowance} off their tax bill.
         body: |

--- a/lib/smart_answer_flows/locales/en/calculate-married-couples-allowance.yml
+++ b/lib/smart_answer_flows/locales/en/calculate-married-couples-allowance.yml
@@ -65,26 +65,3 @@ en-GB:
         title: How much do you expect to donate to charity through Gift Aid during the entire tax year?
         hint: Only enter what you pay - don’t include any tax relief. If none, please enter 0.
         error_message: Please use numbers only, eg 9000
-
-#outcomes
-      husband_done:
-        title: The husband qualifies for Married Couple's Allowance - he'll get %{allowance} off his tax bill.
-        body: |
-          Contact HM Revenue & Customs to claim.
-
-
-          $C
-          **HM Revenue & Customs**\\
-          **Telephone** 0300 200 3300\\
-          **Textphone** 0300 200 3319\\
-          [Find out about call charges](/call-charges)
-          $C
-
-
-          %This result is an estimate based on your answers.%
-
-        next_steps: |
-          Read the [guide to Married Couple's Allowance](/married-couples-allowance) to:
-
-          - learn more about what you'll get and how to claim
-          - find out how to transfer your Married Couple's Allowance to your  partner

--- a/lib/smart_answer_flows/locales/en/calculate-married-couples-allowance.yml
+++ b/lib/smart_answer_flows/locales/en/calculate-married-couples-allowance.yml
@@ -67,27 +67,6 @@ en-GB:
         error_message: Please use numbers only, eg 9000
 
 #outcomes
-      highest_earner_done:
-        title: The highest earner qualifies for Married Couple's Allowance - they'll get %{allowance} off their tax bill.
-        body: |
-          Contact HM Revenue & Customs to claim.
-
-
-          $C
-          **HM Revenue & Customs**\\
-          **Telephone** 0300 200 3300\\
-          **Textphone** 0300 200 3319\\
-          [Find out about call charges](/call-charges)
-          $C
-
-
-          %This result is an estimate based on your answers.%
-        next_steps: |
-          Read the [guide to Married Couple's Allowance](/married-couples-allowance) to:
-
-          - learn more about what you'll get and how to claim
-          - find out how to transfer your Married Couple's Allowance to your  partner
-
       husband_done:
         title: The husband qualifies for Married Couple's Allowance - he'll get %{allowance} off his tax bill.
         body: |

--- a/test/data/calculate-married-couples-allowance-files.yml
+++ b/test/data/calculate-married-couples-allowance-files.yml
@@ -1,7 +1,12 @@
 --- 
-lib/smart_answer_flows/calculate-married-couples-allowance.rb: c7e93d8d17bfa0f57793048c6a100ff0
-lib/smart_answer_flows/locales/en/calculate-married-couples-allowance.yml: 443009d73289059eff85152dc2226def
+lib/smart_answer_flows/calculate-married-couples-allowance.rb: 23ab1ba6758d3437b93f5352c1547632
+lib/smart_answer_flows/locales/en/calculate-married-couples-allowance.yml: a327a55a834e3f9344bebeafd12d7a95
 test/data/calculate-married-couples-allowance-questions-and-responses.yml: 1bbef5f2f30d470433bbb63f029881cd
 test/data/calculate-married-couples-allowance-responses-and-expected-results.yml: 3bb53e4211718b8b1b7dacfaa52f3f49
+lib/smart_answer_flows/calculate-married-couples-allowance/_done_body.govspeak.erb: cb025369e07d6cdbedbfe7d54df39eee
+lib/smart_answer_flows/calculate-married-couples-allowance/_done_next_steps.govspeak.erb: bd570369ab0b5cf668541917daa5ef9b
+lib/smart_answer_flows/calculate-married-couples-allowance/highest_earner_done.govspeak.erb: 2f76aafab1fed220e5e673ac8b6eb6ac
+lib/smart_answer_flows/calculate-married-couples-allowance/husband_done.govspeak.erb: 59213bc03e06d8a231c2c6d914aa9fba
+lib/smart_answer_flows/calculate-married-couples-allowance/sorry.govspeak.erb: db151933e18cc0b0b30764723f5ffc22
 lib/data/rates/married_couples_allowance.yml: 2a981979d28576078696119ea1938315
 lib/smart_answer/calculators/married_couples_allowance_calculator.rb: e1e66b360f09a5f3282348151e7ffdfd

--- a/test/data/calculate-married-couples-allowance-files.yml
+++ b/test/data/calculate-married-couples-allowance-files.yml
@@ -5,8 +5,8 @@ test/data/calculate-married-couples-allowance-questions-and-responses.yml: 1bbef
 test/data/calculate-married-couples-allowance-responses-and-expected-results.yml: 3bb53e4211718b8b1b7dacfaa52f3f49
 lib/smart_answer_flows/calculate-married-couples-allowance/_done_body.govspeak.erb: cb025369e07d6cdbedbfe7d54df39eee
 lib/smart_answer_flows/calculate-married-couples-allowance/_done_next_steps.govspeak.erb: bd570369ab0b5cf668541917daa5ef9b
-lib/smart_answer_flows/calculate-married-couples-allowance/highest_earner_done.govspeak.erb: 2f76aafab1fed220e5e673ac8b6eb6ac
-lib/smart_answer_flows/calculate-married-couples-allowance/husband_done.govspeak.erb: 59213bc03e06d8a231c2c6d914aa9fba
+lib/smart_answer_flows/calculate-married-couples-allowance/highest_earner_done.govspeak.erb: 6a2451a3376c185c3637eaa17f32ded2
+lib/smart_answer_flows/calculate-married-couples-allowance/husband_done.govspeak.erb: 6f033f6c540c5c5fd001451fa50a6d1f
 lib/smart_answer_flows/calculate-married-couples-allowance/sorry.govspeak.erb: db151933e18cc0b0b30764723f5ffc22
 lib/data/rates/married_couples_allowance.yml: 2a981979d28576078696119ea1938315
 lib/smart_answer/calculators/married_couples_allowance_calculator.rb: e1e66b360f09a5f3282348151e7ffdfd

--- a/test/data/calculate-married-couples-allowance-files.yml
+++ b/test/data/calculate-married-couples-allowance-files.yml
@@ -5,8 +5,8 @@ test/data/calculate-married-couples-allowance-questions-and-responses.yml: 1bbef
 test/data/calculate-married-couples-allowance-responses-and-expected-results.yml: 3bb53e4211718b8b1b7dacfaa52f3f49
 lib/smart_answer_flows/calculate-married-couples-allowance/_done_body.govspeak.erb: cb025369e07d6cdbedbfe7d54df39eee
 lib/smart_answer_flows/calculate-married-couples-allowance/_done_next_steps.govspeak.erb: bd570369ab0b5cf668541917daa5ef9b
-lib/smart_answer_flows/calculate-married-couples-allowance/highest_earner_done.govspeak.erb: 6a2451a3376c185c3637eaa17f32ded2
-lib/smart_answer_flows/calculate-married-couples-allowance/husband_done.govspeak.erb: 6f033f6c540c5c5fd001451fa50a6d1f
+lib/smart_answer_flows/calculate-married-couples-allowance/highest_earner_done.govspeak.erb: f1d32989c01c015a1e604213e83e4e2a
+lib/smart_answer_flows/calculate-married-couples-allowance/husband_done.govspeak.erb: 149f7a295ed3e9d19d02a484f8c43012
 lib/smart_answer_flows/calculate-married-couples-allowance/sorry.govspeak.erb: db151933e18cc0b0b30764723f5ffc22
 lib/data/rates/married_couples_allowance.yml: 2a981979d28576078696119ea1938315
 lib/smart_answer/calculators/married_couples_allowance_calculator.rb: e1e66b360f09a5f3282348151e7ffdfd

--- a/test/unit/outcome_helper_test.rb
+++ b/test/unit/outcome_helper_test.rb
@@ -1,0 +1,16 @@
+require_relative '../test_helper'
+
+module SmartAnswer
+  class OutcomeHelperTest < ActiveSupport::TestCase
+    include ActionView::Helpers::NumberHelper
+    include OutcomeHelper
+
+    test "#format_money doesn't add pence for amounts in whole pounds" do
+      assert_equal '£1', format_money('1.00')
+    end
+
+    test "#format_money adds pence for amounts that aren't whole pounds" do
+      assert_equal '£1.23', format_money('1.23')
+    end
+  end
+end


### PR DESCRIPTION
__NOTE.__ This branch has been taken from use-single-erb-template-per-outcome. I'm intending to get that branch merged to master first as it makes adding support for `next_steps` (required for this SmartAnswer) easier than if we were still using multiple templates per outcome.