### PR TITLE
Add missing CO2 form for new and continuing students

### DIFF
--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_uk_ptgc_1516_grant.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_uk_ptgc_1516_grant.txt
@@ -18,3 +18,5 @@ You need to download and fill in [form CB1 (PDF, 463KB)](http://media.slc.co.uk/
 - Income-related Employment Support Allowance (ESA)
 - Housing Benefit
 - Local Housing Allowance
+
+{{snippet: circumstances-changed-co2-form}}

--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_uk_ptgn_1516_grant.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_uk_ptgn_1516_grant.txt
@@ -16,3 +16,5 @@ You need to download and fill in [form CB1 (PDF, 463KB)](http://media.slc.co.uk/
 - Income-related Employment Support Allowance (ESA)
 - Housing Benefit
 - Local Housing Allowance
+
+{{snippet: circumstances-changed-co2-form}}

--- a/lib/smartdown_flows/student-finance-forms/scenarios/uk-students.txt
+++ b/lib/smartdown_flows/student-finance-forms/scenarios/uk-students.txt
@@ -130,6 +130,7 @@ outcome_dsa_1415_pt
 - continuing_student: continuing-student
 - pt_course_start: course-start-before-01092012
 outcome_uk_ptgc_1516_grant
+has marker: circumstances_changed
 
 - type_of_student: uk-part-time
 - form_needed_for_2: apply-loans-grants
@@ -144,6 +145,7 @@ outcome_uk_pt_1516_continuing
 - continuing_student: new-student
 - pt_course_start: course-start-before-01092012
 outcome_uk_ptgn_1516_grant
+has marker: circumstances_changed
 
 - type_of_student: uk-part-time
 - form_needed_for_2: apply-loans-grants

--- a/lib/smartdown_flows/student-finance-forms/snippets/circumstances-changed-co2-form.txt
+++ b/lib/smartdown_flows/student-finance-forms/snippets/circumstances-changed-co2-form.txt
@@ -1,0 +1,8 @@
+##Your circumstances have changed
+
+You need to download and fill in [form CO2 (PDF, 98KB)](http://media.slc.co.uk/sfe/1516/pt/sfe_co2_form_1516_d.pdf) if you’ve changed:
+
+- your course, or left it
+- university or college
+- your name, address or contact details
+{{marker: circumstances_changed}}


### PR DESCRIPTION
If students' circumstances have changed, they need to fill in a CO2
form (nothing to do with carbon dioxide). This was supposed to be added
in 8625e81f24367c3f1915baf65ba0b565fe563894

Test URLs:
/student-finance-forms/y/uk-part-time/apply-loans-grants/year-1516/new-student/course-start-before-01092012
/student-finance-forms/y/uk-part-time/apply-loans-grants/year-1516/continuing-student/course-start-before-01092012

should have a new paragraph with "Your circumstances have changed"