### PR TITLE
An attempt at fixing intermittent test failure

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,7 +17,7 @@ require 'rails/test_help'
 require 'mocha/setup'
 
 require 'webmock/minitest'
-WebMock.disable_net_connect!(allow_localhost: true)
+WebMock.disable_net_connect!(allow_localhost: true, net_http_connect_on_start: true)
 
 class Minitest::Test
   def teardown_with_customisations


### PR DESCRIPTION
    Capybara::Poltergeist::JavascriptError

This error has been occurring intermittently, but annoyingly regularly,
in the Jenkins CI build. The reported underlying error is:

    TypeError: 'null' is not an object (evaluating 'data['title']')

See #1624 for more details.

I've seen the error happen on my local machine and it got to a point yesterday
where it seemed to be happening reasonably regularly, so I decided to
investigate further.

I found I could reproduce the problem by running only the "with JavaScript"
tests in `ReportAProblemTest`, but the error only seemed to happen at all
reliably if I ran multiple tests together, not just one on its own.

When the error occurred, I noticed it seemed to always coincide with a JSON
request to `SmartAnswersController#show` logging something like:

    Completed 500 Internal Server Error in 13m

However, there was never any mention of an exception or a stack trace. So I
then edited `ActionController::LogSubscriber#process_action` to log the details
of the exception:

    WebMock::NetConnectNotAllowedError
    Real HTTP connections are disabled.
    Unregistered request: GET http://contentapi.dev.gov.uk/bridge-of-death.json

The exception made it look as if the `WebMock` stubbing of `GdsApi::ContentApi`
setup by the call to
`GdsApi::TestHelpers::ContentApi#stub_content_api_default_artefact` in
`EngineIntegrationTest#setup` was not working correctly. What was more
confusing was that this stubbing was working most of the time, but just not
all the time, even though the same URLs were being requested.

In reading the `WebMock` documentation to come up with a plausible hypothesis
for why this might be happening, I came across the [`net_http_connect_on_start`
option][2]. More in hope than expectation, I tried enabling this option and the
problem appeared to go away. More encouragingly when I disabled it again, the
problem came back.

Although I can't say for sure that this fixes the problem or exactly how it
might be fixing the problem, I'm about 95% sure it does fix the problem. So
I think it's worth trying it out and see whether we see the problem recur in
the Jenkins CI build.

[2]: https://github.com/bblimke/webmock#connecting-on-nethttpstart