### PR TITLE
Fix New Zealand same sex marriage outcome

### DIFF
--- a/lib/smart_answer/calculators/marriage_abroad_data_query.rb
+++ b/lib/smart_answer/calculators/marriage_abroad_data_query.rb
@@ -26,7 +26,7 @@ module SmartAnswer::Calculators
 
     CP_EQUIVALENT_COUNTRIES = %w(austria belgium brazil colombia czech-republic denmark ecuador finland germany hungary iceland luxembourg netherlands norway portugal slovenia sweden)
 
-    CP_CNI_NOT_REQUIRED_COUNTRIES = %w(argentina mexico uruguay usa andorra bonaire-st-eustatius-saba liechtenstein burundi )
+    CP_CNI_NOT_REQUIRED_COUNTRIES = %w(andorra argentina bonaire-st-eustatius-saba burundi liechtenstein mexico new-zealand uruguay usa)
 
     CP_CONSULAR_COUNTRIES = %w(bulgaria croatia cyprus guatemala moldova panama venezuela)
 

--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -1197,7 +1197,7 @@ en-GB:
           - ’union de fait’, or ’common-law relationship’ (in Manitoba)
           - ’domestic partnership’ (in Nova Scotia)
           - ’union civile’, or ’civil union’ (in Quebec)
-        synonyms_of_cp_in_new_zealand: |
+        synonyms_of_cp_in_new-zealand: |
           You may be able to get married or enter into a ‘civil union’ at the British embassy or consulate in New Zealand. Civil unions are recognised as civil partnerships under British law.
         synonyms_of_cp_in_south_africa: |
           Same-sex relationships in South Africa that are recognised as civil partnerships under British law are known as:

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -1277,7 +1277,7 @@ module SmartAnswer
 
         precalculate :commonwealth_countries_cp_outcome do
           phrases = PhraseList.new
-          if %w(canada new-zealand south-africa).include?(ceremony_country)
+          if %w(canada south-africa).include?(ceremony_country)
             phrases << "synonyms_of_cp_in_#{ceremony_country}".gsub('-', '_').to_sym
           end
 

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -1,8 +1,8 @@
 --- 
-lib/smart_answer_flows/marriage-abroad.rb: 0ad7622ea9240722d16ddc6b6444784a
-lib/smart_answer_flows/locales/en/marriage-abroad.yml: 4e2312057998355b505f94c36e2fd0ef
+lib/smart_answer_flows/marriage-abroad.rb: fa8bcdc5866ae40227358cfc81074b85
+lib/smart_answer_flows/locales/en/marriage-abroad.yml: abb905e3ba438aa30a7a70a74913cc28
 test/data/marriage-abroad-questions-and-responses.yml: 202693ceb110a9851b8d269c6bf77c1f
 test/data/marriage-abroad-responses-and-expected-results.yml: 9f3ca67c58dae770c65e174899f5d80b
-lib/smart_answer/calculators/marriage_abroad_data_query.rb: 5589a6aea2d5bdb5bcf85185a7fcab89
+lib/smart_answer/calculators/marriage_abroad_data_query.rb: e0f062ce08a00bacc9d862457c66990b
 lib/smart_answer/calculators/country_name_formatter.rb: 0cb274748f0daf3965451b6230c183fd
 lib/smart_answer/calculators/registrations_data_query.rb: 2755d76a53d867b350940f1af65fa5d1


### PR DESCRIPTION
The same-sex marriage outcomes for New Zealand stated embassy (even though
it’s a high commission) can perform same-sex marriages and customers can
contact them for advice. This is incorrect. The high commission cannot perform
same-sex marriages and customers should contact the relevant local authorities
in the New Zealand to find out about local laws, including what documents
you’ll need.

CP_CNI_NOT_REQUIRED_COUNTRIES was sorted alphabetically and new-zealand
was added.

There are currently no integration tests to cover New Zealand and I'm not sure it's worth adding it, as it pretty much follows one of the standard outcomes.