### PR TITLE
Update tenant-nationality

### DIFF
--- a/lib/smartdown_flows/landlord-immigration-check/questions/tenant_nationality.txt
+++ b/lib/smartdown_flows/landlord-immigration-check/questions/tenant_nationality.txt
@@ -1,12 +1,10 @@
 # Is the person:
 
 [choice: tenant_country]
-* ci_or_iom: from the Channel Islands or Isle of Man
 * eu_eea_switzerland: from the EU, EEA or Switzerland
 * non_eea_but_with_eu_eea_switzerland_family_member: a non-EEA family member of someone from the EU, EEA or Switzerland
 * somewhere_else: from somewhere else
 
-* tenant_country is 'ci_or_iom' => outcome_can_rent
 * tenant_country is 'eu_eea_switzerland' => documents_exempting_from_immigration_control
-* tenant_country is 'non_eea_but_with_eu_eea_switzerland_family_member' => named_person_of_eea_switzerland_person
+* tenant_country is 'non_eea_but_with_eu_eea_switzerland_family_member' => residence_card_or_eu_eea_swiss_family_member
 * tenant_country is 'somewhere_else' => other_documents_for_indefinite_leave_to_remain


### PR DESCRIPTION
From factcheck:
- removing Channel Islands route (will be caught by later questions)
- changing outcome for non-eea family members to a later outcome (because they won't have the other documents)