### PR TITLE
Births and deaths registration fees in Europe

### DIFF
--- a/lib/smart_answer_flows/register-a-birth/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/oru_result.govspeak.erb
@@ -212,7 +212,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <%= render partial: '../data_partials/button.erb', locals: { button_data: button_data } %>

--- a/lib/smart_answer_flows/register-a-death/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-death/oru_result.govspeak.erb
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <%= render partial: '../data_partials/button.erb', locals: { button_data: button_data } %>

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/brazil.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/china.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/estonia.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/italy.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/libya.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/philippines.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/in_the_uk.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/same_country.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/brazil.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/china.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/estonia.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/italy.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/libya.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/philippines.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/in_the_uk.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/same_country.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/brazil.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/china.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/estonia.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/italy.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/libya.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/philippines.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/in_the_uk.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/same_country.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/brazil.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/china.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/estonia.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/italy.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/libya.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/philippines.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/in_the_uk.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/same_country.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/brazil.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/china.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/estonia.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/italy.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/libya.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/philippines.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/in_the_uk.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/same_country.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/brazil.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/china.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/estonia.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/italy.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/libya.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/philippines.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/in_the_uk.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/same_country.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/brazil.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/china.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/estonia.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/italy.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/libya.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/philippines.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/in_the_uk.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/same_country.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/brazil.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/china.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/estonia.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/italy.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/libya.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/philippines.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/in_the_uk.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/same_country.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/brazil.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/china.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/estonia.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/italy.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/libya.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/philippines.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/in_the_uk.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/same_country.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/brazil.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/china.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/estonia.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/italy.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/libya.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/philippines.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/libya/father/no/2015-02-02/in_the_uk.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/libya/father/no/2015-02-02/same_country.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/libya/father/yes/another_country/brazil.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/libya/father/yes/another_country/china.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/libya/father/yes/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/libya/father/yes/another_country/estonia.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/libya/father/yes/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/libya/father/yes/another_country/italy.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/libya/father/yes/another_country/libya.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/libya/father/yes/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/libya/father/yes/another_country/philippines.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/libya/father/yes/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/libya/father/yes/in_the_uk.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/libya/father/yes/same_country.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/libya/mother/no/another_country/brazil.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/libya/mother/no/another_country/china.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/libya/mother/no/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/libya/mother/no/another_country/estonia.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/libya/mother/no/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/libya/mother/no/another_country/italy.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/libya/mother/no/another_country/libya.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/libya/mother/no/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/libya/mother/no/another_country/philippines.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/libya/mother/no/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/libya/mother/no/in_the_uk.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/libya/mother/no/same_country.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/libya/mother/yes/another_country/brazil.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/libya/mother/yes/another_country/china.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/libya/mother/yes/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/libya/mother/yes/another_country/estonia.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/libya/mother/yes/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/libya/mother/yes/another_country/italy.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/libya/mother/yes/another_country/libya.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/libya/mother/yes/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/libya/mother/yes/another_country/philippines.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/libya/mother/yes/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/libya/mother/yes/in_the_uk.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/libya/mother/yes/same_country.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/brazil.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/china.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/estonia.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/italy.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/libya.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/philippines.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/no/in_the_uk.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/no/same_country.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/brazil.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/china.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/estonia.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/italy.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/libya.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/philippines.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/yes/in_the_uk.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/yes/same_country.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/brazil.txt
@@ -63,7 +63,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/china.txt
@@ -63,7 +63,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/czech-republic.txt
@@ -63,7 +63,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/estonia.txt
@@ -63,7 +63,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/hong-kong.txt
@@ -63,7 +63,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/italy.txt
@@ -63,7 +63,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/libya.txt
@@ -67,7 +67,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -63,7 +63,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/philippines.txt
@@ -67,7 +67,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/taiwan.txt
@@ -63,7 +63,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/in_the_uk.txt
@@ -63,7 +63,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/same_country.txt
@@ -63,7 +63,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/brazil.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/china.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/czech-republic.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/estonia.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/hong-kong.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/italy.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/libya.txt
@@ -66,7 +66,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/papua-new-guinea.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/philippines.txt
@@ -66,7 +66,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/taiwan.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/in_the_uk.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/same_country.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/brazil.txt
@@ -63,7 +63,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/china.txt
@@ -63,7 +63,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/czech-republic.txt
@@ -63,7 +63,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/estonia.txt
@@ -63,7 +63,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/hong-kong.txt
@@ -63,7 +63,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/italy.txt
@@ -63,7 +63,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/libya.txt
@@ -67,7 +67,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/papua-new-guinea.txt
@@ -63,7 +63,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/philippines.txt
@@ -67,7 +67,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/taiwan.txt
@@ -63,7 +63,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/in_the_uk.txt
@@ -63,7 +63,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/same_country.txt
@@ -63,7 +63,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/brazil.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/china.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/czech-republic.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/estonia.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/hong-kong.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/italy.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/libya.txt
@@ -66,7 +66,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/papua-new-guinea.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/philippines.txt
@@ -66,7 +66,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/taiwan.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/in_the_uk.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/same_country.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/brazil.txt
@@ -63,7 +63,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/china.txt
@@ -63,7 +63,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/czech-republic.txt
@@ -63,7 +63,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/estonia.txt
@@ -63,7 +63,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/hong-kong.txt
@@ -63,7 +63,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/italy.txt
@@ -63,7 +63,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/libya.txt
@@ -67,7 +67,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -63,7 +63,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/philippines.txt
@@ -67,7 +67,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/taiwan.txt
@@ -63,7 +63,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/in_the_uk.txt
@@ -63,7 +63,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/same_country.txt
@@ -63,7 +63,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/brazil.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/china.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/czech-republic.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/estonia.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/hong-kong.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/italy.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/libya.txt
@@ -66,7 +66,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/philippines.txt
@@ -66,7 +66,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/taiwan.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/in_the_uk.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/same_country.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/brazil.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/china.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/estonia.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/italy.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/libya.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/philippines.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/in_the_uk.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/brazil.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/china.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/estonia.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/italy.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/libya.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/philippines.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/in_the_uk.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/brazil.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/china.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/estonia.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/italy.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/libya.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/philippines.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/in_the_uk.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/brazil.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/china.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/estonia.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/italy.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/libya.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/philippines.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/in_the_uk.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/brazil.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/china.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/estonia.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/italy.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/libya.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/philippines.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/in_the_uk.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/brazil.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/china.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/estonia.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/italy.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/libya.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/philippines.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/in_the_uk.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/brazil.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/china.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/estonia.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/italy.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/libya.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/philippines.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/in_the_uk.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/same_country.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/brazil.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/china.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/estonia.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/italy.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/libya.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/philippines.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/in_the_uk.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/same_country.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/brazil.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/china.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/estonia.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/italy.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/libya.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/philippines.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/in_the_uk.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/same_country.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/brazil.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/china.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/estonia.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/italy.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/libya.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/philippines.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/in_the_uk.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/same_country.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/brazil.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/china.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/estonia.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/italy.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/libya.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/philippines.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/in_the_uk.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/same_country.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/brazil.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/china.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/estonia.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/italy.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/libya.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/philippines.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/in_the_uk.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/same_country.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/brazil.txt
@@ -75,7 +75,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/china.txt
@@ -75,7 +75,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/czech-republic.txt
@@ -75,7 +75,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/estonia.txt
@@ -75,7 +75,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/hong-kong.txt
@@ -75,7 +75,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/italy.txt
@@ -75,7 +75,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/libya.txt
@@ -79,7 +79,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -75,7 +75,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/philippines.txt
@@ -79,7 +79,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/taiwan.txt
@@ -75,7 +75,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/in_the_uk.txt
@@ -79,7 +79,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/same_country.txt
@@ -79,7 +79,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/brazil.txt
@@ -75,7 +75,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/china.txt
@@ -75,7 +75,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/czech-republic.txt
@@ -75,7 +75,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/estonia.txt
@@ -75,7 +75,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/hong-kong.txt
@@ -75,7 +75,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/italy.txt
@@ -75,7 +75,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/libya.txt
@@ -79,7 +79,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/papua-new-guinea.txt
@@ -75,7 +75,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/philippines.txt
@@ -79,7 +79,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/taiwan.txt
@@ -75,7 +75,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/in_the_uk.txt
@@ -79,7 +79,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/same_country.txt
@@ -79,7 +79,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/brazil.txt
@@ -72,7 +72,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/china.txt
@@ -72,7 +72,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/czech-republic.txt
@@ -72,7 +72,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/estonia.txt
@@ -72,7 +72,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/hong-kong.txt
@@ -72,7 +72,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/italy.txt
@@ -72,7 +72,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/libya.txt
@@ -76,7 +76,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/papua-new-guinea.txt
@@ -72,7 +72,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/philippines.txt
@@ -76,7 +76,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/taiwan.txt
@@ -72,7 +72,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/in_the_uk.txt
@@ -76,7 +76,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/same_country.txt
@@ -76,7 +76,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/brazil.txt
@@ -72,7 +72,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/china.txt
@@ -72,7 +72,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/czech-republic.txt
@@ -72,7 +72,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/estonia.txt
@@ -72,7 +72,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/hong-kong.txt
@@ -72,7 +72,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/italy.txt
@@ -72,7 +72,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/libya.txt
@@ -76,7 +76,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/papua-new-guinea.txt
@@ -72,7 +72,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/philippines.txt
@@ -76,7 +76,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/taiwan.txt
@@ -72,7 +72,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/in_the_uk.txt
@@ -76,7 +76,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/same_country.txt
@@ -76,7 +76,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/brazil.txt
@@ -72,7 +72,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/china.txt
@@ -72,7 +72,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/czech-republic.txt
@@ -72,7 +72,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/estonia.txt
@@ -72,7 +72,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/hong-kong.txt
@@ -72,7 +72,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/italy.txt
@@ -72,7 +72,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/libya.txt
@@ -76,7 +76,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -72,7 +72,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/philippines.txt
@@ -76,7 +76,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/taiwan.txt
@@ -72,7 +72,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/in_the_uk.txt
@@ -76,7 +76,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/same_country.txt
@@ -76,7 +76,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/brazil.txt
@@ -72,7 +72,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/china.txt
@@ -72,7 +72,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/czech-republic.txt
@@ -72,7 +72,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/estonia.txt
@@ -72,7 +72,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/hong-kong.txt
@@ -72,7 +72,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/italy.txt
@@ -72,7 +72,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/libya.txt
@@ -76,7 +76,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -72,7 +72,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/philippines.txt
@@ -76,7 +76,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/taiwan.txt
@@ -72,7 +72,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/in_the_uk.txt
@@ -76,7 +76,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/same_country.txt
@@ -76,7 +76,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/pitcairn-island/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/pitcairn-island/father/no/2015-02-02/in_the_uk.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/pitcairn-island/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/pitcairn-island/father/yes/in_the_uk.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/pitcairn-island/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/pitcairn-island/mother/no/in_the_uk.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/pitcairn-island/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/pitcairn-island/mother/yes/in_the_uk.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/pitcairn-island/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/pitcairn-island/mother_and_father/no/in_the_uk.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/pitcairn-island/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/pitcairn-island/mother_and_father/yes/in_the_uk.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/brazil.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/china.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/czech-republic.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/estonia.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/hong-kong.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/italy.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/libya.txt
@@ -77,7 +77,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/philippines.txt
@@ -77,7 +77,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/taiwan.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/in_the_uk.txt
@@ -77,7 +77,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/same_country.txt
@@ -77,7 +77,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/brazil.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/china.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/czech-republic.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/estonia.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/hong-kong.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/italy.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/libya.txt
@@ -77,7 +77,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/papua-new-guinea.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/philippines.txt
@@ -77,7 +77,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/taiwan.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/in_the_uk.txt
@@ -77,7 +77,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/same_country.txt
@@ -77,7 +77,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/brazil.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/china.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/czech-republic.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/estonia.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/hong-kong.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/italy.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/libya.txt
@@ -77,7 +77,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/papua-new-guinea.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/philippines.txt
@@ -77,7 +77,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/taiwan.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/in_the_uk.txt
@@ -77,7 +77,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/same_country.txt
@@ -77,7 +77,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/brazil.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/china.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/czech-republic.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/estonia.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/hong-kong.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/italy.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/libya.txt
@@ -77,7 +77,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/papua-new-guinea.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/philippines.txt
@@ -77,7 +77,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/taiwan.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/in_the_uk.txt
@@ -77,7 +77,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/same_country.txt
@@ -77,7 +77,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/brazil.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/china.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/czech-republic.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/estonia.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/hong-kong.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/italy.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/libya.txt
@@ -77,7 +77,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/philippines.txt
@@ -77,7 +77,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/taiwan.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/in_the_uk.txt
@@ -77,7 +77,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/same_country.txt
@@ -77,7 +77,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/brazil.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/china.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/czech-republic.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/estonia.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/hong-kong.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/italy.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/libya.txt
@@ -77,7 +77,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/philippines.txt
@@ -77,7 +77,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/taiwan.txt
@@ -73,7 +73,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/in_the_uk.txt
@@ -77,7 +77,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/same_country.txt
@@ -77,7 +77,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/st-martin/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/st-martin/father/no/2015-02-02/in_the_uk.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/st-martin/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/st-martin/father/yes/in_the_uk.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/st-martin/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother/no/in_the_uk.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/st-martin/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother/yes/in_the_uk.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/st-martin/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother_and_father/no/in_the_uk.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/st-martin/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother_and_father/yes/in_the_uk.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/brazil.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/china.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/estonia.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/italy.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/libya.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/philippines.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/in_the_uk.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/same_country.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/brazil.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/china.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/estonia.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/italy.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/libya.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/philippines.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/in_the_uk.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/same_country.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/brazil.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/china.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/estonia.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/italy.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/libya.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/philippines.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/in_the_uk.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/same_country.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/brazil.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/china.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/estonia.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/italy.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/libya.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/philippines.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/in_the_uk.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/same_country.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/brazil.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/china.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/estonia.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/italy.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/libya.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/philippines.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/in_the_uk.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/same_country.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/brazil.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/china.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/estonia.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/italy.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/libya.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/philippines.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/in_the_uk.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/same_country.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/brazil.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/china.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/czech-republic.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/estonia.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/hong-kong.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/italy.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/libya.txt
@@ -66,7 +66,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/philippines.txt
@@ -66,7 +66,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/taiwan.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/in_the_uk.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/same_country.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/brazil.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/china.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/czech-republic.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/estonia.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/hong-kong.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/italy.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/libya.txt
@@ -66,7 +66,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/papua-new-guinea.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/philippines.txt
@@ -66,7 +66,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/taiwan.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/in_the_uk.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/same_country.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/brazil.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/china.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/czech-republic.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/estonia.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/hong-kong.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/italy.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/libya.txt
@@ -66,7 +66,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/papua-new-guinea.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/philippines.txt
@@ -66,7 +66,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/taiwan.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/in_the_uk.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/same_country.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/brazil.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/china.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/czech-republic.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/estonia.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/hong-kong.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/italy.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/libya.txt
@@ -66,7 +66,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/papua-new-guinea.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/philippines.txt
@@ -66,7 +66,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/taiwan.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/in_the_uk.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/same_country.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/brazil.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/china.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/czech-republic.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/estonia.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/hong-kong.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/italy.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/libya.txt
@@ -66,7 +66,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/philippines.txt
@@ -66,7 +66,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/taiwan.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/in_the_uk.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/same_country.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/brazil.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/china.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/czech-republic.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/estonia.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/hong-kong.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/italy.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/libya.txt
@@ -66,7 +66,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/philippines.txt
@@ -66,7 +66,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/taiwan.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/in_the_uk.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/same_country.txt
@@ -62,7 +62,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/brazil.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/china.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/estonia.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/italy.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/libya.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/philippines.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/in_the_uk.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/same_country.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/brazil.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/china.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/estonia.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/italy.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/libya.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/philippines.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/in_the_uk.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/same_country.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/brazil.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/china.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/estonia.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/italy.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/libya.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/philippines.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/in_the_uk.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/same_country.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/brazil.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/china.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/estonia.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/italy.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/libya.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/philippines.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/in_the_uk.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/same_country.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/brazil.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/china.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/estonia.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/italy.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/libya.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/philippines.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/in_the_uk.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/same_country.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/brazil.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/china.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/estonia.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/italy.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/libya.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/philippines.txt
@@ -65,7 +65,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/in_the_uk.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/same_country.txt
@@ -61,7 +61,7 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/libya/another_country/algeria.txt
+++ b/test/artefacts/register-a-death/overseas/libya/another_country/algeria.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/libya/another_country/brazil.txt
+++ b/test/artefacts/register-a-death/overseas/libya/another_country/brazil.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/libya/another_country/china.txt
+++ b/test/artefacts/register-a-death/overseas/libya/another_country/china.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/libya/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-death/overseas/libya/another_country/czech-republic.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/libya/another_country/estonia.txt
+++ b/test/artefacts/register-a-death/overseas/libya/another_country/estonia.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/libya/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-death/overseas/libya/another_country/hong-kong.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/libya/another_country/italy.txt
+++ b/test/artefacts/register-a-death/overseas/libya/another_country/italy.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/libya/another_country/libya.txt
+++ b/test/artefacts/register-a-death/overseas/libya/another_country/libya.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/libya/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-death/overseas/libya/another_country/papua-new-guinea.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/libya/another_country/philippines.txt
+++ b/test/artefacts/register-a-death/overseas/libya/another_country/philippines.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/libya/another_country/south-georgia-and-south-sandwich-islands.txt
+++ b/test/artefacts/register-a-death/overseas/libya/another_country/south-georgia-and-south-sandwich-islands.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/libya/another_country/taiwan.txt
+++ b/test/artefacts/register-a-death/overseas/libya/another_country/taiwan.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/libya/in_the_uk.txt
+++ b/test/artefacts/register-a-death/overseas/libya/in_the_uk.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/libya/same_country.txt
+++ b/test/artefacts/register-a-death/overseas/libya/same_country.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/algeria.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/algeria.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/brazil.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/brazil.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/china.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/china.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/czech-republic.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/estonia.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/estonia.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/hong-kong.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/italy.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/italy.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/libya.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/libya.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/papua-new-guinea.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/philippines.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/philippines.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/south-georgia-and-south-sandwich-islands.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/south-georgia-and-south-sandwich-islands.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/taiwan.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/taiwan.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/north-korea/in_the_uk.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/in_the_uk.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/algeria.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/algeria.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/brazil.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/brazil.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/china.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/china.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/czech-republic.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/estonia.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/estonia.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/hong-kong.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/italy.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/italy.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/libya.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/libya.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/papua-new-guinea.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/philippines.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/philippines.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/south-georgia-and-south-sandwich-islands.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/south-georgia-and-south-sandwich-islands.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/taiwan.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/taiwan.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/in_the_uk.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/in_the_uk.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/same_country.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/same_country.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/pitcairn-island/in_the_uk.txt
+++ b/test/artefacts/register-a-death/overseas/pitcairn-island/in_the_uk.txt
@@ -51,7 +51,7 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 UK | £4.50
-Europe | £12.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/data/register-a-birth-files.yml
+++ b/test/data/register-a-birth-files.yml
@@ -10,7 +10,7 @@ lib/smart_answer_flows/register-a-birth/homeoffice_result.govspeak.erb: 4fa787c3
 lib/smart_answer_flows/register-a-birth/no_birth_certificate_result.govspeak.erb: 77f97df8c7ae5caa7c617ff22dd5ac12
 lib/smart_answer_flows/register-a-birth/no_embassy_result.govspeak.erb: bd130d2316e0545995f73fcb8344aa98
 lib/smart_answer_flows/register-a-birth/no_registration_result.govspeak.erb: 7767f9e0f48b974c84e1cf01f63bc75c
