### PR TITLE
Marriage abroad FC feedback. Thailand

### DIFF
--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -178,6 +178,10 @@ en-GB:
 # "what you need to do" phrases
         what_you_need_to_do: |
           ##What you need to do
+        what_you_need_to_do_affirmation_or_affidavit: |
+          ##What you need to do
+
+          You may be asked to provide an ‘Affirmation for marriage’ (non-religious) or an ‘Affidavit for marriage’ (religious) document to prove you’re allowed to marry.
         what_you_need_to_do_affirmation: |
           ##What you need to do
 
@@ -232,6 +236,8 @@ en-GB:
           Contact the British embassy or consulate in %{country_name_lowercase_prefix} to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
         appointment_for_affidavit: |
           Make an appointment at the British embassy or consulate in %{country_name_lowercase_prefix} to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
+        appointment_for_affirmation_or_affidavit: |
+          Make an appointment at the British embassy or consulate in %{country_name_lowercase_prefix} to swear an affirmation or affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
         appointment_for_affidavit_in_hong_kong: |
           Make an appointment at the British Consulate General Hong Kong to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
         appointment_for_affidavit_norway: |
@@ -253,6 +259,8 @@ en-GB:
           ^Your partner will need to get an affidavit as well.^
         affirmation_os_translation_in_local_language_text: |
           You might need to get your affirmation [translated](/government/collections/list-of-lawyers) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
+        affirmation_or_affidavit_os_translation_in_local_language_text: |
+          You might need to get your affirmation or affidavit [translated](/government/collections/list-of-lawyers) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
 
 # fee tables
         fee_table_45_70_55: |

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -951,6 +951,8 @@ module SmartAnswer
             phrases << :what_you_need_to_do
           elsif data_query.os_21_days_residency_required_countries?(ceremony_country)
             phrases << :what_you_need_to_do_affirmation_21_days
+          elsif ceremony_country == 'thailand'
+            phrases << :what_you_need_to_do_affirmation_or_affidavit
           else
             phrases << :what_you_need_to_do_affirmation
           end
@@ -970,6 +972,8 @@ module SmartAnswer
             phrases << :appointment_for_affidavit_norway
           elsif ceremony_country == 'macao'
             phrases << :appointment_for_affidavit_in_hong_kong
+          elsif ceremony_country == 'thailand'
+            phrases << :appointment_for_affirmation_or_affidavit
           else
             phrases << :appointment_for_affidavit
           end
@@ -1008,7 +1012,11 @@ module SmartAnswer
               end
             else
               phrases << :legalisation_and_translation
-              phrases << :affirmation_os_translation_in_local_language_text
+              if ceremony_country == 'thailand'
+                phrases << :affirmation_or_affidavit_os_translation_in_local_language_text
+              else
+                phrases << :affirmation_os_translation_in_local_language_text
+              end
             end
           end
           if ceremony_country == 'philippines'

--- a/test/artefacts/marriage-abroad/thailand/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/thailand/ceremony_country/partner_british/opposite_sex.txt
@@ -8,10 +8,10 @@ Contact the relevant local authorities in Thailand to find out about local marri
 
 ##What you need to do
 
-You may be asked to provide an ‘affirmation for marriage’ document to prove you’re allowed to marry.
+You may be asked to provide an ‘Affirmation for marriage’ (non-religious) or an ‘Affidavit for marriage’ (religious) document to prove you’re allowed to marry.
 
 
-Make an appointment at the British embassy or consulate in Thailand to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
+Make an appointment at the British embassy or consulate in Thailand to swear an affirmation or affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
 [Make an appointment at the embassy in Bangkok](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bangkok/oaths-affirmations-and-affidavits/slot_picker).
@@ -20,7 +20,7 @@ Make an appointment at the British embassy or consulate in Thailand to swear an 
 ###Legalisation and translation
 
 
-You might need to get your affirmation [translated](/government/collections/list-of-lawyers) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
+You might need to get your affirmation or affidavit [translated](/government/collections/list-of-lawyers) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
 
 
 If you’ve been divorced or widowed, you’ll also need:

