### PR TITLE
Remove unreachable code from calculate-statutory-sick-pay

### DIFF
--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -146,13 +146,5 @@ module SmartAnswer::Calculators
       ## 2. return only the first days_that_can_be_paid_for_this_period
       payable_days_temp.shift(days_that_can_be_paid_for_this_period)
     end
-
-    def find_6th_april_after(date)
-      year = date.year
-      if (date.month > 4) or (date.month == 4 and date.day > 6)
-        year += 1
-      end
-      Date.new(year, 4, 6)
-    end
   end
 end

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -251,17 +251,10 @@ module SmartAnswer
         end
 
         # Answer 8
-        next_node_if(:maximum_entitlement_reached) do |response|
-          days_worked = response.split(',').size
-
-          prior_sick_days and prior_sick_days.to_i >= (days_worked * 28 + 3)
-        end
+        next_node_if(:maximum_entitlement_reached) { calculator.days_that_can_be_paid_for_this_period == 0 }
 
         # Answer 6
         next_node_if(:entitled_to_sick_pay) { calculator.ssp_payment > 0 }
-
-        # Answer 8
-        next_node_if(:maximum_entitlement_reached) { calculator.days_that_can_be_paid_for_this_period == 0 }
 
         # Answer 7
         next_node(:not_entitled_3_days_not_paid)


### PR DESCRIPTION
The `days_that_can_be_paid_for_this_period` method was introduced into
`SmartAnswer::Calculators::StatutorySickPayCalculator` in [this commit][1].
At this point it was being used in the `entitled_or_not_enough_days` outcome
to determine what `outcome_text` was to be displayed.

In a (considerably) [later commit][2], a new `next_node_if` block was added to
the `usual_work_days?` question which directed the user to the
`maximum_entitlement_reached` outcome depending on whether the value returned
by the `days_that_can_be_paid_for_this_period` method was zero.

However, this effectively duplicated an existing `next_node_if` block which
already did (effectively) the same calculation and directed the user to the
same `maximum_entitlement_reached` outcome. Thus the condition for the new
`next_node_if` block was could never be satisfied.

Unfortunately there are no clues in the tests or git history which explain what
the intention was. I've elected to replace the older `next_node_if` block with
the more recent one, because this looks as if what was intended. Note that the
calculation in the newer version of the code (in the calculator object) does a
rounding which the older version doesn't.

The integration test which covers the `maximum_entitlement_reached` outcome
continues to work after this change, so I'm reasonably confident nothing has
gone awry. However, I've emailed @lutgendorff to check that this approach is
OK.

[1]: 3c1c42c0f2289c4a482ab7dc9d035d401baa770c
[2]: 89812f9c5515b1731751dbb26e2c9e7e26d657a5