### PR TITLE
Births and deaths fees table changes

### DIFF
--- a/lib/data/rates/births_and_deaths_document_return_fees.yml
+++ b/lib/data/rates/births_and_deaths_document_return_fees.yml
@@ -1,0 +1,13 @@
+---
+- start_date: 2014-01-01 # This is an arbitrary date, it's not know when's the last time the rates changed
+  end_date: 2015-07-31
+  post_to_uk: £4.50
+  post_to_europe: £12.50
+  post_to_rest_of_the_world: £22
+
+- start_date: 2015-08-01
+  end_date: 2999-01-01
+  post_to_uk: £5.50
+  post_to_europe: £14.50
+  post_to_rest_of_the_world: £25
+

--- a/lib/smart_answer/calculators/registrations_data_query.rb
+++ b/lib/smart_answer/calculators/registrations_data_query.rb
@@ -163,6 +163,10 @@ module SmartAnswer::Calculators
       ORU_REGISTRATION_DURATION[country_slug]
     end
 
+    def document_return_fees
+      SmartAnswer::Calculators::RatesQuery.new('births_and_deaths_document_return_fees').rates
+    end
+
     def self.registration_data
       @embassy_data ||= YAML.load_file(Rails.root.join("lib", "data", "registrations.yml"))
     end

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -172,6 +172,10 @@ module SmartAnswer
           reg_data_query
         end
 
+        precalculate :document_return_fees do
+          reg_data_query.document_return_fees
+        end
+
         precalculate :button_data do
           {text: "Pay now", url: "https://pay-register-birth-abroad.service.gov.uk/start"}
         end
@@ -179,7 +183,7 @@ module SmartAnswer
         precalculate :custom_waiting_time do
           reg_data_query.custom_registration_duration(country_of_birth)
         end
-        
+
         precalculate :born_in_lower_risk_country do
           reg_data_query.class::HIGHER_RISK_COUNTRIES.exclude?(country_of_birth)
         end

--- a/lib/smart_answer_flows/register-a-birth/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/oru_result.govspeak.erb
@@ -207,7 +207,7 @@ Service | Fee
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-<%= render partial: '../shared/births_and_deaths_registration/document_return_fees.govspeak.erb' %>
+<%= render partial: '../shared/births_and_deaths_registration/document_return_fees.govspeak.erb', locals: { document_return_fees: document_return_fees } %>
 <%= render partial: '../data_partials/button.erb', locals: { button_data: button_data } %>
 
 <% if country_of_birth == 'venezuela' && same_country %>

--- a/lib/smart_answer_flows/register-a-birth/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/oru_result.govspeak.erb
@@ -207,14 +207,7 @@ Service | Fee
 Register a birth | £105
 Copy of a birth registration certificate | £65
 
-You must also pay for your documents to be returned to you.
-
-Postage destination | Fee
--|-
-UK | £4.50
-Europe | £12.50
-Rest of world | £22
-
+<%= render partial: '../shared/births_and_deaths_registration/document_return_fees.govspeak.erb' %>
 <%= render partial: '../data_partials/button.erb', locals: { button_data: button_data } %>
 
 <% if country_of_birth == 'venezuela' && same_country %>

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -120,6 +120,10 @@ module SmartAnswer
         precalculate :reg_data_query do
           SmartAnswer::Calculators::RegistrationsDataQuery.new
         end
+
+        precalculate :document_return_fees do
+          reg_data_query.document_return_fees
+        end
       end
 
       outcome :embassy_result do

--- a/lib/smart_answer_flows/register-a-death/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-death/oru_result.govspeak.erb
@@ -55,16 +55,11 @@ Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> i
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
-You must also pay for your documents to be returned to you.
-
-Postage destination | Fee
-UK | £4.50
-Europe | £12.50
-Rest of world | £22
-
+<%= render partial: '../shared/births_and_deaths_registration/document_return_fees.govspeak.erb' %>
 <%= render partial: '../data_partials/button.erb', locals: { button_data: button_data } %>
 
 

--- a/lib/smart_answer_flows/register-a-death/oru_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-death/oru_result.govspeak.erb
@@ -59,7 +59,7 @@ Service | Fee
 Register a death | £105
 Copy of a death registration certificate | £65
 
-<%= render partial: '../shared/births_and_deaths_registration/document_return_fees.govspeak.erb' %>
+<%= render partial: '../shared/births_and_deaths_registration/document_return_fees.govspeak.erb', locals: { document_return_fees: document_return_fees } %>
 <%= render partial: '../data_partials/button.erb', locals: { button_data: button_data } %>
 
 

--- a/lib/smart_answer_flows/shared/births_and_deaths_registration/_document_return_fees.govspeak.erb
+++ b/lib/smart_answer_flows/shared/births_and_deaths_registration/_document_return_fees.govspeak.erb
@@ -2,6 +2,6 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22

--- a/lib/smart_answer_flows/shared/births_and_deaths_registration/_document_return_fees.govspeak.erb
+++ b/lib/smart_answer_flows/shared/births_and_deaths_registration/_document_return_fees.govspeak.erb
@@ -2,6 +2,6 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK address or British Forces Post Office | £4.50
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
-Rest of world | £22
+UK address or British Forces Post Office | <%= document_return_fees.post_to_uk %>
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | <%= document_return_fees.post_to_europe %>
+Rest of world | <%= document_return_fees.post_to_rest_of_the_world %>

