### PR TITLE
Add a custom outcome for Hong Kong

### DIFF
--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -1751,6 +1751,14 @@ en-GB:
           Marriage in Indonesia
         body: |
           %{indonesia_os_phraselist}
+# Opposite sex outcome in Hong Kong
+      outcome_os_hong_kong:
+        title: |
+          Marriage in Hong Kong
+        body: |
+          Contact the [Immigration Department ](http://www.immd.gov.hk/eng/faq/marriage-registration.html) in Hong Kong to find out about local marriage laws, including what documents you’ll need.
+
+          ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for %{country_name_lowercase_prefix}](/foreign-travel-advice/%{ceremony_country}) before making any plans.
 # outcome Kosovo - Opposite sex
       outcome_os_kosovo:
         title: |

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -219,6 +219,7 @@ module SmartAnswer
         next_node_if(:outcome_consular_cni_os_residing_in_third_country, marriage_in_spain_third_country)
 
         on_condition(responded_with('opposite_sex')) do
+          next_node_if(:outcome_os_hong_kong, variable_matches(:ceremony_country, 'hong-kong'))
           next_node_if(:outcome_consular_cni_os_residing_in_third_country, consular_cni_residing_in_third_country)
           next_node_if(:outcome_consular_cni_os_residing_in_third_country, marriage_in_norway_third_country)
           next_node_if(:outcome_os_local_japan, os_marriage_with_local_in_japan)
@@ -443,6 +444,8 @@ module SmartAnswer
           )
         end
       end
+
+      outcome :outcome_os_hong_kong
 
       outcome :outcome_os_kosovo do
         precalculate :kosovo_os_phraselist do

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -1,8 +1,8 @@
 --- 
-lib/smart_answer_flows/marriage-abroad.rb: ff6a592e5a68e669fc57e31c9d32f304
-lib/smart_answer_flows/locales/en/marriage-abroad.yml: f01298b531fed655b654284e43145dec
-test/data/marriage-abroad-questions-and-responses.yml: 5dfe754a55c5ec5b7c2ef3bea3ce4946
-test/data/marriage-abroad-responses-and-expected-results.yml: e04917b191c1419b067d01f58d4ebffc
+lib/smart_answer_flows/marriage-abroad.rb: 7d195fa774ccfa9151de9e9cea0bc3db
+lib/smart_answer_flows/locales/en/marriage-abroad.yml: af00dd7c1f1815707d068285dfeb90af
+test/data/marriage-abroad-questions-and-responses.yml: 402997e8c66660f976890acb983043d7
+test/data/marriage-abroad-responses-and-expected-results.yml: d1e658a46767e549cd66aba75fa12978
 lib/smart_answer/calculators/marriage_abroad_data_query.rb: 8609783188bb4a354eaceb97bdfcd92e
 lib/smart_answer/calculators/country_name_formatter.rb: 0cb274748f0daf3965451b6230c183fd
 lib/smart_answer/calculators/registrations_data_query.rb: 2755d76a53d867b350940f1af65fa5d1

--- a/test/data/marriage-abroad-questions-and-responses.yml
+++ b/test/data/marriage-abroad-questions-and-responses.yml
@@ -37,6 +37,7 @@
 - germany
 - greece
 - guatemala
+- hong-kong
 - iceland
 - india
 - indonesia

--- a/test/data/marriage-abroad-responses-and-expected-results.yml
+++ b/test/data/marriage-abroad-responses-and-expected-results.yml
@@ -20118,6 +20118,521 @@
   :outcome_node: true
 - :current_node: :country_of_ceremony?
   :responses: 
