### PR TITLE
[In Fact Check - DO NOT MERGE] Updates to calculate-statutory-sick-pay (re-worked)

### DIFF
--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -204,9 +204,6 @@ module SmartAnswer
         option yes: :linked_sickness_start_date?
         option :no
 
-        next_node_if(:not_earned_enough) do
-          employee_average_weekly_earnings < Calculators::StatutorySickPayCalculator.lower_earning_limit_on(sick_start_date)
-        end
         next_node :usual_work_days?
       end
 
@@ -216,9 +213,6 @@ module SmartAnswer
         to { Date.today.end_of_year }
         validate_in_range
 
-        next_node_if(:not_earned_enough) do |response|
-          employee_average_weekly_earnings < Calculators::StatutorySickPayCalculator.lower_earning_limit_on(response)
-        end
         next_node(:how_many_days_sick?)
       end
 
@@ -232,6 +226,10 @@ module SmartAnswer
       checkbox_question :usual_work_days? do
         %w{1 2 3 4 5 6 0}.each { |n| option n.to_s }
 
+        next_node_if(:not_earned_enough) do
+          employee_average_weekly_earnings < Calculators::StatutorySickPayCalculator.lower_earning_limit_on(sick_start_date)
+        end
+      
         calculate :ssp_payment do
           Money.new(calculator.ssp_payment)
         end

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -99,8 +99,12 @@ module SmartAnswer
         to { Date.today.end_of_year }
         validate_in_range
 
-        calculate :sick_start_date_for_awe do |response|
+        next_node_calculation :sick_start_date_for_awe do |response|
           response
+        end
+
+        validate :linked_sickness_must_be_before do
+          sick_start_date > sick_start_date_for_awe
         end
 
         next_node(:linked_sickness_end_date?)

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -112,8 +112,13 @@ module SmartAnswer
         to { Date.today.end_of_year }
         validate_in_range
 
-        calculate :sick_end_date_for_awe do |response|
+        next_node_calculation :sick_end_date_for_awe do |response|
           response
+        end
+
+        validate :must_be_within_eight_weeks do
+          furthest_allowed_date = sick_start_date - 8.weeks
+          sick_end_date_for_awe > furthest_allowed_date
         end
 
         next_node_calculation :prior_sick_days do |response|

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -116,10 +116,14 @@ module SmartAnswer
           response
         end
 
-        calculate :prior_sick_days do |response|
+        next_node_calculation :prior_sick_days do |response|
           start_date = sick_start_date_for_awe
           last_day_sick = response
           (last_day_sick - start_date).to_i + 1
+        end
+
+        validate :start_before_end do
+          prior_sick_days >= 1
         end
 
         next_node(:paid_at_least_8_weeks?)

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -54,6 +54,10 @@ module SmartAnswer
           response
         end
 
+        calculate :sick_start_date_for_awe do |response|
+          response
+        end
+
         next_node :last_sick_day?
 
       end
@@ -68,17 +72,60 @@ module SmartAnswer
           response
         end
 
+        calculate :sick_end_date_for_awe do |response|
+          response
+        end
+
         next_node_calculation(:days_sick) do |response|
           start_date = sick_start_date
           last_day_sick = response
           (last_day_sick - start_date).to_i + 1
         end
+
         validate { days_sick >= 1 }
-        next_node_if(:paid_at_least_8_weeks?) { days_sick > 3 }
+        next_node_if(:has_linked_sickness?) { days_sick > 3 }
         next_node(:must_be_sick_for_4_days)
       end
 
-      # Question 5.1
+      # Question 6
+      multiple_choice :has_linked_sickness? do
+        option yes: :linked_sickness_start_date?
+        option no: :paid_at_least_8_weeks?
+      end
+
+      # Question 6.1
+      date_question :linked_sickness_start_date? do
+        from { Date.new(2010, 1, 1) }
+        to { Date.today.end_of_year }
+        validate_in_range
+
+        calculate :sick_start_date_for_awe do |response|
+          response
+        end
+
+        next_node(:linked_sickness_end_date?)
+      end
+
+      # Question 6.2
+      date_question :linked_sickness_end_date? do
+        from { Date.new(2010, 1, 1) }
+        to { Date.today.end_of_year }
+        validate_in_range
+
+        calculate :sick_end_date_for_awe do |response|
+          response
+        end
+
+        calculate :prior_sick_days do |response|
+          start_date = sick_start_date_for_awe
+          last_day_sick = response
+          (last_day_sick - start_date).to_i + 1
+        end
+
+        next_node(:paid_at_least_8_weeks?)
+      end
+
+      # Question 7.1
       multiple_choice :paid_at_least_8_weeks? do
         option eight_weeks_more: :how_often_pay_employee_pay_patterns? # Question 5.2
         option eight_weeks_less: :total_earnings_before_sick_period? # Question 8