--- a/test/artefacts/marriage-abroad/thailand/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/thailand/ceremony_country/partner_local/opposite_sex.txt
@@ -8,10 +8,10 @@ Contact the relevant local authorities in Thailand to find out about local marri
 
 ##What you need to do
 
-You may be asked to provide an ‘affirmation for marriage’ document to prove you’re allowed to marry.
+You may be asked to provide an ‘Affirmation for marriage’ (non-religious) or an ‘Affidavit for marriage’ (religious) document to prove you’re allowed to marry.
 
 
-Make an appointment at the British embassy or consulate in Thailand to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
+Make an appointment at the British embassy or consulate in Thailand to swear an affirmation or affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
 [Make an appointment at the embassy in Bangkok](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bangkok/oaths-affirmations-and-affidavits/slot_picker).
@@ -20,7 +20,7 @@ Make an appointment at the British embassy or consulate in Thailand to swear an 
 ###Legalisation and translation
 
 
-You might need to get your affirmation [translated](/government/collections/list-of-lawyers) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
+You might need to get your affirmation or affidavit [translated](/government/collections/list-of-lawyers) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
 
 
 If you’ve been divorced or widowed, you’ll also need:

--- a/test/artefacts/marriage-abroad/thailand/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/thailand/ceremony_country/partner_other/opposite_sex.txt
@@ -8,10 +8,10 @@ Contact the relevant local authorities in Thailand to find out about local marri
 
 ##What you need to do
 
-You may be asked to provide an ‘affirmation for marriage’ document to prove you’re allowed to marry.
+You may be asked to provide an ‘Affirmation for marriage’ (non-religious) or an ‘Affidavit for marriage’ (religious) document to prove you’re allowed to marry.
 
 
-Make an appointment at the British embassy or consulate in Thailand to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
+Make an appointment at the British embassy or consulate in Thailand to swear an affirmation or affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
 [Make an appointment at the embassy in Bangkok](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bangkok/oaths-affirmations-and-affidavits/slot_picker).
@@ -20,7 +20,7 @@ Make an appointment at the British embassy or consulate in Thailand to swear an 
 ###Legalisation and translation
 
 
-You might need to get your affirmation [translated](/government/collections/list-of-lawyers) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
+You might need to get your affirmation or affidavit [translated](/government/collections/list-of-lawyers) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
 
 
 If you’ve been divorced or widowed, you’ll also need:

--- a/test/artefacts/marriage-abroad/thailand/third_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/thailand/third_country/partner_british/opposite_sex.txt
@@ -8,10 +8,10 @@ Contact the relevant local authorities in Thailand to find out about local marri
 
 ##What you need to do
 
-You may be asked to provide an ‘affirmation for marriage’ document to prove you’re allowed to marry.
+You may be asked to provide an ‘Affirmation for marriage’ (non-religious) or an ‘Affidavit for marriage’ (religious) document to prove you’re allowed to marry.
 
 
-Make an appointment at the British embassy or consulate in Thailand to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
+Make an appointment at the British embassy or consulate in Thailand to swear an affirmation or affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
 [Make an appointment at the embassy in Bangkok](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bangkok/oaths-affirmations-and-affidavits/slot_picker).
@@ -20,7 +20,7 @@ Make an appointment at the British embassy or consulate in Thailand to swear an 
 ###Legalisation and translation
 
 
-You might need to get your affirmation [translated](/government/collections/list-of-lawyers) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
+You might need to get your affirmation or affidavit [translated](/government/collections/list-of-lawyers) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
 
 
 If you’ve been divorced or widowed, you’ll also need:

--- a/test/artefacts/marriage-abroad/thailand/third_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/thailand/third_country/partner_local/opposite_sex.txt
@@ -8,10 +8,10 @@ Contact the relevant local authorities in Thailand to find out about local marri
 
 ##What you need to do
 