-lib/smart_answer_flows/register-a-birth/oru_result.govspeak.erb: 7971c364ec722d56a78fc21bff33f7ef
+lib/smart_answer_flows/register-a-birth/oru_result.govspeak.erb: 03c9346b0cabd28bb8d904633cefd603
 lib/data/translators.yml: d86f628f0b85e24ffb0dc0ec77401387
 lib/smart_answer_flows/data_partials/_button.erb: bdd3818dfd2b9d6396daf6f60fd887a0
 lib/smart_answer_flows/data_partials/_overseas_passports_embassies.erb: 2f521bae99c2f48b49d07bcb283a8063

--- a/test/data/register-a-death-files.yml
+++ b/test/data/register-a-death-files.yml
@@ -7,7 +7,7 @@ lib/smart_answer_flows/register-a-death/_footnote_oru_variants.govspeak.erb: b95
 lib/smart_answer_flows/register-a-death/commonwealth_result.govspeak.erb: 6b5814f3cba887a5484ba498ed7de91a
 lib/smart_answer_flows/register-a-death/embassy_result.govspeak.erb: 9010cc642d909a096842712be6465615
 lib/smart_answer_flows/register-a-death/no_embassy_result.govspeak.erb: 185c14c695621e9e262e4310429b4411
-lib/smart_answer_flows/register-a-death/oru_result.govspeak.erb: 02fd17dc2179da8ce70e4249a9547ebf
+lib/smart_answer_flows/register-a-death/oru_result.govspeak.erb: ecd110e623e590c94d28c923bf8753af
 lib/smart_answer_flows/register-a-death/uk_result.govspeak.erb: ea696e35b5bb8fe3c31303e5db58a6ef
 lib/data/translators.yml: d86f628f0b85e24ffb0dc0ec77401387
 lib/smart_answer_flows/data_partials/_button.erb: bdd3818dfd2b9d6396daf6f60fd887a0


### PR DESCRIPTION
Postage fees for Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina,
Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey
and Ukraine are the same as "Rest of World", not "Europe". 

Make it clear in the fees table for births and deaths registration document returns.

Sample affected paths:
- /register-a-death/y/overseas/bangladesh/same_country
- /register-a-birth/y/austria/mother_and_father/no/same_country

<img width="717" alt="screenshot 2015-08-10 15 43 15" src="https://cloud.githubusercontent.com/assets/218239/8798068/937578bc-2f97-11e5-992d-f49afca11fa3.png">
