### PR TITLE
Marriage Abroad ticket 15. Fact Check feedback on appointment booking

### DIFF
--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -670,7 +670,7 @@ en-GB:
           You’ll need to have been living in %{country_name_lowercase_prefix} for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.. You can then book an appointment at the British Embassy in Rome.
 
         consular_cni_os_giving_notice_in_ceremony_country: |
-          If you need a CNI, you must give notice of your intended marriage in %{country_name_lowercase_prefix}. You must do this at a British embassy or in front of a notary public in that country.
+          If you need a CNI, you must give notice of your intended marriage in %{country_name_lowercase_prefix}. You must do this at the British embassy or in front of a notary public in that country.
 
         arrange_cni_via_costa_rica: |
           If you need a CNI, you must arrange this through the British Embassy in Costa Rica because there aren’t any British consular facilities in Nicaragua.
@@ -1373,7 +1373,7 @@ en-GB:
 
           You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
-          If you need a CNI, you must give notice of your intended marriage in %{country_name_lowercase_prefix}. You must do this at a British embassy or in front of a notary public in that country.
+          If you need a CNI, you must give notice of your intended marriage in %{country_name_lowercase_prefix}. You must do this at the British embassy or in front of a notary public in that country.
 
           [Make an appointment at the embassy in Pristina](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-pristina/notice-of-marriage-or-civil-partnership/slot_picker).
 

--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -660,7 +660,7 @@ en-GB:
 
           You’ll need to have been living in the Russian Federation for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-          You can then book an appointment at the consulate in the district you’re living, to give notice of your marriage.
+          You can then book an appointment at the consulate in the district you’re living in, to give notice of your marriage.
 
         consular_cni_os_local_resident_italy: |
           To get a Nulla Osta, you’ll first need to give notice of your intended marriage at the British Embassy in Rome.

--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -231,7 +231,7 @@ en-GB:
         appointment_for_affidavit: |
           Make an appointment at the local British embassy or consulate in %{country_name_lowercase_prefix} to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
         appointment_for_affidavit_in_hong_kong: |
-          Make an appointment at the British embassy or consulate in Hong Kong to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
+          Make an appointment at the British Consulate General Hong Kong to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
         appointment_for_affidavit_norway: |
           Make an appointment at the British embassy in Oslo to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, a copy of your partner’s passport and pay a fee.
         appointment_for_affidavit_indonesia: |

--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -648,7 +648,9 @@ en-GB:
 
           ###Applying for a CNI from the %{embassy_or_consulate_ceremony_country}
 
-          You’ll need to have been living in %{country_name_lowercase_prefix} for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.. You can then book an appointment at the embassy to give notice of your marriage. There’s a fee for this service (read the table on this page).
+          You’ll need to have been living in %{country_name_lowercase_prefix} for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
+
+          You can then book an appointment at the embassy to give notice of your marriage. There’s a fee for this service (read the table on this page).
         kazakhstan_os_local_resident: |
           If you need a CNI, you’ll first need to give notice of your intended marriage (banns) at the British Embassy Office in Almaty.
 
@@ -667,7 +669,7 @@ en-GB:
 
           ###Applying for a Nulla Osta from the embassy
 
-          You’ll need to have been living in %{country_name_lowercase_prefix} for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.. You can then book an appointment at the British Embassy in Rome.
+          You’ll need to have been living in %{country_name_lowercase_prefix} for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday. You can then book an appointment at the British Embassy in Rome.
 
         consular_cni_os_giving_notice_in_ceremony_country: |
           If you need a CNI, you must give notice of your intended marriage in %{country_name_lowercase_prefix}. You must do this at the British embassy or in front of a notary public in that country.

--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -322,9 +322,9 @@ en-GB:
         what_to_do_os_local_japan: |
           Make an appointment at the British embassy in Tokyo or British Consulate General in Osaka to swear an affirmation/affidavit (written statement of facts) that you’re free to marry.
 
-          [Make an appointment at the embassy in Tokyo](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tokyo/oaths-affirmations-and-affidavits/slot_picker)
+          [Make an appointment at the embassy in Tokyo](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tokyo/oaths-affirmations-and-affidavits/slot_picker).
 
-          [Make an appointment at the Consulate General in Osaka](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-osaka/oaths-affirmations-and-affidavits/slot_picker)
+          [Make an appointment at the Consulate General in Osaka](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-osaka/oaths-affirmations-and-affidavits/slot_picker).
 
           You can [download and fill in a form](/government/publications/affidavitaffirmation-of-marital-status-japan) for an ‘Affirmation for marriage’ (non-religious) or an ‘Affidavit for marriage’ (religious) before your appointment. Don’t sign it - you’ll do that at the appointment.
 
@@ -905,7 +905,7 @@ en-GB:
 
           You can then collect your CNI at the British embassy in Athens or ask for it to be sent to you by post. You must provide the registrar’s original Notice of Marriage if you posted notice in the UK.
 
-          [Make an appointment to collect your CNI at the embassy in Athens.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-athens/certificate-of-no-impediment/slot_picker)
+          [Make an appointment to collect your CNI at the embassy in Athens](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-athens/certificate-of-no-impediment/slot_picker).
 
         notary_public_will_charge_a_fee: |
           The notary public will charge a fee for taking the oath, and then give you your notice of marriage. You should take this notice to the local authorities where you’re getting married.
@@ -1375,7 +1375,7 @@ en-GB:
 
           If you need a CNI, you must give notice of your intended marriage in %{country_name_lowercase_prefix}. You must do this at a British embassy or in front of a notary public in that country.
 
-          [Make an appointment at the embassy in Pristina.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-pristina/notice-of-marriage-or-civil-partnership/slot_picker)
+          [Make an appointment at the embassy in Pristina](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-pristina/notice-of-marriage-or-civil-partnership/slot_picker).
 
           You need to have been living in %{country_name_lowercase_prefix} for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
@@ -1514,158 +1514,158 @@ en-GB:
         appointment_links:
           opposite_sex:
             albania: |
-              [Make an appointment at the embassy in Tirana.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Tirana](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker).
             algeria: |
-              [Make an appointment at the embassy in Algeria.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-algeria/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Algeria](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-algeria/notice-of-marriage-or-civil-partnership/slot_picker).
             angola: |
-              [Make an appointment at the embassy in Luanda.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-luanda/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Luanda](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-luanda/notice-of-marriage-or-civil-partnership/slot_picker).
             armenia: |
-              [Make an appointment at the embassy in Yerevan.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-yerevan/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Yerevan](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-yerevan/notice-of-marriage-or-civil-partnership/slot_picker).
             austria: |
-              [Make an appointment at the embassy in Vienna.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-vienna/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Vienna](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-vienna/notice-of-marriage-or-civil-partnership/slot_picker).
             azerbaijan: |
-              [Make an appointment at the embassy in Baku.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-baku/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Baku](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-baku/notice-of-marriage-or-civil-partnership/slot_picker).
             bahrain: |
-              [Make an appointment at the embassy in Manama.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-manama/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Manama](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-manama/notice-of-marriage-or-civil-partnership/slot_picker).
             belgium: |
