### PR TITLE
Users in Macao can now have Opposite Sex marriages registered

### DIFF
--- a/lib/smart_answer/calculators/marriage_abroad_data_query.rb
+++ b/lib/smart_answer/calculators/marriage_abroad_data_query.rb
@@ -16,13 +16,13 @@ module SmartAnswer::Calculators
 
     OS_NO_CONSULAR_CNI_COUNTRIES = %w(argentina burundi czech-republic democratic-republic-of-congo mexico saint-barthelemy senegal st-martin slovakia taiwan usa uruguay)
 
-    OS_NO_MARRIAGE_CONSULAR_SERVICES = %w(afghanistan american-samoa andorra aruba benin bhutan bonaire-st-eustatius-saba burkina-faso burundi cape-verde central-african-republic chad comoros congo costa-rica cote-d-ivoire curacao djibouti equatorial-guinea eritrea gabon guinea guinea-bissau haiti hong-kong iraq israel kosovo laos liberia liechtenstein macao madagascar mali marshall-islands mauritania micronesia monaco nicaragua niger palau paraguay rwanda san-marino sao-tome-and-principe south-sudan st-maarten suriname timor-leste togo western-sahara)
+    OS_NO_MARRIAGE_CONSULAR_SERVICES = %w(afghanistan american-samoa andorra aruba benin bhutan bonaire-st-eustatius-saba burkina-faso burundi cape-verde central-african-republic chad comoros congo costa-rica cote-d-ivoire curacao djibouti equatorial-guinea eritrea gabon guinea guinea-bissau haiti hong-kong iraq israel kosovo laos liberia liechtenstein madagascar mali marshall-islands mauritania micronesia monaco nicaragua niger palau paraguay rwanda san-marino sao-tome-and-principe south-sudan st-maarten suriname timor-leste togo western-sahara)
 
     OS_CONSULAR_CNI_IN_NEARBY_COUNTRY = %w(nicaragua)
 
     OS_OTHER_COUNTRIES = %w(burma north-korea iran somalia syria yemen saudi-arabia)
 
-    OS_AFFIRMATION_COUNTRIES = %w(belgium cambodia colombia china ecuador egypt lebanon finland mongolia morocco peru philippines qatar south-korea thailand turkey united-arab-emirates vietnam)
+    OS_AFFIRMATION_COUNTRIES = %w(belgium cambodia colombia china ecuador egypt lebanon finland macao mongolia morocco peru philippines qatar south-korea thailand turkey united-arab-emirates vietnam)
 
     CP_EQUIVALENT_COUNTRIES = %w(austria belgium brazil colombia czech-republic denmark ecuador finland germany hungary iceland luxembourg netherlands norway portugal slovenia sweden)
 

--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -218,10 +218,18 @@ en-GB:
           [Download ‘Affidavit for marriage’ and ’Affirmation for marriage’](/government/publications/affidavitaffirmation-of-marital-status-form-belgium)
           $D
 
+        download_affidavit_and_affirmation_macao: |
+          $D
+          [Download ‘Affidavit for marriage’](/government/publications/affidavit-form-macao)
+          [Download ’Affirmation for marriage’](/government/publications/affirmation-form-macao)
+          $D
+
         contact_for_affidavit: |
           Contact the local British embassy or consulate in %{country_name_lowercase_prefix} to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
         appointment_for_affidavit: |
           Make an appointment at the local British embassy or consulate in %{country_name_lowercase_prefix} to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
+        appointment_for_affidavit_in_hong_kong: |
+          Make an appointment at the British embassy or consulate in Hong Kong to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
         appointment_for_affidavit_indonesia: |
           Make an appointment at the local British embassy or consulate in Indonesia to swear an affidavit (written statement of facts) that you’re free to marry.
 
@@ -745,6 +753,15 @@ en-GB:
           - your passport
           - your [full birth certificate](/order-copy-birth-death-marriage-certificate/)
           - equivalent documents for your partner
+
+        required_supporting_documents_macao: |
+          You’ll need to provide supporting documents, including:
+
+          - your passport
+          - your partner’s passport (if they’re not British)
+          - your [full birth certificate](/order-copy-birth-death-marriage-certificate) or [naturalisation certificate](/get-replacement-citizenship-certificate)
+          - proof of residence, such as a residence certificate - check with the embassy or notary public to find out what you need
+          - equivalent documents for your partner 
 
         partner_needs_egyptian_id: |
           Your partner will need to provide their Egyptian ID card, if they’re an Egyptian national.
@@ -1565,6 +1582,8 @@ en-GB:
               [Make an appointment at the embassy in Vilnius.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-vilnius/notice-of-marriage-or-civil-partnership/slot_picker)
             luxembourg: |
               [Make an appointment at the embassy in Luxembourg.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-luxembourg/notice-of-marriage-or-civil-partnership/slot_picker)
