### PR TITLE
Pip checker updates

### DIFF
--- a/lib/smart_answer_flows/locales/en/pip-checker.yml
+++ b/lib/smart_answer_flows/locales/en/pip-checker.yml
@@ -23,49 +23,48 @@ en-GB:
       phrases:
         scheme_postcodes: |
 
-          Check if this also applies in your area.
+          In the following areas you'll be asked to claim PIP from 27 July 2015:
 
-          ###East of England
+          - AL (St Albans)
+          - CT (Canterbury)
+          - EN (Enfield)
+          - HA (Harrow)
+          - HS (Hebrides)
+          - KT (Kingston)
+          - KW (Kirkwall)
+          - ME (Maidstone)
+          - N (London North)
+          - NW (London North West)
+          - SL (Slough)
+          - SM (Sutton)
+          - TN (Tonbridge)
+          - TW (Twickenham)
+          - UB (Uxbridge)
+          - W (London West)
+          - WD (Watford)
+          - ZE (Lerwick)
 
-          From 25 May | From 22 June | From 27 July
-          - | - | -
-          CB (Cambridge), SS (Southend), CO (Colchester), CM (Chelmsford) | SG (Stevenage), HP (Hemel Hempstead), LU (Luton) | AL (St Albans), WD (Watford)
+          ###Your DLA ends after September 2017 or DLA awards with no end date
 
-          ###London
+          Some people will be invited to claim PIP from 13 July 2015 if you live in the following areas:
 
-          From 25 May | From 22 June | From 27 July
-          - | - | -
-          RM (Romford) | BR (Bromley),  CR (Croydon), E (London East), EC (London East Central), IG (Ilford), SE (London South East), SW (London South West), WC (London West Central) | EN (Enfield), HA (Harrow), KT (Kingston), N (London North), NW (London North West), SM (Sutton), TW (Twickenham), UB (Uxbridge), W (London West)
+          - Blackburn (BB)
+          - Bolton (BL)
+          - Derby (DE)
+          - Leicester (LE)
+          - Manchester (M)
+          - Oldham (OL)
+          - Preston (PR)
+          - Stoke (ST)
+          - Warrington (WA)
+          - Wigan (WN)
 
-          ###Northeast England (current postcodes)
+          This includes if you have an indefinite or long-term awards of DLA.
 
-          DH (Durham), DL (Darlington), NE (Newcastle), SR (Sunderland)
+          ^You can be contacted anytime between 13 July 2015 and 30 September 2017. Not everyone in these postcode areas will be contacted to claim PIP right away.^
 
-          ###Northwest England (current postcodes)
+          You'll continue to get DLA until DWP writes to you about when it will end.
 
