### PR TITLE
Update contact info for advice for unmarried couples.

### DIFF
--- a/lib/smart_answer_flows/register-a-birth/homeoffice_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-birth/homeoffice_result.govspeak.erb
@@ -5,5 +5,6 @@ You can’t register your child’s birth with the UK authorities abroad. This i
 
 You may still be able to apply for [British citizenship](https://www.gov.uk/browse/citizenship/citizenship) for the child.
 
-You may also be able to register the birth if you’ve married the other parent since the child was born. [Contact your local British embassy](/government/world) to find out.
+You may also be able to register the birth if you’ve married the other parent since the child was born.
+Contact the Overseas Registration Unit for advice at <birthregistrationenquiries@fco.gov.uk>.
 <% end %>

--- a/test/artefacts/register-a-birth/afghanistan/father/no/2006-06-30.txt
+++ b/test/artefacts/register-a-birth/afghanistan/father/no/2006-06-30.txt
@@ -6,5 +6,6 @@ You can’t register your child’s birth with the UK authorities abroad. This i
 
 You may still be able to apply for [British citizenship](https://www.gov.uk/browse/citizenship/citizenship) for the child.
 
-You may also be able to register the birth if you’ve married the other parent since the child was born. [Contact your local British embassy](/government/world) to find out.
+You may also be able to register the birth if you’ve married the other parent since the child was born.
+Contact the Overseas Registration Unit for advice at <birthregistrationenquiries@fco.gov.uk>.
 

--- a/test/artefacts/register-a-birth/algeria/father/no/2006-06-30.txt
+++ b/test/artefacts/register-a-birth/algeria/father/no/2006-06-30.txt
@@ -6,5 +6,6 @@ You can’t register your child’s birth with the UK authorities abroad. This i
 
 You may still be able to apply for [British citizenship](https://www.gov.uk/browse/citizenship/citizenship) for the child.
 
-You may also be able to register the birth if you’ve married the other parent since the child was born. [Contact your local British embassy](/government/world) to find out.
+You may also be able to register the birth if you’ve married the other parent since the child was born.
+Contact the Overseas Registration Unit for advice at <birthregistrationenquiries@fco.gov.uk>.
 

--- a/test/artefacts/register-a-birth/libya/father/no/2006-06-30.txt
+++ b/test/artefacts/register-a-birth/libya/father/no/2006-06-30.txt
@@ -6,5 +6,6 @@ You can’t register your child’s birth with the UK authorities abroad. This i
 
 You may still be able to apply for [British citizenship](https://www.gov.uk/browse/citizenship/citizenship) for the child.
 
-You may also be able to register the birth if you’ve married the other parent since the child was born. [Contact your local British embassy](/government/world) to find out.
+You may also be able to register the birth if you’ve married the other parent since the child was born.
+Contact the Overseas Registration Unit for advice at <birthregistrationenquiries@fco.gov.uk>.
 

--- a/test/artefacts/register-a-birth/morocco/father/no/2006-06-30.txt
+++ b/test/artefacts/register-a-birth/morocco/father/no/2006-06-30.txt
@@ -6,5 +6,6 @@ You can’t register your child’s birth with the UK authorities abroad. This i
 
 You may still be able to apply for [British citizenship](https://www.gov.uk/browse/citizenship/citizenship) for the child.
 
-You may also be able to register the birth if you’ve married the other parent since the child was born. [Contact your local British embassy](/government/world) to find out.
+You may also be able to register the birth if you’ve married the other parent since the child was born.
+Contact the Overseas Registration Unit for advice at <birthregistrationenquiries@fco.gov.uk>.
 

--- a/test/artefacts/register-a-birth/north-korea/father/no/2006-06-30.txt
+++ b/test/artefacts/register-a-birth/north-korea/father/no/2006-06-30.txt
@@ -6,5 +6,6 @@ You can’t register your child’s birth with the UK authorities abroad. This i
 
 You may still be able to apply for [British citizenship](https://www.gov.uk/browse/citizenship/citizenship) for the child.
 
-You may also be able to register the birth if you’ve married the other parent since the child was born. [Contact your local British embassy](/government/world) to find out.
+You may also be able to register the birth if you’ve married the other parent since the child was born.
+Contact the Overseas Registration Unit for advice at <birthregistrationenquiries@fco.gov.uk>.
 

--- a/test/artefacts/register-a-birth/papua-new-guinea/father/no/2006-06-30.txt
+++ b/test/artefacts/register-a-birth/papua-new-guinea/father/no/2006-06-30.txt
@@ -6,5 +6,6 @@ You can’t register your child’s birth with the UK authorities abroad. This i
 
 You may still be able to apply for [British citizenship](https://www.gov.uk/browse/citizenship/citizenship) for the child.
 
-You may also be able to register the birth if you’ve married the other parent since the child was born. [Contact your local British embassy](/government/world) to find out.
+You may also be able to register the birth if you’ve married the other parent since the child was born.
+Contact the Overseas Registration Unit for advice at <birthregistrationenquiries@fco.gov.uk>.
 

--- a/test/artefacts/register-a-birth/philippines/father/no/2006-06-30.txt
+++ b/test/artefacts/register-a-birth/philippines/father/no/2006-06-30.txt
@@ -6,5 +6,6 @@ You can’t register your child’s birth with the UK authorities abroad. This i
 
 You may still be able to apply for [British citizenship](https://www.gov.uk/browse/citizenship/citizenship) for the child.
 
-You may also be able to register the birth if you’ve married the other parent since the child was born. [Contact your local British embassy](/government/world) to find out.
+You may also be able to register the birth if you’ve married the other parent since the child was born.
+Contact the Overseas Registration Unit for advice at <birthregistrationenquiries@fco.gov.uk>.
 

--- a/test/artefacts/register-a-birth/pitcairn-island/father/no/2006-06-30.txt
+++ b/test/artefacts/register-a-birth/pitcairn-island/father/no/2006-06-30.txt
@@ -6,5 +6,6 @@ You can’t register your child’s birth with the UK authorities abroad. This i
 
 You may still be able to apply for [British citizenship](https://www.gov.uk/browse/citizenship/citizenship) for the child.
 
-You may also be able to register the birth if you’ve married the other parent since the child was born. [Contact your local British embassy](/government/world) to find out.
+You may also be able to register the birth if you’ve married the other parent since the child was born.
+Contact the Overseas Registration Unit for advice at <birthregistrationenquiries@fco.gov.uk>.
 

--- a/test/artefacts/register-a-birth/sierra-leone/father/no/2006-06-30.txt
+++ b/test/artefacts/register-a-birth/sierra-leone/father/no/2006-06-30.txt
@@ -6,5 +6,6 @@ You can’t register your child’s birth with the UK authorities abroad. This i
 
 You may still be able to apply for [British citizenship](https://www.gov.uk/browse/citizenship/citizenship) for the child.
 
-You may also be able to register the birth if you’ve married the other parent since the child was born. [Contact your local British embassy](/government/world) to find out.
+You may also be able to register the birth if you’ve married the other parent since the child was born.
+Contact the Overseas Registration Unit for advice at <birthregistrationenquiries@fco.gov.uk>.
 

--- a/test/artefacts/register-a-birth/st-martin/father/no/2006-06-30.txt
+++ b/test/artefacts/register-a-birth/st-martin/father/no/2006-06-30.txt
@@ -6,5 +6,6 @@ You can’t register your child’s birth with the UK authorities abroad. This i
 
 You may still be able to apply for [British citizenship](https://www.gov.uk/browse/citizenship/citizenship) for the child.
 
-You may also be able to register the birth if you’ve married the other parent since the child was born. [Contact your local British embassy](/government/world) to find out.
+You may also be able to register the birth if you’ve married the other parent since the child was born.
+Contact the Overseas Registration Unit for advice at <birthregistrationenquiries@fco.gov.uk>.
 

--- a/test/artefacts/register-a-birth/timor-leste/father/no/2006-06-30.txt
+++ b/test/artefacts/register-a-birth/timor-leste/father/no/2006-06-30.txt
@@ -6,5 +6,6 @@ You can’t register your child’s birth with the UK authorities abroad. This i
 
 You may still be able to apply for [British citizenship](https://www.gov.uk/browse/citizenship/citizenship) for the child.
 
-You may also be able to register the birth if you’ve married the other parent since the child was born. [Contact your local British embassy](/government/world) to find out.
+You may also be able to register the birth if you’ve married the other parent since the child was born.
+Contact the Overseas Registration Unit for advice at <birthregistrationenquiries@fco.gov.uk>.
 

--- a/test/artefacts/register-a-birth/usa/father/no/2006-06-30.txt
+++ b/test/artefacts/register-a-birth/usa/father/no/2006-06-30.txt
@@ -6,5 +6,6 @@ You can’t register your child’s birth with the UK authorities abroad. This i
 
 You may still be able to apply for [British citizenship](https://www.gov.uk/browse/citizenship/citizenship) for the child.
 
-You may also be able to register the birth if you’ve married the other parent since the child was born. [Contact your local British embassy](/government/world) to find out.
+You may also be able to register the birth if you’ve married the other parent since the child was born.
+Contact the Overseas Registration Unit for advice at <birthregistrationenquiries@fco.gov.uk>.
 

--- a/test/artefacts/register-a-birth/venezuela/father/no/2006-06-30.txt
+++ b/test/artefacts/register-a-birth/venezuela/father/no/2006-06-30.txt
@@ -6,5 +6,6 @@ You can’t register your child’s birth with the UK authorities abroad. This i
 
 You may still be able to apply for [British citizenship](https://www.gov.uk/browse/citizenship/citizenship) for the child.
 
-You may also be able to register the birth if you’ve married the other parent since the child was born. [Contact your local British embassy](/government/world) to find out.
+You may also be able to register the birth if you’ve married the other parent since the child was born.
+Contact the Overseas Registration Unit for advice at <birthregistrationenquiries@fco.gov.uk>.
 

--- a/test/data/register-a-birth-files.yml
+++ b/test/data/register-a-birth-files.yml
@@ -6,7 +6,7 @@ test/data/register-a-birth-responses-and-expected-results.yml: 3c431cc901085e1e4
 lib/smart_answer_flows/register-a-birth/_footnote_oru_variants.govspeak.erb: ead05885bbb3636b7718bad1745253b0
 lib/smart_answer_flows/register-a-birth/commonwealth_result.govspeak.erb: f80551c78dfe9ae0b0bf8d34aae766e3
 lib/smart_answer_flows/register-a-birth/embassy_result.govspeak.erb: 566a158f4a2acf2270d1b92a708fec25
-lib/smart_answer_flows/register-a-birth/homeoffice_result.govspeak.erb: 4fa787c325efeb2db5f4cb2a11a44630
+lib/smart_answer_flows/register-a-birth/homeoffice_result.govspeak.erb: 003ec0dd6b720cf5c5f0af85a12e2241
 lib/smart_answer_flows/register-a-birth/no_birth_certificate_result.govspeak.erb: 77f97df8c7ae5caa7c617ff22dd5ac12
 lib/smart_answer_flows/register-a-birth/no_embassy_result.govspeak.erb: bd130d2316e0545995f73fcb8344aa98
 lib/smart_answer_flows/register-a-birth/no_registration_result.govspeak.erb: 7767f9e0f48b974c84e1cf01f63bc75c


### PR DESCRIPTION
Affects all scenarios where the child was born before 1 July 2006 and father is unmarried,
for example: /register-a-birth/y/austria/father/no/2006-06-30

The tool used to say: 'Contact your local British embassy...' This has changed.
Users can contact the Overseas Registration Unit for advice at
birthregistrationenquiries@fco.gov.uk