### PR TITLE
Always expose cost_change_4_weeks to views

### DIFF
--- a/lib/smart_answer_flows/childcare-costs-for-tax-credits.rb
+++ b/lib/smart_answer_flows/childcare-costs-for-tax-credits.rb
@@ -242,6 +242,10 @@ module SmartAnswer
           weekly_difference_abs >= 10
         end
 
+        precalculate :cost_change_4_weeks do
+          cost_change_4_weeks || false
+        end
+
         precalculate :title_change_text do
           weekly_difference >= 10 ? "increased" : "decreased"
         end

--- a/test/artefacts/childcare-costs-for-tax-credits/yes/yes/monthly_diff_amount/2400.0/10.txt
+++ b/test/artefacts/childcare-costs-for-tax-credits/yes/yes/monthly_diff_amount/2400.0/10.txt
@@ -1,0 +1,4 @@
+Your average weekly childcare costs have increased by £37.
+
+Tell the Tax Credit Office so they can adjust your tax credit.
+

--- a/test/data/childcare-costs-for-tax-credits-files.yml
+++ b/test/data/childcare-costs-for-tax-credits-files.yml
@@ -1,8 +1,8 @@
 --- 
-lib/smart_answer_flows/childcare-costs-for-tax-credits.rb: 67023acc40f8985fc144a38b524fe5d2
+lib/smart_answer_flows/childcare-costs-for-tax-credits.rb: 5a81da259c587f65355e4e9ce7e52eee
 lib/smart_answer_flows/locales/en/childcare-costs-for-tax-credits.yml: 7199a8c4f6e40c21c5ff299f29937f62
-test/data/childcare-costs-for-tax-credits-questions-and-responses.yml: a08324e8455e6fca10e731a4b5e6313a
-test/data/childcare-costs-for-tax-credits-responses-and-expected-results.yml: 1e97f8dab86660e2bc2e94e95077182b
+test/data/childcare-costs-for-tax-credits-questions-and-responses.yml: 136aea3591662aa753c3c630546e68ad
+test/data/childcare-costs-for-tax-credits-responses-and-expected-results.yml: 7d90f3446d1e2c9551d7d363fbc4d639
 lib/smart_answer_flows/childcare-costs-for-tax-credits/call_helpline_detailed.govspeak.erb: 4ba4bfe082f1b5d82e74d07846de3a56
 lib/smart_answer_flows/childcare-costs-for-tax-credits/call_helpline_plain.govspeak.erb: bc6252b203f2ab9834f3d83bb1f3982d
 lib/smart_answer_flows/childcare-costs-for-tax-credits/cost_changed.govspeak.erb: 1822427f2df787c7ec16bff6916dbbda

--- a/test/data/childcare-costs-for-tax-credits-questions-and-responses.yml
+++ b/test/data/childcare-costs-for-tax-credits-questions-and-responses.yml
@@ -31,6 +31,7 @@
 :how_much_12_months_2?:
 - 0
 - 520
+- 2400
 :how_much_each_month?:
 - 43.3
 :pay_same_each_time?:

--- a/test/data/childcare-costs-for-tax-credits-responses-and-expected-results.yml
+++ b/test/data/childcare-costs-for-tax-credits-responses-and-expected-results.yml
@@ -155,6 +155,23 @@
   - "10"
   :next_node: :cost_changed
   :outcome_node: true
+- :current_node: :how_much_12_months_2?
+  :responses: 
+  - "yes"
+  - "yes"
+  - monthly_diff_amount
+  - "2400"
+  :next_node: :old_weekly_amount_1?
+  :outcome_node: false
+- :current_node: :old_weekly_amount_1?
+  :responses: 
+  - "yes"
+  - "yes"
+  - monthly_diff_amount
+  - "2400.0"
+  - "10"
+  :next_node: :cost_changed
+  :outcome_node: true
 - :current_node: :how_often_pay_2?
   :responses: 
   - "yes"

--- a/test/integration/smart_answer_flows/childcare_costs_for_tax_credits_test.rb
+++ b/test/integration/smart_answer_flows/childcare_costs_for_tax_credits_test.rb
@@ -248,6 +248,7 @@ class ChildcareCostsForTaxCreditsTest < ActiveSupport::TestCase
         assert_state_variable :old_weekly_cost, 2
         assert_state_variable :weekly_difference, -1
         assert_state_variable :weekly_difference_abs, 1
+        assert_state_variable :cost_change_4_weeks, false
         assert_current_node :cost_changed
       end
     end # Q18
@@ -287,6 +288,7 @@ class ChildcareCostsForTaxCreditsTest < ActiveSupport::TestCase
         assert_state_variable :weekly_difference, -10
         assert_state_variable :weekly_difference_abs, 10
         assert_state_variable :ten_or_more, true
+        assert_state_variable :cost_change_4_weeks, true
         assert_current_node :cost_changed
       end
 
@@ -330,6 +332,7 @@ class ChildcareCostsForTaxCreditsTest < ActiveSupport::TestCase
         assert_state_variable :weekly_difference, -9
         assert_state_variable :ten_or_more, false
         assert_state_variable :title_change_text, "decreased"
+        assert_state_variable :cost_change_4_weeks, false
         assert_current_node :cost_changed
       end
     end


### PR DESCRIPTION
This is addressing an error from errbit.
Sample affected path: /childcare-costs-for-tax-credits/y/yes/yes/monthly_diff_amount/2400.0/127.0

cost_change_4_weeks was only set if it's true, otherwise erb views could not
see it as a defined variable. There was also no input set for regression tests
that covers a case where `ten_or_more` is true, therefore this code branch
in erb was never exected.

The issue is fixed by explicitly exposing cost_change_4_weeks for the outcome
that may need it and setting it to false unless it's already set.

Add a regression test input to reproduce the issue and some extra assertions
to highlight the importance of cost_change_4_weeks.

This is very similar to https://github.com/alphagov/smart-answers/pull/1826