@@ -87,7 +134,7 @@ module SmartAnswer
         save_input_as :eight_weeks_earnings
       end
 
-      # Question 5.2
+      # Question 7.2
       multiple_choice :how_often_pay_employee_pay_patterns? do
         option :weekly
         option :fortnightly
@@ -101,7 +148,7 @@ module SmartAnswer
         next_node(:pay_amount_if_not_sick?) # Question 7
       end
 
-      # Question 6
+      # Question 8
       date_question :last_payday_before_sickness? do
         from { Date.new(2010, 1, 1) }
         to { Date.today.end_of_year }
@@ -125,7 +172,7 @@ module SmartAnswer
         next_node(:last_payday_before_offset?)
       end
 
-      # Question 6.1
+      # Question 8.1
       date_question :last_payday_before_offset? do
         from { Date.new(2010, 1, 1) }
         to { Date.today.end_of_year }
@@ -148,7 +195,7 @@ module SmartAnswer
         next_node(:total_employee_earnings?)
       end
 
-      # Question 6.2
+      # Question 8.2
       money_question :total_employee_earnings? do
         save_input_as :relevant_period_pay
 
@@ -158,17 +205,17 @@ module SmartAnswer
             relevant_period_to: relevant_period_to, relevant_period_from: relevant_period_from)
         end
 
-        next_node :off_sick_4_days?
+        next_node :usual_work_days?
       end
 
-      # Question 7
+      # Question 9
       money_question :pay_amount_if_not_sick? do
         save_input_as :relevant_contractual_pay
 
         next_node :contractual_days_covered_by_earnings?
       end
 
-      # Question 7.1
+      # Question 9.1
       value_question :contractual_days_covered_by_earnings? do
         save_input_as :contractual_earnings_days
 
@@ -177,17 +224,17 @@ module SmartAnswer
           days_worked = response
           Calculators::StatutorySickPayCalculator.contractual_earnings_awe(pay, days_worked)
         end
-        next_node :off_sick_4_days?
+        next_node :usual_work_days?
       end
 
-      # Question 8
+      # Question 10
       money_question :total_earnings_before_sick_period? do
         save_input_as :earnings
 
         next_node :days_covered_by_earnings?
       end
 
-      # Question 8.1
+      # Question 10.1
       value_question :days_covered_by_earnings? do
 
         calculate :employee_average_weekly_earnings do |response|
@@ -196,40 +243,17 @@ module SmartAnswer
           Calculators::StatutorySickPayCalculator.total_earnings_awe(pay, days_worked)
         end
 
-        next_node :off_sick_4_days?
-      end
-
-      # Question 11
-      multiple_choice :off_sick_4_days? do
-        option yes: :linked_sickness_start_date?
-        option :no
-
         next_node :usual_work_days?
       end
 
-      # Question 11.1
-      date_question :linked_sickness_start_date? do
-        from { Date.new(2010, 1, 1) }
-        to { Date.today.end_of_year }
-        validate_in_range
-
-        next_node(:how_many_days_sick?)
-      end
-
-      # Q12
-      value_question :how_many_days_sick? do
-        save_input_as :prior_sick_days
-        next_node :usual_work_days?
-      end
-
-      # Q13
+      # Q11
       checkbox_question :usual_work_days? do
         %w{1 2 3 4 5 6 0}.each { |n| option n.to_s }
 
         next_node_if(:not_earned_enough) do
           employee_average_weekly_earnings < Calculators::StatutorySickPayCalculator.lower_earning_limit_on(sick_start_date)
         end
-      
+
         calculate :ssp_payment do
           Money.new(calculator.ssp_payment)
         end
@@ -251,7 +275,6 @@ module SmartAnswer
         # Answer 8
         next_node_if(:maximum_entitlement_reached) do |response|
           days_worked = response.split(',').size
-
           prior_sick_days and prior_sick_days.to_i >= (days_worked * 28 + 3)
         end
 

