### PR TITLE
Add page option to GA Event tracking of Outcomes

### DIFF
--- a/app/views/smart_answers/_result.html.erb
+++ b/app/views/smart_answers/_result.html.erb
@@ -23,5 +23,13 @@
 
 <script type="text/javascript">
   var flowName = '<%= @name %>';
-  GOVUK.analytics.trackEvent('Smart Answer', 'Completed', {label: flowName, nonInteraction: true});
+  event = {
+    hitType: 'event',
+    eventCategory: 'Smart Answer',
+    eventAction: 'Completed',
+    eventLabel: flowName,
+    nonInteraction: 1,
+    page: document.location.pathname
+  };
+  window.ga('send', event);
 </script>


### PR DESCRIPTION
*NOTE.* The use of `ga()` is an interim measure while we work out whether this
records the data we're interested in.

Chris Russell highlighted a problem with our tracking of the outcome pages. The
reports show the "Completed" event being fired on the Smart Answer start pages
(e.g. /student-finance-forms/y).

This is because of the way Smart Answers uses JavaScript to partially replace
the page when navigating through the flow. The `location` recorded with the
Event is that of the start page instead of the outcome page.

We already have to work around this in our pageview tracking of Smart Answers.
We do that by passing the current URL as the `page` option to `ga()` (via
[`trackPageView()`][1]).

I'm fairly confident that I can use the same technique to record the actual
page we're looking at by passing the current URL as the [`page` option to
`ga()`][2]. Unfortunately, [`GoogleAnalyticsUniversalTracker.trackEvent()`][3]
doesn't support the setting of the `page` option which is why I've used `ga()`
directly.

Assuming sending the `page` option does what we're after (i.e. we start getting
useful Analytics data) then I'll make the change to govuk_frontend_toolkit to
support this option properly.

The [Google Analytics debugger][4] shows me the data sent to Google Analytics
before and after this change:

Before
------

Command: ga("send", {hitType: "event", eventCategory: "Smart Answer",
eventAction: "Completed", eventLabel: "student-finance-forms", nonInteraction:
1})

Location (&dl): https://www.gov.uk/student-finance-forms/y

Page (&dp): Not Set

After
-----

Command: ga("send", {hitType: "event", eventCategory: "Smart Answer",
eventAction: "Completed", eventLabel: "student-finance-forms", nonInteraction:
1, page: "/student-finance-forms/y/eu-full-time/year-1415/new-student"})

Location (&dl): http://smartanswers.dev.gov.uk/student-finance-forms/y

Page (&dp): /student-finance-forms/y/eu-full-time/year-1415/new-student

This is much closer to what we send for the virtual pageview:

Command: ga("send", "pageview", {page:
"/student-finance-forms/y/eu-full-time/year-1415/new-student"})

Location (&dl): https://www.gov.uk/student-finance-forms/y

Page (&dp): /student-finance-forms/y/eu-full-time/year-1415/new-student

[1]: https://github.com/alphagov/smart-answers/blob/master/app/assets/javascripts/smart-answers.js#L98
[2]: https://developers.google.com/analytics/devguides/collection/analyticsjs/events#implementation
[3]: https://github.com/alphagov/govuk_frontend_toolkit/blob/master/javascripts/govuk/analytics/google-analytics-universal-tracker.js#L43
[4]: https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna?hl=en