--- a/lib/smart_answer_flows/shared/births_and_deaths_registration/_document_return_fees.govspeak.erb
+++ b/lib/smart_answer_flows/shared/births_and_deaths_registration/_document_return_fees.govspeak.erb
@@ -1,0 +1,7 @@
+You must also pay for your documents to be returned to you.
+
+Postage destination | Fee
+-|-
+UK | £4.50
+Europe | £12.50
+Rest of world | £22

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/brazil.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/china.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/czech-republic.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/estonia.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/hong-kong.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/italy.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/libya.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/papua-new-guinea.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/philippines.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/another_country/taiwan.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/in_the_uk.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/yes/same_country.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/brazil.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/china.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/czech-republic.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/estonia.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/hong-kong.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/italy.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/libya.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/papua-new-guinea.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/philippines.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/another_country/taiwan.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/in_the_uk.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother/yes/same_country.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/brazil.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/china.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/czech-republic.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/estonia.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/hong-kong.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/italy.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/libya.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/philippines.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/another_country/taiwan.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/in_the_uk.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/afghanistan/mother_and_father/yes/same_country.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/brazil.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/china.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/czech-republic.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/estonia.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/hong-kong.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/italy.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/libya.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/philippines.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/another_country/taiwan.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/in_the_uk.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2015-02-02/same_country.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/brazil.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/china.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/czech-republic.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/estonia.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/hong-kong.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/italy.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/libya.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/papua-new-guinea.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/philippines.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/another_country/taiwan.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/in_the_uk.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/algeria/father/yes/same_country.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/brazil.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/china.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/czech-republic.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/estonia.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/hong-kong.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/italy.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/libya.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/papua-new-guinea.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/philippines.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/another_country/taiwan.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/in_the_uk.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/no/same_country.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/brazil.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/china.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/czech-republic.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/estonia.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/hong-kong.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/italy.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/libya.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/papua-new-guinea.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/philippines.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/another_country/taiwan.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/in_the_uk.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/algeria/mother/yes/same_country.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/brazil.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/china.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/czech-republic.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/estonia.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/hong-kong.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/italy.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/libya.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/philippines.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/another_country/taiwan.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/in_the_uk.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/no/same_country.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/brazil.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/china.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/czech-republic.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/estonia.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/hong-kong.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/italy.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/libya.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/philippines.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/another_country/taiwan.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/in_the_uk.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/algeria/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/algeria/mother_and_father/yes/same_country.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/brazil.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/china.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/czech-republic.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/estonia.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/hong-kong.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/italy.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/libya.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/philippines.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/libya/father/no/2015-02-02/another_country/taiwan.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/libya/father/no/2015-02-02/in_the_uk.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/libya/father/no/2015-02-02/same_country.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/libya/father/yes/another_country/brazil.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/libya/father/yes/another_country/china.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/libya/father/yes/another_country/czech-republic.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/libya/father/yes/another_country/estonia.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/libya/father/yes/another_country/hong-kong.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/libya/father/yes/another_country/italy.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/libya/father/yes/another_country/libya.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/libya/father/yes/another_country/papua-new-guinea.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/libya/father/yes/another_country/philippines.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/libya/father/yes/another_country/taiwan.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/libya/father/yes/in_the_uk.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/libya/father/yes/same_country.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/libya/mother/no/another_country/brazil.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/libya/mother/no/another_country/china.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/libya/mother/no/another_country/czech-republic.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/libya/mother/no/another_country/estonia.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/libya/mother/no/another_country/hong-kong.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/libya/mother/no/another_country/italy.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/libya/mother/no/another_country/libya.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/libya/mother/no/another_country/papua-new-guinea.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/libya/mother/no/another_country/philippines.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/libya/mother/no/another_country/taiwan.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/libya/mother/no/in_the_uk.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/libya/mother/no/same_country.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/libya/mother/yes/another_country/brazil.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/libya/mother/yes/another_country/china.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/libya/mother/yes/another_country/czech-republic.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/libya/mother/yes/another_country/estonia.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/libya/mother/yes/another_country/hong-kong.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/libya/mother/yes/another_country/italy.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/libya/mother/yes/another_country/libya.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/libya/mother/yes/another_country/papua-new-guinea.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/libya/mother/yes/another_country/philippines.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/libya/mother/yes/another_country/taiwan.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/libya/mother/yes/in_the_uk.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/libya/mother/yes/same_country.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/brazil.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/china.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/czech-republic.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/estonia.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/hong-kong.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/italy.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/libya.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/philippines.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/no/another_country/taiwan.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/no/in_the_uk.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/no/same_country.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/brazil.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/china.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/czech-republic.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/estonia.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/hong-kong.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/italy.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/libya.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/philippines.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/yes/another_country/taiwan.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/yes/in_the_uk.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/libya/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/libya/mother_and_father/yes/same_country.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/brazil.txt
@@ -62,8 +62,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/china.txt
@@ -62,8 +62,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/czech-republic.txt
@@ -62,8 +62,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/estonia.txt
@@ -62,8 +62,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/hong-kong.txt
@@ -62,8 +62,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/italy.txt
@@ -62,8 +62,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/libya.txt
@@ -66,8 +66,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -62,8 +62,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/philippines.txt
@@ -66,8 +66,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/another_country/taiwan.txt
@@ -62,8 +62,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/in_the_uk.txt
@@ -62,8 +62,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2015-02-02/same_country.txt
@@ -62,8 +62,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/brazil.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/china.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/czech-republic.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/estonia.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/hong-kong.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/italy.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/libya.txt
@@ -65,8 +65,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/papua-new-guinea.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/philippines.txt
@@ -65,8 +65,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/another_country/taiwan.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/in_the_uk.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/morocco/father/yes/same_country.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/brazil.txt
@@ -62,8 +62,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/china.txt
@@ -62,8 +62,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/czech-republic.txt
@@ -62,8 +62,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/estonia.txt
@@ -62,8 +62,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/hong-kong.txt
@@ -62,8 +62,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/italy.txt
@@ -62,8 +62,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/libya.txt
@@ -66,8 +66,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/papua-new-guinea.txt
@@ -62,8 +62,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/philippines.txt
@@ -66,8 +66,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/another_country/taiwan.txt
@@ -62,8 +62,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/in_the_uk.txt
@@ -62,8 +62,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/no/same_country.txt
@@ -62,8 +62,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/brazil.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/china.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/czech-republic.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/estonia.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/hong-kong.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/italy.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/libya.txt
@@ -65,8 +65,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/papua-new-guinea.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/philippines.txt
@@ -65,8 +65,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/another_country/taiwan.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/in_the_uk.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/morocco/mother/yes/same_country.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/brazil.txt
@@ -62,8 +62,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/china.txt
@@ -62,8 +62,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/czech-republic.txt
@@ -62,8 +62,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/estonia.txt
@@ -62,8 +62,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/hong-kong.txt
@@ -62,8 +62,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/italy.txt
@@ -62,8 +62,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/libya.txt
@@ -66,8 +66,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -62,8 +62,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/philippines.txt
@@ -66,8 +66,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/another_country/taiwan.txt
@@ -62,8 +62,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/in_the_uk.txt
@@ -62,8 +62,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/no/same_country.txt
@@ -62,8 +62,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/brazil.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/china.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/czech-republic.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/estonia.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/hong-kong.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/italy.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/libya.txt
@@ -65,8 +65,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/philippines.txt
@@ -65,8 +65,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/another_country/taiwan.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/in_the_uk.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/morocco/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/morocco/mother_and_father/yes/same_country.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/brazil.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/china.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/czech-republic.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/estonia.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/hong-kong.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/italy.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/libya.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/philippines.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/another_country/taiwan.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2015-02-02/in_the_uk.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/brazil.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/china.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/czech-republic.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/estonia.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/hong-kong.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/italy.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/libya.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/papua-new-guinea.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/philippines.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/another_country/taiwan.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/yes/in_the_uk.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/brazil.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/china.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/czech-republic.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/estonia.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/hong-kong.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/italy.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/libya.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/papua-new-guinea.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/philippines.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/another_country/taiwan.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/no/in_the_uk.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/brazil.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/china.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/czech-republic.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/estonia.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/hong-kong.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/italy.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/libya.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/papua-new-guinea.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/philippines.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/another_country/taiwan.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother/yes/in_the_uk.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/brazil.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/china.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/czech-republic.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/estonia.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/hong-kong.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/italy.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/libya.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/philippines.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/another_country/taiwan.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/no/in_the_uk.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/brazil.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/china.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/czech-republic.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/estonia.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/hong-kong.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/italy.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/libya.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/philippines.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/another_country/taiwan.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/north-korea/mother_and_father/yes/in_the_uk.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/brazil.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/china.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/czech-republic.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/estonia.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/hong-kong.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/italy.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/libya.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/philippines.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/another_country/taiwan.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/in_the_uk.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2015-02-02/same_country.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/brazil.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/china.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/czech-republic.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/estonia.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/hong-kong.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/italy.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/libya.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/papua-new-guinea.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/philippines.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/another_country/taiwan.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/in_the_uk.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/yes/same_country.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/brazil.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/china.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/czech-republic.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/estonia.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/hong-kong.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/italy.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/libya.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/papua-new-guinea.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/philippines.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/another_country/taiwan.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/in_the_uk.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/no/same_country.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/brazil.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/china.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/czech-republic.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/estonia.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/hong-kong.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/italy.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/libya.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/papua-new-guinea.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/philippines.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/another_country/taiwan.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/in_the_uk.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother/yes/same_country.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/brazil.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/china.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/czech-republic.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/estonia.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/hong-kong.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/italy.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/libya.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/philippines.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/another_country/taiwan.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/in_the_uk.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/no/same_country.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/brazil.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/china.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/czech-republic.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/estonia.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/hong-kong.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/italy.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/libya.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/philippines.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/another_country/taiwan.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/in_the_uk.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/mother_and_father/yes/same_country.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/brazil.txt
@@ -74,8 +74,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/china.txt
@@ -74,8 +74,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/czech-republic.txt
@@ -74,8 +74,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/estonia.txt
@@ -74,8 +74,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/hong-kong.txt
@@ -74,8 +74,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/italy.txt
@@ -74,8 +74,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/libya.txt
@@ -78,8 +78,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -74,8 +74,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/philippines.txt
@@ -78,8 +78,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/another_country/taiwan.txt
@@ -74,8 +74,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/in_the_uk.txt
@@ -78,8 +78,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2015-02-02/same_country.txt
@@ -78,8 +78,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/brazil.txt
@@ -74,8 +74,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/china.txt
@@ -74,8 +74,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/czech-republic.txt
@@ -74,8 +74,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/estonia.txt
@@ -74,8 +74,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/hong-kong.txt
@@ -74,8 +74,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/italy.txt
@@ -74,8 +74,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/libya.txt
@@ -78,8 +78,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/papua-new-guinea.txt
@@ -74,8 +74,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/philippines.txt
@@ -78,8 +78,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/another_country/taiwan.txt
@@ -74,8 +74,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/in_the_uk.txt
@@ -78,8 +78,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/philippines/father/yes/same_country.txt
@@ -78,8 +78,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/brazil.txt
@@ -71,8 +71,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/china.txt
@@ -71,8 +71,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/czech-republic.txt
@@ -71,8 +71,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/estonia.txt
@@ -71,8 +71,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/hong-kong.txt
@@ -71,8 +71,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/italy.txt
@@ -71,8 +71,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/libya.txt
@@ -75,8 +75,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/papua-new-guinea.txt
@@ -71,8 +71,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/philippines.txt
@@ -75,8 +75,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/another_country/taiwan.txt
@@ -71,8 +71,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/in_the_uk.txt
@@ -75,8 +75,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/no/same_country.txt
@@ -75,8 +75,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/brazil.txt
@@ -71,8 +71,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/china.txt
@@ -71,8 +71,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/czech-republic.txt
@@ -71,8 +71,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/estonia.txt
@@ -71,8 +71,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/hong-kong.txt
@@ -71,8 +71,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/italy.txt
@@ -71,8 +71,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/libya.txt
@@ -75,8 +75,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/papua-new-guinea.txt
@@ -71,8 +71,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/philippines.txt
@@ -75,8 +75,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/another_country/taiwan.txt
@@ -71,8 +71,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/in_the_uk.txt
@@ -75,8 +75,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/philippines/mother/yes/same_country.txt
@@ -75,8 +75,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/brazil.txt
@@ -71,8 +71,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/china.txt
@@ -71,8 +71,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/czech-republic.txt
@@ -71,8 +71,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/estonia.txt
@@ -71,8 +71,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/hong-kong.txt
@@ -71,8 +71,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/italy.txt
@@ -71,8 +71,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/libya.txt
@@ -75,8 +75,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -71,8 +71,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/philippines.txt
@@ -75,8 +75,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/another_country/taiwan.txt
@@ -71,8 +71,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/in_the_uk.txt
@@ -75,8 +75,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/no/same_country.txt
@@ -75,8 +75,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/brazil.txt
@@ -71,8 +71,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/china.txt
@@ -71,8 +71,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/czech-republic.txt
@@ -71,8 +71,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/estonia.txt
@@ -71,8 +71,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/hong-kong.txt
@@ -71,8 +71,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/italy.txt
@@ -71,8 +71,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/libya.txt
@@ -75,8 +75,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -71,8 +71,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/philippines.txt
@@ -75,8 +75,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/another_country/taiwan.txt
@@ -71,8 +71,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/in_the_uk.txt
@@ -75,8 +75,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/philippines/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/philippines/mother_and_father/yes/same_country.txt
@@ -75,8 +75,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/pitcairn-island/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/pitcairn-island/father/no/2015-02-02/in_the_uk.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/pitcairn-island/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/pitcairn-island/father/yes/in_the_uk.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/pitcairn-island/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/pitcairn-island/mother/no/in_the_uk.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/pitcairn-island/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/pitcairn-island/mother/yes/in_the_uk.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/pitcairn-island/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/pitcairn-island/mother_and_father/no/in_the_uk.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/pitcairn-island/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/pitcairn-island/mother_and_father/yes/in_the_uk.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/brazil.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/china.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/czech-republic.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/estonia.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/hong-kong.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/italy.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/libya.txt
@@ -76,8 +76,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/philippines.txt
@@ -76,8 +76,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/another_country/taiwan.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/in_the_uk.txt
@@ -76,8 +76,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2015-02-02/same_country.txt
@@ -76,8 +76,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/brazil.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/china.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/czech-republic.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/estonia.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/hong-kong.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/italy.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/libya.txt
@@ -76,8 +76,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/papua-new-guinea.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/philippines.txt
@@ -76,8 +76,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/another_country/taiwan.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/in_the_uk.txt
@@ -76,8 +76,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/yes/same_country.txt
@@ -76,8 +76,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/brazil.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/china.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/czech-republic.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/estonia.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/hong-kong.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/italy.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/libya.txt
@@ -76,8 +76,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/papua-new-guinea.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/philippines.txt
@@ -76,8 +76,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/another_country/taiwan.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/in_the_uk.txt
@@ -76,8 +76,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/no/same_country.txt
@@ -76,8 +76,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/brazil.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/china.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/czech-republic.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/estonia.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/hong-kong.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/italy.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/libya.txt
@@ -76,8 +76,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/papua-new-guinea.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/philippines.txt
@@ -76,8 +76,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/another_country/taiwan.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/in_the_uk.txt
@@ -76,8 +76,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother/yes/same_country.txt
@@ -76,8 +76,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/brazil.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/china.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/czech-republic.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/estonia.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/hong-kong.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/italy.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/libya.txt
@@ -76,8 +76,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/philippines.txt
@@ -76,8 +76,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/another_country/taiwan.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/in_the_uk.txt
@@ -76,8 +76,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/no/same_country.txt
@@ -76,8 +76,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/brazil.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/china.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/czech-republic.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/estonia.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/hong-kong.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/italy.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/libya.txt
@@ -76,8 +76,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/philippines.txt
@@ -76,8 +76,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/another_country/taiwan.txt
@@ -72,8 +72,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/in_the_uk.txt
@@ -76,8 +76,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/mother_and_father/yes/same_country.txt
@@ -76,8 +76,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/st-martin/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/st-martin/father/no/2015-02-02/in_the_uk.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/st-martin/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/st-martin/father/yes/in_the_uk.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/st-martin/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother/no/in_the_uk.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/st-martin/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother/yes/in_the_uk.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/st-martin/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother_and_father/no/in_the_uk.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/st-martin/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/st-martin/mother_and_father/yes/in_the_uk.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/brazil.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/china.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/czech-republic.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/estonia.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/hong-kong.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/italy.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/libya.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/philippines.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/another_country/taiwan.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/in_the_uk.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2015-02-02/same_country.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/brazil.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/china.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/czech-republic.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/estonia.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/hong-kong.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/italy.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/libya.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/papua-new-guinea.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/philippines.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/another_country/taiwan.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/in_the_uk.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/yes/same_country.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/brazil.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/china.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/czech-republic.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/estonia.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/hong-kong.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/italy.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/libya.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/papua-new-guinea.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/philippines.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/another_country/taiwan.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/in_the_uk.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/no/same_country.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/brazil.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/china.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/czech-republic.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/estonia.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/hong-kong.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/italy.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/libya.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/papua-new-guinea.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/philippines.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/another_country/taiwan.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/in_the_uk.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother/yes/same_country.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/brazil.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/china.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/czech-republic.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/estonia.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/hong-kong.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/italy.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/libya.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/philippines.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/another_country/taiwan.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/in_the_uk.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/no/same_country.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/brazil.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/china.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/czech-republic.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/estonia.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/hong-kong.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/italy.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/libya.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/philippines.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/another_country/taiwan.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/in_the_uk.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/timor-leste/mother_and_father/yes/same_country.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/brazil.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/china.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/czech-republic.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/estonia.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/hong-kong.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/italy.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/libya.txt
@@ -65,8 +65,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/philippines.txt
@@ -65,8 +65,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/another_country/taiwan.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/in_the_uk.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2015-02-02/same_country.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/brazil.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/china.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/czech-republic.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/estonia.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/hong-kong.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/italy.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/libya.txt
@@ -65,8 +65,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/papua-new-guinea.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/philippines.txt
@@ -65,8 +65,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/another_country/taiwan.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/in_the_uk.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/usa/father/yes/same_country.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/brazil.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/china.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/czech-republic.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/estonia.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/hong-kong.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/italy.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/libya.txt
@@ -65,8 +65,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/papua-new-guinea.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/philippines.txt
@@ -65,8 +65,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/another_country/taiwan.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/in_the_uk.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/usa/mother/no/same_country.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/brazil.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/china.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/czech-republic.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/estonia.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/hong-kong.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/italy.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/libya.txt
@@ -65,8 +65,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/papua-new-guinea.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/philippines.txt
@@ -65,8 +65,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/another_country/taiwan.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/in_the_uk.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/usa/mother/yes/same_country.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/brazil.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/china.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/czech-republic.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/estonia.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/hong-kong.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/italy.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/libya.txt
@@ -65,8 +65,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/philippines.txt
@@ -65,8 +65,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/another_country/taiwan.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/in_the_uk.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/no/same_country.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/brazil.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/china.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/czech-republic.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/estonia.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/hong-kong.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/italy.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/libya.txt
@@ -65,8 +65,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/philippines.txt
@@ -65,8 +65,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/another_country/taiwan.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/in_the_uk.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/usa/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/usa/mother_and_father/yes/same_country.txt
@@ -61,8 +61,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/brazil.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/china.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/china.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/czech-republic.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/estonia.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/hong-kong.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/italy.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/libya.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/papua-new-guinea.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/philippines.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/another_country/taiwan.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/in_the_uk.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/same_country.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2015-02-02/same_country.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/brazil.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/china.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/czech-republic.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/estonia.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/hong-kong.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/italy.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/libya.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/papua-new-guinea.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/philippines.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/another_country/taiwan.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/in_the_uk.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/yes/same_country.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/brazil.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/china.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/czech-republic.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/estonia.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/hong-kong.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/italy.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/libya.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/papua-new-guinea.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/philippines.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/another_country/taiwan.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/in_the_uk.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/no/same_country.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/no/same_country.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/brazil.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/china.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/czech-republic.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/estonia.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/hong-kong.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/italy.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/libya.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/papua-new-guinea.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/philippines.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/another_country/taiwan.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/in_the_uk.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother/yes/same_country.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/brazil.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/china.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/china.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/czech-republic.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/estonia.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/hong-kong.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/italy.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/libya.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/papua-new-guinea.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/philippines.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/another_country/taiwan.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/in_the_uk.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/no/same_country.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/no/same_country.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/brazil.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/brazil.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/china.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/china.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/czech-republic.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/estonia.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/estonia.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/hong-kong.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/italy.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/italy.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/libya.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/libya.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/papua-new-guinea.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/philippines.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/philippines.txt
@@ -64,8 +64,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/taiwan.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/another_country/taiwan.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/in_the_uk.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/in_the_uk.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/same_country.txt
+++ b/test/artefacts/register-a-birth/venezuela/mother_and_father/yes/same_country.txt
@@ -60,8 +60,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-birth-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/libya/another_country/algeria.txt
+++ b/test/artefacts/register-a-death/overseas/libya/another_country/algeria.txt
@@ -44,12 +44,14 @@ Pay by credit or debit card - fill in the [credit card authorisation slip](/gove
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/libya/another_country/algeria.txt
+++ b/test/artefacts/register-a-death/overseas/libya/another_country/algeria.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/libya/another_country/brazil.txt
+++ b/test/artefacts/register-a-death/overseas/libya/another_country/brazil.txt
@@ -44,12 +44,14 @@ Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> i
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/libya/another_country/brazil.txt
+++ b/test/artefacts/register-a-death/overseas/libya/another_country/brazil.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/libya/another_country/china.txt
+++ b/test/artefacts/register-a-death/overseas/libya/another_country/china.txt
@@ -44,12 +44,14 @@ Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> i
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/libya/another_country/china.txt
+++ b/test/artefacts/register-a-death/overseas/libya/another_country/china.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/libya/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-death/overseas/libya/another_country/czech-republic.txt
@@ -44,12 +44,14 @@ Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> i
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/libya/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-death/overseas/libya/another_country/czech-republic.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/libya/another_country/estonia.txt
+++ b/test/artefacts/register-a-death/overseas/libya/another_country/estonia.txt
@@ -44,12 +44,14 @@ Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> i
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/libya/another_country/estonia.txt
+++ b/test/artefacts/register-a-death/overseas/libya/another_country/estonia.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/libya/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-death/overseas/libya/another_country/hong-kong.txt
@@ -44,12 +44,14 @@ Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> i
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/libya/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-death/overseas/libya/another_country/hong-kong.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/libya/another_country/italy.txt
+++ b/test/artefacts/register-a-death/overseas/libya/another_country/italy.txt
@@ -44,12 +44,14 @@ Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> i
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/libya/another_country/italy.txt
+++ b/test/artefacts/register-a-death/overseas/libya/another_country/italy.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/libya/another_country/libya.txt
+++ b/test/artefacts/register-a-death/overseas/libya/another_country/libya.txt
@@ -44,12 +44,14 @@ Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> i
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/libya/another_country/libya.txt
+++ b/test/artefacts/register-a-death/overseas/libya/another_country/libya.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/libya/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-death/overseas/libya/another_country/papua-new-guinea.txt
@@ -44,12 +44,14 @@ Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> i
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/libya/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-death/overseas/libya/another_country/papua-new-guinea.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/libya/another_country/philippines.txt
+++ b/test/artefacts/register-a-death/overseas/libya/another_country/philippines.txt
@@ -44,12 +44,14 @@ Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> i
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/libya/another_country/philippines.txt
+++ b/test/artefacts/register-a-death/overseas/libya/another_country/philippines.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/libya/another_country/south-georgia-and-south-sandwich-islands.txt
+++ b/test/artefacts/register-a-death/overseas/libya/another_country/south-georgia-and-south-sandwich-islands.txt
@@ -44,12 +44,14 @@ Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> i
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/libya/another_country/south-georgia-and-south-sandwich-islands.txt
+++ b/test/artefacts/register-a-death/overseas/libya/another_country/south-georgia-and-south-sandwich-islands.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/libya/another_country/taiwan.txt
+++ b/test/artefacts/register-a-death/overseas/libya/another_country/taiwan.txt
@@ -44,12 +44,14 @@ Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> i
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/libya/another_country/taiwan.txt
+++ b/test/artefacts/register-a-death/overseas/libya/another_country/taiwan.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/libya/in_the_uk.txt
+++ b/test/artefacts/register-a-death/overseas/libya/in_the_uk.txt
@@ -44,12 +44,14 @@ Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> i
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/libya/in_the_uk.txt
+++ b/test/artefacts/register-a-death/overseas/libya/in_the_uk.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/libya/same_country.txt
+++ b/test/artefacts/register-a-death/overseas/libya/same_country.txt
@@ -44,12 +44,14 @@ Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> i
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/libya/same_country.txt
+++ b/test/artefacts/register-a-death/overseas/libya/same_country.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/algeria.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/algeria.txt
@@ -44,12 +44,14 @@ Pay by credit or debit card - fill in the [credit card authorisation slip](/gove
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/algeria.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/algeria.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/brazil.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/brazil.txt
@@ -44,12 +44,14 @@ Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> i
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/brazil.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/brazil.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/china.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/china.txt
@@ -44,12 +44,14 @@ Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> i
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/china.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/china.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/czech-republic.txt
@@ -44,12 +44,14 @@ Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> i
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/czech-republic.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/estonia.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/estonia.txt
@@ -44,12 +44,14 @@ Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> i
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/estonia.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/estonia.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/hong-kong.txt
@@ -44,12 +44,14 @@ Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> i
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/hong-kong.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/italy.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/italy.txt
@@ -44,12 +44,14 @@ Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> i
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/italy.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/italy.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/libya.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/libya.txt
@@ -44,12 +44,14 @@ Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> i
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/libya.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/libya.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/papua-new-guinea.txt
@@ -44,12 +44,14 @@ Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> i
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/papua-new-guinea.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/philippines.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/philippines.txt
@@ -44,12 +44,14 @@ Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> i
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/philippines.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/philippines.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/south-georgia-and-south-sandwich-islands.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/south-georgia-and-south-sandwich-islands.txt
@@ -44,12 +44,14 @@ Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> i
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/south-georgia-and-south-sandwich-islands.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/south-georgia-and-south-sandwich-islands.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/taiwan.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/taiwan.txt
@@ -44,12 +44,14 @@ Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> i
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/north-korea/another_country/taiwan.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/another_country/taiwan.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/north-korea/in_the_uk.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/in_the_uk.txt
@@ -44,12 +44,14 @@ Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> i
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/north-korea/in_the_uk.txt
+++ b/test/artefacts/register-a-death/overseas/north-korea/in_the_uk.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/algeria.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/algeria.txt
@@ -44,12 +44,14 @@ Pay by credit or debit card - fill in the [credit card authorisation slip](/gove
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/algeria.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/algeria.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/brazil.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/brazil.txt
@@ -44,12 +44,14 @@ Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> i
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/brazil.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/brazil.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/china.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/china.txt
@@ -44,12 +44,14 @@ Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> i
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/china.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/china.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/czech-republic.txt
@@ -44,12 +44,14 @@ Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> i
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/czech-republic.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/czech-republic.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/estonia.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/estonia.txt
@@ -44,12 +44,14 @@ Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> i
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/estonia.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/estonia.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/hong-kong.txt
@@ -44,12 +44,14 @@ Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> i
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/hong-kong.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/hong-kong.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/italy.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/italy.txt
@@ -44,12 +44,14 @@ Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> i
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/italy.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/italy.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/libya.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/libya.txt
@@ -44,12 +44,14 @@ Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> i
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/libya.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/libya.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/papua-new-guinea.txt
@@ -44,12 +44,14 @@ Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> i
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/papua-new-guinea.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/papua-new-guinea.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/philippines.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/philippines.txt
@@ -44,12 +44,14 @@ Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> i
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/philippines.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/philippines.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/south-georgia-and-south-sandwich-islands.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/south-georgia-and-south-sandwich-islands.txt
@@ -44,12 +44,14 @@ Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> i
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/south-georgia-and-south-sandwich-islands.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/south-georgia-and-south-sandwich-islands.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/taiwan.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/taiwan.txt
@@ -44,12 +44,14 @@ Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> i
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/taiwan.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/another_country/taiwan.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/in_the_uk.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/in_the_uk.txt
@@ -44,12 +44,14 @@ Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> i
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/in_the_uk.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/in_the_uk.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/same_country.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/same_country.txt
@@ -44,12 +44,14 @@ Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> i
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/papua-new-guinea/same_country.txt
+++ b/test/artefacts/register-a-death/overseas/papua-new-guinea/same_country.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/artefacts/register-a-death/overseas/pitcairn-island/in_the_uk.txt
+++ b/test/artefacts/register-a-death/overseas/pitcairn-island/in_the_uk.txt
@@ -44,12 +44,14 @@ Pay online for the registration. Email <deathregistrationenquiries@fco.gov.uk> i
 The registration fee doesn't include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from September the year after you register.
 
 Service | Fee
+-|-
 Register a death | £105
 Copy of a death registration certificate | £65
 
 You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
+-|-
 UK | £4.50
 Europe | £12.50
 Rest of world | £22

--- a/test/artefacts/register-a-death/overseas/pitcairn-island/in_the_uk.txt
+++ b/test/artefacts/register-a-death/overseas/pitcairn-island/in_the_uk.txt
@@ -52,8 +52,8 @@ You must also pay for your documents to be returned to you.
 
 Postage destination | Fee
 -|-
-UK | £4.50
-Europe | £12.50
+UK address or British Forces Post Office | £4.50
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | £12.50
 Rest of world | £22
 
 <a rel="nofollow" href= "https://pay-register-death-abroad.service.gov.uk/start" class="big button">Pay now</a>

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -6,4 +6,4 @@ test/data/marriage-abroad-responses-and-expected-results.yml: 9f3ca67c58dae770c6
 lib/smart_answer_flows/data_partials/_overseas_passports_embassies.erb: 2f521bae99c2f48b49d07bcb283a8063
 lib/smart_answer/calculators/marriage_abroad_data_query.rb: 6fa278754bc9ad08f8f9d89bd54e87f3
 lib/smart_answer/calculators/country_name_formatter.rb: 0cb274748f0daf3965451b6230c183fd
-lib/smart_answer/calculators/registrations_data_query.rb: 2755d76a53d867b350940f1af65fa5d1
+lib/smart_answer/calculators/registrations_data_query.rb: 94d313beec66eec0748d544ee21b77b0

--- a/test/data/register-a-birth-files.yml
+++ b/test/data/register-a-birth-files.yml
@@ -1,5 +1,5 @@
 --- 
-lib/smart_answer_flows/register-a-birth.rb: 8bfd060c93357a69ad7c2e0146100d25
+lib/smart_answer_flows/register-a-birth.rb: 23f691ca380818683bb069ec39782333
 lib/smart_answer_flows/locales/en/register-a-birth.yml: 570b5821a64274d765cdf46d4d5b5b92
 test/data/register-a-birth-questions-and-responses.yml: b8656669a138a00d52afdd33cc9b4590
 test/data/register-a-birth-responses-and-expected-results.yml: 3c431cc901085e1e4c0fcc9fe50eef47
@@ -10,13 +10,14 @@ lib/smart_answer_flows/register-a-birth/homeoffice_result.govspeak.erb: 4fa787c3
 lib/smart_answer_flows/register-a-birth/no_birth_certificate_result.govspeak.erb: 77f97df8c7ae5caa7c617ff22dd5ac12
 lib/smart_answer_flows/register-a-birth/no_embassy_result.govspeak.erb: bd130d2316e0545995f73fcb8344aa98
 lib/smart_answer_flows/register-a-birth/no_registration_result.govspeak.erb: 7767f9e0f48b974c84e1cf01f63bc75c
-lib/smart_answer_flows/register-a-birth/oru_result.govspeak.erb: bf19c913c07798e90351ab70bedeffd3
+lib/smart_answer_flows/register-a-birth/oru_result.govspeak.erb: 46e741ab69a286d4f79a27c349548aec
+lib/data/rates/births_and_deaths_document_return_fees.yml: 4ac203e9fd076c12f62b57f8d1b64ffc
 lib/data/translators.yml: d86f628f0b85e24ffb0dc0ec77401387
 lib/smart_answer_flows/data_partials/_button.erb: bdd3818dfd2b9d6396daf6f60fd887a0
 lib/smart_answer_flows/data_partials/_overseas_passports_embassies.erb: 2f521bae99c2f48b49d07bcb283a8063
 lib/data/registrations.yml: f9c542793c73aa0a8abd6920e49be735
 lib/smart_answer/calculators/country_name_formatter.rb: 0cb274748f0daf3965451b6230c183fd
-lib/smart_answer/calculators/registrations_data_query.rb: 2755d76a53d867b350940f1af65fa5d1
+lib/smart_answer/calculators/registrations_data_query.rb: 94d313beec66eec0748d544ee21b77b0
 lib/smart_answer/calculators/translator_links.rb: 079592f6c5ede06d7c6ae4e8c5553127
 test/fixtures/worldwide_locations.yml: 063711faceec3a4081d6d5fb386c8029
 test/fixtures/worldwide/afghanistan_organisations.json: 1fd89b60eb079c7b3fddcab985f37366

--- a/test/data/register-a-birth-files.yml
+++ b/test/data/register-a-birth-files.yml
@@ -10,8 +10,7 @@ lib/smart_answer_flows/register-a-birth/homeoffice_result.govspeak.erb: 4fa787c3
 lib/smart_answer_flows/register-a-birth/no_birth_certificate_result.govspeak.erb: 77f97df8c7ae5caa7c617ff22dd5ac12
 lib/smart_answer_flows/register-a-birth/no_embassy_result.govspeak.erb: bd130d2316e0545995f73fcb8344aa98
 lib/smart_answer_flows/register-a-birth/no_registration_result.govspeak.erb: 7767f9e0f48b974c84e1cf01f63bc75c
-lib/smart_answer_flows/register-a-birth/oru_result.govspeak.erb: 06803bbaa749f684457408319611af63
-lib/smart_answer_flows/shared/births_and_deaths_registration/_document_return_fees.govspeak.erb: a3a2efcb468f6044a36bde1080136d7d
+lib/smart_answer_flows/register-a-birth/oru_result.govspeak.erb: bf19c913c07798e90351ab70bedeffd3
 lib/data/translators.yml: d86f628f0b85e24ffb0dc0ec77401387
 lib/smart_answer_flows/data_partials/_button.erb: bdd3818dfd2b9d6396daf6f60fd887a0
 lib/smart_answer_flows/data_partials/_overseas_passports_embassies.erb: 2f521bae99c2f48b49d07bcb283a8063

--- a/test/data/register-a-birth-files.yml
+++ b/test/data/register-a-birth-files.yml
@@ -10,7 +10,8 @@ lib/smart_answer_flows/register-a-birth/homeoffice_result.govspeak.erb: 4fa787c3
 lib/smart_answer_flows/register-a-birth/no_birth_certificate_result.govspeak.erb: 77f97df8c7ae5caa7c617ff22dd5ac12
 lib/smart_answer_flows/register-a-birth/no_embassy_result.govspeak.erb: bd130d2316e0545995f73fcb8344aa98
 lib/smart_answer_flows/register-a-birth/no_registration_result.govspeak.erb: 7767f9e0f48b974c84e1cf01f63bc75c
-lib/smart_answer_flows/register-a-birth/oru_result.govspeak.erb: 00694ed1d71ac4cf18346fe4b2917591
+lib/smart_answer_flows/register-a-birth/oru_result.govspeak.erb: 06803bbaa749f684457408319611af63
+lib/smart_answer_flows/shared/births_and_deaths_registration/_document_return_fees.govspeak.erb: a3a2efcb468f6044a36bde1080136d7d
 lib/data/translators.yml: d86f628f0b85e24ffb0dc0ec77401387
 lib/smart_answer_flows/data_partials/_button.erb: bdd3818dfd2b9d6396daf6f60fd887a0
 lib/smart_answer_flows/data_partials/_overseas_passports_embassies.erb: 2f521bae99c2f48b49d07bcb283a8063

--- a/test/data/register-a-death-files.yml
+++ b/test/data/register-a-death-files.yml
@@ -7,8 +7,9 @@ lib/smart_answer_flows/register-a-death/_footnote_oru_variants.govspeak.erb: b95
 lib/smart_answer_flows/register-a-death/commonwealth_result.govspeak.erb: 6b5814f3cba887a5484ba498ed7de91a
 lib/smart_answer_flows/register-a-death/embassy_result.govspeak.erb: 9010cc642d909a096842712be6465615
 lib/smart_answer_flows/register-a-death/no_embassy_result.govspeak.erb: 185c14c695621e9e262e4310429b4411
-lib/smart_answer_flows/register-a-death/oru_result.govspeak.erb: 02fd17dc2179da8ce70e4249a9547ebf
+lib/smart_answer_flows/register-a-death/oru_result.govspeak.erb: 2b47ac044dee2fc2f2365b5bb8de7466
 lib/smart_answer_flows/register-a-death/uk_result.govspeak.erb: ea696e35b5bb8fe3c31303e5db58a6ef
+lib/smart_answer_flows/shared/births_and_deaths_registration/_document_return_fees.govspeak.erb: a3a2efcb468f6044a36bde1080136d7d
 lib/data/translators.yml: d86f628f0b85e24ffb0dc0ec77401387
 lib/smart_answer_flows/data_partials/_button.erb: bdd3818dfd2b9d6396daf6f60fd887a0
 lib/smart_answer_flows/data_partials/_overseas_passports_embassies.erb: 2f521bae99c2f48b49d07bcb283a8063

--- a/test/data/register-a-death-files.yml
+++ b/test/data/register-a-death-files.yml
@@ -9,7 +9,7 @@ lib/smart_answer_flows/register-a-death/embassy_result.govspeak.erb: 9010cc642d9
 lib/smart_answer_flows/register-a-death/no_embassy_result.govspeak.erb: 185c14c695621e9e262e4310429b4411
 lib/smart_answer_flows/register-a-death/oru_result.govspeak.erb: 2b47ac044dee2fc2f2365b5bb8de7466
 lib/smart_answer_flows/register-a-death/uk_result.govspeak.erb: ea696e35b5bb8fe3c31303e5db58a6ef
-lib/smart_answer_flows/shared/births_and_deaths_registration/_document_return_fees.govspeak.erb: a3a2efcb468f6044a36bde1080136d7d
+lib/smart_answer_flows/shared/births_and_deaths_registration/_document_return_fees.govspeak.erb: 3df8f50b765b03bdfb0cb4916abe3d45
 lib/data/translators.yml: d86f628f0b85e24ffb0dc0ec77401387
 lib/smart_answer_flows/data_partials/_button.erb: bdd3818dfd2b9d6396daf6f60fd887a0
 lib/smart_answer_flows/data_partials/_overseas_passports_embassies.erb: 2f521bae99c2f48b49d07bcb283a8063

--- a/test/data/register-a-death-files.yml
+++ b/test/data/register-a-death-files.yml
@@ -1,5 +1,5 @@
 --- 
-lib/smart_answer_flows/register-a-death.rb: 18554292100028ece89c4b7e7f77c312
+lib/smart_answer_flows/register-a-death.rb: 2b6d204e39bf3f8b0b142cc052aa4ca9
 lib/smart_answer_flows/locales/en/register-a-death.yml: 117a44ad76a2b05ed2a638e76b378640
 test/data/register-a-death-questions-and-responses.yml: 6df917ccdc09d3d7ac36be40ae9203c9
 test/data/register-a-death-responses-and-expected-results.yml: 170051e64fd33b79a62eba850cbc6116
@@ -7,14 +7,14 @@ lib/smart_answer_flows/register-a-death/_footnote_oru_variants.govspeak.erb: b95
 lib/smart_answer_flows/register-a-death/commonwealth_result.govspeak.erb: 6b5814f3cba887a5484ba498ed7de91a
 lib/smart_answer_flows/register-a-death/embassy_result.govspeak.erb: 9010cc642d909a096842712be6465615
 lib/smart_answer_flows/register-a-death/no_embassy_result.govspeak.erb: 185c14c695621e9e262e4310429b4411
-lib/smart_answer_flows/register-a-death/oru_result.govspeak.erb: 2b47ac044dee2fc2f2365b5bb8de7466
+lib/smart_answer_flows/register-a-death/oru_result.govspeak.erb: 3d0db2ec7779d4b483bd8cdae299121b
 lib/smart_answer_flows/register-a-death/uk_result.govspeak.erb: ea696e35b5bb8fe3c31303e5db58a6ef
-lib/smart_answer_flows/shared/births_and_deaths_registration/_document_return_fees.govspeak.erb: 3df8f50b765b03bdfb0cb4916abe3d45
+lib/data/rates/births_and_deaths_document_return_fees.yml: 4ac203e9fd076c12f62b57f8d1b64ffc
 lib/data/translators.yml: d86f628f0b85e24ffb0dc0ec77401387
 lib/smart_answer_flows/data_partials/_button.erb: bdd3818dfd2b9d6396daf6f60fd887a0
 lib/smart_answer_flows/data_partials/_overseas_passports_embassies.erb: 2f521bae99c2f48b49d07bcb283a8063
 test/fixtures/worldwide/italy_organisations.json: dc5feb424edeeb12835be916605caf46
-lib/smart_answer/calculators/registrations_data_query.rb: 2755d76a53d867b350940f1af65fa5d1
+lib/smart_answer/calculators/registrations_data_query.rb: 94d313beec66eec0748d544ee21b77b0
 lib/smart_answer/calculators/country_name_formatter.rb: 0cb274748f0daf3965451b6230c183fd
 lib/smart_answer/calculators/translator_links.rb: 079592f6c5ede06d7c6ae4e8c5553127
 test/fixtures/worldwide_locations.yml: 063711faceec3a4081d6d5fb386c8029

--- a/test/integration/smart_answer_flows/register_a_birth_test.rb
+++ b/test/integration/smart_answer_flows/register_a_birth_test.rb
@@ -40,6 +40,7 @@ class RegisterABirthTest < ActiveSupport::TestCase
         should "ask where you are now and go to oru result" do
           add_response "same_country"
           assert_current_node :oru_result
+          assert current_state.send(:document_return_fees).present?
         end
       end # not married/cp
     end # mother

--- a/test/integration/smart_answer_flows/register_a_death_test.rb
+++ b/test/integration/smart_answer_flows/register_a_death_test.rb
@@ -177,6 +177,7 @@ class RegisterADeathTest < ActiveSupport::TestCase
         should "give the embassy result and be done" do
           assert_current_node :oru_result
           assert_state_variable :translator_link_url, "/government/publications/spain-list-of-lawyers"
+          assert current_state.send(:document_return_fees).present?
         end
       end # Answer embassy
       context "answer ORU office in the uk" do

--- a/test/unit/calculators/registrations_data_query_test.rb
+++ b/test/unit/calculators/registrations_data_query_test.rb
@@ -84,6 +84,31 @@ module SmartAnswer::Calculators
         end
       end
 
+      context "fetching document return fees" do
+        context "when before 2015-08-01" do
+          setup do
+            Timecop.travel("2015-07-31")
+          end
+
+          should "display 4.50, 12.50 and 22" do
+            assert_equal "£4.50", @query.document_return_fees.post_to_uk
+            assert_equal "£12.50", @query.document_return_fees.post_to_europe
+            assert_equal "£22", @query.document_return_fees.post_to_rest_of_the_world
+          end
+        end
+
+        context "on and after 2015-08-01" do
+          setup do
+            Timecop.travel("2015-08-01")
+          end
+
+          should "display 4.50, 12.50 and 22" do
+            assert_equal "£5.50", @query.document_return_fees.post_to_uk
+            assert_equal "£14.50", @query.document_return_fees.post_to_europe
+            assert_equal "£25", @query.document_return_fees.post_to_rest_of_the_world
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
There are a couple changes to the document returns fees tables in births and deaths. I've extracted a shared partial with the fees before making the changes, as those fees are identical. As a side effect the register-a-death fees tables started using `<th>` element for headers, this makes it more consistent with the rest of the tables.

Summary: 
1) Clarification of what qualifies as UK and Europe regions
2) Fee changes that will kick in on 1st of August 2015

I've used the mechanism we use for calculators to store the rate values that change on a certain date. I guess this could work for all the fee tables if we thing this would help reduce the cost to making changes.

Also worth noting that this will break the regression tests on 1st August as the rates in the views will change. I don't think there is an elegant solution to this so I'll just resolve it manually when it happens.