--- a/lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml
+++ b/lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml
@@ -89,6 +89,7 @@ en-GB:
       linked_sickness_end_date?:
         title: Enter the end date for this linked period of sickness.
         start_before_end:  End date should be on or after start date
+        must_be_within_eight_weeks: You need to enter a date within 8 weeks of the current period of sickness or it isn't a linked period of sickness.
 
       # Q7.1
       paid_at_least_8_weeks?:

--- a/lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml
+++ b/lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml
@@ -26,7 +26,6 @@ en-GB:
         You’re only responsible for paying SSP if:
 
         - you pay Class 1 National Insurance contributions for your employee (or would do if not for their age or their level of earnings)
-        - you don’t provide your own occupational sick pay scheme
         - your employee was sick for 4 or more days in a row (including non-working days)
         - your employee has told you they’re sick within your own time limit (or 7 days if you don’t have one)
 

--- a/lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml
+++ b/lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml
@@ -73,72 +73,70 @@ en-GB:
         hint: This can include non-working days and bank holidays
         error_message:  End date should be on or after start date
 
-      # Q5.1
-      paid_at_least_8_weeks?:
-        title: On %{sick_start_date} had you paid your employee at least 8 weeks of earnings?
-        options:
-          eight_weeks_more: "Yes, paid at least 8 weeks earnings"
-          eight_weeks_less: "No, paid less than 8 weeks earnings"
-          before_payday: "No, employee is new and fell sick before their first payday"
-
-      # Q5.2
-      how_often_pay_employee_pay_patterns?:
-        title: How often do you pay the employee?
-
       # Question 6
-      last_payday_before_sickness?:
-        title: What was the last normal payday before %{sick_start_date}?
-        error_message: You must enter a date before %{sick_start_date}
-
-      # Question 6.1
-      last_payday_before_offset?:
-        title: What was the last normal payday on or before %{pay_day_offset}?
-        error_message: You must enter a date on or before %{pay_day_offset}
-
-      # Question 6.2
-      total_employee_earnings?:
-        title: Enter the total amount (before deductions like Income Tax and National Insurance) of your employee’s earnings on paydays between %{relevant_period_from} and %{relevant_period_to}.
-        body: |
-          Different rules apply for [directors of limited companies incorporated before 1 October 2009](/statutory-sick-pay-how-different-employment-types-affect-what-you-pay)
-        error_message: Please enter a number greater than 0
-
-      # Question 7
-      pay_amount_if_not_sick?:
-        title: Enter how much you would have paid the employee on their first payday if they hadn’t been sick.
-
-      # Question 7.1
-      contractual_days_covered_by_earnings?:
-        title: How many days does the period represented by these earnings cover?
-        hint: If it’s 2 weeks and 3 days enter ‘17’.
-
-      # Question 8
-      total_earnings_before_sick_period?:
-        title: Enter the total earnings paid before %{sick_start_date}.
-
-      # Question 8.1
-      days_covered_by_earnings?:
-        title: How many days does the period represented by these earnings cover?
-        hint: If it’s 2 weeks and 3 days enter ‘17’.
-
-      # Question 11
-      off_sick_4_days?:
+      has_linked_sickness?:
         title: Was your employee off sick within the previous 8 weeks for 4 or more days (including non-working days, weekends and holidays)?
         body: |
           These are called ‘linked Periods of Incapacity for Work (PIW)’. Check if an employee’s [PIW links to a previous one.](/government/publications/statutory-sick-pay-tables-for-linking-periods-of-incapacity-for-work)
 
           *[PIW]: Period of Incapacity for Work
 
-      # Question 11.1
+      # Question 6.1
       linked_sickness_start_date?:
         title: Enter the start date for this linked period of sickness.
 