+            macao: |
+              [Make an appointment at the British Consulate General in Hong Kong](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-hong-kong/oaths-affirmations-and-affidavits/slot_picker)
             mexico: |
               [Make an appointment at the embassy in Mexico City.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-mexico-city/notice-of-marriage-or-civil-partnership/slot_picker)
             moldova: |

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -960,6 +960,8 @@ module SmartAnswer
             phrases << prelude
             phrases << contact_method_key
             phrases << :book_online_china_affirmation_affidavit
+          elsif ceremony_country == 'macao'
+            phrases << :appointment_for_affidavit_in_hong_kong
           else
             phrases << :appointment_for_affidavit
           end
@@ -975,6 +977,14 @@ module SmartAnswer
 
             if ceremony_country == 'philippines'
               phrases << :required_supporting_documents_philippines
+            end
+
+            if ceremony_country == 'macao'
+              phrases << :complete_affirmation_or_affidavit_forms
+              phrases << :download_and_fill_but_not_sign
+              phrases << :download_affidavit_and_affirmation_macao
+              phrases << :required_supporting_documents_macao
+              phrases << :partner_probably_needs_affirmation
             end
 
             if ceremony_country == 'cambodia'
@@ -1071,7 +1081,7 @@ module SmartAnswer
           #fee tables
           if %w(south-korea thailand turkey vietnam).include?(ceremony_country)
             phrases << :fee_table_affidavit_55
-          elsif %w(cambodia ecuador morocco belgium).include? ceremony_country
+          elsif %w(belgium cambodia ecuador macao morocco).include?(ceremony_country)
             phrases << :fee_table_affirmation_55
           elsif ceremony_country == 'finland'
             phrases << :fee_table_affirmation_65
@@ -1418,7 +1428,6 @@ module SmartAnswer
       end
 
       outcome :outcome_os_marriage_impossible_no_laos_locals
-
     end
   end
 end

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -1,8 +1,8 @@
 --- 
-lib/smart_answer_flows/marriage-abroad.rb: 9ffa446fc15d385d318ccc9874cec97f
-lib/smart_answer_flows/locales/en/marriage-abroad.yml: 9b81d2d56de4528a046408e554500c5b
+lib/smart_answer_flows/marriage-abroad.rb: 02885180f5fb441ed94aba33e298b686
+lib/smart_answer_flows/locales/en/marriage-abroad.yml: a5dd654f0d8011427692f4580cc2bf54
 test/data/marriage-abroad-questions-and-responses.yml: 202693ceb110a9851b8d269c6bf77c1f
 test/data/marriage-abroad-responses-and-expected-results.yml: 9f3ca67c58dae770c65e174899f5d80b
-lib/smart_answer/calculators/marriage_abroad_data_query.rb: e0f062ce08a00bacc9d862457c66990b
+lib/smart_answer/calculators/marriage_abroad_data_query.rb: 9cdbe16978c165cdb74973084404614a
 lib/smart_answer/calculators/country_name_formatter.rb: 0cb274748f0daf3965451b6230c183fd
 lib/smart_answer/calculators/registrations_data_query.rb: 2755d76a53d867b350940f1af65fa5d1

--- a/test/integration/smart_answer_flows/marriage_abroad_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_test.rb
@@ -2562,6 +2562,18 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
   end
 
+  context "Macao" do
+    should "lead to an affirmation outcome for opposite sex marriages directing users to Hong-Kong" do
+      worldwide_api_has_no_organisations_for_location('macao')
+      add_response 'macao'
+      add_response 'ceremony_country'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+
+      assert_current_node :outcome_os_affirmation
+      assert_phrase_list :affirmation_os_outcome, [:contact_local_authorities_in_country_marriage, :get_legal_advice, :what_you_need_to_do_affirmation, :appointment_for_affidavit_in_hong_kong, "appointment_links.opposite_sex.macao", :complete_affirmation_or_affidavit_forms, :download_and_fill_but_not_sign, :download_affidavit_and_affirmation_macao, :required_supporting_documents_macao, :partner_probably_needs_affirmation, :legalisation_and_translation, :affirmation_os_translation_in_local_language_text, :docs_decree_and_death_certificate, :divorced_or_widowed_evidences, :change_of_name_evidence, :partner_probably_needs_affirmation, :fee_table_affirmation_55, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
 
   context "Seychelles" do
     should "lead to outcome_ss_marriage for same sex marriages" do


### PR DESCRIPTION
They can do it via Hong-Kong. They need to swear affirmation or affidavit. It costs £55