-          BL (Bolton), BB (Blackburn), CA (Carlisle), CH (Chester), CW (Crewe), FY (Fylde), L (Liverpool), LA (Lancaster), M (Manchester), OL (Oldham), PR (Preston), SK (Stockport), WA (Warrington), WN (Wigan)
-
-          ###Southeast England
-
-          Current postcodes | From 25 May | From 22 June | From 27 July
-          - | - | -
-          PO (Portsmouth), SO (Southampton) | DA (Dartford), MK (Milton Keynes) | BN (Brighton), GU (Guildford), OX (Oxford), RH (Redhill),  RG (Reading) | CT (Canterbury), ME (Maidstone), TN (Tonbridge), SL (Slough)
-
-          ###Southwest England
-
-          Current postcodes | From 25 May | From 22 June
-          - | - | -
-          EX (Exeter), PL (Plymouth), TA (Taunton), TQ (Torquay), TR (Truro) | BS (Bristol), GL (Gloucester), SN (Swindon), SP (Salisbury) |  BA (Bath), BH (Bournemouth), DT (Dorchester)
-
-          ###Yorkshire and Humber (current postcodes)
-
-          BD (Bradford), DN (Doncaster), HD (Huddersfield), HG (Harrogate), HU (Hull), HX (Halifax), LS (Leeds), S (Sheffield), TS (Cleveland), WF (Wakefield), YO (York)
-
-          ###Scotland
-
-          Current postcodes | From 25 May | From 27 July
-          - | - | -
-          AB (Aberdeen), DD (Dundee), DG (Dumfries and Galloway), EH (Edinburgh), G (Glasgow, IV (Inverness), KA (Kilmarnock), KY (Kirkcaldy), ML (Motherwell), PH (Perth), TD (Galashiels), FK (Falkirk) | PA (Paisley)  | HS (Hebrides), KW (Kirkwall), ZE (Lerwick)
 
       ## Q1
       are_you_getting_dla?:
@@ -107,26 +106,19 @@ en-GB:
 
       result_4:
         body: |
-          $!You shouldn't be affected by Personal Independence Payment (PIP) until 2015 or later, but there are some exceptions.$!
+          $!Some people in England, Scotland and Wales have been invited to claim Personal Independence Payment (PIP).$!
 
-          You don't need to do anything now - you'll get a letter in 2015 or later explaining:
+          If you're still getting Disability Living Allowance, when you'll be invited to claim PIP depends on:
 
-          + what will happen to your Disability Living Allowance (DLA)
-          + how you can claim PIP
+          - when your DLA ends
+          - your postcode area
+          - if your care and mobility needs change
 
-          ##Exceptions
+          ###Your DLA ends before September 2017
 
-          You’ll be invited to claim PIP if either:
+          You'll be told 20 weeks before your DLA ends and invited to claim PIP in most areas of England, Scotland and Wales.
 
-          + there’s a change in how your condition affects you
-          + your DLA is due to end and you haven’t received a renewal letter
-
-          This applies if you live in:
-
-          - Wales
-          - East Midlands
-          - West Midlands
-          - East Anglia
+          You'll also be invited to claim PIP if you tell the Department for Work and Pensions (DWP) that your care or mobility needs have changed.
 
           %{postcodes}
 
@@ -135,20 +127,64 @@ en-GB:
 
       result_5:
         body: |
-          $!You can continue to claim Disability Living Allowance (DLA) for the child for now – but there are some exceptions.$!
+          $!Some people in England, Scotland and Wales have been invited to claim Personal Independence Payment (PIP).$!
 
-          ##Exceptions
+          If your child is still getting Disability Living Allowance, when they'll be invited to claim PIP depends on:
 
-          Your child will normally get a letter before they turn 16 inviting them to apply for PIP if they live in:
+          - when their DLA ends
+          - their postcode area
+          - their age
+          - if their care and mobility needs change
 
-          - Wales
-          - East Midlands
-          - West Midlands
-          - East Anglia
+          ###Your child's DLA ends before September 2017
 
-          Contact the [Disability Benefits helpline](/disability-benefits-helpline) if their sixteenth birthday is in less than 28 days and they haven’t received this. Their payment may stop if you don’t.
+          Your child will normally get a letter before they turn 16 inviting them to apply for PIP.
 
-          %{postcodes}
+          ^Contact the [Disability Benefits helpline](/disability-benefits-helpline) if your child's sixteenth birthday is in less than 28 days and you haven’t received a letter. Your child's payment may stop if you don’t.^
+
+          Your child will also be invited to claim PIP if you tell the Department for Work and Pensions (DWP) that their care or mobility needs have changed.
+
+          In the following areas your child be asked to claim PIP from 27 July 2015:
+
+          - AL (St Albans)
+          - CT (Canterbury)
+          - EN (Enfield)
+          - HA (Harrow)
+          - HS (Hebrides)
+          - KT (Kingston)
+          - KW (Kirkwall)
+          - ME (Maidstone)
+          - N (London North)
+          - NW (London North West)
+          - SL (Slough)
+          - SM (Sutton)
+          - TN (Tonbridge)
+          - TW (Twickenham)
+          - UB (Uxbridge)
+          - W (London West)
+          - WD (Watford)
+          - ZE (Lerwick)
+
+          ###Your child's DLA ends after September 2017 or DLA awards with no end date
+
+          Some people will be invited to claim PIP from 13 July 2015 if you live in the following areas:
+
+          - Blackburn (BB)
+          - Bolton (BL)
+          - Derby (DE)
+          - Leicester (LE)
+          - Manchester (M)
+          - Oldham (OL)
+          - Preston (PR)
+          - Stoke (ST)
+          - Warrington (WA)
+          - Wigan (WN)
+
+          This includes if your child has an indefinite or long-term awards of DLA.
+
+          ^You can be contacted anytime between 13 July 2015 and 30 September 2017. Not everyone in these postcode areas will be contacted to claim PIP right away.^
+
+          Your child will continue to get DLA until DWP writes to you about when it will end.
 
           *[DLA]: Disability Living Allowance
           *[PIP]: Personal Independence Payment
@@ -161,26 +197,21 @@ en-GB:
 
       result_7:
         body: |
-          $!You shouldn't be affected by Personal Independence Payment (PIP) until 2015 or later, but there are some exceptions.$!
+          $!Some people in England, Scotland and Wales have been invited to claim Personal Independence Payment (PIP).$!
 
-          You don't need to do anything now - you'll get a letter in 2015 or later explaining:
+          If you're still getting Disability Living Allowance, when you'll be invited to claim PIP depends on:
 
-          + what will happen to your Disability Living Allowance (DLA)
-          + how you can claim PIP
+          - when your DLA ends
+          - your postcode area
+          - if your care and mobility needs change
 
-          ^Contact the [Disability Benefits helpline](/disability-benefits-helpline) if your DLA payment is due to end in less than 28 days and you haven't received a letter about making a new claim. Your payment may stop if you don't.^
+          ###Your DLA ends before September 2017
 
-          You’ll be invited to claim PIP if either:
+          You'll be told 20 weeks before your DLA ends and invited to claim PIP in most areas of England, Scotland and Wales.
 
-          + there’s a change in how your condition affects you
-          + your DLA is due to end and you haven’t received a renewal letter
+          ^Contact the [Disability Benefits helpline](/disability-benefits-helpline) if your DLA payment is due to end in less than 28 days and you haven’t received a letter about making a new claim. Your payment may stop if you don’t.^
 
-          This applies if you live in:
-
-          - Wales
-          - East Midlands
-          - West Midlands
-          - East Anglia
+          You'll also be invited to claim PIP if you tell the Department for Work and Pensions (DWP) that your care or mobility needs have changed.
 
           %{postcodes}
 

--- a/test/artefacts/pip-checker/no/1948-03-01.html
+++ b/test/artefacts/pip-checker/no/1948-03-01.html
@@ -46,6 +46,11 @@
   </article>
 </div>
 
+<script type="text/javascript">
+  var flowName = 'pip-checker';
+  GOVUK.analytics.trackEvent('Smart Answer', 'Completed', {label: flowName, nonInteraction: true});
+</script>
+
     <div class="previous-answers ">
     <div class="done-questions">
       <article>

--- a/test/artefacts/pip-checker/no/1949-02-03.html
+++ b/test/artefacts/pip-checker/no/1949-02-03.html
@@ -46,6 +46,11 @@
   </article>
 </div>
 
+<script type="text/javascript">
+  var flowName = 'pip-checker';
+  GOVUK.analytics.trackEvent('Smart Answer', 'Completed', {label: flowName, nonInteraction: true});
+</script>
+
     <div class="previous-answers ">
     <div class="done-questions">
       <article>

--- a/test/artefacts/pip-checker/no/1990-03-05.html
+++ b/test/artefacts/pip-checker/no/1990-03-05.html
@@ -44,6 +44,11 @@
   </article>
 </div>
 
+<script type="text/javascript">
+  var flowName = 'pip-checker';
+  GOVUK.analytics.trackEvent('Smart Answer', 'Completed', {label: flowName, nonInteraction: true});
+</script>
+
     <div class="previous-answers ">
     <div class="done-questions">
       <article>

--- a/test/artefacts/pip-checker/no/1997-05-08.html
+++ b/test/artefacts/pip-checker/no/1997-05-08.html
@@ -44,6 +44,11 @@
   </article>
 </div>
 
+<script type="text/javascript">
+  var flowName = 'pip-checker';
+  GOVUK.analytics.trackEvent('Smart Answer', 'Completed', {label: flowName, nonInteraction: true});
+</script>
+
     <div class="previous-answers ">
     <div class="done-questions">
       <article>

--- a/test/artefacts/pip-checker/no/2000-04-05.html
+++ b/test/artefacts/pip-checker/no/2000-04-05.html
@@ -46,6 +46,11 @@
   </article>
 </div>
 
+<script type="text/javascript">
+  var flowName = 'pip-checker';
+  GOVUK.analytics.trackEvent('Smart Answer', 'Completed', {label: flowName, nonInteraction: true});
+</script>
+
     <div class="previous-answers ">
     <div class="done-questions">
       <article>

--- a/test/artefacts/pip-checker/yes/1948-03-01.html
+++ b/test/artefacts/pip-checker/yes/1948-03-01.html
@@ -43,6 +43,11 @@
   </article>
 </div>
 
+<script type="text/javascript">
+  var flowName = 'pip-checker';
+  GOVUK.analytics.trackEvent('Smart Answer', 'Completed', {label: flowName, nonInteraction: true});
+</script>
+
     <div class="previous-answers ">
     <div class="done-questions">
       <article>

--- a/test/artefacts/pip-checker/yes/1949-02-03.html
+++ b/test/artefacts/pip-checker/yes/1949-02-03.html
@@ -33,152 +33,85 @@
       <div class="inner group">
           
 <div class="summary">
-<p>You shouldn’t be affected by Personal Independence Payment (<abbr title="Personal Independence Payment">PIP</abbr>) until 2015 or later, but there are some exceptions.</p>
+<p>Some people in England, Scotland and Wales have been invited to claim Personal Independence Payment (<abbr title="Personal Independence Payment">PIP</abbr>).</p>
 </div>
 
-<p>You don&rsquo;t need to do anything now - you&rsquo;ll get a letter in 2015 or later explaining:</p>
+<p>If you&rsquo;re still getting Disability Living Allowance, when you&rsquo;ll be invited to claim <abbr title="Personal Independence Payment">PIP</abbr> depends on:</p>
 
 <ul>
-  <li>what will happen to your Disability Living Allowance (<abbr title="Disability Living Allowance">DLA</abbr>)</li>
-  <li>how you can claim <abbr title="Personal Independence Payment">PIP</abbr></li>
+  <li>when your <abbr title="Disability Living Allowance">DLA</abbr> ends</li>
+  <li>your postcode area</li>
+  <li>if your care and mobility needs change</li>
 </ul>
+
+<h3 id="your-dla-ends-before-september-2017">Your <abbr title="Disability Living Allowance">DLA</abbr> ends before September 2017</h3>
+
+<p>You&rsquo;ll be told 20 weeks before your <abbr title="Disability Living Allowance">DLA</abbr> ends and invited to claim <abbr title="Personal Independence Payment">PIP</abbr> in most areas of England, Scotland and Wales.</p>
 
 <div role="note" aria-label="Information" class="application-notice info-notice">
-<p>Contact the <a href="/disability-benefits-helpline">Disability Benefits helpline</a> if your <abbr title="Disability Living Allowance">DLA</abbr> payment is due to end in less than 28 days and you haven&rsquo;t received a letter about making a new claim. Your payment may stop if you don&rsquo;t.</p>
+<p>Contact the <a href="/disability-benefits-helpline">Disability Benefits helpline</a> if your <abbr title="Disability Living Allowance">DLA</abbr> payment is due to end in less than 28 days and you haven’t received a letter about making a new claim. Your payment may stop if you don’t.</p>
 </div>
 
-<p>You’ll be invited to claim <abbr title="Personal Independence Payment">PIP</abbr> if either:</p>
+<p>You&rsquo;ll also be invited to claim <abbr title="Personal Independence Payment">PIP</abbr> if you tell the Department for Work and Pensions (DWP) that your care or mobility needs have changed.</p>
+
+<p>In the following areas you&rsquo;ll be asked to claim <abbr title="Personal Independence Payment">PIP</abbr> from 27 July 2015:</p>
 
 <ul>
-  <li>there’s a change in how your condition affects you</li>
-  <li>your <abbr title="Disability Living Allowance">DLA</abbr> is due to end and you haven’t received a renewal letter</li>
+  <li>AL (St Albans)</li>
+  <li>CT (Canterbury)</li>
+  <li>EN (Enfield)</li>
+  <li>HA (Harrow)</li>
+  <li>HS (Hebrides)</li>
+  <li>KT (Kingston)</li>
+  <li>KW (Kirkwall)</li>
+  <li>ME (Maidstone)</li>
+  <li>N (London North)</li>
+  <li>NW (London North West)</li>
+  <li>SL (Slough)</li>
+  <li>SM (Sutton)</li>
+  <li>TN (Tonbridge)</li>
+  <li>TW (Twickenham)</li>
+  <li>UB (Uxbridge)</li>
+  <li>W (London West)</li>
+  <li>WD (Watford)</li>
+  <li>ZE (Lerwick)</li>
 </ul>
 
-<p>This applies if you live in:</p>
+<h3 id="your-dla-ends-after-september-2017-or-dla-awards-with-no-end-date">Your <abbr title="Disability Living Allowance">DLA</abbr> ends after September 2017 or <abbr title="Disability Living Allowance">DLA</abbr> awards with no end date</h3>
+
+<p>Some people will be invited to claim <abbr title="Personal Independence Payment">PIP</abbr> from 13 July 2015 if you live in the following areas:</p>
 
 <ul>
-  <li>Wales</li>
-  <li>East Midlands</li>
-  <li>West Midlands</li>
-  <li>East Anglia</li>
+  <li>Blackburn (BB)</li>
+  <li>Bolton (BL)</li>
+  <li>Derby (DE)</li>
+  <li>Leicester (LE)</li>
+  <li>Manchester (M)</li>
+  <li>Oldham (OL)</li>
+  <li>Preston (PR)</li>
+  <li>Stoke (ST)</li>
+  <li>Warrington (WA)</li>
+  <li>Wigan (WN)</li>
 </ul>
 
-<p>Check if this also applies in your area.</p>
+<p>This includes if you have an indefinite or long-term awards of <abbr title="Disability Living Allowance">DLA</abbr>.</p>
 
-<h3 id="east-of-england">East of England</h3>
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>You can be contacted anytime between 13 July 2015 and 30 September 2017. Not everyone in these postcode areas will be contacted to claim <abbr title="Personal Independence Payment">PIP</abbr> right away.</p>
+</div>
 
-<table>
-  <thead>
-    <tr>
-      <th>From 25 May</th>
-      <th>From 22 June</th>
-      <th>From 27 July</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>CB (Cambridge), SS (Southend), CO (Colchester), CM (Chelmsford)</td>
-      <td>SG (Stevenage), HP (Hemel Hempstead), LU (Luton)</td>
-      <td>AL (St Albans), WD (Watford)</td>
-    </tr>
-  </tbody>
-</table>
-
-<h3 id="london">London</h3>
-
-<table>
-  <thead>
-    <tr>
-      <th>From 25 May</th>
-      <th>From 22 June</th>
-      <th>From 27 July</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>RM (Romford)</td>
-      <td>BR (Bromley),  CR (Croydon), E (London East), EC (London East Central), IG (Ilford), SE (London South East), SW (London South West), WC (London West Central)</td>
-      <td>EN (Enfield), HA (Harrow), KT (Kingston), N (London North), NW (London North West), SM (Sutton), TW (Twickenham), UB (Uxbridge), W (London West)</td>
-    </tr>
-  </tbody>
-</table>
-
-<h3 id="northeast-england-current-postcodes">Northeast England (current postcodes)</h3>
-
-<p>DH (Durham), DL (Darlington), NE (Newcastle), SR (Sunderland)</p>
-
-<h3 id="northwest-england-current-postcodes">Northwest England (current postcodes)</h3>
-
-<p>BL (Bolton), BB (Blackburn), CA (Carlisle), CH (Chester), CW (Crewe), FY (Fylde), L (Liverpool), LA (Lancaster), M (Manchester), OL (Oldham), PR (Preston), SK (Stockport), WA (Warrington), WN (Wigan)</p>
-
-<h3 id="southeast-england">Southeast England</h3>
-
-<table>
-  <thead>
-    <tr>
-      <th>Current postcodes</th>
-      <th>From 25 May</th>
-      <th>From 22 June</th>
-      <th>From 27 July</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>PO (Portsmouth), SO (Southampton)</td>
-      <td>DA (Dartford), MK (Milton Keynes)</td>
-      <td>BN (Brighton), GU (Guildford), OX (Oxford), RH (Redhill),  RG (Reading)</td>
-      <td>CT (Canterbury), ME (Maidstone), TN (Tonbridge), SL (Slough)</td>
-    </tr>
-  </tbody>
-</table>
-
-<h3 id="southwest-england">Southwest England</h3>
-
-<table>
-  <thead>
-    <tr>
-      <th>Current postcodes</th>
-      <th>From 25 May</th>
-      <th>From 22 June</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>EX (Exeter), PL (Plymouth), TA (Taunton), TQ (Torquay), TR (Truro)</td>
-      <td>BS (Bristol), GL (Gloucester), SN (Swindon), SP (Salisbury)</td>
-      <td>BA (Bath), BH (Bournemouth), DT (Dorchester)</td>
-    </tr>
-  </tbody>
-</table>
-
-<h3 id="yorkshire-and-humber-current-postcodes">Yorkshire and Humber (current postcodes)</h3>
-
-<p>BD (Bradford), DN (Doncaster), HD (Huddersfield), HG (Harrogate), HU (Hull), HX (Halifax), LS (Leeds), S (Sheffield), TS (Cleveland), WF (Wakefield), YO (York)</p>
-
-<h3 id="scotland">Scotland</h3>
-
-<table>
-  <thead>
-    <tr>
-      <th>Current postcodes</th>
-      <th>From 25 May</th>
-      <th>From 27 July</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>AB (Aberdeen), DD (Dundee), DG (Dumfries and Galloway), EH (Edinburgh), G (Glasgow, IV (Inverness), KA (Kilmarnock), KY (Kirkcaldy), ML (Motherwell), PH (Perth), TD (Galashiels), FK (Falkirk)</td>
-      <td>PA (Paisley)</td>
-      <td>HS (Hebrides), KW (Kirkwall), ZE (Lerwick)</td>
-    </tr>
-  </tbody>
-</table>
+<p>You&rsquo;ll continue to get <abbr title="Disability Living Allowance">DLA</abbr> until DWP writes to you about when it will end.</p>
 
 
       </div>
     </div>
   </article>
 </div>
+
+<script type="text/javascript">
+  var flowName = 'pip-checker';
+  GOVUK.analytics.trackEvent('Smart Answer', 'Completed', {label: flowName, nonInteraction: true});
+</script>
 
     <div class="previous-answers ">
     <div class="done-questions">

--- a/test/artefacts/pip-checker/yes/1990-03-05.html
+++ b/test/artefacts/pip-checker/yes/1990-03-05.html
@@ -33,152 +33,85 @@
       <div class="inner group">
           
 <div class="summary">
-<p>You shouldn’t be affected by Personal Independence Payment (<abbr title="Personal Independence Payment">PIP</abbr>) until 2015 or later, but there are some exceptions.</p>
+<p>Some people in England, Scotland and Wales have been invited to claim Personal Independence Payment (<abbr title="Personal Independence Payment">PIP</abbr>).</p>
 </div>
 
-<p>You don&rsquo;t need to do anything now - you&rsquo;ll get a letter in 2015 or later explaining:</p>
+<p>If you&rsquo;re still getting Disability Living Allowance, when you&rsquo;ll be invited to claim <abbr title="Personal Independence Payment">PIP</abbr> depends on:</p>
 
 <ul>
-  <li>what will happen to your Disability Living Allowance (<abbr title="Disability Living Allowance">DLA</abbr>)</li>
-  <li>how you can claim <abbr title="Personal Independence Payment">PIP</abbr></li>
+  <li>when your <abbr title="Disability Living Allowance">DLA</abbr> ends</li>
+  <li>your postcode area</li>
+  <li>if your care and mobility needs change</li>
 </ul>
+
+<h3 id="your-dla-ends-before-september-2017">Your <abbr title="Disability Living Allowance">DLA</abbr> ends before September 2017</h3>
+
+<p>You&rsquo;ll be told 20 weeks before your <abbr title="Disability Living Allowance">DLA</abbr> ends and invited to claim <abbr title="Personal Independence Payment">PIP</abbr> in most areas of England, Scotland and Wales.</p>
 
 <div role="note" aria-label="Information" class="application-notice info-notice">
-<p>Contact the <a href="/disability-benefits-helpline">Disability Benefits helpline</a> if your <abbr title="Disability Living Allowance">DLA</abbr> payment is due to end in less than 28 days and you haven&rsquo;t received a letter about making a new claim. Your payment may stop if you don&rsquo;t.</p>
+<p>Contact the <a href="/disability-benefits-helpline">Disability Benefits helpline</a> if your <abbr title="Disability Living Allowance">DLA</abbr> payment is due to end in less than 28 days and you haven’t received a letter about making a new claim. Your payment may stop if you don’t.</p>
 </div>
 
-<p>You’ll be invited to claim <abbr title="Personal Independence Payment">PIP</abbr> if either:</p>
+<p>You&rsquo;ll also be invited to claim <abbr title="Personal Independence Payment">PIP</abbr> if you tell the Department for Work and Pensions (DWP) that your care or mobility needs have changed.</p>
+
+<p>In the following areas you&rsquo;ll be asked to claim <abbr title="Personal Independence Payment">PIP</abbr> from 27 July 2015:</p>
 
 <ul>
-  <li>there’s a change in how your condition affects you</li>
-  <li>your <abbr title="Disability Living Allowance">DLA</abbr> is due to end and you haven’t received a renewal letter</li>
+  <li>AL (St Albans)</li>
+  <li>CT (Canterbury)</li>
+  <li>EN (Enfield)</li>
+  <li>HA (Harrow)</li>
+  <li>HS (Hebrides)</li>
+  <li>KT (Kingston)</li>
+  <li>KW (Kirkwall)</li>
+  <li>ME (Maidstone)</li>
+  <li>N (London North)</li>
+  <li>NW (London North West)</li>
+  <li>SL (Slough)</li>
+  <li>SM (Sutton)</li>
+  <li>TN (Tonbridge)</li>
+  <li>TW (Twickenham)</li>
+  <li>UB (Uxbridge)</li>
+  <li>W (London West)</li>
+  <li>WD (Watford)</li>
+  <li>ZE (Lerwick)</li>
 </ul>
 
-<p>This applies if you live in:</p>
+<h3 id="your-dla-ends-after-september-2017-or-dla-awards-with-no-end-date">Your <abbr title="Disability Living Allowance">DLA</abbr> ends after September 2017 or <abbr title="Disability Living Allowance">DLA</abbr> awards with no end date</h3>
+
+<p>Some people will be invited to claim <abbr title="Personal Independence Payment">PIP</abbr> from 13 July 2015 if you live in the following areas:</p>
 
 <ul>
-  <li>Wales</li>
-  <li>East Midlands</li>
-  <li>West Midlands</li>
-  <li>East Anglia</li>
+  <li>Blackburn (BB)</li>
+  <li>Bolton (BL)</li>
+  <li>Derby (DE)</li>
+  <li>Leicester (LE)</li>
+  <li>Manchester (M)</li>
+  <li>Oldham (OL)</li>
+  <li>Preston (PR)</li>
+  <li>Stoke (ST)</li>
+  <li>Warrington (WA)</li>
+  <li>Wigan (WN)</li>
 </ul>
 
-<p>Check if this also applies in your area.</p>
+<p>This includes if you have an indefinite or long-term awards of <abbr title="Disability Living Allowance">DLA</abbr>.</p>
 
-<h3 id="east-of-england">East of England</h3>
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>You can be contacted anytime between 13 July 2015 and 30 September 2017. Not everyone in these postcode areas will be contacted to claim <abbr title="Personal Independence Payment">PIP</abbr> right away.</p>
+</div>
 
-<table>
-  <thead>
-    <tr>
-      <th>From 25 May</th>
-      <th>From 22 June</th>
-      <th>From 27 July</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>CB (Cambridge), SS (Southend), CO (Colchester), CM (Chelmsford)</td>
-      <td>SG (Stevenage), HP (Hemel Hempstead), LU (Luton)</td>
-      <td>AL (St Albans), WD (Watford)</td>
-    </tr>
-  </tbody>
-</table>
-
-<h3 id="london">London</h3>
-
-<table>
-  <thead>
-    <tr>
-      <th>From 25 May</th>
-      <th>From 22 June</th>
-      <th>From 27 July</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>RM (Romford)</td>
-      <td>BR (Bromley),  CR (Croydon), E (London East), EC (London East Central), IG (Ilford), SE (London South East), SW (London South West), WC (London West Central)</td>
-      <td>EN (Enfield), HA (Harrow), KT (Kingston), N (London North), NW (London North West), SM (Sutton), TW (Twickenham), UB (Uxbridge), W (London West)</td>
-    </tr>
-  </tbody>
-</table>
-
-<h3 id="northeast-england-current-postcodes">Northeast England (current postcodes)</h3>
-
-<p>DH (Durham), DL (Darlington), NE (Newcastle), SR (Sunderland)</p>
-
-<h3 id="northwest-england-current-postcodes">Northwest England (current postcodes)</h3>
-
-<p>BL (Bolton), BB (Blackburn), CA (Carlisle), CH (Chester), CW (Crewe), FY (Fylde), L (Liverpool), LA (Lancaster), M (Manchester), OL (Oldham), PR (Preston), SK (Stockport), WA (Warrington), WN (Wigan)</p>
-
-<h3 id="southeast-england">Southeast England</h3>
-
-<table>
-  <thead>
-    <tr>
-      <th>Current postcodes</th>
-      <th>From 25 May</th>
-      <th>From 22 June</th>
-      <th>From 27 July</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>PO (Portsmouth), SO (Southampton)</td>
-      <td>DA (Dartford), MK (Milton Keynes)</td>
-      <td>BN (Brighton), GU (Guildford), OX (Oxford), RH (Redhill),  RG (Reading)</td>
-      <td>CT (Canterbury), ME (Maidstone), TN (Tonbridge), SL (Slough)</td>
-    </tr>
-  </tbody>
-</table>
-
-<h3 id="southwest-england">Southwest England</h3>
-
-<table>
-  <thead>
-    <tr>
-      <th>Current postcodes</th>
-      <th>From 25 May</th>
-      <th>From 22 June</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>EX (Exeter), PL (Plymouth), TA (Taunton), TQ (Torquay), TR (Truro)</td>
-      <td>BS (Bristol), GL (Gloucester), SN (Swindon), SP (Salisbury)</td>
-      <td>BA (Bath), BH (Bournemouth), DT (Dorchester)</td>
-    </tr>
-  </tbody>
-</table>
-
-<h3 id="yorkshire-and-humber-current-postcodes">Yorkshire and Humber (current postcodes)</h3>
-
-<p>BD (Bradford), DN (Doncaster), HD (Huddersfield), HG (Harrogate), HU (Hull), HX (Halifax), LS (Leeds), S (Sheffield), TS (Cleveland), WF (Wakefield), YO (York)</p>
-
-<h3 id="scotland">Scotland</h3>
-
-<table>
-  <thead>
-    <tr>
-      <th>Current postcodes</th>
-      <th>From 25 May</th>
-      <th>From 27 July</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>AB (Aberdeen), DD (Dundee), DG (Dumfries and Galloway), EH (Edinburgh), G (Glasgow, IV (Inverness), KA (Kilmarnock), KY (Kirkcaldy), ML (Motherwell), PH (Perth), TD (Galashiels), FK (Falkirk)</td>
-      <td>PA (Paisley)</td>
-      <td>HS (Hebrides), KW (Kirkwall), ZE (Lerwick)</td>
-    </tr>
-  </tbody>
-</table>
+<p>You&rsquo;ll continue to get <abbr title="Disability Living Allowance">DLA</abbr> until DWP writes to you about when it will end.</p>
 
 
       </div>
     </div>
   </article>
 </div>
+
+<script type="text/javascript">
+  var flowName = 'pip-checker';
+  GOVUK.analytics.trackEvent('Smart Answer', 'Completed', {label: flowName, nonInteraction: true});
+</script>
 
     <div class="previous-answers ">
     <div class="done-questions">

--- a/test/artefacts/pip-checker/yes/1997-05-08.html
+++ b/test/artefacts/pip-checker/yes/1997-05-08.html
@@ -33,150 +33,81 @@
       <div class="inner group">
           
 <div class="summary">
-<p>You shouldn’t be affected by Personal Independence Payment (<abbr title="Personal Independence Payment">PIP</abbr>) until 2015 or later, but there are some exceptions.</p>
+<p>Some people in England, Scotland and Wales have been invited to claim Personal Independence Payment (<abbr title="Personal Independence Payment">PIP</abbr>).</p>
 </div>
 
-<p>You don&rsquo;t need to do anything now - you&rsquo;ll get a letter in 2015 or later explaining:</p>
+<p>If you&rsquo;re still getting Disability Living Allowance, when you&rsquo;ll be invited to claim <abbr title="Personal Independence Payment">PIP</abbr> depends on:</p>
 
 <ul>
-  <li>what will happen to your Disability Living Allowance (<abbr title="Disability Living Allowance">DLA</abbr>)</li>
-  <li>how you can claim <abbr title="Personal Independence Payment">PIP</abbr></li>
+  <li>when your <abbr title="Disability Living Allowance">DLA</abbr> ends</li>
+  <li>your postcode area</li>
+  <li>if your care and mobility needs change</li>
 </ul>
 
-<h2 id="exceptions">Exceptions</h2>
+<h3 id="your-dla-ends-before-september-2017">Your <abbr title="Disability Living Allowance">DLA</abbr> ends before September 2017</h3>
 
-<p>You’ll be invited to claim <abbr title="Personal Independence Payment">PIP</abbr> if either:</p>
+<p>You&rsquo;ll be told 20 weeks before your <abbr title="Disability Living Allowance">DLA</abbr> ends and invited to claim <abbr title="Personal Independence Payment">PIP</abbr> in most areas of England, Scotland and Wales.</p>
+
+<p>You&rsquo;ll also be invited to claim <abbr title="Personal Independence Payment">PIP</abbr> if you tell the Department for Work and Pensions (DWP) that your care or mobility needs have changed.</p>
+
+<p>In the following areas you&rsquo;ll be asked to claim <abbr title="Personal Independence Payment">PIP</abbr> from 27 July 2015:</p>
 
 <ul>
-  <li>there’s a change in how your condition affects you</li>
-  <li>your <abbr title="Disability Living Allowance">DLA</abbr> is due to end and you haven’t received a renewal letter</li>
+  <li>AL (St Albans)</li>
+  <li>CT (Canterbury)</li>
+  <li>EN (Enfield)</li>
+  <li>HA (Harrow)</li>
+  <li>HS (Hebrides)</li>
+  <li>KT (Kingston)</li>
+  <li>KW (Kirkwall)</li>
+  <li>ME (Maidstone)</li>
+  <li>N (London North)</li>
+  <li>NW (London North West)</li>
+  <li>SL (Slough)</li>
+  <li>SM (Sutton)</li>
+  <li>TN (Tonbridge)</li>
+  <li>TW (Twickenham)</li>
+  <li>UB (Uxbridge)</li>
+  <li>W (London West)</li>
+  <li>WD (Watford)</li>
+  <li>ZE (Lerwick)</li>
 </ul>
 
-<p>This applies if you live in:</p>
+<h3 id="your-dla-ends-after-september-2017-or-dla-awards-with-no-end-date">Your <abbr title="Disability Living Allowance">DLA</abbr> ends after September 2017 or <abbr title="Disability Living Allowance">DLA</abbr> awards with no end date</h3>
+
+<p>Some people will be invited to claim <abbr title="Personal Independence Payment">PIP</abbr> from 13 July 2015 if you live in the following areas:</p>
 
 <ul>
-  <li>Wales</li>
-  <li>East Midlands</li>
-  <li>West Midlands</li>
-  <li>East Anglia</li>
+  <li>Blackburn (BB)</li>
+  <li>Bolton (BL)</li>
+  <li>Derby (DE)</li>
+  <li>Leicester (LE)</li>
+  <li>Manchester (M)</li>
+  <li>Oldham (OL)</li>
+  <li>Preston (PR)</li>
+  <li>Stoke (ST)</li>
+  <li>Warrington (WA)</li>
+  <li>Wigan (WN)</li>
 </ul>
 
-<p>Check if this also applies in your area.</p>
+<p>This includes if you have an indefinite or long-term awards of <abbr title="Disability Living Allowance">DLA</abbr>.</p>
 
-<h3 id="east-of-england">East of England</h3>
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>You can be contacted anytime between 13 July 2015 and 30 September 2017. Not everyone in these postcode areas will be contacted to claim <abbr title="Personal Independence Payment">PIP</abbr> right away.</p>
+</div>
 
-<table>
-  <thead>
-    <tr>
-      <th>From 25 May</th>
-      <th>From 22 June</th>
-      <th>From 27 July</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>CB (Cambridge), SS (Southend), CO (Colchester), CM (Chelmsford)</td>
-      <td>SG (Stevenage), HP (Hemel Hempstead), LU (Luton)</td>
-      <td>AL (St Albans), WD (Watford)</td>
-    </tr>
-  </tbody>
-</table>
-
-<h3 id="london">London</h3>
-
-<table>
-  <thead>
-    <tr>
-      <th>From 25 May</th>
-      <th>From 22 June</th>
-      <th>From 27 July</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>RM (Romford)</td>
-      <td>BR (Bromley),  CR (Croydon), E (London East), EC (London East Central), IG (Ilford), SE (London South East), SW (London South West), WC (London West Central)</td>
-      <td>EN (Enfield), HA (Harrow), KT (Kingston), N (London North), NW (London North West), SM (Sutton), TW (Twickenham), UB (Uxbridge), W (London West)</td>
-    </tr>
-  </tbody>
-</table>
-
-<h3 id="northeast-england-current-postcodes">Northeast England (current postcodes)</h3>
-
-<p>DH (Durham), DL (Darlington), NE (Newcastle), SR (Sunderland)</p>
-
-<h3 id="northwest-england-current-postcodes">Northwest England (current postcodes)</h3>
-
-<p>BL (Bolton), BB (Blackburn), CA (Carlisle), CH (Chester), CW (Crewe), FY (Fylde), L (Liverpool), LA (Lancaster), M (Manchester), OL (Oldham), PR (Preston), SK (Stockport), WA (Warrington), WN (Wigan)</p>
-
-<h3 id="southeast-england">Southeast England</h3>
-
-<table>
-  <thead>
-    <tr>
-      <th>Current postcodes</th>
-      <th>From 25 May</th>
-      <th>From 22 June</th>
-      <th>From 27 July</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>PO (Portsmouth), SO (Southampton)</td>
-      <td>DA (Dartford), MK (Milton Keynes)</td>
-      <td>BN (Brighton), GU (Guildford), OX (Oxford), RH (Redhill),  RG (Reading)</td>
-      <td>CT (Canterbury), ME (Maidstone), TN (Tonbridge), SL (Slough)</td>
-    </tr>
-  </tbody>
-</table>
-
-<h3 id="southwest-england">Southwest England</h3>
-
-<table>
-  <thead>
-    <tr>
-      <th>Current postcodes</th>
-      <th>From 25 May</th>
-      <th>From 22 June</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>EX (Exeter), PL (Plymouth), TA (Taunton), TQ (Torquay), TR (Truro)</td>
-      <td>BS (Bristol), GL (Gloucester), SN (Swindon), SP (Salisbury)</td>
-      <td>BA (Bath), BH (Bournemouth), DT (Dorchester)</td>
-    </tr>
-  </tbody>
-</table>
-
-<h3 id="yorkshire-and-humber-current-postcodes">Yorkshire and Humber (current postcodes)</h3>
-
-<p>BD (Bradford), DN (Doncaster), HD (Huddersfield), HG (Harrogate), HU (Hull), HX (Halifax), LS (Leeds), S (Sheffield), TS (Cleveland), WF (Wakefield), YO (York)</p>
-
-<h3 id="scotland">Scotland</h3>
-
-<table>
-  <thead>
-    <tr>
-      <th>Current postcodes</th>
-      <th>From 25 May</th>
-      <th>From 27 July</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>AB (Aberdeen), DD (Dundee), DG (Dumfries and Galloway), EH (Edinburgh), G (Glasgow, IV (Inverness), KA (Kilmarnock), KY (Kirkcaldy), ML (Motherwell), PH (Perth), TD (Galashiels), FK (Falkirk)</td>
-      <td>PA (Paisley)</td>
-      <td>HS (Hebrides), KW (Kirkwall), ZE (Lerwick)</td>
-    </tr>
-  </tbody>
-</table>
+<p>You&rsquo;ll continue to get <abbr title="Disability Living Allowance">DLA</abbr> until DWP writes to you about when it will end.</p>
 
 
       </div>
     </div>
   </article>
 </div>
+
+<script type="text/javascript">
+  var flowName = 'pip-checker';
+  GOVUK.analytics.trackEvent('Smart Answer', 'Completed', {label: flowName, nonInteraction: true});
+</script>
 
     <div class="previous-answers ">
     <div class="done-questions">

--- a/test/artefacts/pip-checker/yes/2000-04-05.html
+++ b/test/artefacts/pip-checker/yes/2000-04-05.html
@@ -33,138 +33,86 @@
       <div class="inner group">
           
 <div class="summary">
-<p>You can continue to claim Disability Living Allowance (<abbr title="Disability Living Allowance">DLA</abbr>) for the child for now – but there are some exceptions.</p>
+<p>Some people in England, Scotland and Wales have been invited to claim Personal Independence Payment (<abbr title="Personal Independence Payment">PIP</abbr>).</p>
 </div>
 
-<h2 id="exceptions">Exceptions</h2>
-
-<p>Your child will normally get a letter before they turn 16 inviting them to apply for <abbr title="Personal Independence Payment">PIP</abbr> if they live in:</p>
+<p>If your child is still getting Disability Living Allowance, when they&rsquo;ll be invited to claim <abbr title="Personal Independence Payment">PIP</abbr> depends on:</p>
 
 <ul>
-  <li>Wales</li>
-  <li>East Midlands</li>
-  <li>West Midlands</li>
-  <li>East Anglia</li>
+  <li>when their <abbr title="Disability Living Allowance">DLA</abbr> ends</li>
+  <li>their postcode area</li>
+  <li>their age</li>
+  <li>if their care and mobility needs change</li>
 </ul>
 
-<p>Contact the <a href="/disability-benefits-helpline">Disability Benefits helpline</a> if their sixteenth birthday is in less than 28 days and they haven’t received this. Their payment may stop if you don’t.</p>
+<h3 id="your-childs-dla-ends-before-september-2017">Your child&rsquo;s <abbr title="Disability Living Allowance">DLA</abbr> ends before September 2017</h3>
 
-<p>Check if this also applies in your area.</p>
+<p>Your child will normally get a letter before they turn 16 inviting them to apply for <abbr title="Personal Independence Payment">PIP</abbr>.</p>
 
-<h3 id="east-of-england">East of England</h3>
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>Contact the <a href="/disability-benefits-helpline">Disability Benefits helpline</a> if your child&rsquo;s sixteenth birthday is in less than 28 days and you haven’t received a letter. Your child&rsquo;s payment may stop if you don’t.</p>
+</div>
 
-<table>
-  <thead>
-    <tr>
-      <th>From 25 May</th>
-      <th>From 22 June</th>
-      <th>From 27 July</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>CB (Cambridge), SS (Southend), CO (Colchester), CM (Chelmsford)</td>
-      <td>SG (Stevenage), HP (Hemel Hempstead), LU (Luton)</td>
-      <td>AL (St Albans), WD (Watford)</td>
-    </tr>
-  </tbody>
-</table>
+<p>Your child will also be invited to claim <abbr title="Personal Independence Payment">PIP</abbr> if you tell the Department for Work and Pensions (DWP) that their care or mobility needs have changed.</p>
 
-<h3 id="london">London</h3>
+<p>In the following areas your child be asked to claim <abbr title="Personal Independence Payment">PIP</abbr> from 27 July 2015:</p>
 
-<table>
-  <thead>
-    <tr>
-      <th>From 25 May</th>
-      <th>From 22 June</th>
-      <th>From 27 July</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>RM (Romford)</td>
-      <td>BR (Bromley),  CR (Croydon), E (London East), EC (London East Central), IG (Ilford), SE (London South East), SW (London South West), WC (London West Central)</td>
-      <td>EN (Enfield), HA (Harrow), KT (Kingston), N (London North), NW (London North West), SM (Sutton), TW (Twickenham), UB (Uxbridge), W (London West)</td>
-    </tr>
-  </tbody>
-</table>
+<ul>
+  <li>AL (St Albans)</li>
+  <li>CT (Canterbury)</li>
+  <li>EN (Enfield)</li>
+  <li>HA (Harrow)</li>
+  <li>HS (Hebrides)</li>
+  <li>KT (Kingston)</li>
+  <li>KW (Kirkwall)</li>
+  <li>ME (Maidstone)</li>
+  <li>N (London North)</li>
+  <li>NW (London North West)</li>
+  <li>SL (Slough)</li>
+  <li>SM (Sutton)</li>
+  <li>TN (Tonbridge)</li>
+  <li>TW (Twickenham)</li>
+  <li>UB (Uxbridge)</li>
+  <li>W (London West)</li>
+  <li>WD (Watford)</li>
+  <li>ZE (Lerwick)</li>
+</ul>
 
-<h3 id="northeast-england-current-postcodes">Northeast England (current postcodes)</h3>
+<h3 id="your-childs-dla-ends-after-september-2017-or-dla-awards-with-no-end-date">Your child&rsquo;s <abbr title="Disability Living Allowance">DLA</abbr> ends after September 2017 or <abbr title="Disability Living Allowance">DLA</abbr> awards with no end date</h3>
 
-<p>DH (Durham), DL (Darlington), NE (Newcastle), SR (Sunderland)</p>
+<p>Some people will be invited to claim <abbr title="Personal Independence Payment">PIP</abbr> from 13 July 2015 if you live in the following areas:</p>
 
-<h3 id="northwest-england-current-postcodes">Northwest England (current postcodes)</h3>
+<ul>
+  <li>Blackburn (BB)</li>
+  <li>Bolton (BL)</li>
+  <li>Derby (DE)</li>
+  <li>Leicester (LE)</li>
+  <li>Manchester (M)</li>
+  <li>Oldham (OL)</li>
+  <li>Preston (PR)</li>
+  <li>Stoke (ST)</li>
+  <li>Warrington (WA)</li>
+  <li>Wigan (WN)</li>
+</ul>
 
-<p>BL (Bolton), BB (Blackburn), CA (Carlisle), CH (Chester), CW (Crewe), FY (Fylde), L (Liverpool), LA (Lancaster), M (Manchester), OL (Oldham), PR (Preston), SK (Stockport), WA (Warrington), WN (Wigan)</p>
+<p>This includes if your child has an indefinite or long-term awards of <abbr title="Disability Living Allowance">DLA</abbr>.</p>
 
-<h3 id="southeast-england">Southeast England</h3>
+<div role="note" aria-label="Information" class="application-notice info-notice">
+<p>You can be contacted anytime between 13 July 2015 and 30 September 2017. Not everyone in these postcode areas will be contacted to claim <abbr title="Personal Independence Payment">PIP</abbr> right away.</p>
+</div>
 
-<table>
-  <thead>
-    <tr>
-      <th>Current postcodes</th>
-      <th>From 25 May</th>
-      <th>From 22 June</th>
-      <th>From 27 July</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>PO (Portsmouth), SO (Southampton)</td>
-      <td>DA (Dartford), MK (Milton Keynes)</td>
-      <td>BN (Brighton), GU (Guildford), OX (Oxford), RH (Redhill),  RG (Reading)</td>
-      <td>CT (Canterbury), ME (Maidstone), TN (Tonbridge), SL (Slough)</td>
-    </tr>
-  </tbody>
-</table>
-
-<h3 id="southwest-england">Southwest England</h3>
-
-<table>
-  <thead>
-    <tr>
-      <th>Current postcodes</th>
-      <th>From 25 May</th>
-      <th>From 22 June</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>EX (Exeter), PL (Plymouth), TA (Taunton), TQ (Torquay), TR (Truro)</td>
-      <td>BS (Bristol), GL (Gloucester), SN (Swindon), SP (Salisbury)</td>
-      <td>BA (Bath), BH (Bournemouth), DT (Dorchester)</td>
-    </tr>
-  </tbody>
-</table>
-
-<h3 id="yorkshire-and-humber-current-postcodes">Yorkshire and Humber (current postcodes)</h3>
-
-<p>BD (Bradford), DN (Doncaster), HD (Huddersfield), HG (Harrogate), HU (Hull), HX (Halifax), LS (Leeds), S (Sheffield), TS (Cleveland), WF (Wakefield), YO (York)</p>
-
-<h3 id="scotland">Scotland</h3>
-
-<table>
-  <thead>
-    <tr>
-      <th>Current postcodes</th>
-      <th>From 25 May</th>
-      <th>From 27 July</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>AB (Aberdeen), DD (Dundee), DG (Dumfries and Galloway), EH (Edinburgh), G (Glasgow, IV (Inverness), KA (Kilmarnock), KY (Kirkcaldy), ML (Motherwell), PH (Perth), TD (Galashiels), FK (Falkirk)</td>
-      <td>PA (Paisley)</td>
-      <td>HS (Hebrides), KW (Kirkwall), ZE (Lerwick)</td>
-    </tr>
-  </tbody>
-</table>
+<p>Your child will continue to get <abbr title="Disability Living Allowance">DLA</abbr> until DWP writes to you about when it will end.</p>
 
 
       </div>
     </div>
   </article>
 </div>
+
+<script type="text/javascript">
+  var flowName = 'pip-checker';
+  GOVUK.analytics.trackEvent('Smart Answer', 'Completed', {label: flowName, nonInteraction: true});
+</script>
 
     <div class="previous-answers ">
     <div class="done-questions">

--- a/test/data/pip-checker-files.yml
+++ b/test/data/pip-checker-files.yml
@@ -1,6 +1,6 @@
 --- 
 lib/smart_answer_flows/pip-checker.rb: 0e09d0bf53dfe2a921363f53be3e6cd4
-lib/smart_answer_flows/locales/en/pip-checker.yml: f380187c0e66824c1061e35841e979ee
+lib/smart_answer_flows/locales/en/pip-checker.yml: a561039b116a6efefe4e34e9ef758beb
 test/data/pip-checker-questions-and-responses.yml: b1d68ebfb76a9e2793705c55b82294f5
 test/data/pip-checker-responses-and-expected-results.yml: f0c8c243623cad06b9c65dbb504d5b4d
 lib/smart_answer/calculators/pip_dates.rb: 773342998eae28adbbc7403a24e9548c


### PR DESCRIPTION
This is just https://github.com/alphagov/smart-answers/pull/1745 with whitespace fixes and the regression test dance :dancer:

I'll deploy this branch on preview so that Liz can check it out and merge it when she confirms everything is ok.

## Original PR

Update pip checker

Big rework to remove the postcode area info.
Replaced with new text and new postcode areas, divided by pre/post 2017.
Made the child outcome independent of the postcode info because the way the text needs to work to explain how it all now works.

Affected URLs
https://www.gov.uk/pip-checker/y/yes/2000-03-01
https://www.gov.uk/pip-checker/y/yes/1980-03-01
https://www.gov.uk/pip-checker/y/yes/1997-05-01