-      # Question 12
-      how_many_days_sick?:
-        title: During the previous illness(es), how many normal workdays did your employee take off sick?
-        hint: ‘Normal workdays’ are the days your employee works on a regular basis.
+      # Question 6.2
+      linked_sickness_end_date?:
+        title: Enter the end date for this linked period of sickness.
+
+      # Q7.1
+      paid_at_least_8_weeks?:
+        title: On %{sick_start_date_for_awe} had you paid your employee at least 8 weeks of earnings?
+        options:
+          eight_weeks_more: "Yes, paid at least 8 weeks earnings"
+          eight_weeks_less: "No, paid less than 8 weeks earnings"
+          before_payday: "No, employee is new and fell sick before their first payday"
+
+      # Q7.2
+      how_often_pay_employee_pay_patterns?:
+        title: How often do you pay the employee?
+
+      # Question 8
+      last_payday_before_sickness?:
+        title: What was the last normal payday before %{sick_start_date_for_awe}?
+        error_message: You must enter a date before %{sick_start_date_for_awe}
+
+      # Question 8.1
+      last_payday_before_offset?:
+        title: What was the last normal payday on or before %{pay_day_offset}?
+        error_message: You must enter a date on or before %{pay_day_offset}
+
+      # Question 8.2
+      total_employee_earnings?:
+        title: Enter the total amount (before deductions like Income Tax and National Insurance) of your employee’s earnings on paydays between %{relevant_period_from} and %{relevant_period_to}.
+        body: |
+          Different rules apply for [directors of limited companies incorporated before 1 October 2009](/statutory-sick-pay-how-different-employment-types-affect-what-you-pay)
         error_message: Please enter a number greater than 0
 
-      # Question 13:
+      # Question 9
+      pay_amount_if_not_sick?:
+        title: Enter how much you would have paid the employee on their first payday if they hadn’t been sick.
+
+      # Question 9.1
+      contractual_days_covered_by_earnings?:
+        title: How many days does the period represented by these earnings cover?
+        hint: If it’s 2 weeks and 3 days enter ‘17’.
+
+      # Question 10
+      total_earnings_before_sick_period?:
+        title: Enter the total earnings paid before %{sick_start_date_for_awe}.
+
+      # Question 10.1
+      days_covered_by_earnings?:
+        title: How many days does the period represented by these earnings cover?
+        hint: If it’s 2 weeks and 3 days enter ‘17’.
+
+      # Question 11:
       usual_work_days?:
         title: Which days of the week do they usually work?
         options:

--- a/lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml
+++ b/lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml
@@ -88,6 +88,7 @@ en-GB:
       # Question 6.2
       linked_sickness_end_date?:
         title: Enter the end date for this linked period of sickness.
+        start_before_end:  End date should be on or after start date
 
       # Q7.1
       paid_at_least_8_weeks?:

--- a/lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml
+++ b/lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml
@@ -84,6 +84,7 @@ en-GB:
       # Question 6.1
       linked_sickness_start_date?:
         title: Enter the start date for this linked period of sickness.
+        linked_sickness_must_be_before: Linked sickness must be in the past
 
       # Question 6.2
       linked_sickness_end_date?:

--- a/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
@@ -299,6 +299,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response '100' # Q7
       add_response '7' # Q7.1
       add_response 'no' # Q11
+      add_response '1,2,3,4,5' # Q13
     end
     should "take you to result A5 as awe < LEL (as of 2013-06-10)" do
       assert_state_variable :employee_average_weekly_earnings, 100

--- a/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
@@ -518,6 +518,11 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response (Date.today.end_of_year + 1.day).to_s
       assert_current_node_is_error
     end
+
+    should "not allow dates before start_date" do
+      add_response "01/04/2013"
+      assert_current_node_is_error
+    end
   end
 
   context "linked_sickness_start_date? date validation" do
@@ -561,6 +566,11 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
 
     should "not allow dates next year" do
       add_response (Date.today.end_of_year + 1.day).to_s
+      assert_current_node_is_error
+    end
+
+    should "not allow dates before start_date" do
+      add_response "01/03/2013"
       assert_current_node_is_error
     end
   end

--- a/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
@@ -530,8 +530,8 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response :additional_statutory_paternity_pay
       add_response :yes
       add_response :no
-      add_response "02/04/2013"
-      add_response "10/04/2013"
+      add_response "2015-03-19"
+      add_response "2015-03-27"
       add_response :yes
       assert_current_node :linked_sickness_start_date?
     end
@@ -552,11 +552,12 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response :additional_statutory_paternity_pay
       add_response :yes
       add_response :no
-      add_response "02/04/2013"
-      add_response "10/04/2013"
+      add_response "2015-05-21"
+      add_response "2015-05-29"
       add_response :yes
-      add_response "12/03/2013"
+      add_response "2015-03-20"
       assert_current_node :linked_sickness_end_date?
