### PR TITLE
Fix hidden and failing tests

### DIFF
--- a/test/integration/smart_answer_flows/am_i_getting_minimum_wage_test.rb
+++ b/test/integration/smart_answer_flows/am_i_getting_minimum_wage_test.rb
@@ -283,8 +283,8 @@ class AmIGettingMinimumWageTest < ActiveSupport::TestCase
         end
         should "make outcome calculations" do
           assert_state_variable "total_hours", 45
-          assert_state_variable "minimum_hourly_rate", 6.08
-          assert_state_variable "total_hourly_rate", 6.07
+          assert_state_variable "minimum_hourly_rate", 6.5
+          assert_state_variable "total_hourly_rate", "6.12"
           assert_state_variable "above_minimum_wage", false
         end
       end
@@ -321,7 +321,7 @@ class AmIGettingMinimumWageTest < ActiveSupport::TestCase
       end
 
       # Scenario 8 - part 2 - living in free accommodation instead of charged
-      context "25 year old" do
+      context "25 year old, living in free accommodation" do
         setup do
           add_response 25         # age
           add_response 7          # pay_frequency

--- a/test/integration/smart_answer_flows/uk_benefits_abroad_test.rb
+++ b/test/integration/smart_answer_flows/uk_benefits_abroad_test.rb
@@ -1104,12 +1104,12 @@ class UKBenefitsAbroadTest < ActiveSupport::TestCase
     end
 
     # Child benefits
-    context "answer Guernsey/Jersey" do
+    context "answer Guernsey/Jersey and child benefits" do
       setup do
         add_response 'child_benefit'
-        add_response 'guernsey_jersey'
+        add_response 'jersey'
       end
-      should "take you to SS outcome" do
+      should "take you to which country question" do
         assert_current_node :child_benefit_ss_outcome
       end
     end
@@ -1461,7 +1461,7 @@ class UKBenefitsAbroadTest < ActiveSupport::TestCase
     end
 
     # Bereavement benefits
-    context "answer Guernsey/Jersey" do
+    context "answer Guernsey/Jersey and bereavement benefits" do
       setup do
         add_response 'bereavement_benefits'
         add_response 'guernsey'


### PR DESCRIPTION
I was bitten by the duplicate context/test issue (documented in #1626) while converting energy-grants-calculator to use ERB templates: My conversion caused tests to become invalid, but they didn't fail because of the duplicate name problem.

I used the code from the gist referenced in that issue to give each context a unique name and found these two failing tests.

There are still more hidden tests but I figured these failing ones were a priority.