### PR TITLE
Marriage abroad FC feedback. Macao 

### DIFF
--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -27,6 +27,8 @@ en-GB:
         title_ss_marriage: Same-sex marriage
         title_ss_marriage_and_partnership: Same-sex marriage and civil partnership
         title_civil_partnership: Civil Partnership
+        one_must_be_a_resident: |
+          You can only get married in %{country_name_lowercase_prefix} if you or your partner live there, eg on a valid work visa.
         able_to_ss_marriage: |
           You may be able to get married at the British embassy or consulate in %{country_name_lowercase_prefix}.
         able_to_ss_marriage_and_partnership: |

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -914,6 +914,10 @@ module SmartAnswer
         precalculate :affirmation_os_outcome do
           phrases = PhraseList.new
 
+          if ceremony_country == 'macao' && resident_of != 'ceremony_country'
+            phrases << :one_must_be_a_resident
+          end
+
           if resident_of == 'uk'
             phrases << :contact_embassy_of_ceremony_country_in_uk_marriage
             if ceremony_country == 'morocco'

--- a/test/artefacts/marriage-abroad/macao/third_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/macao/third_country/partner_british/opposite_sex.txt
@@ -1,5 +1,8 @@
 Marriage in Macao
 
+You can only get married in Macao if you or your partner live there, eg on a valid work visa.
+
+
 Contact the relevant local authorities in Macao to find out about local marriage laws, including what documents you’ll need.
 
 

--- a/test/artefacts/marriage-abroad/macao/third_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/macao/third_country/partner_local/opposite_sex.txt
@@ -1,5 +1,8 @@
 Marriage in Macao
 
+You can only get married in Macao if you or your partner live there, eg on a valid work visa.
+
+
 Contact the relevant local authorities in Macao to find out about local marriage laws, including what documents you’ll need.
 
 

--- a/test/artefacts/marriage-abroad/macao/third_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/macao/third_country/partner_other/opposite_sex.txt
@@ -1,5 +1,8 @@
 Marriage in Macao
 
+You can only get married in Macao if you or your partner live there, eg on a valid work visa.
+
+
 Contact the relevant local authorities in Macao to find out about local marriage laws, including what documents you’ll need.
 
 

--- a/test/artefacts/marriage-abroad/macao/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/macao/uk/partner_british/opposite_sex.txt
@@ -1,5 +1,8 @@
 Marriage in Macao
 
+You can only get married in Macao if you or your partner live there, eg on a valid work visa.
+
+
 Contact the [Embassy of Macao](/government/publications/foreign-embassies-in-the-uk) before making any plans to find out about local marriage laws, including what documents you’ll need.
 
 

--- a/test/artefacts/marriage-abroad/macao/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/macao/uk/partner_local/opposite_sex.txt
@@ -1,5 +1,8 @@
 Marriage in Macao
 
+You can only get married in Macao if you or your partner live there, eg on a valid work visa.
+
+
 Contact the [Embassy of Macao](/government/publications/foreign-embassies-in-the-uk) before making any plans to find out about local marriage laws, including what documents you’ll need.
 
 

--- a/test/artefacts/marriage-abroad/macao/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/macao/uk/partner_other/opposite_sex.txt
@@ -1,5 +1,8 @@
 Marriage in Macao
 
+You can only get married in Macao if you or your partner live there, eg on a valid work visa.
+
+
 Contact the [Embassy of Macao](/government/publications/foreign-embassies-in-the-uk) before making any plans to find out about local marriage laws, including what documents you’ll need.
 
 

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -1,6 +1,6 @@
 --- 
-lib/smart_answer_flows/marriage-abroad.rb: 8e68dca261008ab9d9648e42fdce1878
-lib/smart_answer_flows/locales/en/marriage-abroad.yml: ba337534f67e91ace15472269a80bd1c
+lib/smart_answer_flows/marriage-abroad.rb: 8808a524e477045b5a0467f2c478c30c
+lib/smart_answer_flows/locales/en/marriage-abroad.yml: adbc987ac81a6ac0c9a3addc98a30b38
 test/data/marriage-abroad-questions-and-responses.yml: eabbd09ca91fab72a9a520d1087fb35e
 test/data/marriage-abroad-responses-and-expected-results.yml: e2a77265651bd20a9892bde75f375e82
 lib/smart_answer_flows/data_partials/_overseas_passports_embassies.erb: 2f521bae99c2f48b49d07bcb283a8063

--- a/test/integration/smart_answer_flows/marriage_abroad_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_test.rb
@@ -2487,6 +2487,17 @@ class MarriageAbroadTest < ActiveSupport::TestCase
       assert_current_node :outcome_os_affirmation
       assert_phrase_list :affirmation_os_outcome, [:contact_local_authorities_in_country_marriage, :get_legal_advice, :what_you_need_to_do_affirmation, :appointment_for_affidavit_in_hong_kong, "appointment_links.opposite_sex.macao", :complete_affirmation_or_affidavit_forms, :download_and_fill_but_not_sign, :download_affidavit_and_affirmation_macao, :required_supporting_documents_macao, :partner_probably_needs_affirmation, :legalisation_and_translation, :affirmation_os_translation_in_local_language_text, :docs_decree_and_death_certificate, :divorced_or_widowed_evidences, :change_of_name_evidence, :partner_probably_needs_affirmation, :fee_table_affirmation_55, :link_to_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
     end
+
+    should "lead to an affirmation outcome for opposite sex marriages directing users to Hong Kong with an intro about residency" do
+      worldwide_api_has_no_organisations_for_location('macao')
+      add_response 'macao'
+      add_response 'third_country'
+      add_response 'partner_british'
+      add_response 'opposite_sex'
+
+      assert_current_node :outcome_os_affirmation
+      assert_phrase_list :affirmation_os_outcome, [:one_must_be_a_resident, :contact_local_authorities_in_country_marriage, :get_legal_and_travel_advice, :what_you_need_to_do_affirmation, :appointment_for_affidavit_in_hong_kong, "appointment_links.opposite_sex.macao", :complete_affirmation_or_affidavit_forms, :download_and_fill_but_not_sign, :download_affidavit_and_affirmation_macao, :required_supporting_documents_macao, :partner_probably_needs_affirmation, :legalisation_and_translation, :affirmation_os_translation_in_local_language_text, :docs_decree_and_death_certificate, :divorced_or_widowed_evidences, :change_of_name_evidence, :partner_probably_needs_affirmation, :fee_table_affirmation_55, :link_to_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+    end
   end
 
   context "Hong Kong" do


### PR DESCRIPTION
At least one person must be a resident in Macao to marry there.

The requirement is listed in the required documents section already,
but we have been asked to make it clearer. At least one person from a
couple must live in Macao to have an opposite sex marriage there.

We do not show this sentence for users who answer that they live
in Macao.