+      @furthest_linked_sickness_end_date = Date.parse("2015-03-27") # (Date.parse("2015-05-21") - 8.weeks).tomorrow
     end
 
     should "not allow dates before 2010" do
@@ -570,8 +571,18 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
     end
 
     should "not allow dates before start_date" do
-      add_response "01/03/2013"
+      add_response "2013-01-31"
       assert_current_node_is_error
+    end
+
+    should "allow the latest allowed end date" do
+      add_response @furthest_linked_sickness_end_date.to_s
+      assert_current_node :paid_at_least_8_weeks?
+    end
+
+    should "not allow a day before the latest allowed date" do
+      add_response (@furthest_linked_sickness_end_date - 1.day).to_s
+      assert_current_node_is_error "must_be_within_eight_weeks"
     end
   end
 

--- a/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
@@ -338,7 +338,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response :ordinary_statutory_paternity_pay
       add_response :yes
       add_response :no
-      add_response "2013-01-07"
+      add_response "2013-01-08"
       add_response "2013-05-03"
       add_response :yes
       add_response "2013-01-07"
@@ -375,7 +375,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response :ordinary_statutory_paternity_pay
       add_response :yes
       add_response :no
-      add_response "2013-01-07"
+      add_response "2013-01-08"
       add_response "2013-05-03"
       add_response :yes
       add_response "2013-01-07"
@@ -544,6 +544,11 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
     should "not allow dates next year" do
       add_response (Date.today.end_of_year + 1.day).to_s
       assert_current_node_is_error
+    end
+
+    should "only allow linked sickness to be before the recent one" do
+      add_response "2015-03-20"
+      assert_current_node_is_error "linked_sickness_must_be_before"
     end
   end
 

--- a/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
@@ -62,6 +62,8 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
         add_response '2014-03-02'
         assert_current_node :last_sick_day?
         add_response '2014-06-02'
+        assert_current_node :has_linked_sickness?
+        add_response 'no'
         assert_current_node :paid_at_least_8_weeks?
         add_response 'before_payday'
         assert_current_node :how_often_pay_employee_pay_patterns?
@@ -70,8 +72,6 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
         add_response '3000'
         assert_current_node :contractual_days_covered_by_earnings?
         add_response '17'
-        assert_current_node :off_sick_4_days?
-        add_response 'no'
         assert_current_node :usual_work_days?
         add_response '1,2,3,4,5'
         assert_current_node :entitled_to_sick_pay
@@ -116,11 +116,11 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
           add_response '2013-04-02'
           assert_state_variable :sick_start_date, Date.parse(' 2 April 2013')
           assert_current_node :last_sick_day? # Q5
-
           add_response '2013-04-10'
           assert_state_variable :sick_end_date, Date.parse('10 April 2013')
+          assert_current_node :has_linked_sickness?
+          add_response 'no'
           assert_current_node :paid_at_least_8_weeks?
-
           add_response 'eight_weeks_more'
           assert_current_node :how_often_pay_employee_pay_patterns?
           assert_state_variable :eight_weeks_earnings, 'eight_weeks_more'
@@ -132,13 +132,6 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
           add_response '2013-01-31'
           assert_current_node :total_employee_earnings?
           add_response '4000'
-          assert_current_node :off_sick_4_days?
-
-          add_response 'yes'
-          assert_current_node :linked_sickness_start_date?
-          add_response '2013-01-01'
-          assert_current_node :how_many_days_sick?
-          add_response '6'
           assert_current_node :usual_work_days?
           add_response '1,2,3,4,5'
           assert_current_node :entitled_to_sick_pay
@@ -153,8 +146,9 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
 
           add_response '2013-04-10'
           assert_state_variable :sick_end_date, Date.parse('10 April 2013')
+          assert_current_node :has_linked_sickness?
+          add_response 'no'
           assert_current_node :paid_at_least_8_weeks?
-
           add_response 'eight_weeks_more'
           assert_current_node :how_often_pay_employee_pay_patterns?
           assert_state_variable :eight_weeks_earnings, 'eight_weeks_more'
@@ -166,9 +160,6 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
           add_response '2013-01-31'
           assert_current_node :total_employee_earnings?
           add_response '4000'
-          assert_current_node :off_sick_4_days?
-
-          add_response 'no'
           assert_current_node :usual_work_days?
           add_response '1,2,3,4,5'
           assert_current_node :entitled_to_sick_pay
