### PR TITLE
Convert plan-adoption-leave outcomes to use ERB templates

### DIFF
--- a/lib/smart_answer/calculators/plan_adoption_leave.rb
+++ b/lib/smart_answer/calculators/plan_adoption_leave.rb
@@ -33,6 +33,10 @@ module SmartAnswer::Calculators
       @arrival_date - 14
     end
 
+    def earliest_start_formatted
+      formatted_date(earliest_start)
+    end
+
     def expected_week
       sunday = @match_date - @match_date.wday
       saturday = sunday + 6
@@ -41,6 +45,10 @@ module SmartAnswer::Calculators
 
     def qualifying_week
       expected_week && weeks_later(expected_week, -1)
+    end
+
+    def last_qualifying_week_formatted
+      formatted_date(qualifying_week.last)
     end
 
     def period_of_ordinary_leave

--- a/lib/smart_answer_flows/locales/en/plan-adoption-leave.yml
+++ b/lib/smart_answer_flows/locales/en/plan-adoption-leave.yml
@@ -23,24 +23,3 @@ en-GB:
         title: When do you want to start your adoption leave?
         hint: Leave can start up to 14 days before the child comes to live with you.
         error_message: Enter a date up to 14 days before the child comes to live with you.
-      # Outcomes
-      adoption_leave_details:
-        title: Your Adoption Leave dates
-        next_steps: |
-          Read our guide to [adoption pay and leave](/adoption-pay-leave)
-        body: |
-          You can take up to 52 weeks Statutory Adoption Leave.
-
-          The dates below are based on this and the date the child starts to live with you: %{arrival_date_formatted}.
-
-          Leave | Key dates
-          - | -
-          Ordinary Adoption Leave (first 26 weeks): | %{period_of_ordinary_leave}
-          Additional Adoption Leave (last 26 weeks): | %{period_of_additional_leave}
-          Earliest leave can start: | %{earliest_start_formatted}
-          Latest date to give notice: | %{last_qualifying_week_formatted}
-
-          You could get more time off if your employer has a company adoption leave scheme.
-
-          ##Statutory Adoption Pay
-          While on leave, you might get [Statutory Adoption Pay](/statutory-adoption-pay).

--- a/lib/smart_answer_flows/locales/en/plan-adoption-leave.yml
+++ b/lib/smart_answer_flows/locales/en/plan-adoption-leave.yml
@@ -37,8 +37,8 @@ en-GB:
           - | -
           Ordinary Adoption Leave (first 26 weeks): | %{period_of_ordinary_leave}
           Additional Adoption Leave (last 26 weeks): | %{period_of_additional_leave}
-          Earliest leave can start: | %{earliest_start}
-          Latest date to give notice: | %{qualifying_week}
+          Earliest leave can start: | %{earliest_start_formatted}
+          Latest date to give notice: | %{last_qualifying_week_formatted}
 
           You could get more time off if your employer has a company adoption leave scheme.
 

--- a/lib/smart_answer_flows/plan-adoption-leave.rb
+++ b/lib/smart_answer_flows/plan-adoption-leave.rb
@@ -50,12 +50,11 @@ module SmartAnswer
         precalculate :distance_start do
           calculator.distance_start
         end
-        precalculate :qualifying_week do
-          calculator.qualifying_week.last
-          # calculator.formatted_date (match_date - 7)
+        precalculate :last_qualifying_week_formatted do
+          calculator.last_qualifying_week_formatted
         end
-        precalculate :earliest_start do
-          calculator.earliest_start
+        precalculate :earliest_start_formatted do
+          calculator.earliest_start_formatted
         end
         precalculate :period_of_ordinary_leave do
           calculator.format_date_range calculator.period_of_ordinary_leave

--- a/lib/smart_answer_flows/plan-adoption-leave.rb
+++ b/lib/smart_answer_flows/plan-adoption-leave.rb
@@ -37,6 +37,8 @@ module SmartAnswer
         next_node :adoption_leave_details
       end
 
+      use_outcome_templates
+
       outcome :adoption_leave_details do
         precalculate :match_date_formatted do
           calculator.formatted_match_date

