### PR TITLE
Marriage Abroad ticket 15. Kazakhstan and Kyrgyzstan

### DIFF
--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -659,9 +659,7 @@ en-GB:
         kazakhstan_os_local_resident: |
           If you need a CNI, you’ll first need to give notice of your intended marriage (banns) at the British Embassy Office in Almaty.
 
-          ###Applying for a CNI from the consulate
-
-          You can then book an appointment at the consulate to give notice of your marriage. There’s a fee for this service (see below).
+          Make an appointment at the embassy in Kazakhstan to give notice of your marriage. There’s a fee for this service (see below).
         russia_os_local_resident: |
           If you need a CNI, you’ll first need to give notice of your intended marriage at your nearest British %{embassy_or_consulate_ceremony_country}.
 

--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -661,7 +661,7 @@ en-GB:
 
           ###Applying for a CNI from the consulate
 
-          You’ll normally need to have been living in Kazakhstan for at least 3 days. You can then book an appointment at the consulate to give notice of your marriage. There’s a fee for this service (see below).
+          You can then book an appointment at the consulate to give notice of your marriage. There’s a fee for this service (see below).
         russia_os_local_resident: |
           If you need a CNI, you’ll first need to give notice of your intended marriage at your nearest British %{embassy_or_consulate_ceremony_country}.
 

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -730,7 +730,12 @@ module SmartAnswer
               phrases << :cni_exception_for_permanent_residents_estonia
             end
 
-            phrases << :"#{ceremony_country}_os_local_resident" if %w(kazakhstan russia).include?(ceremony_country)
+            if %w(kazakhstan kyrgyzstan).include?(ceremony_country)
+              phrases << :kazakhstan_os_local_resident
+            elsif ceremony_country == 'russia'
+              phrases << :russia_os_local_resident
+            end
+
             unless %w(germany italy japan spain).include?(ceremony_country)
               if ceremony_country == 'macedonia'
                 phrases << :consular_cni_os_foreign_resident_3_days_macedonia
@@ -871,7 +876,7 @@ module SmartAnswer
             end
 
             unless data_query.countries_without_consular_facilities?(ceremony_country) || ceremony_country == 'cote-d-ivoire'
-              if ceremony_country == 'kazakhstan'
+              if %w(kazakhstan kyrgyzstan).include?(ceremony_country)
                 phrases << :list_of_consular_kazakhstan
               else
                 phrases << :list_of_consular_fees

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -1,8 +1,8 @@
 --- 
-lib/smart_answer_flows/marriage-abroad.rb: 02885180f5fb441ed94aba33e298b686
-lib/smart_answer_flows/locales/en/marriage-abroad.yml: a5dd654f0d8011427692f4580cc2bf54
-test/data/marriage-abroad-questions-and-responses.yml: 202693ceb110a9851b8d269c6bf77c1f
-test/data/marriage-abroad-responses-and-expected-results.yml: 9f3ca67c58dae770c65e174899f5d80b
+lib/smart_answer_flows/marriage-abroad.rb: bed6ba83ea25d1a39a6e0b9a3b0afd7c
+lib/smart_answer_flows/locales/en/marriage-abroad.yml: cae2ef6c08de86782c1f913c83b7cdcc
+test/data/marriage-abroad-questions-and-responses.yml: 00141c1a4458ef50f6603bbf88491ed0
+test/data/marriage-abroad-responses-and-expected-results.yml: dbeff0201388b8d9f928058a36e7e3e7
 lib/smart_answer/calculators/marriage_abroad_data_query.rb: 9cdbe16978c165cdb74973084404614a
 lib/smart_answer/calculators/country_name_formatter.rb: 0cb274748f0daf3965451b6230c183fd
 lib/smart_answer/calculators/registrations_data_query.rb: 2755d76a53d867b350940f1af65fa5d1

--- a/test/data/marriage-abroad-questions-and-responses.yml
+++ b/test/data/marriage-abroad-questions-and-responses.yml
@@ -48,6 +48,7 @@
 - kazakhstan
 - kosovo
 - kuwait
+- kyrgyzstan
 - laos
 - latvia
 - lebanon

--- a/test/data/marriage-abroad-responses-and-expected-results.yml
+++ b/test/data/marriage-abroad-responses-and-expected-results.yml
@@ -25753,6 +25753,521 @@
   :outcome_node: true
 - :current_node: :country_of_ceremony?
   :responses: 
