### PR TITLE
[Deploy on Mon 27th July] Remove service message from apply-tier-4-visa

### DIFF
--- a/lib/smart_answer_flows/locales/en/apply-tier-4-visa.yml
+++ b/lib/smart_answer_flows/locales/en/apply-tier-4-visa.yml
@@ -12,7 +12,6 @@ en-GB:
         * extending or switching to a [Tier 4 (General) student visa](/tier-4-general-visa)
         * extending or switching to a [Tier 4 (Child) student visa](/child-study-visa)
         
-        %This service will be unavailable from 8am on Saturday 25 July to 2am on Sunday 26 July.%
 
 #Q1
       extending_or_switching?:

--- a/test/data/apply-tier-4-visa-files.yml
+++ b/test/data/apply-tier-4-visa-files.yml
@@ -1,6 +1,6 @@
 --- 
 lib/smart_answer_flows/apply-tier-4-visa.rb: 44ce7b4a25bb0877d3972fbe9ed94a16
-lib/smart_answer_flows/locales/en/apply-tier-4-visa.yml: 897aef4fdf55b613f86e0be63007e2f2
+lib/smart_answer_flows/locales/en/apply-tier-4-visa.yml: 52618ea258e1dcddb758adc934a524aa
 test/data/apply-tier-4-visa-questions-and-responses.yml: fe87a99e4337e45586806181742f0b8f
 test/data/apply-tier-4-visa-responses-and-expected-results.yml: 339690f2a3125ef29d63f29a79ae1cba
 lib/smart_answer_flows/apply-tier-4-visa/outcome.govspeak.erb: f68864437aaec0bf9e39217906ed0709


### PR DESCRIPTION
This contains @lutgendorff's commit from #1843 (which reverts a827cc0642022e707fbcca5602b779ad5f0ca223) and the updated checksum data for apply-tier-4-visa.

I haven't had to update the rendered outcomes because this text is on the start page and we don't have regression tests for those pages.