@@ -182,11 +173,15 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
           add_response '2013-04-02'
           assert_state_variable :sick_start_date, Date.parse(' 2 April 2013')
           assert_current_node :last_sick_day? # Q5
-
           add_response '2013-04-10'
           assert_state_variable :sick_end_date, Date.parse('10 April 2013')
+          assert_current_node :has_linked_sickness?
+          add_response 'yes'
+          assert_current_node :linked_sickness_start_date?
+          add_response '2013-03-12'
+          assert_current_node :linked_sickness_end_date?
+          add_response '2013-03-16'
           assert_current_node :paid_at_least_8_weeks?
-
           add_response 'before_payday'
           assert_current_node :how_often_pay_employee_pay_patterns?
           add_response 'monthly'
@@ -194,13 +189,6 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
           add_response '2000'
           assert_current_node :contractual_days_covered_by_earnings?
           add_response '30'
-          assert_current_node :off_sick_4_days?
-
-          add_response 'yes'
-          assert_current_node :linked_sickness_start_date?
-          add_response '2013-03-12'
-          assert_current_node :how_many_days_sick?
-          add_response '4'
           assert_current_node :usual_work_days?
           add_response '1,2,3'
           assert_current_node :entitled_to_sick_pay
@@ -212,11 +200,11 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
           add_response '2013-04-02'
           assert_state_variable :sick_start_date, Date.parse(' 2 April 2013')
           assert_current_node :last_sick_day? # Q5
-
           add_response '2013-04-10'
           assert_state_variable :sick_end_date, Date.parse('10 April 2013')
+          assert_current_node :has_linked_sickness?
+          add_response 'no'
           assert_current_node :paid_at_least_8_weeks?
-
           add_response 'before_payday'
           assert_current_node :how_often_pay_employee_pay_patterns?
           add_response 'monthly'
@@ -224,9 +212,6 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
           add_response '2000'
           assert_current_node :contractual_days_covered_by_earnings?
           add_response '30'
-          assert_current_node :off_sick_4_days?
-
-          add_response 'no'
           assert_current_node :usual_work_days?
           add_response '1,2,3,4,5'
           assert_current_node :entitled_to_sick_pay
@@ -238,23 +223,20 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
           add_response '2013-04-02'
           assert_state_variable :sick_start_date, Date.parse(' 2 April 2013')
           assert_current_node :last_sick_day? # Q5
-
           add_response '2013-04-10'
           assert_state_variable :sick_end_date, Date.parse('10 April 2013')
+          assert_current_node :has_linked_sickness?
+          add_response 'yes'
+          assert_current_node :linked_sickness_start_date?
+          add_response '2013-03-24'
+          assert_current_node :linked_sickness_end_date?
+          add_response '2013-03-29'
           assert_current_node :paid_at_least_8_weeks?
-
           add_response :eight_weeks_less
           assert_current_node :total_earnings_before_sick_period?
           add_response '3000'
           assert_current_node :days_covered_by_earnings?
           add_response '35'
-          assert_current_node :off_sick_4_days?
-
-          add_response 'yes'
-          assert_current_node :linked_sickness_start_date?
-          add_response '2013-03-24'
-          assert_current_node :how_many_days_sick?
-          add_response '5'
           assert_current_node :usual_work_days?
           add_response '1,2,3,4,5'
           assert_current_node :entitled_to_sick_pay
@@ -266,19 +248,16 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
           add_response '2013-04-02'
           assert_state_variable :sick_start_date, Date.parse(' 2 April 2013')
           assert_current_node :last_sick_day? # Q5
-
           add_response '2013-04-10'
           assert_state_variable :sick_end_date, Date.parse('10 April 2013')
+          assert_current_node :has_linked_sickness?
+          add_response 'no'
           assert_current_node :paid_at_least_8_weeks?
-
           add_response :eight_weeks_less
           assert_current_node :total_earnings_before_sick_period?
           add_response '3000'
           assert_current_node :days_covered_by_earnings?
           add_response '35'
-          assert_current_node :off_sick_4_days?
-
-          add_response 'no'
           assert_current_node :usual_work_days?
           add_response '1,2,3,4,5'
           assert_current_node :entitled_to_sick_pay
@@ -294,11 +273,11 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response 'no' # Q3
       add_response '2013-06-10' # Q4
       add_response '2013-06-20' # Q5