-You may be asked to provide an ‘affirmation for marriage’ document to prove you’re allowed to marry.
+You may be asked to provide an ‘Affirmation for marriage’ (non-religious) or an ‘Affidavit for marriage’ (religious) document to prove you’re allowed to marry.
 
 
-Make an appointment at the British embassy or consulate in Thailand to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
+Make an appointment at the British embassy or consulate in Thailand to swear an affirmation or affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
 [Make an appointment at the embassy in Bangkok](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bangkok/oaths-affirmations-and-affidavits/slot_picker).
@@ -20,7 +20,7 @@ Make an appointment at the British embassy or consulate in Thailand to swear an 
 ###Legalisation and translation
 
 
-You might need to get your affirmation [translated](/government/collections/list-of-lawyers) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
+You might need to get your affirmation or affidavit [translated](/government/collections/list-of-lawyers) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
 
 
 If you’ve been divorced or widowed, you’ll also need:

--- a/test/artefacts/marriage-abroad/thailand/third_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/thailand/third_country/partner_other/opposite_sex.txt
@@ -8,10 +8,10 @@ Contact the relevant local authorities in Thailand to find out about local marri
 
 ##What you need to do
 
-You may be asked to provide an ‘affirmation for marriage’ document to prove you’re allowed to marry.
+You may be asked to provide an ‘Affirmation for marriage’ (non-religious) or an ‘Affidavit for marriage’ (religious) document to prove you’re allowed to marry.
 
 
-Make an appointment at the British embassy or consulate in Thailand to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
+Make an appointment at the British embassy or consulate in Thailand to swear an affirmation or affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
 [Make an appointment at the embassy in Bangkok](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bangkok/oaths-affirmations-and-affidavits/slot_picker).
@@ -20,7 +20,7 @@ Make an appointment at the British embassy or consulate in Thailand to swear an 
 ###Legalisation and translation
 
 
-You might need to get your affirmation [translated](/government/collections/list-of-lawyers) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
+You might need to get your affirmation or affidavit [translated](/government/collections/list-of-lawyers) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
 
 
 If you’ve been divorced or widowed, you’ll also need:

--- a/test/artefacts/marriage-abroad/thailand/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/thailand/uk/partner_british/opposite_sex.txt
@@ -8,10 +8,10 @@ Contact the [Embassy of Thailand](/government/publications/foreign-embassies-in-
 
 ##What you need to do
 
-You may be asked to provide an ‘affirmation for marriage’ document to prove you’re allowed to marry.
+You may be asked to provide an ‘Affirmation for marriage’ (non-religious) or an ‘Affidavit for marriage’ (religious) document to prove you’re allowed to marry.
 
 
-Make an appointment at the British embassy or consulate in Thailand to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
+Make an appointment at the British embassy or consulate in Thailand to swear an affirmation or affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
 [Make an appointment at the embassy in Bangkok](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bangkok/oaths-affirmations-and-affidavits/slot_picker).
@@ -20,7 +20,7 @@ Make an appointment at the British embassy or consulate in Thailand to swear an 
 ###Legalisation and translation
 
 
-You might need to get your affirmation [translated](/government/collections/list-of-lawyers) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
+You might need to get your affirmation or affidavit [translated](/government/collections/list-of-lawyers) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
 
 
 If you’ve been divorced or widowed, you’ll also need:

--- a/test/artefacts/marriage-abroad/thailand/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/thailand/uk/partner_local/opposite_sex.txt
@@ -8,10 +8,10 @@ Contact the [Embassy of Thailand](/government/publications/foreign-embassies-in-
 
 ##What you need to do
 
-You may be asked to provide an ‘affirmation for marriage’ document to prove you’re allowed to marry.
+You may be asked to provide an ‘Affirmation for marriage’ (non-religious) or an ‘Affidavit for marriage’ (religious) document to prove you’re allowed to marry.
 
 
-Make an appointment at the British embassy or consulate in Thailand to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
+Make an appointment at the British embassy or consulate in Thailand to swear an affirmation or affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
 [Make an appointment at the embassy in Bangkok](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bangkok/oaths-affirmations-and-affidavits/slot_picker).
@@ -20,7 +20,7 @@ Make an appointment at the British embassy or consulate in Thailand to swear an 
 ###Legalisation and translation
 
 
-You might need to get your affirmation [translated](/government/collections/list-of-lawyers) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
+You might need to get your affirmation or affidavit [translated](/government/collections/list-of-lawyers) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
 
 
 If you’ve been divorced or widowed, you’ll also need:

--- a/test/artefacts/marriage-abroad/thailand/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/thailand/uk/partner_other/opposite_sex.txt
@@ -8,10 +8,10 @@ Contact the [Embassy of Thailand](/government/publications/foreign-embassies-in-
 
 ##What you need to do
 
-You may be asked to provide an ‘affirmation for marriage’ document to prove you’re allowed to marry.
+You may be asked to provide an ‘Affirmation for marriage’ (non-religious) or an ‘Affidavit for marriage’ (religious) document to prove you’re allowed to marry.
 
 
-Make an appointment at the British embassy or consulate in Thailand to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
+Make an appointment at the British embassy or consulate in Thailand to swear an affirmation or affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
 
 [Make an appointment at the embassy in Bangkok](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bangkok/oaths-affirmations-and-affidavits/slot_picker).
@@ -20,7 +20,7 @@ Make an appointment at the British embassy or consulate in Thailand to swear an 
 ###Legalisation and translation
 
 
-You might need to get your affirmation [translated](/government/collections/list-of-lawyers) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
+You might need to get your affirmation or affidavit [translated](/government/collections/list-of-lawyers) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
 
 
 If you’ve been divorced or widowed, you’ll also need:

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -1,6 +1,6 @@
 --- 
-lib/smart_answer_flows/marriage-abroad.rb: 8808a524e477045b5a0467f2c478c30c
-lib/smart_answer_flows/locales/en/marriage-abroad.yml: adbc987ac81a6ac0c9a3addc98a30b38
+lib/smart_answer_flows/marriage-abroad.rb: 1fde6c9b354f8f5448abf8a522be5399
+lib/smart_answer_flows/locales/en/marriage-abroad.yml: 5aa05b82e71bbae60a6498271f61436f
 test/data/marriage-abroad-questions-and-responses.yml: eabbd09ca91fab72a9a520d1087fb35e
 test/data/marriage-abroad-responses-and-expected-results.yml: e2a77265651bd20a9892bde75f375e82
 lib/smart_answer_flows/data_partials/_overseas_passports_embassies.erb: 2f521bae99c2f48b49d07bcb283a8063

--- a/test/integration/smart_answer_flows/marriage_abroad_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_test.rb
@@ -811,7 +811,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "go to os affirmation outcome" do
       assert_current_node :outcome_os_affirmation
-      assert_phrase_list :affirmation_os_outcome, [:contact_embassy_of_ceremony_country_in_uk_marriage, :get_legal_and_travel_advice, :what_you_need_to_do_affirmation, :appointment_for_affidavit, "appointment_links.opposite_sex.thailand", :legalisation_and_translation, :affirmation_os_translation_in_local_language_text, :docs_decree_and_death_certificate, :divorced_or_widowed_evidences, :change_of_name_evidence, :callout_partner_equivalent_document, :partner_naturalisation_in_uk, :fee_table_affidavit_55, :link_to_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+      assert_phrase_list :affirmation_os_outcome, [:contact_embassy_of_ceremony_country_in_uk_marriage, :get_legal_and_travel_advice, :what_you_need_to_do_affirmation_or_affidavit, :appointment_for_affirmation_or_affidavit, "appointment_links.opposite_sex.thailand", :legalisation_and_translation, :affirmation_or_affidavit_os_translation_in_local_language_text, :docs_decree_and_death_certificate, :divorced_or_widowed_evidences, :change_of_name_evidence, :callout_partner_equivalent_document, :partner_naturalisation_in_uk, :fee_table_affidavit_55, :link_to_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
     end
   end
 


### PR DESCRIPTION
Clarify affirmation/affidavit requirements in Thailand

Either of affirmation/affidavit document is accepted, so avoid confusion and make sure both are mentioned in the relevant sentences.

This is addressing FC feedback