+  - hong-kong
+  :next_node: :legal_residency?
+  :outcome_node: false
+- :current_node: :legal_residency?
+  :responses: 
+  - hong-kong
+  - uk
+  :next_node: :residency_uk?
+  :outcome_node: false
+- :current_node: :residency_uk?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_england
+  :next_node: :what_is_your_partners_nationality?
+  :outcome_node: false
+- :current_node: :what_is_your_partners_nationality?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_england
+  - partner_british
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_england
+  - partner_british
+  - opposite_sex
+  :next_node: :outcome_os_hong_kong
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_england
+  - partner_british
+  - same_sex
+  :next_node: :outcome_cp_all_other_countries
+  :outcome_node: true
+- :current_node: :what_is_your_partners_nationality?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_england
+  - partner_local
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_england
+  - partner_local
+  - opposite_sex
+  :next_node: :outcome_os_hong_kong
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_england
+  - partner_local
+  - same_sex
+  :next_node: :outcome_cp_all_other_countries
+  :outcome_node: true
+- :current_node: :what_is_your_partners_nationality?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_england
+  - partner_other
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_england
+  - partner_other
+  - opposite_sex
+  :next_node: :outcome_os_hong_kong
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_england
+  - partner_other
+  - same_sex
+  :next_node: :outcome_cp_all_other_countries
+  :outcome_node: true
+- :current_node: :residency_uk?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_wales
+  :next_node: :what_is_your_partners_nationality?
+  :outcome_node: false
+- :current_node: :what_is_your_partners_nationality?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_wales
+  - partner_british
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_wales
+  - partner_british
+  - opposite_sex
+  :next_node: :outcome_os_hong_kong
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_wales
+  - partner_british
+  - same_sex
+  :next_node: :outcome_cp_all_other_countries
+  :outcome_node: true
+- :current_node: :what_is_your_partners_nationality?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_wales
+  - partner_local
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_wales
+  - partner_local
+  - opposite_sex
+  :next_node: :outcome_os_hong_kong
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_wales
+  - partner_local
+  - same_sex
+  :next_node: :outcome_cp_all_other_countries
+  :outcome_node: true
+- :current_node: :what_is_your_partners_nationality?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_wales
+  - partner_other
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_wales
+  - partner_other
+  - opposite_sex
+  :next_node: :outcome_os_hong_kong
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_wales
+  - partner_other
+  - same_sex
+  :next_node: :outcome_cp_all_other_countries
+  :outcome_node: true
+- :current_node: :residency_uk?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_scotland
+  :next_node: :what_is_your_partners_nationality?
+  :outcome_node: false
+- :current_node: :what_is_your_partners_nationality?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_scotland
+  - partner_british
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_scotland
+  - partner_british
+  - opposite_sex
+  :next_node: :outcome_os_hong_kong
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_scotland
+  - partner_british
+  - same_sex
+  :next_node: :outcome_cp_all_other_countries
+  :outcome_node: true
+- :current_node: :what_is_your_partners_nationality?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_scotland
+  - partner_local
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_scotland
+  - partner_local
+  - opposite_sex
+  :next_node: :outcome_os_hong_kong
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_scotland
+  - partner_local
+  - same_sex
+  :next_node: :outcome_cp_all_other_countries
+  :outcome_node: true
+- :current_node: :what_is_your_partners_nationality?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_scotland
+  - partner_other
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_scotland
+  - partner_other
+  - opposite_sex
+  :next_node: :outcome_os_hong_kong
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_scotland
+  - partner_other
+  - same_sex
+  :next_node: :outcome_cp_all_other_countries
+  :outcome_node: true
+- :current_node: :residency_uk?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_ni
+  :next_node: :what_is_your_partners_nationality?
+  :outcome_node: false
+- :current_node: :what_is_your_partners_nationality?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_ni
+  - partner_british
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_ni
+  - partner_british
+  - opposite_sex
+  :next_node: :outcome_os_hong_kong
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_ni
+  - partner_british
+  - same_sex
+  :next_node: :outcome_cp_all_other_countries
+  :outcome_node: true
+- :current_node: :what_is_your_partners_nationality?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_ni
+  - partner_local
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_ni
+  - partner_local
+  - opposite_sex
+  :next_node: :outcome_os_hong_kong
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_ni
+  - partner_local
+  - same_sex
+  :next_node: :outcome_cp_all_other_countries
+  :outcome_node: true
+- :current_node: :what_is_your_partners_nationality?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_ni
+  - partner_other
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_ni
+  - partner_other
+  - opposite_sex
+  :next_node: :outcome_os_hong_kong
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_ni
+  - partner_other
+  - same_sex
+  :next_node: :outcome_cp_all_other_countries
+  :outcome_node: true
+- :current_node: :residency_uk?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_iom
+  :next_node: :outcome_os_iom_ci
+  :outcome_node: true
+- :current_node: :residency_uk?
+  :responses: 
+  - hong-kong
+  - uk
+  - uk_ci
+  :next_node: :outcome_os_iom_ci
+  :outcome_node: true
+- :current_node: :legal_residency?
+  :responses: 
+  - hong-kong
+  - ceremony_country
+  :next_node: :what_is_your_partners_nationality?
+  :outcome_node: false
+- :current_node: :what_is_your_partners_nationality?
+  :responses: 
+  - hong-kong
+  - ceremony_country
+  - partner_british
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - hong-kong
+  - ceremony_country
+  - partner_british
+  - opposite_sex
+  :next_node: :outcome_os_hong_kong
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - hong-kong
+  - ceremony_country
+  - partner_british
+  - same_sex
+  :next_node: :outcome_cp_all_other_countries
+  :outcome_node: true
+- :current_node: :what_is_your_partners_nationality?
+  :responses: 
+  - hong-kong
+  - ceremony_country
+  - partner_local
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - hong-kong
+  - ceremony_country
+  - partner_local
+  - opposite_sex
+  :next_node: :outcome_os_hong_kong
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - hong-kong
+  - ceremony_country
+  - partner_local
+  - same_sex
+  :next_node: :outcome_cp_all_other_countries
+  :outcome_node: true
+- :current_node: :what_is_your_partners_nationality?
+  :responses: 
+  - hong-kong
+  - ceremony_country
+  - partner_other
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - hong-kong
+  - ceremony_country
+  - partner_other
+  - opposite_sex
+  :next_node: :outcome_os_hong_kong
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - hong-kong
+  - ceremony_country
+  - partner_other
+  - same_sex
+  :next_node: :outcome_cp_all_other_countries
+  :outcome_node: true
+- :current_node: :legal_residency?
+  :responses: 
+  - hong-kong
+  - third_country
+  :next_node: :what_is_your_partners_nationality?
+  :outcome_node: false
+- :current_node: :what_is_your_partners_nationality?
+  :responses: 
+  - hong-kong
+  - third_country
+  - partner_british
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - hong-kong
+  - third_country
+  - partner_british
+  - opposite_sex
+  :next_node: :outcome_os_hong_kong
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - hong-kong
+  - third_country
+  - partner_british
+  - same_sex
+  :next_node: :outcome_cp_all_other_countries
+  :outcome_node: true
+- :current_node: :what_is_your_partners_nationality?
+  :responses: 
+  - hong-kong
+  - third_country
+  - partner_local
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - hong-kong
+  - third_country
+  - partner_local
+  - opposite_sex
+  :next_node: :outcome_os_hong_kong
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - hong-kong
+  - third_country
+  - partner_local
+  - same_sex
+  :next_node: :outcome_cp_all_other_countries
+  :outcome_node: true
+- :current_node: :what_is_your_partners_nationality?
+  :responses: 
+  - hong-kong
+  - third_country
+  - partner_other
+  :next_node: :partner_opposite_or_same_sex?
+  :outcome_node: false
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - hong-kong
+  - third_country
+  - partner_other
+  - opposite_sex
+  :next_node: :outcome_os_hong_kong
+  :outcome_node: true
+- :current_node: :partner_opposite_or_same_sex?
+  :responses: 
+  - hong-kong
+  - third_country
+  - partner_other
+  - same_sex
+  :next_node: :outcome_cp_all_other_countries
+  :outcome_node: true
+- :current_node: :country_of_ceremony?
+  :responses: 
   - iceland
   :next_node: :legal_residency?
   :outcome_node: false