+      add_response 'no' # Q11
       add_response 'before_payday' # Q5.1
       add_response 'weekly' # Q5.2
       add_response '100' # Q7
       add_response '7' # Q7.1
-      add_response 'no' # Q11
       add_response '1,2,3,4,5' # Q13
     end
     should "take you to result A5 as awe < LEL (as of 2013-06-10)" do
@@ -321,23 +300,35 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
   end
 
   context "no SSP payable as already had maximum" do
-    setup do
-      add_response 'none'
-      add_response 'yes'
-      add_response 'no'
-      add_response '2013-06-10'
-      add_response '2013-06-20'
-      add_response 'eight_weeks_more'
-      add_response 'monthly'
-      add_response '2013-05-31'
-      add_response '2013-03-31'
-      add_response '4000'
-      add_response 'yes'
-      add_response '2013-01-01'
-      add_response '183'
-      add_response '1,2,3,4,5'
-    end
     should "take you to result A8 as already claimed > 28 weeks (max amount)" do
+      add_response 'none'
+      assert_current_node :employee_tell_within_limit?
+      add_response 'yes'
+      assert_current_node :employee_work_different_days?
+      add_response 'no'
+      assert_current_node :first_sick_day?
+      add_response '2014-10-10'
+      assert_current_node :last_sick_day?
+      add_response '2014-10-20'
+      assert_current_node :has_linked_sickness?
+      add_response 'yes'
+      assert_current_node :linked_sickness_start_date?
+      add_response '2014-05-01'
+      assert_current_node :linked_sickness_end_date?
+      add_response '2014-09-20'
+      assert_current_node :paid_at_least_8_weeks?
+      add_response 'eight_weeks_more'
+      assert_current_node :how_often_pay_employee_pay_patterns?
+      add_response 'monthly'
+      assert_current_node :last_payday_before_sickness?
+      add_response '2013-04-01'
+      assert_current_node :last_payday_before_offset?
+      add_response '2013-02-3'
+      assert_current_node :total_employee_earnings?
+      add_response '4000'
+      assert_current_node :usual_work_days?
+      add_response '1,2,3,4,5'
+
       assert_current_node :maximum_entitlement_reached
     end
   end
@@ -349,14 +340,14 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response :no
       add_response "2013-01-07"
       add_response "2013-05-03"
+      add_response :yes
+      add_response "2013-01-07"
+      add_response "2013-01-15"
       add_response :eight_weeks_more
       add_response :monthly
       add_response "2012-12-28"
       add_response "2012-10-26"
       add_response 1600.0
-      add_response :yes
-      add_response "2012-11-11"
-      add_response 8
       add_response "3,6"
 
       assert_current_node :entitled_to_sick_pay
@@ -386,14 +377,14 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response :no
       add_response "2013-01-07"
       add_response "2013-05-03"
+      add_response :yes
+      add_response "2013-01-07"
+      add_response "2013-02-03"
       add_response :eight_weeks_more
       add_response :monthly
       add_response "2012-12-28"
       add_response "2012-10-26"
       add_response 1250.75
-      add_response :yes
-      add_response "2012-11-09"
-      add_response 23
       add_response "2,3,4"
 
       assert_current_node :entitled_to_sick_pay
@@ -423,12 +414,12 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response :no
       add_response "2013-01-07"
       add_response "2013-05-03"
+      add_response :no
       add_response :eight_weeks_more
       add_response :irregularly
       add_response "2012-12-28"
       add_response "2012-10-26"
       add_response 3000.0
-      add_response :no
       add_response "1,2,3,4"
 
       assert_current_node :entitled_to_sick_pay
@@ -459,12 +450,12 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response :no
       add_response "2013-01-07"
       add_response "2013-05-03"
+      add_response :no
       add_response :eight_weeks_more
       add_response :irregularly
       add_response "2012-12-28"
       add_response "2012-10-26"
       add_response 3000.0
-      add_response :no
       add_response "1,2,3,4"
 
       assert_current_node :entitled_to_sick_pay
@@ -529,6 +520,51 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
     end
   end
 
