### PR TITLE
Apply tier 4: remove downtime message

### DIFF
--- a/lib/smart_answer_flows/locales/en/apply-tier-4-visa.yml
+++ b/lib/smart_answer_flows/locales/en/apply-tier-4-visa.yml
@@ -12,7 +12,6 @@ en-GB:
         * extending or switching to a [Tier 4 (General) student visa](/tier-4-general-visa)
         * extending or switching to a [Tier 4 (Child) student visa](/child-study-visa)
 
-        %This service will be unavailable from 8am on Saturday 5 July to 8am on Sunday 6 July.%
 #Q1
       extending_or_switching?:
         title: "Are you:"

--- a/test/data/apply-tier-4-visa-files.yml
+++ b/test/data/apply-tier-4-visa-files.yml
@@ -1,6 +1,6 @@
 --- 
 lib/smart_answer_flows/apply-tier-4-visa.rb: 44ce7b4a25bb0877d3972fbe9ed94a16
-lib/smart_answer_flows/locales/en/apply-tier-4-visa.yml: a07fa0de8a496f203b2beb6311d0809c
+lib/smart_answer_flows/locales/en/apply-tier-4-visa.yml: 0fcef552743955e900c28e22cda2e314
 test/data/apply-tier-4-visa-questions-and-responses.yml: fe87a99e4337e45586806181742f0b8f
 test/data/apply-tier-4-visa-responses-and-expected-results.yml: 339690f2a3125ef29d63f29a79ae1cba
 lib/smart_answer_flows/apply-tier-4-visa/outcome.govspeak.erb: 35321ca47529db52e86f07a6864ef4f2


### PR DESCRIPTION
The downtime is in the past now so the users do not need to see the temporary downtime message introduced in 6ca437a3e052379fe24219cc0233eb33c9219c19 anymore.

Closes https://github.com/alphagov/smart-answers/pull/1782