### PR TITLE
Remove unreachable code paths

### DIFF
--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -270,7 +270,7 @@ module SmartAnswer
           })
 
           next_node_if(:outcome_cp_commonwealth_countries, -> {
-            %w(canada new-zealand south-africa).include?(ceremony_country)
+            %w(canada south-africa).include?(ceremony_country)
           })
 
           next_node_if(:outcome_cp_consular, -> {
@@ -1271,19 +1271,12 @@ module SmartAnswer
 
       outcome :outcome_cp_commonwealth_countries do
         precalculate :type_of_ceremony do
-          phrases = PhraseList.new
-          if ceremony_country == 'new-zealand'
-            phrases << :title_ss_marriage_and_partnership
-          else
-            phrases << :title_civil_partnership
-          end
+          phrases = PhraseList.new(:title_civil_partnership)
         end
 
         precalculate :commonwealth_countries_cp_outcome do
           phrases = PhraseList.new
-          if %w(canada south-africa).include?(ceremony_country)
-            phrases << "synonyms_of_cp_in_#{ceremony_country}".gsub('-', '_').to_sym
-          end
+          phrases << "synonyms_of_cp_in_#{ceremony_country}".gsub('-', '_').to_sym
 
           if resident_of == 'uk'
             phrases << :contact_high_comission_of_ceremony_country_in_uk_cp
@@ -1299,9 +1292,6 @@ module SmartAnswer
 
           phrases << contact_method_key
 
-          if ceremony_country == 'new-zealand'
-            phrases << :cant_issue_cni_for_commonwealth
-          end
           if partner_nationality != 'partner_british'
             phrases << :partner_naturalisation_in_uk
           end

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -1,5 +1,5 @@
 --- 
-lib/smart_answer_flows/marriage-abroad.rb: ef37c24a70eb544d37b4f2fac5da58f1
+lib/smart_answer_flows/marriage-abroad.rb: e065416edd1aeecae7493f197519936a
 lib/smart_answer_flows/locales/en/marriage-abroad.yml: 69ea1378d7c0ea17142c33f7eef209f4
 test/data/marriage-abroad-questions-and-responses.yml: eabbd09ca91fab72a9a520d1087fb35e
 test/data/marriage-abroad-responses-and-expected-results.yml: e2a77265651bd20a9892bde75f375e82


### PR DESCRIPTION
Same sex marriages in New Zealand lead to outcome_cp_no_cni. Remove
all code branches and references that are New Zealand-specific in
the outcome_cp_commonwealth_countries outcome that was used for NZ
before the change.

It was uncovered using this command:
```
        $ rm -rf coverage && \
          TEST_COVERAGE=true \
          rails r script/generate-responses-and-expected-results-for-smart-answer.rb \
          marriage-abroad
```