--- a/test/integration/smart_answer_flows/marriage_abroad_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_test.rb
@@ -14,7 +14,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
   SS_COUNTRIES_WITH_APPOINTMENTS = translations["en-GB"]["flow"]["marriage-abroad"]["phrases"]["appointment_links"]["same_sex"].keys
 
   setup do
-    @location_slugs = (OS_COUNTRIES_WITH_APPOINTMENTS + SS_COUNTRIES_WITH_APPOINTMENTS + %w(albania american-samoa anguilla argentina armenia aruba australia austria azerbaijan bahamas belarus belgium bonaire-st-eustatius-saba brazil british-indian-ocean-territory burma burundi cambodia canada china costa-rica cote-d-ivoire croatia colombia cyprus czech-republic denmark ecuador egypt estonia finland france germany greece indonesia iran ireland italy japan jordan kazakhstan kosovo laos latvia lebanon lithuania macedonia malta mayotte mexico monaco morocco netherlands nicaragua north-korea oman guatemala paraguay peru philippines poland portugal qatar russia rwanda saint-barthelemy san-marino saudi-arabia serbia seychelles slovakia south-africa st-maarten st-martin south-korea spain sweden switzerland thailand turkey turkmenistan united-arab-emirates usa uzbekistan vietnam wallis-and-futuna yemen zimbabwe)).uniq
+    @location_slugs = (OS_COUNTRIES_WITH_APPOINTMENTS + SS_COUNTRIES_WITH_APPOINTMENTS + %w(albania american-samoa anguilla argentina armenia aruba australia austria azerbaijan bahamas belarus belgium bonaire-st-eustatius-saba brazil british-indian-ocean-territory burma burundi cambodia canada china costa-rica cote-d-ivoire croatia colombia cyprus czech-republic denmark ecuador egypt estonia finland france germany greece hong-kong indonesia iran ireland italy japan jordan kazakhstan kosovo laos latvia lebanon lithuania macedonia malta mayotte mexico monaco morocco netherlands nicaragua north-korea oman guatemala paraguay peru philippines poland portugal qatar russia rwanda saint-barthelemy san-marino saudi-arabia serbia seychelles slovakia south-africa st-maarten st-martin south-korea spain sweden switzerland thailand turkey turkmenistan united-arab-emirates usa uzbekistan vietnam wallis-and-futuna yemen zimbabwe)).uniq
     worldwide_api_has_locations(@location_slugs)
     setup_for_testing_flow 'marriage-abroad'
   end
