### PR TITLE
Landlord immigration check FC feedback

### DIFF
--- a/lib/smartdown_flows/landlord-immigration-check/outcomes/outcome_can_rent_for_12_months.txt
+++ b/lib/smartdown_flows/landlord-immigration-check/outcomes/outcome_can_rent_for_12_months.txt
@@ -8,9 +8,9 @@ The person will be able to stay in the property for 12 months. The verification 
 
 ##When the person can't rent your property 
 
-The person won’t be able to rent the property:
+The person won’t be able to rent the property if:
 
-- if they don’t have the right documents
+- they don’t have the right documents
 - you get a negative result back from the verification check
 
 ^You may get a [civil penalty](/penalties-illegal-renting) if you get a Negative Verification notice and you still rent your property to the person who isn't allowed to rent property in the UK.^

--- a/lib/smartdown_flows/landlord-immigration-check/questions/named_person_of_eea_switzerland_person.txt
+++ b/lib/smartdown_flows/landlord-immigration-check/questions/named_person_of_eea_switzerland_person.txt
@@ -1,8 +1,0 @@
-# Does the person have a passport or national identity card that shows that they're a national of the EEA or Switzerland?
-
-[choice: eea_switzerland]
-* yes: Yes
-* no: No
-
-* eea_switzerland is 'yes' => outcome_can_rent
-* eea_switzerland is 'no' => documents_exempting_from_immigration_control

--- a/lib/smartdown_flows/landlord-immigration-check/questions/tenant_nationality.txt
+++ b/lib/smartdown_flows/landlord-immigration-check/questions/tenant_nationality.txt
@@ -1,12 +1,10 @@
 # Is the person:
 
 [choice: tenant_country]
-* ci_or_iom: from the Channel Islands or Isle of Man
 * eu_eea_switzerland: from the EU, EEA or Switzerland
 * non_eea_but_with_eu_eea_switzerland_family_member: a non-EEA family member of someone from the EU, EEA or Switzerland
 * somewhere_else: from somewhere else
 
-* tenant_country is 'ci_or_iom' => outcome_can_rent
 * tenant_country is 'eu_eea_switzerland' => documents_exempting_from_immigration_control
 * tenant_country is 'non_eea_but_with_eu_eea_switzerland_family_member' => named_person_of_eea_switzerland_person
 * tenant_country is 'somewhere_else' => other_documents_for_indefinite_leave_to_remain

--- a/lib/smartdown_flows/landlord-immigration-check/questions/tenant_nationality.txt
+++ b/lib/smartdown_flows/landlord-immigration-check/questions/tenant_nationality.txt
@@ -6,5 +6,5 @@
 * somewhere_else: from somewhere else
 
 * tenant_country is 'eu_eea_switzerland' => documents_exempting_from_immigration_control
-* tenant_country is 'non_eea_but_with_eu_eea_switzerland_family_member' => named_person_of_eea_switzerland_person
+* tenant_country is 'non_eea_but_with_eu_eea_switzerland_family_member' => residence_card_or_eu_eea_swiss_family_member
 * tenant_country is 'somewhere_else' => other_documents_for_indefinite_leave_to_remain

--- a/lib/smartdown_flows/landlord-immigration-check/scenarios/landlord-immigration-check-scenarios.txt
+++ b/lib/smartdown_flows/landlord-immigration-check/scenarios/landlord-immigration-check-scenarios.txt
@@ -17,6 +17,18 @@ outcome_check_not_needed
 outcome_can_not_rent
 
 - property: B1 1PW
+- main_home: yes
+- tenant_over_18: yes
+- has_uk_passport: no
+- right_to_abode: no
+- has_certificate: no
+- tenant_country: non_eea_but_with_eu_eea_switzerland_family_member
+- has_residence_card_or_eu_eea_swiss_family_member: no
+- has_asylum_card: no
+- immigration_application: no
+outcome_can_not_rent
+
+- property: B1 1PW
 - main_home: no
 - property_type: holiday_accommodation
 outcome_check_not_needed_if_holiday_or_under_3_months


### PR DESCRIPTION
Closes #1792 and #1793.

In addition to the above, this PR removes a no longer used `named_person_of_eea_switzerland_person` node and adds a test for the modified flow.

Note: this smartanswer is in draft state, so it's safe to merge to master.

### Original PR description

From factcheck:

- removing Channel Islands route (will be caught by later questions)
- changing outcome for non-eea family members to a later outcome (because they won't have the other documents)
- fixing a typo