### PR TITLE
Fix Kyrgyzstan payment callout

### DIFF
--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -156,6 +156,8 @@ en-GB:
           You can pay by credit card (Visa, Visa Electron or MasterCard), but not by personal cheque.
         pay_by_cash_or_us_dollars_only: |
           You can only pay fees for consular services by cash in US dollars.
+        pay_in_local_currency_ceremony_in_kazakhstan: |
+          ^You can only pay by cash in Kazakhstan. This must be in the local currency.^
         pay_in_local_currency_ceremony_country_name: |
           ^You can only pay by cash in %{country_name_lowercase_prefix}. This must be in the local currency.^
         pay_in_euros_or_visa_electron: |

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -869,8 +869,10 @@ module SmartAnswer
           end
 
           unless data_query.countries_without_consular_facilities?(ceremony_country)
-            if %w(armenia bosnia-and-herzegovina cambodia iceland kazakhstan latvia slovenia tunisia tajikistan).include?(ceremony_country)
+            if %w(armenia bosnia-and-herzegovina cambodia iceland latvia slovenia tunisia tajikistan).include?(ceremony_country)
               phrases << :pay_in_local_currency_ceremony_country_name
+            elsif %w(kazakhstan kyrgyzstan).include?(ceremony_country)
+              phrases << :pay_in_local_currency_ceremony_in_kazakhstan
             elsif ceremony_country == 'luxembourg'
               phrases << :pay_in_cash_visa_or_mastercard
             elsif ceremony_country == 'russia'

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -1,6 +1,6 @@
 --- 
-lib/smart_answer_flows/marriage-abroad.rb: 3c5959f768dbaea752083fd7e0accc0a
-lib/smart_answer_flows/locales/en/marriage-abroad.yml: bf15b4da6d04d1a13a8b9bd9ade4af26
+lib/smart_answer_flows/marriage-abroad.rb: 8c14059fa357a1ad99e4ce1236f37dce
+lib/smart_answer_flows/locales/en/marriage-abroad.yml: a2641159626d0031a95a9cbd42a7649d
 test/data/marriage-abroad-questions-and-responses.yml: eabbd09ca91fab72a9a520d1087fb35e
 test/data/marriage-abroad-responses-and-expected-results.yml: e2a77265651bd20a9892bde75f375e82
 lib/smart_answer_flows/data_partials/_overseas_passports_embassies.erb: 2f521bae99c2f48b49d07bcb283a8063

--- a/test/integration/smart_answer_flows/marriage_abroad_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_test.rb
@@ -2564,7 +2564,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
       assert_current_node :outcome_os_consular_cni
 
       assert_phrase_list :consular_cni_os_start,  [:contact_local_authorities_in_country_marriage, :get_legal_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :consular_cni_os_giving_notice_in_ceremony_country, :living_in_ceremony_country_3_days, :kazakhstan_os_local_resident, "appointment_links.opposite_sex.kyrgyzstan", :required_supporting_documents_notary_public, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :download_and_fill_notice_and_affidavit_but_not_sign, :consular_cni_os_foreign_resident_ceremony_notary_public]
-      assert_phrase_list :consular_cni_os_remainder, [:same_cni_process_and_fees_for_partner, :names_on_documents_must_match, :check_if_cni_needs_to_be_legalised, :no_need_to_stay_after_posting_notice, :consular_cni_os_fees_not_italy_not_uk, :list_of_consular_kazakhstan, :pay_by_cash_or_credit_card_no_cheque]
+      assert_phrase_list :consular_cni_os_remainder, [:same_cni_process_and_fees_for_partner, :names_on_documents_must_match, :check_if_cni_needs_to_be_legalised, :no_need_to_stay_after_posting_notice, :consular_cni_os_fees_not_italy_not_uk, :list_of_consular_kazakhstan, :pay_in_local_currency_ceremony_in_kazakhstan]
     end
   end
 


### PR DESCRIPTION
This is addressing internal FC.

Users in Kyrgyzstan need to use institutions in Kazakhstan, therefore
the payments are done there. Make sure they match.

I am not generating HTML as this is one of quite a few changes I need to address today and time is pressing. I'll check HTML changes once all of the feedback from internal FC is addressed.