### PR TITLE
Run setup for every regression test if teardown hooks installed

### DIFF
--- a/test/regression/smart_answers_regression_test.rb
+++ b/test/regression/smart_answers_regression_test.rb
@@ -25,6 +25,18 @@ class SmartAnswersRegressionTest < ActionController::TestCase
     def setup_has_run?
       @setup_has_run
     end
+
+    def webmock_teardown_hook_installed?
+      Minitest::Test.method_defined?(:teardown_with_webmock)
+    end
+
+    def custom_teardown_hook_installed?
+      Minitest::Test.method_defined?(:teardown_with_customisations)
+    end
+
+    def teardown_hooks_installed?
+      webmock_teardown_hook_installed? || custom_teardown_hook_installed?
+    end
   end
 
   include GdsApi::TestHelpers::ContentApi
@@ -47,7 +59,7 @@ class SmartAnswersRegressionTest < ActionController::TestCase
 
     context "Smart Answer: #{flow_name}" do
       setup do
-        next if self.class.setup_has_run?
+        next if self.class.setup_has_run? && !self.class.teardown_hooks_installed?
         Timecop.freeze(Date.parse('2015-01-01'))
         stub_content_api_default_artefact
         WebMock.stub_request(:get, WorkingDays::BANK_HOLIDAYS_URL).to_return(body: File.open(fixture_file('bank_holidays.json')))


### PR DESCRIPTION
When the regression tests are run in the same process as the main test suite,
`test/test_helper.rb` installs a couple of teardown hooks for all subclasses of
`Minitest::Test` which are not installed when the regression tests are run in a
separate process. The two teardown hooks are as follows:

* WebMock teardown hook installed by `require 'webmock/minitest'` which calls
`WebMock.reset!`
* Custom teardown hook calls `Timecop.return`

With these teardown hooks installed, the [optimisation][1] of only running the
`setup` block once was no longer safe, because everything that was setup before
the first test was torn down at the end of the first test and never setup again.
And thus we saw build failure like [this one][2] where the expected Content API
stubs were not in place for subsequent tests.

Typically this didn't happen very often, because developers have tended to run
the regression tests separately on their local machine and, as long as the
relevant file checksums had been updated, the main CI build didn't run any
regression tests. However, clearly it was not a good state of affairs.

Unfortunately, because both of these teardown hooks are installed using
`alias_method_chain` and the WebMock one is within library code, it would've
been awkward to disable them just for the duration of the regression tests and
re-instate them afterwards.

Instead, I've chosen to detect when they are installed and in this case disable
the optimisation of only running the `setup` block once in the regression
tests. Unfortunately this will make the main test suite take a bit longer if
any regression tests need to be run. However, since this is a less common
scenario I think this is good enough for now.

[1]: c86ba038821012a70cb5d8ee3c462fd6f9c5e53c
[2]: https://ci-new.alphagov.co.uk/job/govuk_smartanswers_branches/2424/consoleFull