### PR TITLE
Add Google Analytics Event to outcome pages

### DIFF
--- a/app/views/smart_answers/_result.html.erb
+++ b/app/views/smart_answers/_result.html.erb
@@ -20,3 +20,8 @@
     <% end %>
   </article>
 </div>
+
+<script type="text/javascript">
+  var flowName = '<%= @name %>';
+  GOVUK.analytics.trackEvent('Smart Answer', 'Completed', {label: flowName, nonInteraction: true});
+</script>


### PR DESCRIPTION
We hope that recording an event when someone reaches an outcome will help us
understand more about how Smart Answers are used.

We initially investigated using Virtual Pageviews (see PR #1700 for that
discussion) before settling on Events. This approach was suggested by Chris
Russell.

I tested this locally by configuring my local static app to send data to my
personal Google Analytics account and confirming that the events appear as
expected.