--- a/lib/smart_answer_flows/plan-adoption-leave/adoption_leave_details.govspeak.erb
+++ b/lib/smart_answer_flows/plan-adoption-leave/adoption_leave_details.govspeak.erb
@@ -1,0 +1,25 @@
+<% content_for :title do %>
+Your Adoption Leave dates
+<% end %>
+
+<% content_for :body do %>
+You can take up to 52 weeks Statutory Adoption Leave.
+
+The dates below are based on this and the date the child starts to live with you: <%= arrival_date_formatted %>.
+
+Leave | Key dates
+- | -
+Ordinary Adoption Leave (first 26 weeks): | <%= period_of_ordinary_leave %>
+Additional Adoption Leave (last 26 weeks): | <%= period_of_additional_leave %>
+Earliest leave can start: | <%= earliest_start_formatted %>
+Latest date to give notice: | <%= last_qualifying_week_formatted %>
+
+You could get more time off if your employer has a company adoption leave scheme.
+
+##Statutory Adoption Pay
+While on leave, you might get [Statutory Adoption Pay](/statutory-adoption-pay).
+<% end %>
+
+<% content_for :next_steps do %>
+Read our guide to [adoption pay and leave](/adoption-pay-leave)
+<% end %>

--- a/test/data/plan-adoption-leave-files.yml
+++ b/test/data/plan-adoption-leave-files.yml
@@ -1,6 +1,7 @@
 --- 
-lib/smart_answer_flows/plan-adoption-leave.rb: 482e12b12d0a3a379ef6e73bf25bd9c3
-lib/smart_answer_flows/locales/en/plan-adoption-leave.yml: cb253412808f700db51a88ac153274a2
+lib/smart_answer_flows/plan-adoption-leave.rb: b7e08de391492d2554121d8fb4712d53
+lib/smart_answer_flows/locales/en/plan-adoption-leave.yml: 8c28c1f6a3946d3f57fc06538a72703b
 test/data/plan-adoption-leave-questions-and-responses.yml: 19cde22548bdc648de4a1616676283ae
 test/data/plan-adoption-leave-responses-and-expected-results.yml: 11998cff3f7d722bfb842851dde611b8
-lib/smart_answer/calculators/plan_adoption_leave.rb: c4f2304ad8e3f95982f10abf6efaf107
+lib/smart_answer_flows/plan-adoption-leave/adoption_leave_details.govspeak.erb: 7ec32e7c82044dc88dc1fd2578513413
+lib/smart_answer/calculators/plan_adoption_leave.rb: 80b6eb2de784f121761a36e60ce16a57

--- a/test/unit/calculators/plan_adoption_leave_test.rb
+++ b/test/unit/calculators/plan_adoption_leave_test.rb
@@ -48,8 +48,16 @@ module SmartAnswer::Calculators
             assert_equal Date.parse("23 June 2012"), @calculator.qualifying_week.last
           end
 
+          should "last_qualifying_week_formatted give 23 June 2012" do
+            assert_equal "23 June 2012", @calculator.last_qualifying_week_formatted
+          end
+
           should "earliest_start give date of 11 December 2012" do
             assert_equal Date.parse("11 December 2012"), @calculator.earliest_start
+          end
+
+          should "earliest_start_formatted give 11 December 2012" do
+            assert_equal "11 December 2012", @calculator.earliest_start_formatted
           end
 
           should "period_of_ordinary_leave give range of 11 December 2012 - 11 June 2013" do


### PR DESCRIPTION
This was the first time I've had to deal with`Date` objects being supplied by `precalculate` blocks and relying on the [formatting specified in `NodePresenter#value_for_interpolation`][1] and [defined in `en.yml`][2]. For more details on how I decided to handle this, please see the commit note in the first commit i.e. the one with title: `Format all dates for plan-adoption-leave in "calculator" methods`.

Otherwise this conversion was very straightforward - only a single smallish outcome.

[1]: https://github.com/alphagov/smart-answers/blob/de7619dfd88c8f344c67285f003c0e6f159ec3ec/app/presenters/node_presenter.rb#L27
[2]: https://github.com/alphagov/smart-answers/blob/f9974a7a850d874f3bf38d1720efcaac8f1a61ef/config/locales/en.yml#L7