+  - kyrgyzstan
+  :next_node: :legal_residency?
+  :outcome_node: false
+- :current_node: :legal_residency?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  :next_node: :residency_uk?
+  :outcome_node: false
+- :current_node: :residency_uk?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_england
+  :next_node: :what_is_your_partners_nationality?
+  :outcome_node: false
+- :current_node: :what_is_your_partners_nationality?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_england
+  - partner_british
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_england
+  - partner_british
+  - opposite_sex
+  :next_node: :outcome_os_consular_cni
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_england
+  - partner_british
+  - same_sex
+  :next_node: :outcome_cp_all_other_countries
+  :outcome_node: true
+- :current_node: :what_is_your_partners_nationality?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_england
+  - partner_local
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_england
+  - partner_local
+  - opposite_sex
+  :next_node: :outcome_os_consular_cni
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_england
+  - partner_local
+  - same_sex
+  :next_node: :outcome_cp_all_other_countries
+  :outcome_node: true
+- :current_node: :what_is_your_partners_nationality?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_england
+  - partner_other
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_england
+  - partner_other
+  - opposite_sex
+  :next_node: :outcome_os_consular_cni
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_england
+  - partner_other
+  - same_sex
+  :next_node: :outcome_cp_all_other_countries
+  :outcome_node: true
+- :current_node: :residency_uk?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_wales
+  :next_node: :what_is_your_partners_nationality?
+  :outcome_node: false
+- :current_node: :what_is_your_partners_nationality?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_wales
+  - partner_british
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_wales
+  - partner_british
+  - opposite_sex
+  :next_node: :outcome_os_consular_cni
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_wales
+  - partner_british
+  - same_sex
+  :next_node: :outcome_cp_all_other_countries
+  :outcome_node: true
+- :current_node: :what_is_your_partners_nationality?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_wales
+  - partner_local
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_wales
+  - partner_local
+  - opposite_sex
+  :next_node: :outcome_os_consular_cni
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_wales
+  - partner_local
+  - same_sex
+  :next_node: :outcome_cp_all_other_countries
+  :outcome_node: true
+- :current_node: :what_is_your_partners_nationality?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_wales
+  - partner_other
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_wales
+  - partner_other
+  - opposite_sex
+  :next_node: :outcome_os_consular_cni
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_wales
+  - partner_other
+  - same_sex
+  :next_node: :outcome_cp_all_other_countries
+  :outcome_node: true
+- :current_node: :residency_uk?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_scotland
+  :next_node: :what_is_your_partners_nationality?
+  :outcome_node: false
+- :current_node: :what_is_your_partners_nationality?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_scotland
+  - partner_british
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_scotland
+  - partner_british
+  - opposite_sex
+  :next_node: :outcome_os_consular_cni
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_scotland
+  - partner_british
+  - same_sex
+  :next_node: :outcome_cp_all_other_countries
+  :outcome_node: true
+- :current_node: :what_is_your_partners_nationality?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_scotland
+  - partner_local
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_scotland
+  - partner_local
+  - opposite_sex
+  :next_node: :outcome_os_consular_cni
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_scotland
+  - partner_local
+  - same_sex
+  :next_node: :outcome_cp_all_other_countries
+  :outcome_node: true
+- :current_node: :what_is_your_partners_nationality?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_scotland
+  - partner_other
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_scotland
+  - partner_other
+  - opposite_sex
+  :next_node: :outcome_os_consular_cni
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_scotland
+  - partner_other
+  - same_sex
+  :next_node: :outcome_cp_all_other_countries
+  :outcome_node: true
+- :current_node: :residency_uk?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_ni
+  :next_node: :what_is_your_partners_nationality?
+  :outcome_node: false
+- :current_node: :what_is_your_partners_nationality?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_ni
+  - partner_british
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_ni
+  - partner_british
+  - opposite_sex
+  :next_node: :outcome_os_consular_cni
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_ni
+  - partner_british
+  - same_sex
+  :next_node: :outcome_cp_all_other_countries
+  :outcome_node: true
+- :current_node: :what_is_your_partners_nationality?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_ni
+  - partner_local
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_ni
+  - partner_local
+  - opposite_sex
+  :next_node: :outcome_os_consular_cni
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_ni
+  - partner_local
+  - same_sex
+  :next_node: :outcome_cp_all_other_countries
+  :outcome_node: true
+- :current_node: :what_is_your_partners_nationality?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_ni
+  - partner_other
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_ni
+  - partner_other
+  - opposite_sex
+  :next_node: :outcome_os_consular_cni
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_ni
+  - partner_other
+  - same_sex
+  :next_node: :outcome_cp_all_other_countries
+  :outcome_node: true
+- :current_node: :residency_uk?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_iom
+  :next_node: :outcome_os_iom_ci
+  :outcome_node: true
+- :current_node: :residency_uk?
+  :responses: 
+  - kyrgyzstan
+  - uk
+  - uk_ci
+  :next_node: :outcome_os_iom_ci
+  :outcome_node: true
+- :current_node: :legal_residency?
+  :responses: 
+  - kyrgyzstan
+  - ceremony_country
+  :next_node: :what_is_your_partners_nationality?
+  :outcome_node: false
+- :current_node: :what_is_your_partners_nationality?
+  :responses: 
+  - kyrgyzstan
+  - ceremony_country
+  - partner_british
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - kyrgyzstan
+  - ceremony_country
+  - partner_british
+  - opposite_sex
+  :next_node: :outcome_os_consular_cni
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - kyrgyzstan
+  - ceremony_country
+  - partner_british
+  - same_sex
+  :next_node: :outcome_cp_all_other_countries
+  :outcome_node: true
+- :current_node: :what_is_your_partners_nationality?
+  :responses: 
+  - kyrgyzstan
+  - ceremony_country
+  - partner_local
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - kyrgyzstan
+  - ceremony_country
+  - partner_local
+  - opposite_sex
+  :next_node: :outcome_os_consular_cni
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - kyrgyzstan
+  - ceremony_country
+  - partner_local
+  - same_sex
+  :next_node: :outcome_cp_all_other_countries
+  :outcome_node: true
+- :current_node: :what_is_your_partners_nationality?
+  :responses: 
+  - kyrgyzstan
+  - ceremony_country
+  - partner_other
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - kyrgyzstan
+  - ceremony_country
+  - partner_other
+  - opposite_sex
+  :next_node: :outcome_os_consular_cni
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - kyrgyzstan
+  - ceremony_country
+  - partner_other
+  - same_sex
+  :next_node: :outcome_cp_all_other_countries
+  :outcome_node: true
+- :current_node: :legal_residency?
+  :responses: 
+  - kyrgyzstan
+  - third_country
+  :next_node: :what_is_your_partners_nationality?
+  :outcome_node: false
+- :current_node: :what_is_your_partners_nationality?
+  :responses: 
+  - kyrgyzstan
+  - third_country
+  - partner_british
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - kyrgyzstan
+  - third_country
+  - partner_british
+  - opposite_sex
+  :next_node: :outcome_consular_cni_os_residing_in_third_country
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - kyrgyzstan
+  - third_country
+  - partner_british
+  - same_sex
+  :next_node: :outcome_cp_all_other_countries
+  :outcome_node: true
+- :current_node: :what_is_your_partners_nationality?
+  :responses: 
+  - kyrgyzstan
+  - third_country
+  - partner_local
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - kyrgyzstan
+  - third_country
+  - partner_local
+  - opposite_sex
+  :next_node: :outcome_consular_cni_os_residing_in_third_country
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - kyrgyzstan
+  - third_country
+  - partner_local
+  - same_sex
+  :next_node: :outcome_cp_all_other_countries
+  :outcome_node: true
+- :current_node: :what_is_your_partners_nationality?
+  :responses: 
+  - kyrgyzstan
+  - third_country
+  - partner_other
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - kyrgyzstan
+  - third_country
+  - partner_other
+  - opposite_sex
+  :next_node: :outcome_consular_cni_os_residing_in_third_country
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - kyrgyzstan
+  - third_country
+  - partner_other
+  - same_sex
+  :next_node: :outcome_cp_all_other_countries
+  :outcome_node: true
+- :current_node: :country_of_ceremony?
+  :responses: 
   - laos
   :next_node: :legal_residency?
   :outcome_node: false

