### PR TITLE
Log more info about partials rendering

### DIFF
--- a/config/initializers/log_subscriber.rb
+++ b/config/initializers/log_subscriber.rb
@@ -1,0 +1,14 @@
+if ENV['LOG_PARTIAL_SOURCE']
+  module ActionView
+    class LogSubscriber
+      def render_partial(event)
+        info do
+          message = " Rendered #{from_rails_root(event.payload[:identifier])}"
+          message << " within #{from_rails_root(event.payload[:layout])}" if event.payload[:layout]
+          message << " (#{event.duration.round(1)}ms)"
+          message << " from #{caller.find { |line| line =~ /\.erb/}.to_s.split(':in').first.split('/lib').last}"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
With the new smartanswers format the `?debug=1` is not useful in showing where
the content is coming from anymore. The log shows which partials are rendered
but it does not show what code calls it. In some cases the same partial can
be rendered from 10 or more places (e.g. overseas-passports). This adds a line
to the log that shows what code has invoked partial rendering.

Before:
```
Rendered lib/smart_answer_flows/overseas-passports/_passport_costs_ips.govspeak.erb (0.3ms)
```
After:
```
Rendered lib/smart_answer_flows/overseas-passports/_passport_costs_ips.govspeak.erb (0.3ms) from /smart_answer_flows/overseas-passports/ips_application_result.govspeak.erb:120
```

This feature is only invoked when `LOG_PARTIAL_SOURCE` environment variable is set

This is up for discussion, alternative solution suggestions are very welcome