@@ -2580,7 +2580,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
   end
 
   context "Macao" do
-    should "lead to an affirmation outcome for opposite sex marriages directing users to Hong-Kong" do
+    should "lead to an affirmation outcome for opposite sex marriages directing users to Hong Kong" do
       worldwide_api_has_no_organisations_for_location('macao')
       add_response 'macao'
       add_response 'ceremony_country'
@@ -2589,6 +2589,18 @@ class MarriageAbroadTest < ActiveSupport::TestCase
 
       assert_current_node :outcome_os_affirmation
       assert_phrase_list :affirmation_os_outcome, [:contact_local_authorities_in_country_marriage, :get_legal_advice, :what_you_need_to_do_affirmation, :appointment_for_affidavit_in_hong_kong, "appointment_links.opposite_sex.macao", :complete_affirmation_or_affidavit_forms, :download_and_fill_but_not_sign, :download_affidavit_and_affirmation_macao, :required_supporting_documents_macao, :partner_probably_needs_affirmation, :legalisation_and_translation, :affirmation_os_translation_in_local_language_text, :docs_decree_and_death_certificate, :divorced_or_widowed_evidences, :change_of_name_evidence, :partner_probably_needs_affirmation, :fee_table_affirmation_55, :list_of_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
+  end
+
+  context "Hong Kong" do
+    should "lead to the custom outcome directing users to the local Immigration Department for opposite sex marriages" do
+      worldwide_api_has_no_organisations_for_location('hong-kong')
+      add_response 'hong-kong'
+      add_response 'ceremony_country'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+
+      assert_current_node :outcome_os_hong_kong
     end
   end
 


### PR DESCRIPTION
As users in Macao are now directed to Hong Kong, we decided to update the
HK outcome too. Even though local consular facilities do not process
british marriages, it can be done via Immigration Department in HK.