--- a/test/integration/smart_answer_flows/marriage_abroad_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_test.rb
@@ -2587,6 +2587,20 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
   end
 
+  context "Kyrgyzstan" do
+    should "lead to the CNI outcome with a suggestion to post notice in Almaty, Kazakhstan" do
+      worldwide_api_has_no_organisations_for_location('kyrgyzstan')
+      add_response 'kyrgyzstan'
+      add_response 'ceremony_country'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+      assert_current_node :outcome_os_consular_cni
+
+      assert_phrase_list :consular_cni_os_start,  [:contact_local_authorities_in_country_marriage, :get_legal_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :consular_cni_os_giving_notice_in_ceremony_country, :living_in_ceremony_country_3_days, :kazakhstan_os_local_resident, "appointment_links.opposite_sex.kyrgyzstan", :required_supporting_documents_notary_public, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :download_and_fill_notice_and_affidavit_but_not_sign, :consular_cni_os_foreign_resident_ceremony_notary_public]
+      assert_phrase_list :consular_cni_os_remainder, [:same_cni_process_and_fees_for_partner, :names_on_documents_must_match, :check_if_cni_needs_to_be_legalised, :no_need_to_stay_after_posting_notice, :consular_cni_os_fees_not_italy_not_uk, :list_of_consular_kazakhstan, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+
   context "when appointment links for opposite sex marriage exist" do
     # Kosovo is excluded, because it has a custom outcome
     (OS_COUNTRIES_WITH_APPOINTMENTS - ['kosovo']).each do |country|


### PR DESCRIPTION
For all opposite sex marriage outcomes in Kazakhstan and Kyrgyzstan, where the users needs to post notice, they can book an appointment with the embassy in Almaty (based in Kazakhstan) using the following link: https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-office-almaty/certificate-of-no-impediment/slot_picker

Take out all embassy (API) addresses from all outcomes. 