-              [Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
+              [Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker).
             bolivia: |
-              [Make an appointment at the embassy in La Paz.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-la-paz/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in La Paz](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-la-paz/notice-of-marriage-or-civil-partnership/slot_picker).
             bosnia-and-herzegovina: |
-              [Make an appointment at the embassy in Sarajevo.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-sarajevo/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Sarajevo](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-sarajevo/notice-of-marriage-or-civil-partnership/slot_picker).
             colombia: |
-              [Make an appointment at the embassy in Colombia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/oaths-affirmations-and-affidavits/slot_picker)
+              [Make an appointment at the embassy in Colombia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/oaths-affirmations-and-affidavits/slot_picker).
             chile: |
-              [Make an appointment at the embassy in Santiago.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-santiago/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Santiago](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-santiago/notice-of-marriage-or-civil-partnership/slot_picker).
             china: |
-              [Make an appointment at the embassy in Beijing.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beijing/oaths-affirmations-and-affidavits/slot_picker)
+              [Make an appointment at the embassy in Beijing](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beijing/oaths-affirmations-and-affidavits/slot_picker).
 
-              [Make an appointment at the embassy in Shanghai.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-shanghai/oaths-affirmations-and-affidavits/slot_picker)
+              [Make an appointment at the embassy in Shanghai](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-shanghai/oaths-affirmations-and-affidavits/slot_picker).
 
-              [Make an appointment at the embassy in Chongqing.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-chongqing/oaths-affirmations-and-affidavits/slot_picker)
+              [Make an appointment at the embassy in Chongqing](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-chongqing/oaths-affirmations-and-affidavits/slot_picker).
 
-              [Make an appointment at the embassy in Guangzhou.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-guangzhou/oaths-affirmations-and-affidavits/slot_picker)
+              [Make an appointment at the embassy in Guangzhou](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-guangzhou/oaths-affirmations-and-affidavits/slot_picker).
             croatia: |
-              [Make an appointment at the embassy in Zagreb.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-zagreb/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Zagreb](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-zagreb/notice-of-marriage-or-civil-partnership/slot_picker).
             cuba: |
-              [Make an appointment at the embassy in Havana.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-havana/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Havana](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-havana/notice-of-marriage-or-civil-partnership/slot_picker).
             democratic-republic-of-congo: |
-              [Make an appointment at the embassy in Kinshasa.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-kinshasa/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Kinshasa](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-kinshasa/notice-of-marriage-or-civil-partnership/slot_picker).
             denmark: |
-              [Make an appointment at the embassy in Copenhagen.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-copenhagen/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Copenhagen](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-copenhagen/notice-of-marriage-or-civil-partnership/slot_picker).
             egypt: |
-              [Make an appointment at the embassy in Cairo.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-cairo/oaths-affirmations-and-affidavits/slot_picker)
+              [Make an appointment at the embassy in Cairo](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-cairo/oaths-affirmations-and-affidavits/slot_picker).
             el-salvador: |
-              [Make an appointment at the embassy in San Salvador.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-san-salvador/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in San Salvador](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-san-salvador/notice-of-marriage-or-civil-partnership/slot_picker).
             estonia: |
-              [Make an appointment at the embassy in Tallinn.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-tallinn/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Tallinn](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-tallinn/notice-of-marriage-or-civil-partnership/slot_picker).
             georgia: |
-              [Make an appointment at the embassy in Tblisi.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-tblisi/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Tblisi](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-tblisi/notice-of-marriage-or-civil-partnership/slot_picker).
             greece: |
-              [Make an appointment at the embassy in Athens](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-athens/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Athens](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-athens/notice-of-marriage-or-civil-partnership/slot_picker).
             guatemala: |
-              [Make an appointment at the embassy in Guatamala City.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-guatemala-city/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Guatamala City](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-guatemala-city/notice-of-marriage-or-civil-partnership/slot_picker).
             hungary: |
-              [Make an appointment at the embassy in Budapest.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-budapest/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Budapest](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-budapest/notice-of-marriage-or-civil-partnership/slot_picker).
             iceland: |
-              [Make an appointment at the embassy in Reykjavik.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-reykjavik/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Reykjavik](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-reykjavik/notice-of-marriage-or-civil-partnership/slot_picker).
             italy: |
-              [Make an appointment at the embassy in Rome](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rome/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Rome](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rome/notice-of-marriage-or-civil-partnership/slot_picker).
             kazakhstan: |
-              [Make an appointment at the embassy in Almaty.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-office-almaty/certificate-of-no-impediment/slot_picker)
+              [Make an appointment at the embassy in Almaty](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-office-almaty/certificate-of-no-impediment/slot_picker).
             kosovo: |
-              [Make an appointment at the embassy in Pristina.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-pristina/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Pristina](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-pristina/notice-of-marriage-or-civil-partnership/slot_picker).
             kuwait: |
-              [Make an appointment at the embassy in Kuwait City.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-kuwait-city/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Kuwait City](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-kuwait-city/notice-of-marriage-or-civil-partnership/slot_picker).
             kyrgyzstan: |
-              [Make an appointment at the embassy in Almaty.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-office-almaty/certificate-of-no-impediment/slot_picker)
+              [Make an appointment at the embassy in Almaty](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-office-almaty/certificate-of-no-impediment/slot_picker).
             laos: |
-              [Make an appointment at the embassy in Vientiane.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-kinshasa/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Vientiane](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-kinshasa/notice-of-marriage-or-civil-partnership/slot_picker).
             latvia: |
-              [Make an appointment at the embassy in Riga.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-riga/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Riga](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-riga/notice-of-marriage-or-civil-partnership/slot_picker).
             lebanon: |
-              [Make an appointment at the embassy in Beirut.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beirut/oaths-affirmations-and-affidavits/slot_picker)
+              [Make an appointment at the embassy in Beirut](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beirut/oaths-affirmations-and-affidavits/slot_picker).
             lithuania: |
-              [Make an appointment at the embassy in Vilnius.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-vilnius/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Vilnius](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-vilnius/notice-of-marriage-or-civil-partnership/slot_picker).
             luxembourg: |
-              [Make an appointment at the embassy in Luxembourg.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-luxembourg/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Luxembourg](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-luxembourg/notice-of-marriage-or-civil-partnership/slot_picker).
             macao: |
-              [Make an appointment at the British Consulate General Hong Kong](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-hong-kong/oaths-affirmations-and-affidavits/slot_picker)
+              [Make an appointment at the British Consulate General Hong Kong](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-hong-kong/oaths-affirmations-and-affidavits/slot_picker).
             mexico: |
-              [Make an appointment at the embassy in Mexico City.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-mexico-city/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Mexico City](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-mexico-city/notice-of-marriage-or-civil-partnership/slot_picker).
             moldova: |
-              [Make an appointment at the embassy in Chisinau.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-chisinau/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Chisinau](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-chisinau/notice-of-marriage-or-civil-partnership/slot_picker).
             mongolia: |
-              [Make an appointment at the embassy in Ulaanbaatar.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ulaanbaatar/oaths-affirmations-and-affidavits/slot_picker)
+              [Make an appointment at the embassy in Ulaanbaatar](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ulaanbaatar/oaths-affirmations-and-affidavits/slot_picker).
             montenegro: |
-              [Make an appointment at the embassy in Podgorica.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-podgorica/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Podgorica](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-podgorica/notice-of-marriage-or-civil-partnership/slot_picker).
             morocco: |
-              [Make an appointment at the embassy in Rabat.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rabat/oaths-affirmations-and-affidavits/slot_picker)
+              [Make an appointment at the embassy in Rabat](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rabat/oaths-affirmations-and-affidavits/slot_picker).
             nepal: |
-              [Make an appointment at the embassy in Kathmandu.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-kathmandu/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Kathmandu](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-kathmandu/notice-of-marriage-or-civil-partnership/slot_picker).
             norway: |
-              [Make an appointment at the embassy in Oslo.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker)
+              [Make an appointment at the embassy in Oslo](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker).
             panama: |
-              [Make an appointment at the embassy in Panama City.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-panama-city/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Panama City](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-panama-city/notice-of-marriage-or-civil-partnership/slot_picker).
             philippines: |
-              [Make an appointment at the embassy in Manila.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-manila/oaths-affirmations-and-affidavits/slot_picker)
+              [Make an appointment at the embassy in Manila](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-manila/oaths-affirmations-and-affidavits/slot_picker).
             peru: |
-              [Make an appointment at the embassy in Lima.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/oaths-affirmations-and-affidavits/slot_picker)
+              [Make an appointment at the embassy in Lima](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/oaths-affirmations-and-affidavits/slot_picker).
             poland: |
-              [Make an appointment at the embassy in Warsaw.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-warsaw/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Warsaw](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-warsaw/notice-of-marriage-or-civil-partnership/slot_picker).
             romania: |
-              [Make an appointment at the embassy in Budapest.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-budapest/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Budapest](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-budapest/notice-of-marriage-or-civil-partnership/slot_picker).
             russia: |
-              [Make an appointment at the embassy in Moscow.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-moscow/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Moscow](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-moscow/notice-of-marriage-or-civil-partnership/slot_picker).
 
-              [Make an appointment at the embassy in St Petersburg.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-st-petersburg/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in St Petersburg](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-st-petersburg/notice-of-marriage-or-civil-partnership/slot_picker).
             serbia: |
-              [Make an appointment at the embassy in Belgrade.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-belgrade/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Belgrade](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-belgrade/notice-of-marriage-or-civil-partnership/slot_picker).
             sudan: |
-              [Make an appointment at the embassy in Khartoum.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-khartoum/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Khartoum](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-khartoum/notice-of-marriage-or-civil-partnership/slot_picker).
             tajikistan: |
-              [Make an appointment at the embassy in Dushanbe.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-dushanbe/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Dushanbe](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-dushanbe/notice-of-marriage-or-civil-partnership/slot_picker).
             thailand: |
-              [Make an appointment at the embassy in Bangkok.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bangkok/oaths-affirmations-and-affidavits/slot_picker)
+              [Make an appointment at the embassy in Bangkok](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bangkok/oaths-affirmations-and-affidavits/slot_picker).
             tunisia: |
-              [Make an appointment at the embassy in Tunis.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Tunis](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/notice-of-marriage-or-civil-partnership/slot_picker).
             turkey: |
-              [Make an appointment at the British Consulate General Istanbul](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-istanbul/oaths-affirmations-and-affidavits/slot_picker)
+              [Make an appointment at the British Consulate General Istanbul](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-istanbul/oaths-affirmations-and-affidavits/slot_picker).
 
-              [Make an appointment at the embassy in Ankara](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ankara/oaths-affirmations-and-affidavits/slot_picker)
+              [Make an appointment at the embassy in Ankara](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ankara/oaths-affirmations-and-affidavits/slot_picker).
 
-              [Make an appointment at the consulate in Izmir](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-izmir/oaths-affirmations-and-affidavits/slot_picker)
+              [Make an appointment at the consulate in Izmir](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-izmir/oaths-affirmations-and-affidavits/slot_picker).
 
-              [Make an appointment at the consulate in Antalya](https://www.consular-appointments.service.gov.uk/fco/#!/british-vice-consulate-antalya/oaths-affirmations-and-affidavits/slot_picker)
+              [Make an appointment at the consulate in Antalya](https://www.consular-appointments.service.gov.uk/fco/#!/british-vice-consulate-antalya/oaths-affirmations-and-affidavits/slot_picker).
             turkmenistan: |
-              [Make an appointment at the embassy in Ashgabat.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ashgabat/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Ashgabat](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ashgabat/notice-of-marriage-or-civil-partnership/slot_picker).
             uzbekistan: |
-              [Make an appointment at the embassy in Tashkent.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tashkent/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Tashkent](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tashkent/notice-of-marriage-or-civil-partnership/slot_picker).
             venezuela: |
-              [Make an appointment at the embassy in Caracas.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-caracas/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Caracas](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-caracas/notice-of-marriage-or-civil-partnership/slot_picker).
           same_sex:
             albania: |
-              [Make an appointment at the embassy in Tirana](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Tirana](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker).
             australia: |
               Make an appointment at your nearest British embassy or consulate in %{country_name_lowercase_prefix}.
 
-              [Make an appointment at the British Consulate Brisbane](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-brisbane/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the British Consulate Brisbane](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-brisbane/notice-of-marriage-or-civil-partnership/slot_picker).
 
-              [Make an appointment at the British High Commission in Canberra](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-canberra/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the British High Commission in Canberra](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-canberra/notice-of-marriage-or-civil-partnership/slot_picker).
 
-              [Make an appointment at the British Consulate General in Sydney](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-sydney/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the British Consulate General in Sydney](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-sydney/notice-of-marriage-or-civil-partnership/slot_picker).
 
-              [Make an appointment at the British Consulate General in Melbourne](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-melbourne/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the British Consulate General in Melbourne](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-melbourne/notice-of-marriage-or-civil-partnership/slot_picker).
 
-              [Make an appointment at the British Consulate Perth](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-perth/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the British Consulate Perth](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-perth/notice-of-marriage-or-civil-partnership/slot_picker).
             belgium: |
-              [Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
+              [Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker).
             colombia: |
-              [Make an appointment at the British embassy in Colombia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the British embassy in Colombia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/notice-of-marriage-or-civil-partnership/slot_picker).
             montenegro: |
-              [Make an appointment at the embassy in Podgorica.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-podgorica/notice-of-marriage-or-civil-partnership/slot_picker)
+              [Make an appointment at the embassy in Podgorica](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-podgorica/notice-of-marriage-or-civil-partnership/slot_picker).
             norway: |
-              [Make an appointment at the embassy in Oslo.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker)
+              [Make an appointment at the embassy in Oslo](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker).
 
 # Q1
       country_of_ceremony?:

--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -190,7 +190,7 @@ en-GB:
           Make an appointment at the local British embassy or consulate in %{country_name_lowercase_prefix} to make a declaration that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
         make_an_appointment_bring_passport_and_pay_55_colombia: |
-          Make an appointment at the local British embassy or consulate in Colombia to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee of £55.
+          Make an appointment at the British embassy in Bogota to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee of £55.
 
         make_an_appointment_bring_passport_and_pay_55_brazil: |
           Make an appointment at the local British embassy or consulate in Brazil to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee of £55.
@@ -233,9 +233,9 @@ en-GB:
         appointment_for_affidavit_in_hong_kong: |
           Make an appointment at the British embassy or consulate in Hong Kong to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
         appointment_for_affidavit_norway: |
-          Make an appointment at the local British embassy or consulate in %{country_name_lowercase_prefix} to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, a copy of your partner’s passport and pay a fee.
+          Make an appointment at the British embassy in Oslo to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, a copy of your partner’s passport and pay a fee.
         appointment_for_affidavit_indonesia: |
-          Make an appointment at the local British embassy or consulate in Indonesia to swear an affidavit (written statement of facts) that you’re free to marry.
+          Make an appointment at the British Embassy in Jakarta to swear an affidavit (written statement of facts) that you’re free to marry.
 
           Before the appointment you’ll need to pay a fee to the British Embassy in Jakarta. You can do this by credit card or in cash in the local currency. You also need to complete 2 copies of the [‘Affidavit for marriage’ form](/government/publications/marriage-in-indonesia).
 
@@ -652,7 +652,7 @@ en-GB:
         kazakhstan_os_local_resident: |
           If you need a CNI, you’ll first need to give notice of your intended marriage (banns) at the British Embassy Office in Almaty.
 
-          Make an appointment at the embassy in Kazakhstan to give notice of your marriage. There’s a fee for this service (see below).
+          Make an appointment at the embassy in Almaty to give notice of your marriage. There’s a fee for this service (see below).
         russia_os_local_resident: |
           If you need a CNI, you’ll first need to give notice of your intended marriage at your nearest British %{embassy_or_consulate_ceremony_country}.
 
@@ -1534,7 +1534,7 @@ en-GB:
             bosnia-and-herzegovina: |
               [Make an appointment at the embassy in Sarajevo](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-sarajevo/notice-of-marriage-or-civil-partnership/slot_picker).
             colombia: |
-              [Make an appointment at the embassy in Colombia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/oaths-affirmations-and-affidavits/slot_picker).
+              [Make an appointment at the embassy in Bogota](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/oaths-affirmations-and-affidavits/slot_picker).
             chile: |
               [Make an appointment at the embassy in Santiago](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-santiago/notice-of-marriage-or-civil-partnership/slot_picker).
             china: |
@@ -1661,7 +1661,7 @@ en-GB:
             belgium: |
               [Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker).
             colombia: |
-              [Make an appointment at the British embassy in Colombia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/notice-of-marriage-or-civil-partnership/slot_picker).
+              [Make an appointment at the British embassy in Bogota](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/notice-of-marriage-or-civil-partnership/slot_picker).
             montenegro: |
               [Make an appointment at the embassy in Podgorica](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-podgorica/notice-of-marriage-or-civil-partnership/slot_picker).
             norway: |

--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -653,8 +653,6 @@ en-GB:
           You can then book an appointment at the embassy to give notice of your marriage. There’s a fee for this service (read the table on this page).
         kazakhstan_os_local_resident: |
           If you need a CNI, you’ll first need to give notice of your intended marriage (banns) at the British Embassy Office in Almaty.
-
-          Make an appointment at the embassy in Almaty to give notice of your marriage. There’s a fee for this service (see below).
         russia_os_local_resident: |
           If you need a CNI, you’ll first need to give notice of your intended marriage at your nearest British %{embassy_or_consulate_ceremony_country}.
 

--- a/test/artefacts/marriage-abroad/albania/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/albania/ceremony_country/partner_british/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Albania to find out about local marria
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Albania. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Albania. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Albania for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Tirana.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tirana](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/albania/ceremony_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/albania/ceremony_country/partner_british/same_sex.txt
@@ -3,7 +3,7 @@ Same-sex marriage and civil partnership in Albania
 You may be able to register a civil partnership or get married at the British embassy or consulate in Albania.
 
 
-[Make an appointment at the embassy in Tirana](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tirana](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 ##What documents you’ll need

--- a/test/artefacts/marriage-abroad/albania/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/albania/ceremony_country/partner_local/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Albania to find out about local marria
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Albania. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Albania. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Albania for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Tirana.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tirana](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/albania/ceremony_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/albania/ceremony_country/partner_local/same_sex.txt
@@ -3,7 +3,7 @@ Same-sex marriage and civil partnership in Albania
 You may be able to register a civil partnership or get married at the British embassy or consulate in Albania.
 
 
-[Make an appointment at the embassy in Tirana](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tirana](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 ##What documents you’ll need

--- a/test/artefacts/marriage-abroad/albania/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/albania/ceremony_country/partner_other/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Albania to find out about local marria
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Albania. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Albania. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Albania for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Tirana.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tirana](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/albania/ceremony_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/albania/ceremony_country/partner_other/same_sex.txt
@@ -3,7 +3,7 @@ Same-sex marriage and civil partnership in Albania
 You may be able to register a civil partnership or get married at the British embassy or consulate in Albania.
 
 
-[Make an appointment at the embassy in Tirana](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tirana](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 ##What documents you’ll need

--- a/test/artefacts/marriage-abroad/albania/third_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/albania/third_country/partner_british/same_sex.txt
@@ -3,7 +3,7 @@ Same-sex marriage and civil partnership in Albania
 You may be able to register a civil partnership or get married at the British embassy or consulate in Albania.
 
 
-[Make an appointment at the embassy in Tirana](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tirana](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 ##What documents you’ll need

--- a/test/artefacts/marriage-abroad/albania/third_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/albania/third_country/partner_local/same_sex.txt
@@ -3,7 +3,7 @@ Same-sex marriage and civil partnership in Albania
 You may be able to register a civil partnership or get married at the British embassy or consulate in Albania.
 
 
-[Make an appointment at the embassy in Tirana](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tirana](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 ##What documents you’ll need

--- a/test/artefacts/marriage-abroad/albania/third_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/albania/third_country/partner_other/same_sex.txt
@@ -3,7 +3,7 @@ Same-sex marriage and civil partnership in Albania
 You may be able to register a civil partnership or get married at the British embassy or consulate in Albania.
 
 
-[Make an appointment at the embassy in Tirana](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tirana](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 ##What documents you’ll need

--- a/test/artefacts/marriage-abroad/albania/uk/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/albania/uk/partner_british/same_sex.txt
@@ -3,7 +3,7 @@ Same-sex marriage and civil partnership in Albania
 You may be able to register a civil partnership or get married at the British embassy or consulate in Albania.
 
 
-[Make an appointment at the embassy in Tirana](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tirana](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 ##What documents you’ll need

--- a/test/artefacts/marriage-abroad/albania/uk/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/albania/uk/partner_local/same_sex.txt
@@ -3,7 +3,7 @@ Same-sex marriage and civil partnership in Albania
 You may be able to register a civil partnership or get married at the British embassy or consulate in Albania.
 
 
-[Make an appointment at the embassy in Tirana](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tirana](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 ##What documents you’ll need

--- a/test/artefacts/marriage-abroad/albania/uk/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/albania/uk/partner_other/same_sex.txt
@@ -3,7 +3,7 @@ Same-sex marriage and civil partnership in Albania
 You may be able to register a civil partnership or get married at the British embassy or consulate in Albania.
 
 
-[Make an appointment at the embassy in Tirana](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tirana](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 ##What documents you’ll need

--- a/test/artefacts/marriage-abroad/armenia/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/armenia/ceremony_country/partner_british/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Armenia to find out about local marria
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Armenia. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Armenia. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Armenia for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Yerevan.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-yerevan/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Yerevan](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-yerevan/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/armenia/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/armenia/ceremony_country/partner_local/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Armenia to find out about local marria
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Armenia. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Armenia. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Armenia for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Yerevan.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-yerevan/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Yerevan](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-yerevan/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/armenia/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/armenia/ceremony_country/partner_other/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Armenia to find out about local marria
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Armenia. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Armenia. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Armenia for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Yerevan.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-yerevan/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Yerevan](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-yerevan/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/australia/ceremony_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/australia/ceremony_country/partner_british/same_sex.txt
@@ -5,15 +5,15 @@ You may be able to get married at the British embassy or consulate in Australia.
 
 Make an appointment at your nearest British embassy or consulate in Australia.
 
-[Make an appointment at the British Consulate Brisbane](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-brisbane/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British Consulate Brisbane](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-brisbane/notice-of-marriage-or-civil-partnership/slot_picker).
 
-[Make an appointment at the British High Commission in Canberra](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-canberra/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British High Commission in Canberra](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-canberra/notice-of-marriage-or-civil-partnership/slot_picker).
 
-[Make an appointment at the British Consulate General in Sydney](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-sydney/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British Consulate General in Sydney](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-sydney/notice-of-marriage-or-civil-partnership/slot_picker).
 
-[Make an appointment at the British Consulate General in Melbourne](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-melbourne/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British Consulate General in Melbourne](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-melbourne/notice-of-marriage-or-civil-partnership/slot_picker).
 
-[Make an appointment at the British Consulate Perth](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-perth/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British Consulate Perth](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-perth/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 ##What documents you’ll need

--- a/test/artefacts/marriage-abroad/australia/ceremony_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/australia/ceremony_country/partner_local/same_sex.txt
@@ -5,15 +5,15 @@ You may be able to get married at the British embassy or consulate in Australia.
 
 Make an appointment at your nearest British embassy or consulate in Australia.
 
-[Make an appointment at the British Consulate Brisbane](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-brisbane/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British Consulate Brisbane](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-brisbane/notice-of-marriage-or-civil-partnership/slot_picker).
 
-[Make an appointment at the British High Commission in Canberra](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-canberra/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British High Commission in Canberra](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-canberra/notice-of-marriage-or-civil-partnership/slot_picker).
 
-[Make an appointment at the British Consulate General in Sydney](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-sydney/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British Consulate General in Sydney](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-sydney/notice-of-marriage-or-civil-partnership/slot_picker).
 
-[Make an appointment at the British Consulate General in Melbourne](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-melbourne/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British Consulate General in Melbourne](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-melbourne/notice-of-marriage-or-civil-partnership/slot_picker).
 
-[Make an appointment at the British Consulate Perth](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-perth/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British Consulate Perth](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-perth/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 ##What documents you’ll need

--- a/test/artefacts/marriage-abroad/australia/ceremony_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/australia/ceremony_country/partner_other/same_sex.txt
@@ -5,15 +5,15 @@ You may be able to get married at the British embassy or consulate in Australia.
 
 Make an appointment at your nearest British embassy or consulate in Australia.
 
-[Make an appointment at the British Consulate Brisbane](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-brisbane/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British Consulate Brisbane](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-brisbane/notice-of-marriage-or-civil-partnership/slot_picker).
 
-[Make an appointment at the British High Commission in Canberra](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-canberra/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British High Commission in Canberra](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-canberra/notice-of-marriage-or-civil-partnership/slot_picker).
 
-[Make an appointment at the British Consulate General in Sydney](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-sydney/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British Consulate General in Sydney](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-sydney/notice-of-marriage-or-civil-partnership/slot_picker).
 
-[Make an appointment at the British Consulate General in Melbourne](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-melbourne/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British Consulate General in Melbourne](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-melbourne/notice-of-marriage-or-civil-partnership/slot_picker).
 
-[Make an appointment at the British Consulate Perth](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-perth/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British Consulate Perth](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-perth/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 ##What documents you’ll need

--- a/test/artefacts/marriage-abroad/australia/third_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/australia/third_country/partner_british/same_sex.txt
@@ -5,15 +5,15 @@ You may be able to get married at the British embassy or consulate in Australia.
 
 Make an appointment at your nearest British embassy or consulate in Australia.
 
-[Make an appointment at the British Consulate Brisbane](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-brisbane/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British Consulate Brisbane](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-brisbane/notice-of-marriage-or-civil-partnership/slot_picker).
 
-[Make an appointment at the British High Commission in Canberra](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-canberra/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British High Commission in Canberra](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-canberra/notice-of-marriage-or-civil-partnership/slot_picker).
 
-[Make an appointment at the British Consulate General in Sydney](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-sydney/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British Consulate General in Sydney](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-sydney/notice-of-marriage-or-civil-partnership/slot_picker).
 
-[Make an appointment at the British Consulate General in Melbourne](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-melbourne/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British Consulate General in Melbourne](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-melbourne/notice-of-marriage-or-civil-partnership/slot_picker).
 
-[Make an appointment at the British Consulate Perth](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-perth/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British Consulate Perth](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-perth/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 ##What documents you’ll need

--- a/test/artefacts/marriage-abroad/australia/third_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/australia/third_country/partner_local/same_sex.txt
@@ -5,15 +5,15 @@ You may be able to get married at the British embassy or consulate in Australia.
 
 Make an appointment at your nearest British embassy or consulate in Australia.
 
-[Make an appointment at the British Consulate Brisbane](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-brisbane/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British Consulate Brisbane](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-brisbane/notice-of-marriage-or-civil-partnership/slot_picker).
 
-[Make an appointment at the British High Commission in Canberra](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-canberra/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British High Commission in Canberra](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-canberra/notice-of-marriage-or-civil-partnership/slot_picker).
 
-[Make an appointment at the British Consulate General in Sydney](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-sydney/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British Consulate General in Sydney](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-sydney/notice-of-marriage-or-civil-partnership/slot_picker).
 
-[Make an appointment at the British Consulate General in Melbourne](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-melbourne/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British Consulate General in Melbourne](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-melbourne/notice-of-marriage-or-civil-partnership/slot_picker).
 
-[Make an appointment at the British Consulate Perth](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-perth/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British Consulate Perth](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-perth/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 ##What documents you’ll need

--- a/test/artefacts/marriage-abroad/australia/third_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/australia/third_country/partner_other/same_sex.txt
@@ -5,15 +5,15 @@ You may be able to get married at the British embassy or consulate in Australia.
 
 Make an appointment at your nearest British embassy or consulate in Australia.
 
-[Make an appointment at the British Consulate Brisbane](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-brisbane/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British Consulate Brisbane](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-brisbane/notice-of-marriage-or-civil-partnership/slot_picker).
 
-[Make an appointment at the British High Commission in Canberra](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-canberra/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British High Commission in Canberra](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-canberra/notice-of-marriage-or-civil-partnership/slot_picker).
 
-[Make an appointment at the British Consulate General in Sydney](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-sydney/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British Consulate General in Sydney](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-sydney/notice-of-marriage-or-civil-partnership/slot_picker).
 
-[Make an appointment at the British Consulate General in Melbourne](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-melbourne/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British Consulate General in Melbourne](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-melbourne/notice-of-marriage-or-civil-partnership/slot_picker).
 
-[Make an appointment at the British Consulate Perth](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-perth/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British Consulate Perth](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-perth/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 ##What documents you’ll need

--- a/test/artefacts/marriage-abroad/australia/uk/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/australia/uk/partner_british/same_sex.txt
@@ -5,15 +5,15 @@ You may be able to get married at the British embassy or consulate in Australia.
 
 Make an appointment at your nearest British embassy or consulate in Australia.
 
-[Make an appointment at the British Consulate Brisbane](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-brisbane/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British Consulate Brisbane](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-brisbane/notice-of-marriage-or-civil-partnership/slot_picker).
 
-[Make an appointment at the British High Commission in Canberra](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-canberra/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British High Commission in Canberra](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-canberra/notice-of-marriage-or-civil-partnership/slot_picker).
 
-[Make an appointment at the British Consulate General in Sydney](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-sydney/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British Consulate General in Sydney](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-sydney/notice-of-marriage-or-civil-partnership/slot_picker).
 
-[Make an appointment at the British Consulate General in Melbourne](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-melbourne/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British Consulate General in Melbourne](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-melbourne/notice-of-marriage-or-civil-partnership/slot_picker).
 
-[Make an appointment at the British Consulate Perth](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-perth/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British Consulate Perth](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-perth/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 ##What documents you’ll need

--- a/test/artefacts/marriage-abroad/australia/uk/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/australia/uk/partner_local/same_sex.txt
@@ -5,15 +5,15 @@ You may be able to get married at the British embassy or consulate in Australia.
 
 Make an appointment at your nearest British embassy or consulate in Australia.
 
-[Make an appointment at the British Consulate Brisbane](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-brisbane/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British Consulate Brisbane](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-brisbane/notice-of-marriage-or-civil-partnership/slot_picker).
 
-[Make an appointment at the British High Commission in Canberra](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-canberra/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British High Commission in Canberra](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-canberra/notice-of-marriage-or-civil-partnership/slot_picker).
 
-[Make an appointment at the British Consulate General in Sydney](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-sydney/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British Consulate General in Sydney](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-sydney/notice-of-marriage-or-civil-partnership/slot_picker).
 
-[Make an appointment at the British Consulate General in Melbourne](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-melbourne/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British Consulate General in Melbourne](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-melbourne/notice-of-marriage-or-civil-partnership/slot_picker).
 
-[Make an appointment at the British Consulate Perth](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-perth/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British Consulate Perth](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-perth/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 ##What documents you’ll need

--- a/test/artefacts/marriage-abroad/australia/uk/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/australia/uk/partner_other/same_sex.txt
@@ -5,15 +5,15 @@ You may be able to get married at the British embassy or consulate in Australia.
 
 Make an appointment at your nearest British embassy or consulate in Australia.
 
-[Make an appointment at the British Consulate Brisbane](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-brisbane/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British Consulate Brisbane](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-brisbane/notice-of-marriage-or-civil-partnership/slot_picker).
 
-[Make an appointment at the British High Commission in Canberra](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-canberra/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British High Commission in Canberra](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-canberra/notice-of-marriage-or-civil-partnership/slot_picker).
 
-[Make an appointment at the British Consulate General in Sydney](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-sydney/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British Consulate General in Sydney](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-sydney/notice-of-marriage-or-civil-partnership/slot_picker).
 
-[Make an appointment at the British Consulate General in Melbourne](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-melbourne/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British Consulate General in Melbourne](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-melbourne/notice-of-marriage-or-civil-partnership/slot_picker).
 
-[Make an appointment at the British Consulate Perth](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-perth/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British Consulate Perth](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-perth/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 ##What documents you’ll need

--- a/test/artefacts/marriage-abroad/austria/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/austria/ceremony_country/partner_british/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Austria to find out about local marria
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Austria. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Austria. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Austria for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Vienna.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-vienna/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Vienna](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-vienna/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/austria/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/austria/ceremony_country/partner_local/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Austria to find out about local marria
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Austria. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Austria. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Austria for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Vienna.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-vienna/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Vienna](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-vienna/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/austria/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/austria/ceremony_country/partner_other/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Austria to find out about local marria
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Austria. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Austria. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Austria for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Vienna.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-vienna/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Vienna](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-vienna/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/azerbaijan/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/azerbaijan/ceremony_country/partner_british/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Azerbaijan to find out about local mar
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Azerbaijan. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Azerbaijan. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Azerbaijan for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Baku.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-baku/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Baku](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-baku/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/azerbaijan/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/azerbaijan/ceremony_country/partner_local/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Azerbaijan to find out about local mar
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Azerbaijan. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Azerbaijan. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Azerbaijan for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Baku.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-baku/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Baku](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-baku/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/azerbaijan/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/azerbaijan/ceremony_country/partner_other/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Azerbaijan to find out about local mar
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Azerbaijan. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Azerbaijan. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Azerbaijan for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Baku.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-baku/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Baku](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-baku/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/belarus/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/belarus/ceremony_country/partner_british/opposite_sex.txt
@@ -12,7 +12,7 @@ Contact the relevant local authorities in Belarus to find out about local marria
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Belarus. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Belarus. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Belarus for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.

--- a/test/artefacts/marriage-abroad/belarus/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/belarus/ceremony_country/partner_local/opposite_sex.txt
@@ -12,7 +12,7 @@ Contact the relevant local authorities in Belarus to find out about local marria
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Belarus. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Belarus. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Belarus for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.

--- a/test/artefacts/marriage-abroad/belarus/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/belarus/ceremony_country/partner_other/opposite_sex.txt
@@ -12,7 +12,7 @@ Contact the relevant local authorities in Belarus to find out about local marria
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Belarus. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Belarus. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Belarus for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.

--- a/test/artefacts/marriage-abroad/belgium/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/belgium/ceremony_country/partner_british/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Belgium to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.

--- a/test/artefacts/marriage-abroad/belgium/ceremony_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/belgium/ceremony_country/partner_british/same_sex.txt
@@ -20,7 +20,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Belgium to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.

--- a/test/artefacts/marriage-abroad/belgium/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/belgium/ceremony_country/partner_local/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Belgium to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.

--- a/test/artefacts/marriage-abroad/belgium/ceremony_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/belgium/ceremony_country/partner_local/same_sex.txt
@@ -20,7 +20,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Belgium to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.

--- a/test/artefacts/marriage-abroad/belgium/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/belgium/ceremony_country/partner_other/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Belgium to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.

--- a/test/artefacts/marriage-abroad/belgium/ceremony_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/belgium/ceremony_country/partner_other/same_sex.txt
@@ -20,7 +20,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Belgium to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.

--- a/test/artefacts/marriage-abroad/belgium/third_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/belgium/third_country/partner_british/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Belgium to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.

--- a/test/artefacts/marriage-abroad/belgium/third_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/belgium/third_country/partner_british/same_sex.txt
@@ -20,7 +20,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Belgium to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.

--- a/test/artefacts/marriage-abroad/belgium/third_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/belgium/third_country/partner_local/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Belgium to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.

--- a/test/artefacts/marriage-abroad/belgium/third_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/belgium/third_country/partner_local/same_sex.txt
@@ -20,7 +20,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Belgium to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.

--- a/test/artefacts/marriage-abroad/belgium/third_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/belgium/third_country/partner_other/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Belgium to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.

--- a/test/artefacts/marriage-abroad/belgium/third_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/belgium/third_country/partner_other/same_sex.txt
@@ -20,7 +20,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Belgium to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.

--- a/test/artefacts/marriage-abroad/belgium/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/belgium/uk/partner_british/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Belgium to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.

--- a/test/artefacts/marriage-abroad/belgium/uk/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/belgium/uk/partner_british/same_sex.txt
@@ -20,7 +20,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Belgium to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.

--- a/test/artefacts/marriage-abroad/belgium/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/belgium/uk/partner_local/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Belgium to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.

--- a/test/artefacts/marriage-abroad/belgium/uk/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/belgium/uk/partner_local/same_sex.txt
@@ -20,7 +20,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Belgium to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.

--- a/test/artefacts/marriage-abroad/belgium/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/belgium/uk/partner_other/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Belgium to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.

--- a/test/artefacts/marriage-abroad/belgium/uk/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/belgium/uk/partner_other/same_sex.txt
@@ -20,7 +20,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Belgium to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British embassy in Brussels](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.

--- a/test/artefacts/marriage-abroad/china/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/china/ceremony_country/partner_british/opposite_sex.txt
@@ -11,13 +11,13 @@ Contact the relevant local authorities in China to find out about local marriage
 
 Make an appointment at your local British embassy or consulate in China to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Beijing.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beijing/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Beijing](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beijing/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the embassy in Shanghai.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-shanghai/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Shanghai](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-shanghai/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the embassy in Chongqing.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-chongqing/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Chongqing](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-chongqing/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the embassy in Guangzhou.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-guangzhou/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Guangzhou](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-guangzhou/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ form‘.

--- a/test/artefacts/marriage-abroad/china/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/china/ceremony_country/partner_local/opposite_sex.txt
@@ -11,13 +11,13 @@ Contact the relevant local authorities in China to find out about local marriage
 
 Make an appointment at the British embassy or consulate in China nearest to the address in your partner’s Hukou (family registration) book, to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, your partner’s Hukou and pay a fee.
 
-[Make an appointment at the embassy in Beijing.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beijing/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Beijing](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beijing/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the embassy in Shanghai.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-shanghai/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Shanghai](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-shanghai/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the embassy in Chongqing.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-chongqing/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Chongqing](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-chongqing/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the embassy in Guangzhou.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-guangzhou/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Guangzhou](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-guangzhou/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ form‘.

--- a/test/artefacts/marriage-abroad/china/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/china/ceremony_country/partner_other/opposite_sex.txt
@@ -11,13 +11,13 @@ Contact the relevant local authorities in China to find out about local marriage
 
 Make an appointment at your local British embassy or consulate in China to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Beijing.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beijing/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Beijing](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beijing/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the embassy in Shanghai.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-shanghai/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Shanghai](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-shanghai/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the embassy in Chongqing.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-chongqing/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Chongqing](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-chongqing/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the embassy in Guangzhou.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-guangzhou/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Guangzhou](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-guangzhou/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ form‘.

--- a/test/artefacts/marriage-abroad/china/third_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/china/third_country/partner_british/opposite_sex.txt
@@ -11,13 +11,13 @@ Contact the relevant local authorities in China to find out about local marriage
 
 Make an appointment at your local British embassy or consulate in China to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Beijing.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beijing/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Beijing](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beijing/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the embassy in Shanghai.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-shanghai/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Shanghai](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-shanghai/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the embassy in Chongqing.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-chongqing/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Chongqing](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-chongqing/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the embassy in Guangzhou.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-guangzhou/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Guangzhou](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-guangzhou/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ form‘.

--- a/test/artefacts/marriage-abroad/china/third_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/china/third_country/partner_local/opposite_sex.txt
@@ -11,13 +11,13 @@ Contact the relevant local authorities in China to find out about local marriage
 
 Make an appointment at the British embassy or consulate in China nearest to the address in your partner’s Hukou (family registration) book, to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, your partner’s Hukou and pay a fee.
 
-[Make an appointment at the embassy in Beijing.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beijing/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Beijing](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beijing/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the embassy in Shanghai.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-shanghai/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Shanghai](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-shanghai/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the embassy in Chongqing.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-chongqing/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Chongqing](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-chongqing/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the embassy in Guangzhou.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-guangzhou/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Guangzhou](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-guangzhou/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ form‘.

--- a/test/artefacts/marriage-abroad/china/third_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/china/third_country/partner_other/opposite_sex.txt
@@ -11,13 +11,13 @@ Contact the relevant local authorities in China to find out about local marriage
 
 Make an appointment at your local British embassy or consulate in China to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Beijing.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beijing/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Beijing](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beijing/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the embassy in Shanghai.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-shanghai/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Shanghai](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-shanghai/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the embassy in Chongqing.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-chongqing/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Chongqing](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-chongqing/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the embassy in Guangzhou.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-guangzhou/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Guangzhou](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-guangzhou/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ form‘.

--- a/test/artefacts/marriage-abroad/china/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/china/uk/partner_british/opposite_sex.txt
@@ -11,13 +11,13 @@ Contact the [Embassy of China](/government/publications/foreign-embassies-in-the
 
 Make an appointment at your local British embassy or consulate in China to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Beijing.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beijing/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Beijing](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beijing/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the embassy in Shanghai.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-shanghai/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Shanghai](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-shanghai/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the embassy in Chongqing.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-chongqing/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Chongqing](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-chongqing/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the embassy in Guangzhou.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-guangzhou/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Guangzhou](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-guangzhou/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ form‘.

--- a/test/artefacts/marriage-abroad/china/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/china/uk/partner_local/opposite_sex.txt
@@ -11,13 +11,13 @@ Contact the [Embassy of China](/government/publications/foreign-embassies-in-the
 
 Make an appointment at the British embassy or consulate in China nearest to the address in your partner’s Hukou (family registration) book, to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, your partner’s Hukou and pay a fee.
 
-[Make an appointment at the embassy in Beijing.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beijing/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Beijing](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beijing/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the embassy in Shanghai.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-shanghai/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Shanghai](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-shanghai/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the embassy in Chongqing.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-chongqing/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Chongqing](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-chongqing/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the embassy in Guangzhou.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-guangzhou/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Guangzhou](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-guangzhou/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ form‘.

--- a/test/artefacts/marriage-abroad/china/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/china/uk/partner_other/opposite_sex.txt
@@ -11,13 +11,13 @@ Contact the [Embassy of China](/government/publications/foreign-embassies-in-the
 
 Make an appointment at your local British embassy or consulate in China to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Beijing.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beijing/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Beijing](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beijing/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the embassy in Shanghai.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-shanghai/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Shanghai](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-shanghai/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the embassy in Chongqing.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-chongqing/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Chongqing](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-chongqing/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the embassy in Guangzhou.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-guangzhou/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Guangzhou](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-guangzhou/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ form‘.

--- a/test/artefacts/marriage-abroad/colombia/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/colombia/ceremony_country/partner_british/opposite_sex.txt
@@ -12,10 +12,10 @@ Contact the [Embassy of Colombia](/government/publications/foreign-embassies-in-
 You may be asked to provide an ‘affirmation for marriage’ document to prove you’re allowed to marry.
 
 
-Make an appointment at the local British embassy or consulate in Colombia to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee of £55.
+Make an appointment at the British embassy in Bogota to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee of £55.
 
 
-[Make an appointment at the embassy in Colombia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Bogota](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Colombia](/government/publications/colombia-consular-fees).

--- a/test/artefacts/marriage-abroad/colombia/ceremony_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/colombia/ceremony_country/partner_british/same_sex.txt
@@ -3,7 +3,7 @@ Same-sex marriage in Colombia
 You may be able to get married at the British embassy or consulate in Colombia.
 
 
-[Make an appointment at the British embassy in Colombia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British embassy in Bogota](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 ##What documents you’ll need

--- a/test/artefacts/marriage-abroad/colombia/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/colombia/ceremony_country/partner_local/opposite_sex.txt
@@ -12,10 +12,10 @@ Contact the [Embassy of Colombia](/government/publications/foreign-embassies-in-
 You may be asked to provide an ‘affirmation for marriage’ document to prove you’re allowed to marry.
 
 
-Make an appointment at the local British embassy or consulate in Colombia to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee of £55.
+Make an appointment at the British embassy in Bogota to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee of £55.
 
 
-[Make an appointment at the embassy in Colombia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Bogota](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Colombia](/government/publications/colombia-consular-fees).

--- a/test/artefacts/marriage-abroad/colombia/ceremony_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/colombia/ceremony_country/partner_local/same_sex.txt
@@ -3,7 +3,7 @@ Same-sex marriage in Colombia
 You may be able to get married at the British embassy or consulate in Colombia.
 
 
-[Make an appointment at the British embassy in Colombia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British embassy in Bogota](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 ##What documents you’ll need

--- a/test/artefacts/marriage-abroad/colombia/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/colombia/ceremony_country/partner_other/opposite_sex.txt
@@ -12,10 +12,10 @@ Contact the [Embassy of Colombia](/government/publications/foreign-embassies-in-
 You may be asked to provide an ‘affirmation for marriage’ document to prove you’re allowed to marry.
 
 
-Make an appointment at the local British embassy or consulate in Colombia to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee of £55.
+Make an appointment at the British embassy in Bogota to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee of £55.
 
 
-[Make an appointment at the embassy in Colombia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Bogota](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Colombia](/government/publications/colombia-consular-fees).

--- a/test/artefacts/marriage-abroad/colombia/ceremony_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/colombia/ceremony_country/partner_other/same_sex.txt
@@ -3,7 +3,7 @@ Same-sex marriage in Colombia
 You may be able to get married at the British embassy or consulate in Colombia.
 
 
-[Make an appointment at the British embassy in Colombia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British embassy in Bogota](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 ##What documents you’ll need

--- a/test/artefacts/marriage-abroad/colombia/third_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/colombia/third_country/partner_british/opposite_sex.txt
@@ -12,10 +12,10 @@ Contact the [Embassy of Colombia](/government/publications/foreign-embassies-in-
 You may be asked to provide an ‘affirmation for marriage’ document to prove you’re allowed to marry.
 
 
-Make an appointment at the local British embassy or consulate in Colombia to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee of £55.
+Make an appointment at the British embassy in Bogota to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee of £55.
 
 
-[Make an appointment at the embassy in Colombia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Bogota](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Colombia](/government/publications/colombia-consular-fees).

--- a/test/artefacts/marriage-abroad/colombia/third_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/colombia/third_country/partner_british/same_sex.txt
@@ -3,7 +3,7 @@ Same-sex marriage in Colombia
 You may be able to get married at the British embassy or consulate in Colombia.
 
 
-[Make an appointment at the British embassy in Colombia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British embassy in Bogota](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 ##What documents you’ll need

--- a/test/artefacts/marriage-abroad/colombia/third_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/colombia/third_country/partner_local/opposite_sex.txt
@@ -12,10 +12,10 @@ Contact the [Embassy of Colombia](/government/publications/foreign-embassies-in-
 You may be asked to provide an ‘affirmation for marriage’ document to prove you’re allowed to marry.
 
 
-Make an appointment at the local British embassy or consulate in Colombia to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee of £55.
+Make an appointment at the British embassy in Bogota to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee of £55.
 
 
-[Make an appointment at the embassy in Colombia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Bogota](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Colombia](/government/publications/colombia-consular-fees).

--- a/test/artefacts/marriage-abroad/colombia/third_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/colombia/third_country/partner_local/same_sex.txt
@@ -3,7 +3,7 @@ Same-sex marriage in Colombia
 You may be able to get married at the British embassy or consulate in Colombia.
 
 
-[Make an appointment at the British embassy in Colombia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British embassy in Bogota](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 ##What documents you’ll need

--- a/test/artefacts/marriage-abroad/colombia/third_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/colombia/third_country/partner_other/opposite_sex.txt
@@ -12,10 +12,10 @@ Contact the [Embassy of Colombia](/government/publications/foreign-embassies-in-
 You may be asked to provide an ‘affirmation for marriage’ document to prove you’re allowed to marry.
 
 
-Make an appointment at the local British embassy or consulate in Colombia to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee of £55.
+Make an appointment at the British embassy in Bogota to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee of £55.
 
 
-[Make an appointment at the embassy in Colombia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Bogota](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Colombia](/government/publications/colombia-consular-fees).

--- a/test/artefacts/marriage-abroad/colombia/third_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/colombia/third_country/partner_other/same_sex.txt
@@ -3,7 +3,7 @@ Same-sex marriage in Colombia
 You may be able to get married at the British embassy or consulate in Colombia.
 
 
-[Make an appointment at the British embassy in Colombia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British embassy in Bogota](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 ##What documents you’ll need

--- a/test/artefacts/marriage-abroad/colombia/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/colombia/uk/partner_british/opposite_sex.txt
@@ -12,10 +12,10 @@ Contact the [Embassy of Colombia](/government/publications/foreign-embassies-in-
 You may be asked to provide an ‘affirmation for marriage’ document to prove you’re allowed to marry.
 
 
-Make an appointment at the local British embassy or consulate in Colombia to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee of £55.
+Make an appointment at the British embassy in Bogota to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee of £55.
 
 
-[Make an appointment at the embassy in Colombia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Bogota](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Colombia](/government/publications/colombia-consular-fees).

--- a/test/artefacts/marriage-abroad/colombia/uk/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/colombia/uk/partner_british/same_sex.txt
@@ -3,7 +3,7 @@ Same-sex marriage in Colombia
 You may be able to get married at the British embassy or consulate in Colombia.
 
 
-[Make an appointment at the British embassy in Colombia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British embassy in Bogota](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 ##What documents you’ll need

--- a/test/artefacts/marriage-abroad/colombia/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/colombia/uk/partner_local/opposite_sex.txt
@@ -12,10 +12,10 @@ Contact the [Embassy of Colombia](/government/publications/foreign-embassies-in-
 You may be asked to provide an ‘affirmation for marriage’ document to prove you’re allowed to marry.
 
 
-Make an appointment at the local British embassy or consulate in Colombia to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee of £55.
+Make an appointment at the British embassy in Bogota to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee of £55.
 
 
-[Make an appointment at the embassy in Colombia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Bogota](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Colombia](/government/publications/colombia-consular-fees).

--- a/test/artefacts/marriage-abroad/colombia/uk/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/colombia/uk/partner_local/same_sex.txt
@@ -3,7 +3,7 @@ Same-sex marriage in Colombia
 You may be able to get married at the British embassy or consulate in Colombia.
 
 
-[Make an appointment at the British embassy in Colombia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British embassy in Bogota](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 ##What documents you’ll need

--- a/test/artefacts/marriage-abroad/colombia/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/colombia/uk/partner_other/opposite_sex.txt
@@ -12,10 +12,10 @@ Contact the [Embassy of Colombia](/government/publications/foreign-embassies-in-
 You may be asked to provide an ‘affirmation for marriage’ document to prove you’re allowed to marry.
 
 
-Make an appointment at the local British embassy or consulate in Colombia to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee of £55.
+Make an appointment at the British embassy in Bogota to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee of £55.
 
 
-[Make an appointment at the embassy in Colombia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Bogota](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Colombia](/government/publications/colombia-consular-fees).

--- a/test/artefacts/marriage-abroad/colombia/uk/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/colombia/uk/partner_other/same_sex.txt
@@ -3,7 +3,7 @@ Same-sex marriage in Colombia
 You may be able to get married at the British embassy or consulate in Colombia.
 
 
-[Make an appointment at the British embassy in Colombia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the British embassy in Bogota](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 ##What documents you’ll need

--- a/test/artefacts/marriage-abroad/croatia/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/croatia/ceremony_country/partner_british/opposite_sex.txt
@@ -17,10 +17,12 @@ The local registrar may also need a certificate of custom and law, which confirm
 
 ###Applying for a CNI from the embassy
 
-You’ll need to have been living in Croatia for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.. You can then book an appointment at the embassy to give notice of your marriage. There’s a fee for this service (read the table on this page).
+You’ll need to have been living in Croatia for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
+
+You can then book an appointment at the embassy to give notice of your marriage. There’s a fee for this service (read the table on this page).
 
 
-[Make an appointment at the embassy in Zagreb.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-zagreb/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Zagreb](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-zagreb/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/croatia/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/croatia/ceremony_country/partner_local/opposite_sex.txt
@@ -17,10 +17,12 @@ The local registrar may also need a certificate of custom and law, which confirm
 
 ###Applying for a CNI from the embassy
 
-You’ll need to have been living in Croatia for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.. You can then book an appointment at the embassy to give notice of your marriage. There’s a fee for this service (read the table on this page).
+You’ll need to have been living in Croatia for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
+
+You can then book an appointment at the embassy to give notice of your marriage. There’s a fee for this service (read the table on this page).
 
 
-[Make an appointment at the embassy in Zagreb.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-zagreb/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Zagreb](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-zagreb/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/croatia/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/croatia/ceremony_country/partner_other/opposite_sex.txt
@@ -17,10 +17,12 @@ The local registrar may also need a certificate of custom and law, which confirm
 
 ###Applying for a CNI from the embassy
 
-You’ll need to have been living in Croatia for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.. You can then book an appointment at the embassy to give notice of your marriage. There’s a fee for this service (read the table on this page).
+You’ll need to have been living in Croatia for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
+
+You can then book an appointment at the embassy to give notice of your marriage. There’s a fee for this service (read the table on this page).
 
 
-[Make an appointment at the embassy in Zagreb.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-zagreb/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Zagreb](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-zagreb/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/denmark/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/denmark/ceremony_country/partner_british/opposite_sex.txt
@@ -15,13 +15,13 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 ^You don’t need a CNI if you’re getting married in the main town hall in Copenhagen.^
 
 
-If you need a CNI, you must give notice of your intended marriage in Denmark. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Denmark. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Denmark for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Copenhagen.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-copenhagen/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Copenhagen](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-copenhagen/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/denmark/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/denmark/ceremony_country/partner_local/opposite_sex.txt
@@ -15,13 +15,13 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 ^You don’t need a CNI if you’re getting married in the main town hall in Copenhagen.^
 
 
-If you need a CNI, you must give notice of your intended marriage in Denmark. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Denmark. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Denmark for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Copenhagen.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-copenhagen/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Copenhagen](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-copenhagen/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/denmark/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/denmark/ceremony_country/partner_other/opposite_sex.txt
@@ -15,13 +15,13 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 ^You don’t need a CNI if you’re getting married in the main town hall in Copenhagen.^
 
 
-If you need a CNI, you must give notice of your intended marriage in Denmark. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Denmark. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Denmark for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Copenhagen.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-copenhagen/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Copenhagen](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-copenhagen/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/egypt/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/egypt/ceremony_country/partner_british/opposite_sex.txt
@@ -12,7 +12,7 @@ Contact the relevant local authorities in Egypt to find out about local marriage
 Make an appointment at the local British embassy or consulate in Egypt to make a declaration that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Cairo.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-cairo/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Cairo](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-cairo/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/egypt/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/egypt/ceremony_country/partner_local/opposite_sex.txt
@@ -12,7 +12,7 @@ Contact the relevant local authorities in Egypt to find out about local marriage
 Make an appointment at the local British embassy or consulate in Egypt to make a declaration that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Cairo.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-cairo/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Cairo](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-cairo/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/egypt/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/egypt/ceremony_country/partner_other/opposite_sex.txt
@@ -12,7 +12,7 @@ Contact the relevant local authorities in Egypt to find out about local marriage
 Make an appointment at the local British embassy or consulate in Egypt to make a declaration that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Cairo.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-cairo/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Cairo](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-cairo/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/egypt/third_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/egypt/third_country/partner_british/opposite_sex.txt
@@ -12,7 +12,7 @@ Contact the relevant local authorities in Egypt to find out about local marriage
 Make an appointment at the local British embassy or consulate in Egypt to make a declaration that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Cairo.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-cairo/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Cairo](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-cairo/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/egypt/third_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/egypt/third_country/partner_local/opposite_sex.txt
@@ -12,7 +12,7 @@ Contact the relevant local authorities in Egypt to find out about local marriage
 Make an appointment at the local British embassy or consulate in Egypt to make a declaration that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Cairo.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-cairo/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Cairo](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-cairo/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/egypt/third_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/egypt/third_country/partner_other/opposite_sex.txt
@@ -12,7 +12,7 @@ Contact the relevant local authorities in Egypt to find out about local marriage
 Make an appointment at the local British embassy or consulate in Egypt to make a declaration that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Cairo.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-cairo/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Cairo](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-cairo/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/egypt/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/egypt/uk/partner_british/opposite_sex.txt
@@ -12,7 +12,7 @@ Contact the [Embassy of Egypt](/government/publications/foreign-embassies-in-the
 Make an appointment at the local British embassy or consulate in Egypt to make a declaration that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Cairo.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-cairo/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Cairo](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-cairo/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/egypt/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/egypt/uk/partner_local/opposite_sex.txt
@@ -12,7 +12,7 @@ Contact the [Embassy of Egypt](/government/publications/foreign-embassies-in-the
 Make an appointment at the local British embassy or consulate in Egypt to make a declaration that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Cairo.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-cairo/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Cairo](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-cairo/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/egypt/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/egypt/uk/partner_other/opposite_sex.txt
@@ -12,7 +12,7 @@ Contact the [Embassy of Egypt](/government/publications/foreign-embassies-in-the
 Make an appointment at the local British embassy or consulate in Egypt to make a declaration that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Cairo.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-cairo/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Cairo](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-cairo/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/estonia/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/estonia/ceremony_country/partner_british/opposite_sex.txt
@@ -12,7 +12,7 @@ Contact the relevant local authorities in Estonia to find out about local marria
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Estonia. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Estonia. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Estonia for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
@@ -21,7 +21,7 @@ You need to have been living in Estonia for 3 full days before you can post noti
 ^You may be able to get married without a CNI if you have a permanent address in Estonia and have a 6 month residence permit - contact the local authorities to find out.^
 
 
-[Make an appointment at the embassy in Tallinn.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-tallinn/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tallinn](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-tallinn/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/estonia/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/estonia/ceremony_country/partner_local/opposite_sex.txt
@@ -12,7 +12,7 @@ Contact the relevant local authorities in Estonia to find out about local marria
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Estonia. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Estonia. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Estonia for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
@@ -21,7 +21,7 @@ You need to have been living in Estonia for 3 full days before you can post noti
 ^You may be able to get married without a CNI if you have a permanent address in Estonia and have a 6 month residence permit - contact the local authorities to find out.^
 
 
-[Make an appointment at the embassy in Tallinn.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-tallinn/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tallinn](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-tallinn/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/estonia/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/estonia/ceremony_country/partner_other/opposite_sex.txt
@@ -12,7 +12,7 @@ Contact the relevant local authorities in Estonia to find out about local marria
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Estonia. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Estonia. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Estonia for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
@@ -21,7 +21,7 @@ You need to have been living in Estonia for 3 full days before you can post noti
 ^You may be able to get married without a CNI if you have a permanent address in Estonia and have a 6 month residence permit - contact the local authorities to find out.^
 
 
-[Make an appointment at the embassy in Tallinn.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-tallinn/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tallinn](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-tallinn/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/greece/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/greece/ceremony_country/partner_british/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Greece to find out about local marriag
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Greece. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Greece. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Greece for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Athens](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-athens/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Athens](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-athens/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:
@@ -63,7 +63,7 @@ There’s an additional fee for this - the embassy or consulate will contact you
 
 You can then collect your CNI at the British embassy in Athens or ask for it to be sent to you by post. You must provide the registrar’s original Notice of Marriage if you posted notice in the UK.
 
-[Make an appointment to collect your CNI at the embassy in Athens.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-athens/certificate-of-no-impediment/slot_picker)
+[Make an appointment to collect your CNI at the embassy in Athens](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-athens/certificate-of-no-impediment/slot_picker).
 
 ^Your partner will need to follow the same process and pay the fees to get their own CNI.^
 

--- a/test/artefacts/marriage-abroad/greece/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/greece/ceremony_country/partner_local/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Greece to find out about local marriag
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Greece. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Greece. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Greece for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Athens](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-athens/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Athens](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-athens/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:
@@ -63,7 +63,7 @@ There’s an additional fee for this - the embassy or consulate will contact you
 
 You can then collect your CNI at the British embassy in Athens or ask for it to be sent to you by post. You must provide the registrar’s original Notice of Marriage if you posted notice in the UK.
 
-[Make an appointment to collect your CNI at the embassy in Athens.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-athens/certificate-of-no-impediment/slot_picker)
+[Make an appointment to collect your CNI at the embassy in Athens](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-athens/certificate-of-no-impediment/slot_picker).
 
 %The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
 

--- a/test/artefacts/marriage-abroad/greece/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/greece/ceremony_country/partner_other/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Greece to find out about local marriag
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Greece. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Greece. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Greece for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Athens](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-athens/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Athens](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-athens/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:
@@ -63,7 +63,7 @@ There’s an additional fee for this - the embassy or consulate will contact you
 
 You can then collect your CNI at the British embassy in Athens or ask for it to be sent to you by post. You must provide the registrar’s original Notice of Marriage if you posted notice in the UK.
 
-[Make an appointment to collect your CNI at the embassy in Athens.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-athens/certificate-of-no-impediment/slot_picker)
+[Make an appointment to collect your CNI at the embassy in Athens](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-athens/certificate-of-no-impediment/slot_picker).
 
 %The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
 

--- a/test/artefacts/marriage-abroad/guatemala/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/guatemala/ceremony_country/partner_british/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Guatemala to find out about local marr
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Guatemala. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Guatemala. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Guatemala for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Guatamala City.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-guatemala-city/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Guatamala City](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-guatemala-city/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/guatemala/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/guatemala/ceremony_country/partner_local/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Guatemala to find out about local marr
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Guatemala. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Guatemala. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Guatemala for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Guatamala City.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-guatemala-city/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Guatamala City](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-guatemala-city/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/guatemala/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/guatemala/ceremony_country/partner_other/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Guatemala to find out about local marr
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Guatemala. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Guatemala. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Guatemala for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Guatamala City.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-guatemala-city/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Guatamala City](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-guatemala-city/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/iceland/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/iceland/ceremony_country/partner_british/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Iceland to find out about local marria
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Iceland. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Iceland. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Iceland for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Reykjavik.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-reykjavik/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Reykjavik](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-reykjavik/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/iceland/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/iceland/ceremony_country/partner_local/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Iceland to find out about local marria
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Iceland. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Iceland. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Iceland for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Reykjavik.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-reykjavik/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Reykjavik](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-reykjavik/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/iceland/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/iceland/ceremony_country/partner_other/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Iceland to find out about local marria
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Iceland. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Iceland. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Iceland for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Reykjavik.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-reykjavik/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Reykjavik](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-reykjavik/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/indonesia/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/indonesia/ceremony_country/partner_british/opposite_sex.txt
@@ -1,7 +1,7 @@
 Marriage in Indonesia
 
 
-Make an appointment at the local British embassy or consulate in Indonesia to swear an affidavit (written statement of facts) that you’re free to marry.
+Make an appointment at the British Embassy in Jakarta to swear an affidavit (written statement of facts) that you’re free to marry.
 
 Before the appointment you’ll need to pay a fee to the British Embassy in Jakarta. You can do this by credit card or in cash in the local currency. You also need to complete 2 copies of the [‘Affidavit for marriage’ form](/government/publications/marriage-in-indonesia).
 

--- a/test/artefacts/marriage-abroad/indonesia/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/indonesia/ceremony_country/partner_local/opposite_sex.txt
@@ -1,7 +1,7 @@
 Marriage in Indonesia
 
 
-Make an appointment at the local British embassy or consulate in Indonesia to swear an affidavit (written statement of facts) that you’re free to marry.
+Make an appointment at the British Embassy in Jakarta to swear an affidavit (written statement of facts) that you’re free to marry.
 
 Before the appointment you’ll need to pay a fee to the British Embassy in Jakarta. You can do this by credit card or in cash in the local currency. You also need to complete 2 copies of the [‘Affidavit for marriage’ form](/government/publications/marriage-in-indonesia).
 

--- a/test/artefacts/marriage-abroad/indonesia/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/indonesia/ceremony_country/partner_other/opposite_sex.txt
@@ -1,7 +1,7 @@
 Marriage in Indonesia
 
 
-Make an appointment at the local British embassy or consulate in Indonesia to swear an affidavit (written statement of facts) that you’re free to marry.
+Make an appointment at the British Embassy in Jakarta to swear an affidavit (written statement of facts) that you’re free to marry.
 
 Before the appointment you’ll need to pay a fee to the British Embassy in Jakarta. You can do this by credit card or in cash in the local currency. You also need to complete 2 copies of the [‘Affidavit for marriage’ form](/government/publications/marriage-in-indonesia).
 

--- a/test/artefacts/marriage-abroad/indonesia/third_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/indonesia/third_country/partner_british/opposite_sex.txt
@@ -1,7 +1,7 @@
 Marriage in Indonesia
 
 
-Make an appointment at the local British embassy or consulate in Indonesia to swear an affidavit (written statement of facts) that you’re free to marry.
+Make an appointment at the British Embassy in Jakarta to swear an affidavit (written statement of facts) that you’re free to marry.
 
 Before the appointment you’ll need to pay a fee to the British Embassy in Jakarta. You can do this by credit card or in cash in the local currency. You also need to complete 2 copies of the [‘Affidavit for marriage’ form](/government/publications/marriage-in-indonesia).
 

--- a/test/artefacts/marriage-abroad/indonesia/third_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/indonesia/third_country/partner_local/opposite_sex.txt
@@ -1,7 +1,7 @@
 Marriage in Indonesia
 
 
-Make an appointment at the local British embassy or consulate in Indonesia to swear an affidavit (written statement of facts) that you’re free to marry.
+Make an appointment at the British Embassy in Jakarta to swear an affidavit (written statement of facts) that you’re free to marry.
 
 Before the appointment you’ll need to pay a fee to the British Embassy in Jakarta. You can do this by credit card or in cash in the local currency. You also need to complete 2 copies of the [‘Affidavit for marriage’ form](/government/publications/marriage-in-indonesia).
 

--- a/test/artefacts/marriage-abroad/indonesia/third_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/indonesia/third_country/partner_other/opposite_sex.txt
@@ -1,7 +1,7 @@
 Marriage in Indonesia
 
 
-Make an appointment at the local British embassy or consulate in Indonesia to swear an affidavit (written statement of facts) that you’re free to marry.
+Make an appointment at the British Embassy in Jakarta to swear an affidavit (written statement of facts) that you’re free to marry.
 
 Before the appointment you’ll need to pay a fee to the British Embassy in Jakarta. You can do this by credit card or in cash in the local currency. You also need to complete 2 copies of the [‘Affidavit for marriage’ form](/government/publications/marriage-in-indonesia).
 

--- a/test/artefacts/marriage-abroad/indonesia/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/indonesia/uk/partner_british/opposite_sex.txt
@@ -1,7 +1,7 @@
 Marriage in Indonesia
 
 
-Make an appointment at the local British embassy or consulate in Indonesia to swear an affidavit (written statement of facts) that you’re free to marry.
+Make an appointment at the British Embassy in Jakarta to swear an affidavit (written statement of facts) that you’re free to marry.
 
 Before the appointment you’ll need to pay a fee to the British Embassy in Jakarta. You can do this by credit card or in cash in the local currency. You also need to complete 2 copies of the [‘Affidavit for marriage’ form](/government/publications/marriage-in-indonesia).
 

--- a/test/artefacts/marriage-abroad/indonesia/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/indonesia/uk/partner_local/opposite_sex.txt
@@ -1,7 +1,7 @@
 Marriage in Indonesia
 
 
-Make an appointment at the local British embassy or consulate in Indonesia to swear an affidavit (written statement of facts) that you’re free to marry.
+Make an appointment at the British Embassy in Jakarta to swear an affidavit (written statement of facts) that you’re free to marry.
 
 Before the appointment you’ll need to pay a fee to the British Embassy in Jakarta. You can do this by credit card or in cash in the local currency. You also need to complete 2 copies of the [‘Affidavit for marriage’ form](/government/publications/marriage-in-indonesia).
 

--- a/test/artefacts/marriage-abroad/indonesia/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/indonesia/uk/partner_other/opposite_sex.txt
@@ -1,7 +1,7 @@
 Marriage in Indonesia
 
 
-Make an appointment at the local British embassy or consulate in Indonesia to swear an affidavit (written statement of facts) that you’re free to marry.
+Make an appointment at the British Embassy in Jakarta to swear an affidavit (written statement of facts) that you’re free to marry.
 
 Before the appointment you’ll need to pay a fee to the British Embassy in Jakarta. You can do this by credit card or in cash in the local currency. You also need to complete 2 copies of the [‘Affidavit for marriage’ form](/government/publications/marriage-in-indonesia).
 

--- a/test/artefacts/marriage-abroad/italy/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/italy/ceremony_country/partner_british/opposite_sex.txt
@@ -9,14 +9,14 @@ Contact the local comune (town hall) before making any plans to find out about l
 You’ll be asked to provide a ‘Nulla Osta’ by the authorities in Italy. This is a certificate that proves you’re allowed to marry.
 
 
-[Make an appointment at the embassy in Rome](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rome/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Rome](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rome/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 To get a Nulla Osta, you’ll first need to give notice of your intended marriage at the British Embassy in Rome.
 
 ###Applying for a Nulla Osta from the embassy
 
-You’ll need to have been living in Italy for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.. You can then book an appointment at the British Embassy in Rome.
+You’ll need to have been living in Italy for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday. You can then book an appointment at the British Embassy in Rome.
 
 
 You and your partner will need to provide your passports and [full birth certificate](/order-copy-birth-death-marriage-certificate/) or [naturalisation certificate](/get-replacement-citizenship-certificate).

--- a/test/artefacts/marriage-abroad/italy/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/italy/ceremony_country/partner_local/opposite_sex.txt
@@ -9,14 +9,14 @@ Contact the local comune (town hall) before making any plans to find out about l
 You’ll be asked to provide a ‘Nulla Osta’ by the authorities in Italy. This is a certificate that proves you’re allowed to marry.
 
 
-[Make an appointment at the embassy in Rome](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rome/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Rome](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rome/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 To get a Nulla Osta, you’ll first need to give notice of your intended marriage at the British Embassy in Rome.
 
 ###Applying for a Nulla Osta from the embassy
 
-You’ll need to have been living in Italy for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.. You can then book an appointment at the British Embassy in Rome.
+You’ll need to have been living in Italy for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday. You can then book an appointment at the British Embassy in Rome.
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/italy/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/italy/ceremony_country/partner_other/opposite_sex.txt
@@ -9,14 +9,14 @@ Contact the local comune (town hall) before making any plans to find out about l
 You’ll be asked to provide a ‘Nulla Osta’ by the authorities in Italy. This is a certificate that proves you’re allowed to marry.
 
 
-[Make an appointment at the embassy in Rome](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rome/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Rome](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rome/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 To get a Nulla Osta, you’ll first need to give notice of your intended marriage at the British Embassy in Rome.
 
 ###Applying for a Nulla Osta from the embassy
 
-You’ll need to have been living in Italy for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.. You can then book an appointment at the British Embassy in Rome.
+You’ll need to have been living in Italy for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday. You can then book an appointment at the British Embassy in Rome.
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/japan/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/japan/ceremony_country/partner_british/opposite_sex.txt
@@ -11,7 +11,7 @@ Contact your [nearest embassy or consulate](http://www.mofa.go.jp/about/emb_cons
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Japan. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Japan. You must do this at the British embassy or in front of a notary public in that country.
 
 
 

--- a/test/artefacts/marriage-abroad/japan/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/japan/ceremony_country/partner_local/opposite_sex.txt
@@ -12,9 +12,9 @@ Contact the relevant local authorities in Japan to find out about local marriage
 
 Make an appointment at the British embassy in Tokyo or British Consulate General in Osaka to swear an affirmation/affidavit (written statement of facts) that you’re free to marry.
 
-[Make an appointment at the embassy in Tokyo](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tokyo/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Tokyo](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tokyo/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the Consulate General in Osaka](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-osaka/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the Consulate General in Osaka](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-osaka/oaths-affirmations-and-affidavits/slot_picker).
 
 You can [download and fill in a form](/government/publications/affidavitaffirmation-of-marital-status-japan) for an ‘Affirmation for marriage’ (non-religious) or an ‘Affidavit for marriage’ (religious) before your appointment. Don’t sign it - you’ll do that at the appointment.
 

--- a/test/artefacts/marriage-abroad/japan/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/japan/ceremony_country/partner_other/opposite_sex.txt
@@ -11,7 +11,7 @@ Contact your [nearest embassy or consulate](http://www.mofa.go.jp/about/emb_cons
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Japan. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Japan. You must do this at the British embassy or in front of a notary public in that country.
 
 
 

--- a/test/artefacts/marriage-abroad/jordan/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/jordan/ceremony_country/partner_british/opposite_sex.txt
@@ -28,7 +28,7 @@ Make an appointment at the local British embassy or consulate to swear an affida
 For non-Islamic marriages, you may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Jordan. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Jordan. You must do this at the British embassy or in front of a notary public in that country.
 
 
 

--- a/test/artefacts/marriage-abroad/jordan/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/jordan/ceremony_country/partner_local/opposite_sex.txt
@@ -28,7 +28,7 @@ Make an appointment at the local British embassy or consulate to swear an affida
 For non-Islamic marriages, you may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Jordan. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Jordan. You must do this at the British embassy or in front of a notary public in that country.
 
 
 

--- a/test/artefacts/marriage-abroad/jordan/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/jordan/ceremony_country/partner_other/opposite_sex.txt
@@ -28,7 +28,7 @@ Make an appointment at the local British embassy or consulate to swear an affida
 For non-Islamic marriages, you may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Jordan. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Jordan. You must do this at the British embassy or in front of a notary public in that country.
 
 
 

--- a/test/artefacts/marriage-abroad/kazakhstan/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/kazakhstan/ceremony_country/partner_british/opposite_sex.txt
@@ -17,10 +17,8 @@ You need to have been living in Kazakhstan for 3 full days before you can post n
 
 If you need a CNI, you’ll first need to give notice of your intended marriage (banns) at the British Embassy Office in Almaty.
 
-Make an appointment at the embassy in Kazakhstan to give notice of your marriage. There’s a fee for this service (see below).
 
-
-[Make an appointment at the embassy in Almaty.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-office-almaty/certificate-of-no-impediment/slot_picker)
+[Make an appointment at the embassy in Almaty](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-office-almaty/certificate-of-no-impediment/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/kazakhstan/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/kazakhstan/ceremony_country/partner_local/opposite_sex.txt
@@ -17,10 +17,8 @@ You need to have been living in Kazakhstan for 3 full days before you can post n
 
 If you need a CNI, you’ll first need to give notice of your intended marriage (banns) at the British Embassy Office in Almaty.
 
-Make an appointment at the embassy in Kazakhstan to give notice of your marriage. There’s a fee for this service (see below).
 
-
-[Make an appointment at the embassy in Almaty.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-office-almaty/certificate-of-no-impediment/slot_picker)
+[Make an appointment at the embassy in Almaty](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-office-almaty/certificate-of-no-impediment/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/kazakhstan/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/kazakhstan/ceremony_country/partner_other/opposite_sex.txt
@@ -17,10 +17,8 @@ You need to have been living in Kazakhstan for 3 full days before you can post n
 
 If you need a CNI, you’ll first need to give notice of your intended marriage (banns) at the British Embassy Office in Almaty.
 
-Make an appointment at the embassy in Kazakhstan to give notice of your marriage. There’s a fee for this service (see below).
 
-
-[Make an appointment at the embassy in Almaty.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-office-almaty/certificate-of-no-impediment/slot_picker)
+[Make an appointment at the embassy in Almaty](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-office-almaty/certificate-of-no-impediment/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/kosovo/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/kosovo/ceremony_country/partner_british/opposite_sex.txt
@@ -9,9 +9,9 @@ Contact the relevant local authorities in Kosovo to find out about local marriag
 
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
-If you need a CNI, you must give notice of your intended marriage in Kosovo. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Kosovo. You must do this at the British embassy or in front of a notary public in that country.
 
-[Make an appointment at the embassy in Pristina.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-pristina/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Pristina](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-pristina/notice-of-marriage-or-civil-partnership/slot_picker).
 
 You need to have been living in Kosovo for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 

--- a/test/artefacts/marriage-abroad/kosovo/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/kosovo/ceremony_country/partner_local/opposite_sex.txt
@@ -9,9 +9,9 @@ Contact the relevant local authorities in Kosovo to find out about local marriag
 
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
-If you need a CNI, you must give notice of your intended marriage in Kosovo. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Kosovo. You must do this at the British embassy or in front of a notary public in that country.
 
-[Make an appointment at the embassy in Pristina.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-pristina/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Pristina](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-pristina/notice-of-marriage-or-civil-partnership/slot_picker).
 
 You need to have been living in Kosovo for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 

--- a/test/artefacts/marriage-abroad/kosovo/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/kosovo/ceremony_country/partner_other/opposite_sex.txt
@@ -9,9 +9,9 @@ Contact the relevant local authorities in Kosovo to find out about local marriag
 
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
-If you need a CNI, you must give notice of your intended marriage in Kosovo. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Kosovo. You must do this at the British embassy or in front of a notary public in that country.
 
-[Make an appointment at the embassy in Pristina.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-pristina/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Pristina](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-pristina/notice-of-marriage-or-civil-partnership/slot_picker).
 
 You need to have been living in Kosovo for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 

--- a/test/artefacts/marriage-abroad/kuwait/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/kuwait/ceremony_country/partner_british/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Kuwait to find out about local marriag
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry. Contact the local notary public to check if you need a CNI.
 
 
-If you need a CNI, you must give notice of your intended marriage in Kuwait. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Kuwait. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Kuwait for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Kuwait City.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-kuwait-city/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Kuwait City](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-kuwait-city/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/kuwait/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/kuwait/ceremony_country/partner_local/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Kuwait to find out about local marriag
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry. Contact the local notary public to check if you need a CNI.
 
 
-If you need a CNI, you must give notice of your intended marriage in Kuwait. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Kuwait. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Kuwait for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Kuwait City.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-kuwait-city/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Kuwait City](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-kuwait-city/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/kuwait/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/kuwait/ceremony_country/partner_other/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Kuwait to find out about local marriag
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry. Contact the local notary public to check if you need a CNI.
 
 
-If you need a CNI, you must give notice of your intended marriage in Kuwait. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Kuwait. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Kuwait for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Kuwait City.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-kuwait-city/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Kuwait City](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-kuwait-city/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/kyrgyzstan/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/kyrgyzstan/ceremony_country/partner_british/opposite_sex.txt
@@ -12,7 +12,7 @@ Contact the relevant local authorities in Kyrgyzstan to find out about local mar
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Kyrgyzstan. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Kyrgyzstan. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Kyrgyzstan for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
@@ -20,10 +20,8 @@ You need to have been living in Kyrgyzstan for 3 full days before you can post n
 
 If you need a CNI, you’ll first need to give notice of your intended marriage (banns) at the British Embassy Office in Almaty.
 
-Make an appointment at the embassy in Kazakhstan to give notice of your marriage. There’s a fee for this service (see below).
 
-
-[Make an appointment at the embassy in Almaty.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-office-almaty/certificate-of-no-impediment/slot_picker)
+[Make an appointment at the embassy in Almaty](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-office-almaty/certificate-of-no-impediment/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/kyrgyzstan/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/kyrgyzstan/ceremony_country/partner_local/opposite_sex.txt
@@ -12,7 +12,7 @@ Contact the relevant local authorities in Kyrgyzstan to find out about local mar
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Kyrgyzstan. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Kyrgyzstan. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Kyrgyzstan for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
@@ -20,10 +20,8 @@ You need to have been living in Kyrgyzstan for 3 full days before you can post n
 
 If you need a CNI, you’ll first need to give notice of your intended marriage (banns) at the British Embassy Office in Almaty.
 
-Make an appointment at the embassy in Kazakhstan to give notice of your marriage. There’s a fee for this service (see below).
 
-
-[Make an appointment at the embassy in Almaty.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-office-almaty/certificate-of-no-impediment/slot_picker)
+[Make an appointment at the embassy in Almaty](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-office-almaty/certificate-of-no-impediment/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/kyrgyzstan/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/kyrgyzstan/ceremony_country/partner_other/opposite_sex.txt
@@ -12,7 +12,7 @@ Contact the relevant local authorities in Kyrgyzstan to find out about local mar
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Kyrgyzstan. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Kyrgyzstan. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Kyrgyzstan for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
@@ -20,10 +20,8 @@ You need to have been living in Kyrgyzstan for 3 full days before you can post n
 
 If you need a CNI, you’ll first need to give notice of your intended marriage (banns) at the British Embassy Office in Almaty.
 
-Make an appointment at the embassy in Kazakhstan to give notice of your marriage. There’s a fee for this service (see below).
 
-
-[Make an appointment at the embassy in Almaty.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-office-almaty/certificate-of-no-impediment/slot_picker)
+[Make an appointment at the embassy in Almaty](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-office-almaty/certificate-of-no-impediment/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/laos/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/laos/ceremony_country/partner_local/opposite_sex.txt
@@ -15,7 +15,7 @@ You may be asked to provide an [affirmation of freedom to marry document](/gover
 Make an appointment at the British Embassy in Vientiane to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, your partner’s ID and pay a fee.
 
 
-[Make an appointment at the embassy in Vientiane.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-kinshasa/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Vientiane](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-kinshasa/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to pay a fee and bring the following to your appointment:

--- a/test/artefacts/marriage-abroad/laos/third_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/laos/third_country/partner_local/opposite_sex.txt
@@ -15,7 +15,7 @@ You may be asked to provide an [affirmation of freedom to marry document](/gover
 Make an appointment at the British Embassy in Vientiane to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, your partner’s ID and pay a fee.
 
 
-[Make an appointment at the embassy in Vientiane.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-kinshasa/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Vientiane](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-kinshasa/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to pay a fee and bring the following to your appointment:

--- a/test/artefacts/marriage-abroad/laos/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/laos/uk/partner_local/opposite_sex.txt
@@ -15,7 +15,7 @@ You may be asked to provide an [affirmation of freedom to marry document](/gover
 Make an appointment at the British Embassy in Vientiane to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, your partner’s ID and pay a fee.
 
 
-[Make an appointment at the embassy in Vientiane.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-kinshasa/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Vientiane](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-kinshasa/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to pay a fee and bring the following to your appointment:

--- a/test/artefacts/marriage-abroad/latvia/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/latvia/ceremony_country/partner_british/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Latvia to find out about local marriag
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Latvia. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Latvia. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Latvia for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Riga.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-riga/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Riga](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-riga/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/latvia/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/latvia/ceremony_country/partner_local/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Latvia to find out about local marriag
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Latvia. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Latvia. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Latvia for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Riga.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-riga/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Riga](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-riga/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/latvia/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/latvia/ceremony_country/partner_other/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Latvia to find out about local marriag
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Latvia. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Latvia. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Latvia for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Riga.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-riga/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Riga](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-riga/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/lebanon/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/lebanon/ceremony_country/partner_british/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Lebanon to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Beirut.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beirut/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Beirut](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beirut/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ###Legalisation and translation

--- a/test/artefacts/marriage-abroad/lebanon/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/lebanon/ceremony_country/partner_local/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Lebanon to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Beirut.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beirut/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Beirut](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beirut/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ###Legalisation and translation

--- a/test/artefacts/marriage-abroad/lebanon/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/lebanon/ceremony_country/partner_other/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Lebanon to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Beirut.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beirut/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Beirut](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beirut/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ###Legalisation and translation

--- a/test/artefacts/marriage-abroad/lebanon/third_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/lebanon/third_country/partner_british/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Lebanon to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Beirut.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beirut/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Beirut](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beirut/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ###Legalisation and translation

--- a/test/artefacts/marriage-abroad/lebanon/third_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/lebanon/third_country/partner_local/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Lebanon to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Beirut.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beirut/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Beirut](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beirut/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ###Legalisation and translation

--- a/test/artefacts/marriage-abroad/lebanon/third_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/lebanon/third_country/partner_other/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Lebanon to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Beirut.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beirut/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Beirut](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beirut/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ###Legalisation and translation

--- a/test/artefacts/marriage-abroad/lebanon/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/lebanon/uk/partner_british/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Lebanon to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Beirut.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beirut/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Beirut](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beirut/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ###Legalisation and translation

--- a/test/artefacts/marriage-abroad/lebanon/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/lebanon/uk/partner_local/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Lebanon to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Beirut.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beirut/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Beirut](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beirut/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ###Legalisation and translation

--- a/test/artefacts/marriage-abroad/lebanon/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/lebanon/uk/partner_other/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Lebanon to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Beirut.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beirut/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Beirut](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beirut/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ###Legalisation and translation

--- a/test/artefacts/marriage-abroad/lithuania/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/lithuania/ceremony_country/partner_british/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Lithuania to find out about local marr
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Lithuania. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Lithuania. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Lithuania for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Vilnius.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-vilnius/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Vilnius](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-vilnius/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/lithuania/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/lithuania/ceremony_country/partner_local/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Lithuania to find out about local marr
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Lithuania. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Lithuania. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Lithuania for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Vilnius.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-vilnius/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Vilnius](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-vilnius/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/lithuania/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/lithuania/ceremony_country/partner_other/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Lithuania to find out about local marr
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Lithuania. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Lithuania. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Lithuania for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Vilnius.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-vilnius/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Vilnius](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-vilnius/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/luxembourg/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/luxembourg/ceremony_country/partner_british/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Luxembourg to find out about local mar
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Luxembourg. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Luxembourg. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Luxembourg for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Luxembourg.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-luxembourg/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Luxembourg](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-luxembourg/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/luxembourg/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/luxembourg/ceremony_country/partner_local/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Luxembourg to find out about local mar
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Luxembourg. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Luxembourg. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Luxembourg for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Luxembourg.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-luxembourg/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Luxembourg](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-luxembourg/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/luxembourg/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/luxembourg/ceremony_country/partner_other/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Luxembourg to find out about local mar
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Luxembourg. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Luxembourg. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Luxembourg for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Luxembourg.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-luxembourg/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Luxembourg](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-luxembourg/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/macao/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/macao/ceremony_country/partner_british/opposite_sex.txt
@@ -11,10 +11,10 @@ Contact the relevant local authorities in Macao to find out about local marriage
 You may be asked to provide an ‘affirmation for marriage’ document to prove you’re allowed to marry.
 
 
-Make an appointment at the British embassy or consulate in Hong Kong to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
+Make an appointment at the British Consulate General Hong Kong to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the British Consulate General Hong Kong](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-hong-kong/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British Consulate General Hong Kong](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-hong-kong/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.

--- a/test/artefacts/marriage-abroad/macao/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/macao/ceremony_country/partner_local/opposite_sex.txt
@@ -11,10 +11,10 @@ Contact the relevant local authorities in Macao to find out about local marriage
 You may be asked to provide an ‘affirmation for marriage’ document to prove you’re allowed to marry.
 
 
-Make an appointment at the British embassy or consulate in Hong Kong to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
+Make an appointment at the British Consulate General Hong Kong to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the British Consulate General Hong Kong](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-hong-kong/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British Consulate General Hong Kong](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-hong-kong/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.

--- a/test/artefacts/marriage-abroad/macao/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/macao/ceremony_country/partner_other/opposite_sex.txt
@@ -11,10 +11,10 @@ Contact the relevant local authorities in Macao to find out about local marriage
 You may be asked to provide an ‘affirmation for marriage’ document to prove you’re allowed to marry.
 
 
-Make an appointment at the British embassy or consulate in Hong Kong to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
+Make an appointment at the British Consulate General Hong Kong to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the British Consulate General Hong Kong](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-hong-kong/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British Consulate General Hong Kong](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-hong-kong/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.

--- a/test/artefacts/marriage-abroad/macao/third_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/macao/third_country/partner_british/opposite_sex.txt
@@ -11,10 +11,10 @@ Contact the relevant local authorities in Macao to find out about local marriage
 You may be asked to provide an ‘affirmation for marriage’ document to prove you’re allowed to marry.
 
 
-Make an appointment at the British embassy or consulate in Hong Kong to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
+Make an appointment at the British Consulate General Hong Kong to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the British Consulate General Hong Kong](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-hong-kong/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British Consulate General Hong Kong](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-hong-kong/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.

--- a/test/artefacts/marriage-abroad/macao/third_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/macao/third_country/partner_local/opposite_sex.txt
@@ -11,10 +11,10 @@ Contact the relevant local authorities in Macao to find out about local marriage
 You may be asked to provide an ‘affirmation for marriage’ document to prove you’re allowed to marry.
 
 
-Make an appointment at the British embassy or consulate in Hong Kong to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
+Make an appointment at the British Consulate General Hong Kong to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the British Consulate General Hong Kong](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-hong-kong/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British Consulate General Hong Kong](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-hong-kong/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.

--- a/test/artefacts/marriage-abroad/macao/third_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/macao/third_country/partner_other/opposite_sex.txt
@@ -11,10 +11,10 @@ Contact the relevant local authorities in Macao to find out about local marriage
 You may be asked to provide an ‘affirmation for marriage’ document to prove you’re allowed to marry.
 
 
-Make an appointment at the British embassy or consulate in Hong Kong to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
+Make an appointment at the British Consulate General Hong Kong to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the British Consulate General Hong Kong](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-hong-kong/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British Consulate General Hong Kong](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-hong-kong/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.

--- a/test/artefacts/marriage-abroad/macao/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/macao/uk/partner_british/opposite_sex.txt
@@ -11,10 +11,10 @@ Contact the [Embassy of Macao](/government/publications/foreign-embassies-in-the
 You may be asked to provide an ‘affirmation for marriage’ document to prove you’re allowed to marry.
 
 
-Make an appointment at the British embassy or consulate in Hong Kong to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
+Make an appointment at the British Consulate General Hong Kong to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the British Consulate General Hong Kong](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-hong-kong/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British Consulate General Hong Kong](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-hong-kong/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.

--- a/test/artefacts/marriage-abroad/macao/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/macao/uk/partner_local/opposite_sex.txt
@@ -11,10 +11,10 @@ Contact the [Embassy of Macao](/government/publications/foreign-embassies-in-the
 You may be asked to provide an ‘affirmation for marriage’ document to prove you’re allowed to marry.
 
 
-Make an appointment at the British embassy or consulate in Hong Kong to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
+Make an appointment at the British Consulate General Hong Kong to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the British Consulate General Hong Kong](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-hong-kong/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British Consulate General Hong Kong](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-hong-kong/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.

--- a/test/artefacts/marriage-abroad/macao/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/macao/uk/partner_other/opposite_sex.txt
@@ -11,10 +11,10 @@ Contact the [Embassy of Macao](/government/publications/foreign-embassies-in-the
 You may be asked to provide an ‘affirmation for marriage’ document to prove you’re allowed to marry.
 
 
-Make an appointment at the British embassy or consulate in Hong Kong to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
+Make an appointment at the British Consulate General Hong Kong to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the British Consulate General Hong Kong](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-hong-kong/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British Consulate General Hong Kong](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-hong-kong/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.

--- a/test/artefacts/marriage-abroad/mexico/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/mexico/ceremony_country/partner_british/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Mexico to find out about local marriag
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Mexico. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Mexico. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Mexico for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Mexico City.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-mexico-city/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Mexico City](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-mexico-city/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/mexico/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/mexico/ceremony_country/partner_local/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Mexico to find out about local marriag
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Mexico. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Mexico. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Mexico for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Mexico City.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-mexico-city/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Mexico City](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-mexico-city/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/mexico/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/mexico/ceremony_country/partner_other/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Mexico to find out about local marriag
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Mexico. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Mexico. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Mexico for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Mexico City.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-mexico-city/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Mexico City](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-mexico-city/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/montenegro/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/montenegro/ceremony_country/partner_british/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Montenegro to find out about local mar
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry. Contact the local notary public to check if you need a CNI.
 
 
-If you need a CNI, you must give notice of your intended marriage in Montenegro. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Montenegro. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Montenegro for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Podgorica.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-podgorica/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Podgorica](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-podgorica/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/montenegro/ceremony_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/montenegro/ceremony_country/partner_british/same_sex.txt
@@ -3,7 +3,7 @@ Same-sex marriage in Montenegro
 You may be able to get married at the British embassy or consulate in Montenegro.
 
 
-[Make an appointment at the embassy in Podgorica.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-podgorica/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Podgorica](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-podgorica/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 ##What documents you’ll need

--- a/test/artefacts/marriage-abroad/montenegro/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/montenegro/ceremony_country/partner_local/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Montenegro to find out about local mar
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry. Contact the local notary public to check if you need a CNI.
 
 
-If you need a CNI, you must give notice of your intended marriage in Montenegro. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Montenegro. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Montenegro for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Podgorica.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-podgorica/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Podgorica](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-podgorica/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/montenegro/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/montenegro/ceremony_country/partner_other/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Montenegro to find out about local mar
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry. Contact the local notary public to check if you need a CNI.
 
 
-If you need a CNI, you must give notice of your intended marriage in Montenegro. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Montenegro. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Montenegro for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Podgorica.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-podgorica/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Podgorica](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-podgorica/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/montenegro/third_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/montenegro/third_country/partner_british/same_sex.txt
@@ -3,7 +3,7 @@ Same-sex marriage in Montenegro
 You may be able to get married at the British embassy or consulate in Montenegro.
 
 
-[Make an appointment at the embassy in Podgorica.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-podgorica/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Podgorica](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-podgorica/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 ##What documents you’ll need

--- a/test/artefacts/marriage-abroad/montenegro/uk/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/montenegro/uk/partner_british/same_sex.txt
@@ -3,7 +3,7 @@ Same-sex marriage in Montenegro
 You may be able to get married at the British embassy or consulate in Montenegro.
 
 
-[Make an appointment at the embassy in Podgorica.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-podgorica/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Podgorica](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-podgorica/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 ##What documents you’ll need

--- a/test/artefacts/marriage-abroad/morocco/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/morocco/ceremony_country/partner_british/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Morocco to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Rabat.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rabat/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Rabat](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rabat/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ###Legalisation and translation

--- a/test/artefacts/marriage-abroad/morocco/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/morocco/ceremony_country/partner_local/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Morocco to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Rabat.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rabat/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Rabat](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rabat/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ###Legalisation and translation

--- a/test/artefacts/marriage-abroad/morocco/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/morocco/ceremony_country/partner_other/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Morocco to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Rabat.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rabat/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Rabat](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rabat/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ###Legalisation and translation

--- a/test/artefacts/marriage-abroad/morocco/third_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/morocco/third_country/partner_british/opposite_sex.txt
@@ -17,7 +17,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Morocco to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Rabat.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rabat/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Rabat](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rabat/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ###Legalisation and translation

--- a/test/artefacts/marriage-abroad/morocco/third_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/morocco/third_country/partner_local/opposite_sex.txt
@@ -17,7 +17,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Morocco to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Rabat.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rabat/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Rabat](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rabat/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ###Legalisation and translation

--- a/test/artefacts/marriage-abroad/morocco/third_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/morocco/third_country/partner_other/opposite_sex.txt
@@ -17,7 +17,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Morocco to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Rabat.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rabat/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Rabat](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rabat/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ###Legalisation and translation

--- a/test/artefacts/marriage-abroad/morocco/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/morocco/uk/partner_british/opposite_sex.txt
@@ -17,7 +17,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Morocco to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Rabat.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rabat/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Rabat](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rabat/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ###Legalisation and translation

--- a/test/artefacts/marriage-abroad/morocco/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/morocco/uk/partner_local/opposite_sex.txt
@@ -17,7 +17,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Morocco to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Rabat.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rabat/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Rabat](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rabat/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ###Legalisation and translation

--- a/test/artefacts/marriage-abroad/morocco/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/morocco/uk/partner_other/opposite_sex.txt
@@ -17,7 +17,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Morocco to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Rabat.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rabat/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Rabat](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rabat/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ###Legalisation and translation

--- a/test/artefacts/marriage-abroad/norway/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/norway/ceremony_country/partner_british/opposite_sex.txt
@@ -11,10 +11,10 @@ Contact the relevant local authorities in Norway to find out about local marriag
 You may be asked to provide an ‘affirmation for marriage’ document to prove you’re allowed to marry.
 
 
-Make an appointment at the local British embassy or consulate in Norway to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, a copy of your partner’s passport and pay a fee.
+Make an appointment at the British embassy in Oslo to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, a copy of your partner’s passport and pay a fee.
 
 
-[Make an appointment at the embassy in Oslo.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Oslo](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ###Legalisation and translation

--- a/test/artefacts/marriage-abroad/norway/ceremony_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/norway/ceremony_country/partner_british/same_sex.txt
@@ -17,10 +17,10 @@ Contact the relevant local authorities in Norway to find out about local laws, i
 You may be asked to provide an ‘affirmation for marriage’ document to prove you’re allowed to marry.
 
 
-Make an appointment at the local British embassy or consulate in Norway to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, a copy of your partner’s passport and pay a fee.
+Make an appointment at the British embassy in Oslo to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, a copy of your partner’s passport and pay a fee.
 
 
-[Make an appointment at the embassy in Oslo.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Oslo](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ^Your partner will need to get an affirmation as well.^

--- a/test/artefacts/marriage-abroad/norway/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/norway/ceremony_country/partner_local/opposite_sex.txt
@@ -11,10 +11,10 @@ Contact the relevant local authorities in Norway to find out about local marriag
 You may be asked to provide an ‘affirmation for marriage’ document to prove you’re allowed to marry.
 
 
-Make an appointment at the local British embassy or consulate in Norway to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, a copy of your partner’s passport and pay a fee.
+Make an appointment at the British embassy in Oslo to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, a copy of your partner’s passport and pay a fee.
 
 
-[Make an appointment at the embassy in Oslo.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Oslo](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ###Legalisation and translation

--- a/test/artefacts/marriage-abroad/norway/ceremony_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/norway/ceremony_country/partner_local/same_sex.txt
@@ -17,10 +17,10 @@ Contact the relevant local authorities in Norway to find out about local laws, i
 You may be asked to provide an ‘affirmation for marriage’ document to prove you’re allowed to marry.
 
 
-Make an appointment at the local British embassy or consulate in Norway to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, a copy of your partner’s passport and pay a fee.
+Make an appointment at the British embassy in Oslo to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, a copy of your partner’s passport and pay a fee.
 
 
-[Make an appointment at the embassy in Oslo.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Oslo](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ^Your partner will need to get an affirmation as well.^

--- a/test/artefacts/marriage-abroad/norway/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/norway/ceremony_country/partner_other/opposite_sex.txt
@@ -11,10 +11,10 @@ Contact the relevant local authorities in Norway to find out about local marriag
 You may be asked to provide an ‘affirmation for marriage’ document to prove you’re allowed to marry.
 
 
-Make an appointment at the local British embassy or consulate in Norway to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, a copy of your partner’s passport and pay a fee.
+Make an appointment at the British embassy in Oslo to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, a copy of your partner’s passport and pay a fee.
 
 
-[Make an appointment at the embassy in Oslo.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Oslo](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ###Legalisation and translation

--- a/test/artefacts/marriage-abroad/norway/ceremony_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/norway/ceremony_country/partner_other/same_sex.txt
@@ -17,10 +17,10 @@ Contact the relevant local authorities in Norway to find out about local laws, i
 You may be asked to provide an ‘affirmation for marriage’ document to prove you’re allowed to marry.
 
 
-Make an appointment at the local British embassy or consulate in Norway to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, a copy of your partner’s passport and pay a fee.
+Make an appointment at the British embassy in Oslo to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, a copy of your partner’s passport and pay a fee.
 
 
-[Make an appointment at the embassy in Oslo.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Oslo](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ^Your partner will need to get an affirmation as well.^

--- a/test/artefacts/marriage-abroad/norway/third_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/norway/third_country/partner_british/same_sex.txt
@@ -17,10 +17,10 @@ Contact the relevant local authorities in Norway to find out about local laws, i
 You may be asked to provide an ‘affirmation for marriage’ document to prove you’re allowed to marry.
 
 
-Make an appointment at the local British embassy or consulate in Norway to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, a copy of your partner’s passport and pay a fee.
+Make an appointment at the British embassy in Oslo to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, a copy of your partner’s passport and pay a fee.
 
 
-[Make an appointment at the embassy in Oslo.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Oslo](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ^Your partner will need to get an affirmation as well.^

--- a/test/artefacts/marriage-abroad/norway/third_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/norway/third_country/partner_local/same_sex.txt
@@ -17,10 +17,10 @@ Contact the relevant local authorities in Norway to find out about local laws, i
 You may be asked to provide an ‘affirmation for marriage’ document to prove you’re allowed to marry.
 
 
-Make an appointment at the local British embassy or consulate in Norway to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, a copy of your partner’s passport and pay a fee.
+Make an appointment at the British embassy in Oslo to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, a copy of your partner’s passport and pay a fee.
 
 
-[Make an appointment at the embassy in Oslo.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Oslo](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ^Your partner will need to get an affirmation as well.^

--- a/test/artefacts/marriage-abroad/norway/third_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/norway/third_country/partner_other/same_sex.txt
@@ -17,10 +17,10 @@ Contact the relevant local authorities in Norway to find out about local laws, i
 You may be asked to provide an ‘affirmation for marriage’ document to prove you’re allowed to marry.
 
 
-Make an appointment at the local British embassy or consulate in Norway to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, a copy of your partner’s passport and pay a fee.
+Make an appointment at the British embassy in Oslo to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, a copy of your partner’s passport and pay a fee.
 
 
-[Make an appointment at the embassy in Oslo.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Oslo](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ^Your partner will need to get an affirmation as well.^

--- a/test/artefacts/marriage-abroad/norway/uk/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/norway/uk/partner_british/same_sex.txt
@@ -17,10 +17,10 @@ Contact the [Embassy of Norway](/government/publications/foreign-embassies-in-th
 You may be asked to provide an ‘affirmation for marriage’ document to prove you’re allowed to marry.
 
 
-Make an appointment at the local British embassy or consulate in Norway to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, a copy of your partner’s passport and pay a fee.
+Make an appointment at the British embassy in Oslo to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, a copy of your partner’s passport and pay a fee.
 
 
-[Make an appointment at the embassy in Oslo.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Oslo](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ^Your partner will need to get an affirmation as well.^

--- a/test/artefacts/marriage-abroad/norway/uk/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/norway/uk/partner_local/same_sex.txt
@@ -17,10 +17,10 @@ Contact the [Embassy of Norway](/government/publications/foreign-embassies-in-th
 You may be asked to provide an ‘affirmation for marriage’ document to prove you’re allowed to marry.
 
 
-Make an appointment at the local British embassy or consulate in Norway to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, a copy of your partner’s passport and pay a fee.
+Make an appointment at the British embassy in Oslo to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, a copy of your partner’s passport and pay a fee.
 
 
-[Make an appointment at the embassy in Oslo.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Oslo](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ^Your partner will need to get an affirmation as well.^

--- a/test/artefacts/marriage-abroad/norway/uk/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/norway/uk/partner_other/same_sex.txt
@@ -17,10 +17,10 @@ Contact the [Embassy of Norway](/government/publications/foreign-embassies-in-th
 You may be asked to provide an ‘affirmation for marriage’ document to prove you’re allowed to marry.
 
 
-Make an appointment at the local British embassy or consulate in Norway to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, a copy of your partner’s passport and pay a fee.
+Make an appointment at the British embassy in Oslo to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, a copy of your partner’s passport and pay a fee.
 
 
-[Make an appointment at the embassy in Oslo.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Oslo](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ^Your partner will need to get an affirmation as well.^

--- a/test/artefacts/marriage-abroad/oman/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/oman/ceremony_country/partner_british/opposite_sex.txt
@@ -23,7 +23,7 @@ You need to have been living in the country where you intend to marry for 21 ful
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Oman. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Oman. You must do this at the British embassy or in front of a notary public in that country.
 
 
 

--- a/test/artefacts/marriage-abroad/oman/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/oman/ceremony_country/partner_local/opposite_sex.txt
@@ -23,7 +23,7 @@ You need to have been living in the country where you intend to marry for 21 ful
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Oman. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Oman. You must do this at the British embassy or in front of a notary public in that country.
 
 
 

--- a/test/artefacts/marriage-abroad/oman/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/oman/ceremony_country/partner_other/opposite_sex.txt
@@ -23,7 +23,7 @@ You need to have been living in the country where you intend to marry for 21 ful
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Oman. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Oman. You must do this at the British embassy or in front of a notary public in that country.
 
 
 

--- a/test/artefacts/marriage-abroad/peru/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/peru/ceremony_country/partner_british/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Peru to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Lima.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Lima](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ###Legalisation and translation

--- a/test/artefacts/marriage-abroad/peru/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/peru/ceremony_country/partner_local/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Peru to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Lima.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Lima](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ###Legalisation and translation

--- a/test/artefacts/marriage-abroad/peru/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/peru/ceremony_country/partner_other/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Peru to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Lima.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Lima](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ###Legalisation and translation

--- a/test/artefacts/marriage-abroad/peru/third_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/peru/third_country/partner_british/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Peru to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Lima.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Lima](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ###Legalisation and translation

--- a/test/artefacts/marriage-abroad/peru/third_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/peru/third_country/partner_local/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Peru to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Lima.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Lima](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ###Legalisation and translation

--- a/test/artefacts/marriage-abroad/peru/third_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/peru/third_country/partner_other/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Peru to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Lima.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Lima](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ###Legalisation and translation

--- a/test/artefacts/marriage-abroad/peru/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/peru/uk/partner_british/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Peru to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Lima.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Lima](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ###Legalisation and translation

--- a/test/artefacts/marriage-abroad/peru/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/peru/uk/partner_local/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Peru to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Lima.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Lima](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ###Legalisation and translation

--- a/test/artefacts/marriage-abroad/peru/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/peru/uk/partner_other/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Peru to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Lima.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Lima](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ###Legalisation and translation

--- a/test/artefacts/marriage-abroad/philippines/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/philippines/ceremony_country/partner_british/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Contact the local British embassy or consulate in the Philippines to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Manila.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-manila/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Manila](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-manila/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/philippines/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/philippines/ceremony_country/partner_local/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Contact the local British embassy or consulate in the Philippines to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Manila.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-manila/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Manila](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-manila/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/philippines/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/philippines/ceremony_country/partner_other/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Contact the local British embassy or consulate in the Philippines to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Manila.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-manila/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Manila](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-manila/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/philippines/third_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/philippines/third_country/partner_british/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Contact the local British embassy or consulate in the Philippines to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Manila.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-manila/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Manila](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-manila/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/philippines/third_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/philippines/third_country/partner_local/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Contact the local British embassy or consulate in the Philippines to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Manila.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-manila/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Manila](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-manila/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/philippines/third_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/philippines/third_country/partner_other/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Contact the local British embassy or consulate in the Philippines to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Manila.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-manila/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Manila](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-manila/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/philippines/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/philippines/uk/partner_british/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Contact the local British embassy or consulate in the Philippines to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Manila.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-manila/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Manila](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-manila/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/philippines/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/philippines/uk/partner_local/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Contact the local British embassy or consulate in the Philippines to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Manila.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-manila/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Manila](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-manila/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/philippines/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/philippines/uk/partner_other/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Contact the local British embassy or consulate in the Philippines to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Manila.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-manila/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Manila](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-manila/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/poland/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/poland/ceremony_country/partner_british/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Poland to find out about local marriag
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Poland. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Poland. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Poland for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Warsaw.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-warsaw/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Warsaw](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-warsaw/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/poland/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/poland/ceremony_country/partner_local/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Poland to find out about local marriag
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Poland. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Poland. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Poland for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Warsaw.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-warsaw/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Warsaw](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-warsaw/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/poland/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/poland/ceremony_country/partner_other/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Poland to find out about local marriag
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Poland. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Poland. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Poland for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Warsaw.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-warsaw/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Warsaw](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-warsaw/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/russia/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/russia/ceremony_country/partner_british/opposite_sex.txt
@@ -18,12 +18,12 @@ If you need a CNI, you’ll first need to give notice of your intended marriage 
 
 You’ll need to have been living in the Russian Federation for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-You can then book an appointment at the consulate in the district you’re living, to give notice of your marriage.
+You can then book an appointment at the consulate in the district you’re living in, to give notice of your marriage.
 
 
-[Make an appointment at the embassy in Moscow.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-moscow/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Moscow](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-moscow/notice-of-marriage-or-civil-partnership/slot_picker).
 
-[Make an appointment at the embassy in St Petersburg.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-st-petersburg/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in St Petersburg](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-st-petersburg/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/russia/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/russia/ceremony_country/partner_local/opposite_sex.txt
@@ -18,12 +18,12 @@ If you need a CNI, you’ll first need to give notice of your intended marriage 
 
 You’ll need to have been living in the Russian Federation for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-You can then book an appointment at the consulate in the district you’re living, to give notice of your marriage.
+You can then book an appointment at the consulate in the district you’re living in, to give notice of your marriage.
 
 
-[Make an appointment at the embassy in Moscow.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-moscow/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Moscow](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-moscow/notice-of-marriage-or-civil-partnership/slot_picker).
 
-[Make an appointment at the embassy in St Petersburg.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-st-petersburg/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in St Petersburg](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-st-petersburg/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/russia/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/russia/ceremony_country/partner_other/opposite_sex.txt
@@ -18,12 +18,12 @@ If you need a CNI, you’ll first need to give notice of your intended marriage 
 
 You’ll need to have been living in the Russian Federation for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-You can then book an appointment at the consulate in the district you’re living, to give notice of your marriage.
+You can then book an appointment at the consulate in the district you’re living in, to give notice of your marriage.
 
 
-[Make an appointment at the embassy in Moscow.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-moscow/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Moscow](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-moscow/notice-of-marriage-or-civil-partnership/slot_picker).
 
-[Make an appointment at the embassy in St Petersburg.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-st-petersburg/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in St Petersburg](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-st-petersburg/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/serbia/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/serbia/ceremony_country/partner_british/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Serbia to find out about local marriag
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Serbia. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Serbia. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Serbia for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Belgrade.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-belgrade/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Belgrade](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-belgrade/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/serbia/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/serbia/ceremony_country/partner_local/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Serbia to find out about local marriag
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Serbia. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Serbia. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Serbia for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Belgrade.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-belgrade/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Belgrade](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-belgrade/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/serbia/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/serbia/ceremony_country/partner_other/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Serbia to find out about local marriag
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Serbia. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Serbia. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Serbia for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Belgrade.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-belgrade/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Belgrade](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-belgrade/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_british/opposite_sex.txt
@@ -17,7 +17,7 @@ You may be asked to provide a certificate of no impediment (CNI), marital status
 ^You may also need to get a marital status certificate if you’re living with your partner and want to get a ‘[pareja de hecho](/notarial-and-documentary-services-guide-for-spain#marital-status-certificate-for-pareja-de-hecho)’ (cohabitation registration).^
 
 
-If you need a CNI, you must give notice of your intended marriage in Spain. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Spain. You must do this at the British embassy or in front of a notary public in that country.
 
 
 The documents you need are:

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_british/same_sex.txt
@@ -17,7 +17,7 @@ You may be asked to provide a certificate of no impediment (CNI), marital status
 ^You may also need to get a marital status certificate if you’re living with your partner and want to get a ‘[pareja de hecho](/notarial-and-documentary-services-guide-for-spain#marital-status-certificate-for-pareja-de-hecho)’ (cohabitation registration).^
 
 
-If you need a CNI, you must give notice of your intended marriage in Spain. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Spain. You must do this at the British embassy or in front of a notary public in that country.
 
 
 The documents you need are:

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_local/opposite_sex.txt
@@ -17,7 +17,7 @@ You may be asked to provide a certificate of no impediment (CNI), marital status
 ^You may also need to get a marital status certificate if you’re living with your partner and want to get a ‘[pareja de hecho](/notarial-and-documentary-services-guide-for-spain#marital-status-certificate-for-pareja-de-hecho)’ (cohabitation registration).^
 
 
-If you need a CNI, you must give notice of your intended marriage in Spain. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Spain. You must do this at the British embassy or in front of a notary public in that country.
 
 
 The documents you need are:

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_local/same_sex.txt
@@ -17,7 +17,7 @@ You may be asked to provide a certificate of no impediment (CNI), marital status
 ^You may also need to get a marital status certificate if you’re living with your partner and want to get a ‘[pareja de hecho](/notarial-and-documentary-services-guide-for-spain#marital-status-certificate-for-pareja-de-hecho)’ (cohabitation registration).^
 
 
-If you need a CNI, you must give notice of your intended marriage in Spain. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Spain. You must do this at the British embassy or in front of a notary public in that country.
 
 
 The documents you need are:

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_other/opposite_sex.txt
@@ -17,7 +17,7 @@ You may be asked to provide a certificate of no impediment (CNI), marital status
 ^You may also need to get a marital status certificate if you’re living with your partner and want to get a ‘[pareja de hecho](/notarial-and-documentary-services-guide-for-spain#marital-status-certificate-for-pareja-de-hecho)’ (cohabitation registration).^
 
 
-If you need a CNI, you must give notice of your intended marriage in Spain. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Spain. You must do this at the British embassy or in front of a notary public in that country.
 
 
 The documents you need are:

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_other/same_sex.txt
@@ -17,7 +17,7 @@ You may be asked to provide a certificate of no impediment (CNI), marital status
 ^You may also need to get a marital status certificate if you’re living with your partner and want to get a ‘[pareja de hecho](/notarial-and-documentary-services-guide-for-spain#marital-status-certificate-for-pareja-de-hecho)’ (cohabitation registration).^
 
 
-If you need a CNI, you must give notice of your intended marriage in Spain. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Spain. You must do this at the British embassy or in front of a notary public in that country.
 
 
 The documents you need are:

--- a/test/artefacts/marriage-abroad/sweden/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/sweden/ceremony_country/partner_british/opposite_sex.txt
@@ -12,7 +12,7 @@ Contact the relevant local authorities in Sweden to find out about local marriag
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Sweden. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Sweden. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Sweden for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.

--- a/test/artefacts/marriage-abroad/sweden/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/sweden/ceremony_country/partner_local/opposite_sex.txt
@@ -12,7 +12,7 @@ Contact the relevant local authorities in Sweden to find out about local marriag
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Sweden. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Sweden. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Sweden for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.

--- a/test/artefacts/marriage-abroad/sweden/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/sweden/ceremony_country/partner_other/opposite_sex.txt
@@ -12,7 +12,7 @@ Contact the relevant local authorities in Sweden to find out about local marriag
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Sweden. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Sweden. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Sweden for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.

--- a/test/artefacts/marriage-abroad/thailand/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/thailand/ceremony_country/partner_british/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Thailand to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Bangkok.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bangkok/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Bangkok](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bangkok/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ###Legalisation and translation

--- a/test/artefacts/marriage-abroad/thailand/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/thailand/ceremony_country/partner_local/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Thailand to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Bangkok.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bangkok/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Bangkok](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bangkok/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ###Legalisation and translation

--- a/test/artefacts/marriage-abroad/thailand/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/thailand/ceremony_country/partner_other/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Thailand to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Bangkok.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bangkok/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Bangkok](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bangkok/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ###Legalisation and translation

--- a/test/artefacts/marriage-abroad/thailand/third_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/thailand/third_country/partner_british/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Thailand to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Bangkok.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bangkok/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Bangkok](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bangkok/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ###Legalisation and translation

--- a/test/artefacts/marriage-abroad/thailand/third_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/thailand/third_country/partner_local/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Thailand to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Bangkok.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bangkok/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Bangkok](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bangkok/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ###Legalisation and translation

--- a/test/artefacts/marriage-abroad/thailand/third_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/thailand/third_country/partner_other/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Thailand to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Bangkok.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bangkok/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Bangkok](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bangkok/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ###Legalisation and translation

--- a/test/artefacts/marriage-abroad/thailand/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/thailand/uk/partner_british/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Thailand to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Bangkok.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bangkok/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Bangkok](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bangkok/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ###Legalisation and translation

--- a/test/artefacts/marriage-abroad/thailand/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/thailand/uk/partner_local/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Thailand to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Bangkok.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bangkok/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Bangkok](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bangkok/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ###Legalisation and translation

--- a/test/artefacts/marriage-abroad/thailand/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/thailand/uk/partner_other/opposite_sex.txt
@@ -14,7 +14,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 Make an appointment at the local British embassy or consulate in Thailand to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the embassy in Bangkok.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bangkok/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Bangkok](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bangkok/oaths-affirmations-and-affidavits/slot_picker).
 
 
 ###Legalisation and translation

--- a/test/artefacts/marriage-abroad/tunisia/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/tunisia/ceremony_country/partner_british/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Tunisia to find out about local marria
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Tunisia. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Tunisia. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Tunisia for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Tunis.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tunis](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/tunisia/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/tunisia/ceremony_country/partner_local/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Tunisia to find out about local marria
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Tunisia. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Tunisia. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Tunisia for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Tunis.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tunis](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/tunisia/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/tunisia/ceremony_country/partner_other/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Tunisia to find out about local marria
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Tunisia. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Tunisia. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Tunisia for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Tunis.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tunis](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/turkey/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/turkey/ceremony_country/partner_british/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Turkey to find out about local marriag
 Make an appointment at the local British embassy or consulate in Turkey to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the British Consulate General Istanbul](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-istanbul/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British Consulate General Istanbul](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-istanbul/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the embassy in Ankara](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ankara/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Ankara](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ankara/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the consulate in Izmir](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-izmir/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the consulate in Izmir](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-izmir/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the consulate in Antalya](https://www.consular-appointments.service.gov.uk/fco/#!/british-vice-consulate-antalya/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the consulate in Antalya](https://www.consular-appointments.service.gov.uk/fco/#!/british-vice-consulate-antalya/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affidavit for marriage’ form that will be used for your affidavit. Take the completed form with you to your appointment.

--- a/test/artefacts/marriage-abroad/turkey/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/turkey/ceremony_country/partner_local/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Turkey to find out about local marriag
 Make an appointment at the local British embassy or consulate in Turkey to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the British Consulate General Istanbul](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-istanbul/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British Consulate General Istanbul](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-istanbul/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the embassy in Ankara](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ankara/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Ankara](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ankara/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the consulate in Izmir](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-izmir/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the consulate in Izmir](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-izmir/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the consulate in Antalya](https://www.consular-appointments.service.gov.uk/fco/#!/british-vice-consulate-antalya/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the consulate in Antalya](https://www.consular-appointments.service.gov.uk/fco/#!/british-vice-consulate-antalya/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affidavit for marriage’ form that will be used for your affidavit. Take the completed form with you to your appointment.

--- a/test/artefacts/marriage-abroad/turkey/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/turkey/ceremony_country/partner_other/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Turkey to find out about local marriag
 Make an appointment at the local British embassy or consulate in Turkey to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the British Consulate General Istanbul](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-istanbul/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British Consulate General Istanbul](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-istanbul/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the embassy in Ankara](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ankara/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Ankara](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ankara/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the consulate in Izmir](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-izmir/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the consulate in Izmir](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-izmir/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the consulate in Antalya](https://www.consular-appointments.service.gov.uk/fco/#!/british-vice-consulate-antalya/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the consulate in Antalya](https://www.consular-appointments.service.gov.uk/fco/#!/british-vice-consulate-antalya/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affidavit for marriage’ form that will be used for your affidavit. Take the completed form with you to your appointment.

--- a/test/artefacts/marriage-abroad/turkey/third_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/turkey/third_country/partner_british/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Turkey to find out about local marriag
 Make an appointment at the local British embassy or consulate in Turkey to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the British Consulate General Istanbul](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-istanbul/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British Consulate General Istanbul](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-istanbul/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the embassy in Ankara](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ankara/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Ankara](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ankara/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the consulate in Izmir](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-izmir/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the consulate in Izmir](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-izmir/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the consulate in Antalya](https://www.consular-appointments.service.gov.uk/fco/#!/british-vice-consulate-antalya/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the consulate in Antalya](https://www.consular-appointments.service.gov.uk/fco/#!/british-vice-consulate-antalya/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affidavit for marriage’ form that will be used for your affidavit. Take the completed form with you to your appointment.

--- a/test/artefacts/marriage-abroad/turkey/third_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/turkey/third_country/partner_local/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Turkey to find out about local marriag
 Make an appointment at the local British embassy or consulate in Turkey to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the British Consulate General Istanbul](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-istanbul/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British Consulate General Istanbul](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-istanbul/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the embassy in Ankara](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ankara/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Ankara](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ankara/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the consulate in Izmir](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-izmir/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the consulate in Izmir](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-izmir/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the consulate in Antalya](https://www.consular-appointments.service.gov.uk/fco/#!/british-vice-consulate-antalya/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the consulate in Antalya](https://www.consular-appointments.service.gov.uk/fco/#!/british-vice-consulate-antalya/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affidavit for marriage’ form that will be used for your affidavit. Take the completed form with you to your appointment.

--- a/test/artefacts/marriage-abroad/turkey/third_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/turkey/third_country/partner_other/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Turkey to find out about local marriag
 Make an appointment at the local British embassy or consulate in Turkey to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
-[Make an appointment at the British Consulate General Istanbul](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-istanbul/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British Consulate General Istanbul](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-istanbul/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the embassy in Ankara](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ankara/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Ankara](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ankara/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the consulate in Izmir](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-izmir/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the consulate in Izmir](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-izmir/oaths-affirmations-and-affidavits/slot_picker).
 
-[Make an appointment at the consulate in Antalya](https://www.consular-appointments.service.gov.uk/fco/#!/british-vice-consulate-antalya/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the consulate in Antalya](https://www.consular-appointments.service.gov.uk/fco/#!/british-vice-consulate-antalya/oaths-affirmations-and-affidavits/slot_picker).
 
 
 You’ll need to complete an ‘Affidavit for marriage’ form that will be used for your affidavit. Take the completed form with you to your appointment.

--- a/test/artefacts/marriage-abroad/turkmenistan/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/turkmenistan/ceremony_country/partner_british/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Turkmenistan to find out about local m
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Turkmenistan. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Turkmenistan. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Turkmenistan for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Ashgabat.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ashgabat/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Ashgabat](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ashgabat/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/turkmenistan/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/turkmenistan/ceremony_country/partner_local/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Turkmenistan to find out about local m
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Turkmenistan. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Turkmenistan. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Turkmenistan for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Ashgabat.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ashgabat/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Ashgabat](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ashgabat/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/turkmenistan/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/turkmenistan/ceremony_country/partner_other/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Turkmenistan to find out about local m
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Turkmenistan. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Turkmenistan. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Turkmenistan for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Ashgabat.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ashgabat/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Ashgabat](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ashgabat/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/uzbekistan/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/uzbekistan/ceremony_country/partner_british/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Uzbekistan to find out about local mar
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Uzbekistan. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Uzbekistan. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Uzbekistan for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Tashkent.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tashkent/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tashkent](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tashkent/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/uzbekistan/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/uzbekistan/ceremony_country/partner_local/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Uzbekistan to find out about local mar
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Uzbekistan. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Uzbekistan. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Uzbekistan for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Tashkent.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tashkent/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tashkent](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tashkent/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/artefacts/marriage-abroad/uzbekistan/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/uzbekistan/ceremony_country/partner_other/opposite_sex.txt
@@ -12,13 +12,13 @@ Contact the relevant local authorities in Uzbekistan to find out about local mar
 You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
 
 
-If you need a CNI, you must give notice of your intended marriage in Uzbekistan. You must do this at a British embassy or in front of a notary public in that country.
+If you need a CNI, you must give notice of your intended marriage in Uzbekistan. You must do this at the British embassy or in front of a notary public in that country.
 
 
 You need to have been living in Uzbekistan for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 
-[Make an appointment at the embassy in Tashkent.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tashkent/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tashkent](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tashkent/notice-of-marriage-or-civil-partnership/slot_picker).
 
 
 You’ll need to provide supporting documents, including:

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -1,6 +1,6 @@
 --- 
 lib/smart_answer_flows/marriage-abroad.rb: a6205b8ae7faddc4a67f7b83134a4a43
-lib/smart_answer_flows/locales/en/marriage-abroad.yml: f048eee5559d8de8bb3dd6ee4be7efd5
+lib/smart_answer_flows/locales/en/marriage-abroad.yml: e1598d46109a3a02d33eab5f5b881283
 test/data/marriage-abroad-questions-and-responses.yml: eabbd09ca91fab72a9a520d1087fb35e
 test/data/marriage-abroad-responses-and-expected-results.yml: e2a77265651bd20a9892bde75f375e82
 lib/smart_answer_flows/data_partials/_overseas_passports_embassies.erb: 2f521bae99c2f48b49d07bcb283a8063


### PR DESCRIPTION
This addresses feedback from fact check that is related to appointment booking.

Summary:
- use punctuation in appointment booking links consistently
- use city names in appointment booking links consistently
- refer users to concrete institutions for countries that have their own phrases. (For other countries a generic institution name with an interpolated country name is used.)
- stylistic changes and typo fixes