### PR TITLE
Update _scheme_postcodes.govspeak.erb

### DIFF
--- a/lib/smart_answer_flows/pip-checker/_scheme_postcodes.govspeak.erb
+++ b/lib/smart_answer_flows/pip-checker/_scheme_postcodes.govspeak.erb
@@ -1,26 +1,5 @@
 
-In the following areas you'll be asked to claim PIP from 27 July 2015:
-
-- AL (St Albans)
-- CT (Canterbury)
-- EN (Enfield)
-- HA (Harrow)
-- HS (Hebrides)
-- KT (Kingston)
-- KW (Kirkwall)
-- ME (Maidstone)
-- N (London North)
-- NW (London North West)
-- SL (Slough)
-- SM (Sutton)
-- TN (Tonbridge)
-- TW (Twickenham)
-- UB (Uxbridge)
-- W (London West)
-- WD (Watford)
-- ZE (Lerwick)
-
-###Your DLA ends after September 2017 or DLA awards with no end date
+###Your DLA ends after September 2017 or your DLA award has no end date
 
 Some people will be invited to claim PIP from 13 July 2015 if you live in the following areas:
 
@@ -31,7 +10,7 @@ Some people will be invited to claim PIP from 13 July 2015 if you live in the fo
 - Manchester (M)
 - Oldham (OL)
 - Preston (PR)
-- Stoke (ST)
+- Stoke-on-Trent (ST)
 - Warrington (WA)
 - Wigan (WN)
 


### PR DESCRIPTION
Part of 27 July update for personal independence payment
- removed list of postcodes that are now no longer needed
- amended Stoke to Stoke on Trent

Merge and deploy for 27 July