### PR TITLE
Remove reference to scanned documents pre-verification

### DIFF
--- a/lib/smart_answer_flows/register-a-birth/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/oru_result.govspeak.erb
@@ -200,7 +200,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/brazil.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/china.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/czech-republic.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/estonia.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/hong-kong.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/italy.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/libya.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/papua-new-guinea.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/philippines.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/taiwan.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/in_the_uk.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/same_country.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/brazil.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/china.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/czech-republic.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/estonia.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/hong-kong.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/italy.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/libya.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/papua-new-guinea.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/philippines.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/taiwan.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/in_the_uk.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/same_country.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/brazil.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/china.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/czech-republic.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/estonia.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/hong-kong.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/italy.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/libya.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/philippines.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/taiwan.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/in_the_uk.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/same_country.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/brazil.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/china.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/czech-republic.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/estonia.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/hong-kong.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/italy.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/libya.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/philippines.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/taiwan.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/in_the_uk.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/same_country.txt
@@ -53,7 +53,7 @@ Pay by credit or debit card - fill in the [credit card authorisation slip](/gove
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/brazil.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/china.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/czech-republic.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/estonia.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/hong-kong.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/italy.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/libya.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/papua-new-guinea.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/philippines.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/taiwan.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/in_the_uk.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/same_country.txt
@@ -53,7 +53,7 @@ Pay by credit or debit card - fill in the [credit card authorisation slip](/gove
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/brazil.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/china.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/czech-republic.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/estonia.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/hong-kong.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/italy.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/libya.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/papua-new-guinea.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/philippines.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/taiwan.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/in_the_uk.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/same_country.txt
@@ -53,7 +53,7 @@ Pay by credit or debit card - fill in the [credit card authorisation slip](/gove
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/brazil.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/china.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/czech-republic.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/estonia.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/hong-kong.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/italy.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/libya.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/papua-new-guinea.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/philippines.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/taiwan.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/in_the_uk.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/same_country.txt
@@ -53,7 +53,7 @@ Pay by credit or debit card - fill in the [credit card authorisation slip](/gove
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/brazil.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/china.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/czech-republic.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/estonia.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/hong-kong.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/italy.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/libya.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/philippines.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/taiwan.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/in_the_uk.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/same_country.txt
@@ -53,7 +53,7 @@ Pay by credit or debit card - fill in the [credit card authorisation slip](/gove
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/brazil.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/china.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/czech-republic.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/estonia.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/hong-kong.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/italy.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/libya.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/philippines.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/taiwan.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/in_the_uk.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/same_country.txt
@@ -53,7 +53,7 @@ Pay by credit or debit card - fill in the [credit card authorisation slip](/gove
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/brazil.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/china.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/czech-republic.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/estonia.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/hong-kong.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/italy.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/libya.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/philippines.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/taiwan.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/libya/father/no/2015-02-02/in_the_uk.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/libya/father/no/2015-02-02/same_country.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/libya/father/yes/another_country/brazil.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/libya/father/yes/another_country/china.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/libya/father/yes/another_country/czech-republic.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/libya/father/yes/another_country/estonia.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/libya/father/yes/another_country/hong-kong.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/libya/father/yes/another_country/italy.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/libya/father/yes/another_country/libya.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/libya/father/yes/another_country/papua-new-guinea.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/libya/father/yes/another_country/philippines.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/libya/father/yes/another_country/taiwan.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/libya/father/yes/in_the_uk.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/libya/father/yes/same_country.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/libya/mother/no/another_country/brazil.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/libya/mother/no/another_country/china.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/libya/mother/no/another_country/czech-republic.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/libya/mother/no/another_country/estonia.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/libya/mother/no/another_country/hong-kong.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/libya/mother/no/another_country/italy.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/libya/mother/no/another_country/libya.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/libya/mother/no/another_country/papua-new-guinea.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/libya/mother/no/another_country/philippines.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/libya/mother/no/another_country/taiwan.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/libya/mother/no/in_the_uk.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/libya/mother/no/same_country.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/libya/mother/yes/another_country/brazil.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/libya/mother/yes/another_country/china.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/libya/mother/yes/another_country/czech-republic.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/libya/mother/yes/another_country/estonia.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/libya/mother/yes/another_country/hong-kong.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/libya/mother/yes/another_country/italy.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/libya/mother/yes/another_country/libya.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/libya/mother/yes/another_country/papua-new-guinea.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/libya/mother/yes/another_country/philippines.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/libya/mother/yes/another_country/taiwan.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/libya/mother/yes/in_the_uk.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/libya/mother/yes/same_country.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/brazil.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/china.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/czech-republic.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/estonia.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/hong-kong.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/italy.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/libya.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/philippines.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/taiwan.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/no/in_the_uk.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/no/same_country.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/brazil.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/china.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/czech-republic.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/estonia.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/hong-kong.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/italy.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/libya.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/philippines.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/taiwan.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/yes/in_the_uk.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/libya/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/yes/same_country.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/brazil.txt
@@ -51,7 +51,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/china.txt
@@ -51,7 +51,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/czech-republic.txt
@@ -51,7 +51,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/estonia.txt
@@ -51,7 +51,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/hong-kong.txt
@@ -51,7 +51,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/italy.txt
@@ -51,7 +51,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/libya.txt
@@ -55,7 +55,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -51,7 +51,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/philippines.txt
@@ -55,7 +55,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/taiwan.txt
@@ -51,7 +51,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/in_the_uk.txt
@@ -51,7 +51,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/same_country.txt
@@ -51,7 +51,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/brazil.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/china.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/czech-republic.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/estonia.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/hong-kong.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/italy.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/libya.txt
@@ -54,7 +54,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/papua-new-guinea.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/philippines.txt
@@ -54,7 +54,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/taiwan.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/in_the_uk.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/same_country.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/brazil.txt
@@ -51,7 +51,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/china.txt
@@ -51,7 +51,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/czech-republic.txt
@@ -51,7 +51,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/estonia.txt
@@ -51,7 +51,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/hong-kong.txt
@@ -51,7 +51,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/italy.txt
@@ -51,7 +51,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/libya.txt
@@ -55,7 +55,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/papua-new-guinea.txt
@@ -51,7 +51,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/philippines.txt
@@ -55,7 +55,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/taiwan.txt
@@ -51,7 +51,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/in_the_uk.txt
@@ -51,7 +51,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/same_country.txt
@@ -51,7 +51,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/brazil.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/china.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/czech-republic.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/estonia.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/hong-kong.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/italy.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/libya.txt
@@ -54,7 +54,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/papua-new-guinea.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/philippines.txt
@@ -54,7 +54,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/taiwan.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/in_the_uk.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/same_country.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/brazil.txt
@@ -51,7 +51,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/china.txt
@@ -51,7 +51,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/czech-republic.txt
@@ -51,7 +51,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/estonia.txt
@@ -51,7 +51,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/hong-kong.txt
@@ -51,7 +51,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/italy.txt
@@ -51,7 +51,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/libya.txt
@@ -55,7 +55,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -51,7 +51,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/philippines.txt
@@ -55,7 +55,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/taiwan.txt
@@ -51,7 +51,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/in_the_uk.txt
@@ -51,7 +51,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/same_country.txt
@@ -51,7 +51,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/brazil.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/china.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/czech-republic.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/estonia.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/hong-kong.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/italy.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/libya.txt
@@ -54,7 +54,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/philippines.txt
@@ -54,7 +54,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/taiwan.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/in_the_uk.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/same_country.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/brazil.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/china.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/czech-republic.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/estonia.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/hong-kong.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/italy.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/libya.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/philippines.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/taiwan.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/in_the_uk.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/brazil.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/china.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/czech-republic.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/estonia.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/hong-kong.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/italy.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/libya.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/papua-new-guinea.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/philippines.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/taiwan.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/in_the_uk.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/brazil.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/china.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/czech-republic.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/estonia.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/hong-kong.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/italy.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/libya.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/papua-new-guinea.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/philippines.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/taiwan.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/in_the_uk.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/brazil.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/china.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/czech-republic.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/estonia.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/hong-kong.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/italy.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/libya.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/papua-new-guinea.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/philippines.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/taiwan.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/in_the_uk.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/brazil.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/china.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/czech-republic.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/estonia.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/hong-kong.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/italy.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/libya.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/philippines.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/taiwan.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/in_the_uk.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/brazil.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/china.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/czech-republic.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/estonia.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/hong-kong.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/italy.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/libya.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/philippines.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/taiwan.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/in_the_uk.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/brazil.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/china.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/czech-republic.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/estonia.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/hong-kong.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/italy.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/libya.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/philippines.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/taiwan.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/in_the_uk.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/same_country.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/brazil.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/china.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/czech-republic.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/estonia.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/hong-kong.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/italy.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/libya.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/papua-new-guinea.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/philippines.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/taiwan.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/in_the_uk.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/same_country.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/brazil.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/china.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/czech-republic.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/estonia.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/hong-kong.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/italy.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/libya.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/papua-new-guinea.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/philippines.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/taiwan.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/in_the_uk.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/same_country.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/brazil.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/china.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/czech-republic.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/estonia.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/hong-kong.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/italy.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/libya.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/papua-new-guinea.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/philippines.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/taiwan.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/in_the_uk.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/same_country.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/brazil.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/china.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/czech-republic.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/estonia.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/hong-kong.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/italy.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/libya.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/philippines.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/taiwan.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/in_the_uk.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/same_country.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/brazil.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/china.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/czech-republic.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/estonia.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/hong-kong.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/italy.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/libya.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/philippines.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/taiwan.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/in_the_uk.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/same_country.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/brazil.txt
@@ -63,7 +63,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/china.txt
@@ -63,7 +63,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/czech-republic.txt
@@ -63,7 +63,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/estonia.txt
@@ -63,7 +63,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/hong-kong.txt
@@ -63,7 +63,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/italy.txt
@@ -63,7 +63,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/libya.txt
@@ -67,7 +67,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -63,7 +63,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/philippines.txt
@@ -67,7 +67,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/taiwan.txt
@@ -63,7 +63,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/in_the_uk.txt
@@ -67,7 +67,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/same_country.txt
@@ -67,7 +67,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/brazil.txt
@@ -63,7 +63,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/china.txt
@@ -63,7 +63,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/czech-republic.txt
@@ -63,7 +63,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/estonia.txt
@@ -63,7 +63,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/hong-kong.txt
@@ -63,7 +63,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/italy.txt
@@ -63,7 +63,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/libya.txt
@@ -67,7 +67,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/papua-new-guinea.txt
@@ -63,7 +63,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/philippines.txt
@@ -67,7 +67,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/taiwan.txt
@@ -63,7 +63,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/in_the_uk.txt
@@ -67,7 +67,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/same_country.txt
@@ -67,7 +67,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/brazil.txt
@@ -60,7 +60,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/china.txt
@@ -60,7 +60,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/czech-republic.txt
@@ -60,7 +60,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/estonia.txt
@@ -60,7 +60,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/hong-kong.txt
@@ -60,7 +60,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/italy.txt
@@ -60,7 +60,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/libya.txt
@@ -64,7 +64,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/papua-new-guinea.txt
@@ -60,7 +60,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/philippines.txt
@@ -64,7 +64,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/taiwan.txt
@@ -60,7 +60,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/in_the_uk.txt
@@ -64,7 +64,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/same_country.txt
@@ -64,7 +64,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/brazil.txt
@@ -60,7 +60,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/china.txt
@@ -60,7 +60,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/czech-republic.txt
@@ -60,7 +60,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/estonia.txt
@@ -60,7 +60,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/hong-kong.txt
@@ -60,7 +60,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/italy.txt
@@ -60,7 +60,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/libya.txt
@@ -64,7 +64,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/papua-new-guinea.txt
@@ -60,7 +60,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/philippines.txt
@@ -64,7 +64,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/taiwan.txt
@@ -60,7 +60,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/in_the_uk.txt
@@ -64,7 +64,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/same_country.txt
@@ -64,7 +64,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/brazil.txt
@@ -60,7 +60,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/china.txt
@@ -60,7 +60,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/czech-republic.txt
@@ -60,7 +60,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/estonia.txt
@@ -60,7 +60,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/hong-kong.txt
@@ -60,7 +60,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/italy.txt
@@ -60,7 +60,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/libya.txt
@@ -64,7 +64,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -60,7 +60,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/philippines.txt
@@ -64,7 +64,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/taiwan.txt
@@ -60,7 +60,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/in_the_uk.txt
@@ -64,7 +64,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/same_country.txt
@@ -64,7 +64,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/brazil.txt
@@ -60,7 +60,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/china.txt
@@ -60,7 +60,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/czech-republic.txt
@@ -60,7 +60,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/estonia.txt
@@ -60,7 +60,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/hong-kong.txt
@@ -60,7 +60,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/italy.txt
@@ -60,7 +60,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/libya.txt
@@ -64,7 +64,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -60,7 +60,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/philippines.txt
@@ -64,7 +64,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/taiwan.txt
@@ -60,7 +60,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/in_the_uk.txt
@@ -64,7 +64,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/same_country.txt
@@ -64,7 +64,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/pitcairn-island/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/pitcairn-island/father/no/2015-02-02/in_the_uk.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/pitcairn-island/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/pitcairn-island/father/yes/in_the_uk.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/pitcairn-island/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/pitcairn-island/mother/no/in_the_uk.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/pitcairn-island/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/pitcairn-island/mother/yes/in_the_uk.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/pitcairn-island/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/pitcairn-island/mother_and_father/no/in_the_uk.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/pitcairn-island/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/pitcairn-island/mother_and_father/yes/in_the_uk.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/brazil.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/china.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/estonia.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/italy.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/libya.txt
@@ -65,7 +65,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/philippines.txt
@@ -65,7 +65,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/in_the_uk.txt
@@ -65,7 +65,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/same_country.txt
@@ -65,7 +65,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/brazil.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/china.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/estonia.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/italy.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/libya.txt
@@ -65,7 +65,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/philippines.txt
@@ -65,7 +65,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/in_the_uk.txt
@@ -65,7 +65,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/same_country.txt
@@ -65,7 +65,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/brazil.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/china.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/estonia.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/italy.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/libya.txt
@@ -65,7 +65,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/philippines.txt
@@ -65,7 +65,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/in_the_uk.txt
@@ -65,7 +65,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/same_country.txt
@@ -65,7 +65,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/brazil.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/china.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/estonia.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/italy.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/libya.txt
@@ -65,7 +65,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/philippines.txt
@@ -65,7 +65,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/in_the_uk.txt
@@ -65,7 +65,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/same_country.txt
@@ -65,7 +65,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/brazil.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/china.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/estonia.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/italy.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/libya.txt
@@ -65,7 +65,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/philippines.txt
@@ -65,7 +65,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/in_the_uk.txt
@@ -65,7 +65,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/same_country.txt
@@ -65,7 +65,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/brazil.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/china.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/czech-republic.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/estonia.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/hong-kong.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/italy.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/libya.txt
@@ -65,7 +65,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/philippines.txt
@@ -65,7 +65,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/taiwan.txt
@@ -61,7 +61,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/in_the_uk.txt
@@ -65,7 +65,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/same_country.txt
@@ -65,7 +65,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/st-martin/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/st-martin/father/no/2015-02-02/in_the_uk.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/st-martin/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/st-martin/father/yes/in_the_uk.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/st-martin/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother/no/in_the_uk.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/st-martin/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother/yes/in_the_uk.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/st-martin/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother_and_father/no/in_the_uk.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/st-martin/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother_and_father/yes/in_the_uk.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/brazil.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/china.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/czech-republic.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/estonia.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/hong-kong.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/italy.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/libya.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/philippines.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/taiwan.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/in_the_uk.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/same_country.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/brazil.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/china.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/czech-republic.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/estonia.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/hong-kong.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/italy.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/libya.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/papua-new-guinea.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/philippines.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/taiwan.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/in_the_uk.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/same_country.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/brazil.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/china.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/czech-republic.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/estonia.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/hong-kong.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/italy.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/libya.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/papua-new-guinea.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/philippines.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/taiwan.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/in_the_uk.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/same_country.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/brazil.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/china.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/czech-republic.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/estonia.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/hong-kong.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/italy.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/libya.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/papua-new-guinea.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/philippines.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/taiwan.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/in_the_uk.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/same_country.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/brazil.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/china.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/czech-republic.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/estonia.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/hong-kong.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/italy.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/libya.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/philippines.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/taiwan.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/in_the_uk.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/same_country.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/brazil.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/china.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/czech-republic.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/estonia.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/hong-kong.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/italy.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/libya.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/philippines.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/taiwan.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/in_the_uk.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/same_country.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/brazil.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/china.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/czech-republic.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/estonia.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/hong-kong.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/italy.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/libya.txt
@@ -54,7 +54,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/philippines.txt
@@ -54,7 +54,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/taiwan.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/in_the_uk.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/same_country.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/brazil.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/china.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/czech-republic.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/estonia.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/hong-kong.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/italy.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/libya.txt
@@ -54,7 +54,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/papua-new-guinea.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/philippines.txt
@@ -54,7 +54,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/taiwan.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/in_the_uk.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/same_country.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/brazil.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/china.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/czech-republic.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/estonia.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/hong-kong.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/italy.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/libya.txt
@@ -54,7 +54,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/papua-new-guinea.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/philippines.txt
@@ -54,7 +54,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/taiwan.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/in_the_uk.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/same_country.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/brazil.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/china.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/czech-republic.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/estonia.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/hong-kong.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/italy.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/libya.txt
@@ -54,7 +54,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/papua-new-guinea.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/philippines.txt
@@ -54,7 +54,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/taiwan.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/in_the_uk.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/same_country.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/brazil.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/china.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/czech-republic.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/estonia.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/hong-kong.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/italy.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/libya.txt
@@ -54,7 +54,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/philippines.txt
@@ -54,7 +54,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/taiwan.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/in_the_uk.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/same_country.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/brazil.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/china.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/czech-republic.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/estonia.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/hong-kong.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/italy.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/libya.txt
@@ -54,7 +54,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/philippines.txt
@@ -54,7 +54,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/taiwan.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/in_the_uk.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/same_country.txt
@@ -50,7 +50,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/brazil.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/china.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/czech-republic.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/estonia.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/hong-kong.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/italy.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/libya.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/philippines.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/taiwan.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/in_the_uk.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/same_country.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/brazil.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/china.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/czech-republic.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/estonia.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/hong-kong.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/italy.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/libya.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/papua-new-guinea.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/philippines.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/taiwan.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/in_the_uk.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/same_country.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/brazil.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/china.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/czech-republic.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/estonia.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/hong-kong.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/italy.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/libya.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/papua-new-guinea.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/philippines.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/taiwan.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/in_the_uk.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/same_country.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/brazil.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/china.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/czech-republic.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/estonia.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/hong-kong.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/italy.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/libya.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/papua-new-guinea.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/philippines.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/taiwan.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/in_the_uk.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/same_country.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/brazil.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/china.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/czech-republic.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/estonia.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/hong-kong.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/italy.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/libya.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/philippines.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/taiwan.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/in_the_uk.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/same_country.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/brazil.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/china.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/czech-republic.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/estonia.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/hong-kong.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/italy.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/libya.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/philippines.txt
@@ -53,7 +53,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/taiwan.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/in_the_uk.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/same_country.txt
@@ -49,7 +49,7 @@ You should pay online for the registration. Email <birthregistrationenquiries@fc
 
 The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office or the National Records Office of Scotland, but only from September the year after you register.
 
-Once you’ve paid you will be given a reference number to use on your birth registration form. You’ll also be able to scan and email your documents to check that you have the right ones.
+Once you’ve paid you will be given a reference number to use on your birth registration form.
 
 Service | Fee
 -|-

--- a/test/data/register-a-birth-files.yml
+++ b/test/data/register-a-birth-files.yml
@@ -10,7 +10,7 @@ lib/smart_answer_flows/register-a-birth/homeoffice_result.govspeak.erb: 4fa787c3
 lib/smart_answer_flows/register-a-birth/no_birth_certificate_result.govspeak.erb: 77f97df8c7ae5caa7c617ff22dd5ac12
 lib/smart_answer_flows/register-a-birth/no_embassy_result.govspeak.erb: bd130d2316e0545995f73fcb8344aa98
 lib/smart_answer_flows/register-a-birth/no_registration_result.govspeak.erb: 7767f9e0f48b974c84e1cf01f63bc75c
-lib/smart_answer_flows/register-a-birth/oru_result.govspeak.erb: 7971c364ec722d56a78fc21bff33f7ef
+lib/smart_answer_flows/register-a-birth/oru_result.govspeak.erb: 00694ed1d71ac4cf18346fe4b2917591
 lib/data/translators.yml: d86f628f0b85e24ffb0dc0ec77401387
 lib/smart_answer_flows/data_partials/_button.erb: bdd3818dfd2b9d6396daf6f60fd887a0
 lib/smart_answer_flows/data_partials/_overseas_passports_embassies.erb: 2f521bae99c2f48b49d07bcb283a8063


### PR DESCRIPTION
ORU no longer provide a service where they check scanned document copies for users before they send the originals via post. 

We were not told why this service is being discontinued.