+  context "linked_sickness_start_date? date validation" do
+    setup do
+      add_response :additional_statutory_paternity_pay
+      add_response :yes
+      add_response :no
+      add_response "02/04/2013"
+      add_response "10/04/2013"
+      add_response :yes
+      assert_current_node :linked_sickness_start_date?
+    end
+
+    should "not allow dates before 2010" do
+      add_response Date.parse("2009-12-31")
+      assert_current_node_is_error
+    end
+
+    should "not allow dates next year" do
+      add_response (Date.today.end_of_year + 1.day).to_s
+      assert_current_node_is_error
+    end
+  end
+
+  context "linked_sickness_end_date? date validation" do
+    setup do
+      add_response :additional_statutory_paternity_pay
+      add_response :yes
+      add_response :no
+      add_response "02/04/2013"
+      add_response "10/04/2013"
+      add_response :yes
+      add_response "12/03/2013"
+      assert_current_node :linked_sickness_end_date?
+    end
+
+    should "not allow dates before 2010" do
+      add_response Date.parse("2009-12-31")
+      assert_current_node_is_error
+    end
+
+    should "not allow dates next year" do
+      add_response (Date.today.end_of_year + 1.day).to_s
+      assert_current_node_is_error
+    end
+  end
+
   context "last_payday_before_sickness? date validation" do
     setup do
       add_response :additional_statutory_paternity_pay
@@ -536,6 +572,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response :no
       add_response "02/04/2013"
       add_response "10/04/2013"
+      add_response :no
       add_response "eight_weeks_more"
       add_response "weekly"
       assert_current_node :last_payday_before_sickness?
@@ -559,37 +596,11 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response :no
       add_response "02/04/2013"
       add_response "10/04/2013"
+      add_response :no
       add_response "eight_weeks_more"
       add_response "weekly"
       add_response "31/03/2013"
       assert_current_node :last_payday_before_offset?
-    end
-
-    should "not allow dates before 2010" do
-      add_response Date.parse("2009-12-31")
-      assert_current_node_is_error
-    end
-
-    should "not allow dates next year" do
-      add_response (Date.today.end_of_year + 1.day).to_s
-      assert_current_node_is_error
-    end
-  end
-
-  context "linked_sickness_start_date? date validation" do
-    setup do
-      add_response :additional_statutory_paternity_pay
-      add_response :yes
-      add_response :no
-      add_response "02/04/2013"
-      add_response "10/04/2013"
-      add_response "eight_weeks_more"
-      add_response "weekly"
-      add_response "31/03/2013"
-      add_response "31/01/2013"
-      add_response "4000"
-      add_response :yes
-      assert_current_node :linked_sickness_start_date?
     end
 
     should "not allow dates before 2010" do


### PR DESCRIPTION
This is a re-worked version of #1634. Assuming all is well with this PR, I plan to close #1634 in favour of this one. Ideally we'd also deploy this branch (which has been rebased against a recent version of `master`) to Heroku for Fact Checking.

* c93b15096c9f628d1c83b6ffadf2ff325bf61ea8 was applied directly to `master` in 55d84d95f1e7321491f9038727c7f00483674e66
* f935adac60e9e1f0abd4f712cef7344652705e65 was applied directly to `master` in 30415653b3c06bb9eec51c39df1a1e63dbf2a6f4
* 3f805b803b992756e0999e414fc42717177b00bd was applied directly to `master` in 257a36f756cea354e9816188f291a9d5d913fc1a
* I also extracted a couple of other small unrelated changes into commits on `master`:
  * 341b5688b25019e60162c5faf06419d92ef0ef03
  * 7d474468e278bb7c8c34d66519ad681de8b8ffc9
* A rebased version of 757c4663462d3aedb30de7f5e6467c7dd2743870 (i.e. "Move LEL check to last question") has been included as the first commit in this PR.
* The remaining 5 commits have been squashed into the second commit in this PR.

This resulted in a branch with more atomic commits with all the tests passing after each commit. This in turn made it easier to rebase the branch against `master` despite it being very out-of-date and the flow code having been moved into a class in the meantime.

The test URL appears to work ok on my local machine with these changes in place.

The original PR description (by @BenJanecke) is included below for completeness:

I believe this is the related [Pivotal Tracker story](https://www.pivotaltracker.com/story/show/93691714).

We now ask for previous periods of sickness earlier so we can use the correct dates when asking for and calculating AWE

Test url for deploy 

http://smartanswers.dev.gov.uk/calculate-statutory-sick-pay/y/none/yes/no/2014-08-10/2014-08-20/yes/2014-05-01/2014-08-20/eight_weeks_more/monthly/2013-04-01/2013-02-03/4000.0/1,2,3,4,5