### PR TITLE
Convert estimate-self-assessment-penalties to use ERB templates for outcomes

### DIFF
--- a/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
@@ -113,7 +113,9 @@ module SmartAnswer
         next_node :late
       end
 
-      outcome :late, use_outcome_templates: true do
+      use_outcome_templates
+
+      outcome :late do
         precalculate :calculator do
           Calculators::SelfAssessmentPenalties.new(
             submission_method: submission_method,
@@ -142,7 +144,7 @@ module SmartAnswer
         end
       end
 
-      outcome :filed_and_paid_on_time, use_outcome_templates: true
+      outcome :filed_and_paid_on_time
     end
   end
 end

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
@@ -110,38 +110,42 @@ module SmartAnswer
       money_question :how_much_tax? do
         save_input_as :estimated_bill
 
-        calculate :calculator do |response|
+        next_node :late
+      end
+
+      outcome :late do
+        precalculate :calculator do
           Calculators::SelfAssessmentPenalties.new(
             submission_method: submission_method,
             filing_date: filing_date,
             payment_date: payment_date,
-            estimated_bill: response,
+            estimated_bill: estimated_bill,
             dates: calculator_dates,
             tax_year: tax_year
           )
         end
 
-        calculate :late_filing_penalty do
+        precalculate :late_filing_penalty do
           calculator.late_filing_penalty
         end
 
-        calculate :total_owed do
+        precalculate :total_owed do
           calculator.total_owed_plus_filing_penalty
         end
 
-        calculate :interest do
+        precalculate :interest do
           calculator.interest
         end
 
-        calculate :late_payment_penalty do
+        precalculate :late_payment_penalty do
           calculator.late_payment_penalty
         end
 
-        calculate :late_filing_penalty_formatted do
+        precalculate :late_filing_penalty_formatted do
           late_filing_penalty == 0 ? 'none' : late_filing_penalty
         end
 
-        calculate :result_parts do
+        precalculate :result_parts do
           phrases = PhraseList.new
           if calculator.late_payment_penalty == 0
             phrases << :result_part2_no_penalty
@@ -153,11 +157,8 @@ module SmartAnswer
           end
           phrases
         end
-
-        next_node :late
       end
 
-      outcome :late
       outcome :filed_and_paid_on_time
     end
   end

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
@@ -142,7 +142,7 @@ module SmartAnswer
         end
       end
 
-      outcome :filed_and_paid_on_time
+      outcome :filed_and_paid_on_time, use_outcome_templates: true
     end
   end
 end

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
@@ -113,7 +113,7 @@ module SmartAnswer
         next_node :late
       end
 
-      outcome :late do
+      outcome :late, use_outcome_templates: true do
         precalculate :calculator do
           Calculators::SelfAssessmentPenalties.new(
             submission_method: submission_method,
@@ -139,23 +139,6 @@ module SmartAnswer
 
         precalculate :late_payment_penalty do
           calculator.late_payment_penalty
-        end
-
-        precalculate :late_filing_penalty_formatted do
-          late_filing_penalty == 0 ? 'none' : late_filing_penalty
-        end
-
-        precalculate :result_parts do
-          phrases = PhraseList.new
-          if calculator.late_payment_penalty == 0
-            phrases << :result_part2_no_penalty
-          else
-            phrases << :result_part2_penalty
-          end
-          if payment_date >= one_year_after_start_date_for_penalties
-            phrases << :result_part_one_year_late
-          end
-          phrases
         end
       end
 

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties/filed_and_paid_on_time.govspeak.erb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties/filed_and_paid_on_time.govspeak.erb
@@ -1,0 +1,9 @@
+<% content_for :title do %>
+You don't have to pay a penalty
+<% end %>
+
+<% content_for :body do %>
+You sent your tax return on or before the deadline, so you don’t have to pay a penalty.
+
+You paid your bill on time, so there is no interest or penalty for late payment.
+<% end %>

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties/late.govspeak.erb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties/late.govspeak.erb
@@ -1,0 +1,28 @@
+<% content_for :title do %>
+You paid tax or sent your return late
+<% end %>
+
+<% content_for :body do %>
+| Key facts | Your results |
+|-----------|--------------|
+| Your penalty for sending the return late | <%= late_filing_penalty == 0 ? 'none' : format_money(late_filing_penalty) %> |
+<% if calculator.late_payment_penalty == 0 %>
+| What you said your tax bill was | <%= format_money(estimated_bill) %> |
+| Interest added for paying your bill late | <%= interest == 0 ? 0 : format_money(interest) %> |
+| Penalty for paying your bill late | none |
+| Estimate of the total you owe | <%= format_money(total_owed) %> |
+<% else %>
+| What you said your tax bill was | <%= format_money(estimated_bill) %> |
+| Interest added for paying your bill late | <%= interest == 0 ? 0 : format_money(interest) %> |
+| Penalty for paying your bill late | <%= format_money(late_payment_penalty) %> |
+| Estimate of the total you owe | <%= format_money(total_owed) %> |
+<% end %>
+
+<% if payment_date >= one_year_after_start_date_for_penalties %>
+Your penalty can be up to 100% of your tax bill if you deliberately don’t pay it.
+<% end %>
+
+These figures are estimates based on the figures you gave. The total is rounded down to the nearest pound.
+
+^You don’t have to pay any penalties unless you're asked to by HMRC. The amount that HMRC asks for might be different than this estimate.^
+<% end %>

--- a/lib/smart_answer_flows/locales/en/estimate-self-assessment-penalties.yml
+++ b/lib/smart_answer_flows/locales/en/estimate-self-assessment-penalties.yml
@@ -18,22 +18,6 @@ en-GB:
         - outstanding interest or penalties for previous tax years
         - credit you have from previous tax years
 
-      phrases:
-        result_part2_no_penalty: |
-          | What you said your tax bill was | %{estimated_bill} |
-          | Interest added for paying your bill late | %{interest} |
-          | Penalty for paying your bill late | none |
-          | Estimate of the total you owe | %{total_owed} |
-
-        result_part2_penalty: |
-          | What you said your tax bill was | %{estimated_bill} |
-          | Interest added for paying your bill late | %{interest} |
-          | Penalty for paying your bill late | %{late_payment_penalty} |
-          | Estimate of the total you owe | %{total_owed} |
-
-        result_part_one_year_late: |
-          Your penalty can be up to 100% of your tax bill if you deliberately don’t pay it.
-
       which_year?:
         title: For which tax year do you want the estimate?
         options:
@@ -68,14 +52,3 @@ en-GB:
           You sent your tax return on or before the deadline, so you don’t have to pay a penalty.
 
           You paid your bill on time, so there is no interest or penalty for late payment.
-      late:
-        title: You paid tax or sent your return late
-        body: |
-          | Key facts | Your results |
-          |-----------|--------------|
-          | Your penalty for sending the return late | %{late_filing_penalty_formatted} |
-          %{result_parts}
-
-          These figures are estimates based on the figures you gave. The total is rounded down to the nearest pound.
-
-          ^You don’t have to pay any penalties unless you're asked to by HMRC. The amount that HMRC asks for might be different than this estimate.^

--- a/lib/smart_answer_flows/locales/en/estimate-self-assessment-penalties.yml
+++ b/lib/smart_answer_flows/locales/en/estimate-self-assessment-penalties.yml
@@ -46,9 +46,3 @@ en-GB:
         hint: This calculator is anonymous. None of your details will be passed to HMRC.
         suffix_label: for the tax year
         error_message: Please enter a number
-      filed_and_paid_on_time:
-        title: You don't have to pay a penalty
-        body: |
-          You sent your tax return on or before the deadline, so you don’t have to pay a penalty.
-
-          You paid your bill on time, so there is no interest or penalty for late payment.

--- a/test/data/estimate-self-assessment-penalties-files.yml
+++ b/test/data/estimate-self-assessment-penalties-files.yml
@@ -1,6 +1,8 @@
 --- 
-lib/smart_answer_flows/estimate-self-assessment-penalties.rb: fe4648c896af9e8f74a1d1795aa85b27
-lib/smart_answer_flows/locales/en/estimate-self-assessment-penalties.yml: 8aa810f78f3b29a6f3996d7e11aef275
+lib/smart_answer_flows/estimate-self-assessment-penalties.rb: cd353c7d2390d5e88c9d08e1b5a488d0
+lib/smart_answer_flows/locales/en/estimate-self-assessment-penalties.yml: 2d15a489772e13429a7efdee5ef40e1a
 test/data/estimate-self-assessment-penalties-questions-and-responses.yml: 186d93854ea5dc9321408e14dcc8d61f
 test/data/estimate-self-assessment-penalties-responses-and-expected-results.yml: 07a0cd26b8c5e4b1fff6dfe51c20142e
+lib/smart_answer_flows/estimate-self-assessment-penalties/filed_and_paid_on_time.govspeak.erb: 8cef5992d15add5c11deffee31a334a0
+lib/smart_answer_flows/estimate-self-assessment-penalties/late.govspeak.erb: ab6d773d3433a28b5e16940a87dcbf31
 lib/smart_answer/calculators/self_assessment_penalties.rb: 194f3f08f7430a27011e0f9466b3003c

--- a/test/integration/smart_answer_flows/estimate_self_assessment_penalties_test.rb
+++ b/test/integration/smart_answer_flows/estimate_self_assessment_penalties_test.rb
@@ -103,7 +103,6 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
               assert_state_variable :total_owed, 0
               assert_state_variable :interest, 0
               assert_state_variable :late_payment_penalty, 0
-              assert_phrase_list :result_parts, [:result_part2_no_penalty]
             end
           end
         end #end testing paid late but less than 3 months after
@@ -121,7 +120,7 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
     end
 
     should "show results" do
-      assert_phrase_list :result_parts, [:result_part2_penalty, :result_part_one_year_late]
+      assert_current_node :late
     end
   end
 
@@ -143,7 +142,6 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
         add_response "0.00"
       end
       should "show results" do
-        assert_phrase_list :result_parts, [:result_part2_no_penalty]
         assert_state_variable :late_filing_penalty, 100
         assert_state_variable :total_owed, 100
       end
@@ -157,7 +155,6 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
         add_response "0.00"
       end
       should "show results" do
-        assert_phrase_list :result_parts, [:result_part2_no_penalty]
         assert_state_variable :late_filing_penalty, 110
         assert_state_variable :total_owed, 110
       end
@@ -171,7 +168,6 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
         add_response "0.00"
       end
       should "show results" do
-        assert_phrase_list :result_parts, [:result_part2_no_penalty]
         assert_state_variable :late_filing_penalty, 1000
         assert_state_variable :total_owed, 1000
       end
@@ -185,7 +181,6 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
         add_response "0.00"
       end
       should "show results" do
-        assert_phrase_list :result_parts, [:result_part2_no_penalty]
         assert_state_variable :late_filing_penalty, 1300
         assert_state_variable :total_owed, 1300
       end
@@ -199,7 +194,6 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
         add_response "10000.00"
       end
       should "show results" do
-        assert_phrase_list :result_parts, [:result_part2_penalty]
         assert_state_variable :late_filing_penalty, 1500
         assert_state_variable :estimated_bill, 10000
         assert_state_variable :interest, 148.77
@@ -216,7 +210,6 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
         add_response "0.00"
       end
       should "show results" do
-        assert_phrase_list :result_parts, [:result_part2_no_penalty, :result_part_one_year_late]
         assert_state_variable :late_filing_penalty, 1600
         assert_state_variable :total_owed, 1600
       end
@@ -230,7 +223,6 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
         add_response "10000.00"
       end
       should "show results" do
-        assert_phrase_list :result_parts, [:result_part2_penalty, :result_part_one_year_late]
         assert_state_variable :late_filing_penalty, 2000
         assert_state_variable :estimated_bill, 10000
         assert_state_variable :interest, 300


### PR DESCRIPTION
There's some slightly silly logic for formatting zero in different ways in the commit titled "Convert late outcome" which I've naively reproduced exactly. However, I question whether zero should be being formatted in these three different ways. Otherwise everything else was all pretty standard.