### PR TITLE
Update links to student finance forms

### DIFF
--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_ccg_1415.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_ccg_1415.txt
@@ -4,7 +4,7 @@ To apply, estimate your childcare costs on form CCG1 after you've completed your
 
 Academic year | Form
 - | -
-2014 to 2015 | [CCG1 - form (PDF, 88KB)](http://www.sfengland.slc.co.uk/media/682910/sfe_ccg1_1415_d.pdf)
+2014 to 2015 | [CCG1 - form (PDF, 88KB)](http://media.slc.co.uk/sfe/1415/ft/sfe_ccg1_1415_d.pdf)
 
 {{snippet: where-to-send-your-forms-uk}}
 

--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_ccg_1516.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_ccg_1516.txt
@@ -4,7 +4,7 @@ To apply, estimate your childcare costs on form CCG1 after you've completed your
 
 Academic year | Form
 - | -
-2015 to 2016 | [CCG1 - form (PDF, 166KB)](http://www.sfengland.slc.co.uk/media/851447/sfe_ccg1_form_1516_d.pdf)
+2015 to 2016 | [CCG1 - form (PDF, 166KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_ccg1_form_1516_d.pdf)
 
 {{snippet: where-to-send-your-forms-uk}}
 

--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_ccg_expenses.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_ccg_expenses.txt
@@ -5,8 +5,8 @@ At the end of each term confirm your actual childcare costs. Use the CCG2 form f
 Academic Year | Form
 - | -
 2015 to 2016 | CCG2 - available September 2015
-2014 to 2015 | [CCG2 - cost confirmation form (PDF, 343KB)](http://www.sfengland.slc.co.uk/media/839010/sfe_ccg2_1415_d.pdf)
-2013 to 2014 | [CCG2 – cost confirmation form (PDF, 201KB)](http://www.sfengland.slc.co.uk/media/650001/sfe_ccg2_1314_d.pdf)
+2014 to 2015 | [CCG2 - cost confirmation form (PDF, 343KB)](http://media.slc.co.uk/sfe/1415/ft/sfe_ccg2_1415_d.pdf)
+2013 to 2014 | [CCG2 – cost confirmation form (PDF, 201KB)](http://media.slc.co.uk/sfe/1314/ft/sfe_ccg2_1314_d.pdf)
 
 ##Where to send your form(s)
 

--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_dsa_1415.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_dsa_1415.txt
@@ -6,16 +6,16 @@ If you’re only applying for DSA and no other student finance, complete the DSA
 
 Academic Year | Form
 - | -
-2014 to 2015 | [DSA1 - full form (PDF, 653KB)](http://www.sfengland.slc.co.uk/media/682898/sfe_dsa1_form_1415_d.pdf)
-2014 to 2015 | [DSA1 - guidance notes (PDF, 90KB)](http://www.sfengland.slc.co.uk/media/682922/sfe_dsa1_notes_1415_d.pdf)
+2014 to 2015 | [DSA1 - full form (PDF, 653KB)](http://media.slc.co.uk/sfe/1415/ft/sfe_dsa1_form_1415_d.pdf)
+2014 to 2015 | [DSA1 - guidance notes (PDF, 90KB)](http://media.slc.co.uk/sfe/1415/ft/sfe_dsa1_notes_1415_d.pdf)
 
 
 If you've already applied for other student finance (like a Tuition Fee Loan) complete the DSA slim and put your Customer Reference Number (CRN) in the form.
 
 Academic Year | Form
 - | -
-2014 to 2015 | [DSA1 - slim form (PDF, 490KB)](http://www.sfengland.slc.co.uk/media/682901/sfe_dsa_slim_form_1415_d.pdf)
-2014 to 2015 | [DSA1 - guidance notes (PDF, 90KB)](http://www.sfengland.slc.co.uk/media/682922/sfe_dsa1_notes_1415_d.pdf)
+2014 to 2015 | [DSA1 - slim form (PDF, 490KB)](http://media.slc.co.uk/sfe/1415/ft/sfe_dsa_slim_form_1415_d.pdf)
+2014 to 2015 | [DSA1 - guidance notes (PDF, 90KB)](http://media.slc.co.uk/sfe/1415/ft/sfe_dsa1_notes_1415_d.pdf)
 
 
 

--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_dsa_1415_pt.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_dsa_1415_pt.txt
@@ -6,8 +6,8 @@ If you’re only applying for DSA and no other student finance, complete the DSA
 
 Academic Year | Form
 - | -
-2014 to 2015 | [DSA1 - full form (PDF, 653KB)](http://www.sfengland.slc.co.uk/media/682898/sfe_dsa1_form_1415_d.pdf)
-2014 to 2015 | [DSA1 - guidance notes (PDF, 90KB)](http://www.sfengland.slc.co.uk/media/682922/sfe_dsa1_notes_1415_d.pdf)
+2014 to 2015 | [DSA1 - full form (PDF, 653KB)](http://media.slc.co.uk/sfe/1415/ft/sfe_dsa1_form_1415_d.pdf)
+2014 to 2015 | [DSA1 - guidance notes (PDF, 90KB)](http://media.slc.co.uk/sfe/1415/ft/sfe_dsa1_notes_1415_d.pdf)
 
 
 If you've already applied for other student finance (like a Tuition Fee Loan) complete the DSA slim and put your Customer Reference Number (CRN) in the form.
@@ -15,8 +15,8 @@ If you've already applied for other student finance (like a Tuition Fee Loan) co
 
 Academic Year | Form
 - | -
-2014 to 2015 | [DSA1 - slim form (PDF, 490KB)](http://www.sfengland.slc.co.uk/media/682901/sfe_dsa_slim_form_1415_d.pdf)
-2014 to 2015 | [DSA1 - guidance notes (PDF, 90KB)](http://www.sfengland.slc.co.uk/media/682922/sfe_dsa1_notes_1415_d.pdf)
+2014 to 2015 | [DSA1 - slim form (PDF, 490KB)](http://media.slc.co.uk/sfe/1415/ft/sfe_dsa_slim_form_1415_d.pdf)
+2014 to 2015 | [DSA1 - guidance notes (PDF, 90KB)](http://media.slc.co.uk/sfe/1415/ft/sfe_dsa1_notes_1415_d.pdf)
 
 
 {{snippet: where-to-send-your-forms-uk}}

--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_dsa_1516.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_dsa_1516.txt
@@ -6,16 +6,16 @@ If you’re only applying for DSA and no other student finance, complete the DSA
 
 Academic Year | Form
 - | -
-2015 to 2016 | [DSA1 - full form (PDF, 282KB)](http://www.sfengland.slc.co.uk/media/851467/sfe_dsa1_form_1516_d.pdf)
-2015 to 2016 | [DSA1 - guidance notes (PDF, 78KB)](http://www.sfengland.slc.co.uk/media/851471/sfe_dsa1_notes_1516_d.pdf)
+2015 to 2016 | [DSA1 - full form (PDF, 282KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_dsa1_form_1516_d.pdf)
+2015 to 2016 | [DSA1 - guidance notes (PDF, 78KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_dsa1_notes_1516_d.pdf)
 
 If you've already applied for other student finance (like a Tuition Fee Loan) complete the DSA slim and put your Customer Reference Number (CRN) in the form.
 
 
 Academic Year | Form
 - | -
-2015 to 2016 | [DSA - slim form (PDF, 122KB)](http://www.sfengland.slc.co.uk/media/851463/sfe_dsa_slim_form_1516_d.pdf)
-2015 to 2016 | [DSA1 - guidance notes (PDF, 78KB)](http://www.sfengland.slc.co.uk/media/851471/sfe_dsa1_notes_1516_d.pdf)
+2015 to 2016 | [DSA - slim form (PDF, 122KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_dsa_slim_form_1516_d.pdf)
+2015 to 2016 | [DSA1 - guidance notes (PDF, 78KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_dsa1_notes_1516_d.pdf)
 
 
 

--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_dsa_1516_pt.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_dsa_1516_pt.txt
@@ -6,8 +6,8 @@ If you’re only applying for DSA and no other student finance, complete the DSA
 
 Academic Year | Form
 - | -
-2015 to 2016 | [DSA1 - full form (PDF, 653KB)](http://www.sfengland.slc.co.uk/media/682898/sfe_dsa1_form_1516_d.pdf)
-2015 to 2016 | [DSA1 - guidance notes (PDF, 90KB)](http://www.sfengland.slc.co.uk/media/682922/sfe_dsa1_notes_1516_d.pdf)
+2015 to 2016 | [DSA1 - full form (PDF, 653KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_dsa1_form_1516_d.pdf)
+2015 to 2016 | [DSA1 - guidance notes (PDF, 90KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_dsa1_notes_1516_d.pdf)
 
 
 If you've already applied for other student finance (like a Tuition Fee Loan) complete the DSA slim and put your Customer Reference Number (CRN) in the form.
@@ -15,8 +15,8 @@ If you've already applied for other student finance (like a Tuition Fee Loan) co
 
 Academic Year | Form
 - | -
-2015 to 2016 | [DSA1 - slim form (PDF, 490KB)](http://www.sfengland.slc.co.uk/media/682901/sfe_dsa_slim_form_1516_d.pdf)
-2015 to 2016 | [DSA1 - guidance notes (PDF, 90KB)](http://www.sfengland.slc.co.uk/media/682922/sfe_dsa1_notes_1516_d.pdf)
+2015 to 2016 | [DSA1 - slim form (PDF, 490KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_dsa_slim_form_1516_d.pdf)
+2015 to 2016 | [DSA1 - guidance notes (PDF, 90KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_dsa1_notes_1516_d.pdf)
 
 
 {{snippet: where-to-send-your-forms-uk}}

--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_dsa_expenses.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_dsa_expenses.txt
@@ -4,8 +4,8 @@ Use the claim form for the academic year the expenses relate to. You reclaim the
 
 Academic year | Form
 - | -
-2015 to 2016 | [Costs claim form (PDF, 57KB)](http://www.sfengland.slc.co.uk/media/860462/sfe_dsa_claim_form_1516_d.pdf)
-2014 to 2015 | [Costs claim form (PDF, 55KB)](http://www.sfengland.slc.co.uk/media/688506/sfe_dsa_expenses_claim_form_1415_d.pdf)
+2015 to 2016 | [Costs claim form (PDF, 57KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_dsa_claim_form_1516_d.pdf)
+2014 to 2015 | [Costs claim form (PDF, 55KB)](http://media.slc.co.uk/sfe/1415/ft/sfe_dsa_expenses_claim_form_1415_d.pdf)
 
 {{snippet: where-to-send-your-forms-uk}}
 

--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_eu_ft_1415_continuing.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_eu_ft_1415_continuing.txt
@@ -4,7 +4,7 @@ To apply for a Tuition Fee Loan use form EUPR1A.
 
 Academic year | Form
 - | -
-2014 to 2015 | [EUPR1A - form (PDF, 108KB)](http://www.sfengland.slc.co.uk/media/722327/eu_eupr1a_1415_d.pdf)
+2014 to 2015 | [EUPR1A - form (PDF, 108KB)](http://media.slc.co.uk/sfe/1415/eu/eu_eupr1a_form_1415_d.pdf)
 
 ##Additional information
 
@@ -12,10 +12,10 @@ You may need to include additional information on the following forms.
 
 Form | When to use the form
 - | -
-[EUTFLR - form (PDF, 421KB)](http://www.sfengland.slc.co.uk/media/722318/eu_tlrf_1415_d.pdf) | To change the amount of loan you want to apply for
-[Evidence factsheet (PDF, 468KB)](http://www.sfengland.slc.co.uk/media/722312/eu_evidence_factsheet_d.pdf) | List of evidence to send with your application - eg proof of identity or income
-[Certifier checklist (PDF, 477KB)](http://www.sfengland.slc.co.uk/media/722309/eu_certifier_checklist_d.pdf) | Get the person who verifies your evidence to sign this form
-[EUCO1 - form (PDF, 483KB)](http://www.sfengland.slc.co.uk/media/722315/eu_co1_1415_d.pdf) | To update your course, name and other details
+[EUTFLR - form (PDF, 421KB)](http://media.slc.co.uk/sfe/1415/eu/eu_tlrf_1415_d.pdf) | To change the amount of loan you want to apply for
+[Evidence factsheet (PDF, 468KB)](http://media.slc.co.uk/sfe/nysf/eu_evidence_factsheet_d.pdf) | List of evidence to send with your application - eg proof of identity or income
+[Certifier checklist (PDF, 477KB)](http://media.slc.co.uk/sfe/nysf/eu_certifier_checklist_d.pdf) | Get the person who verifies your evidence to sign this form
+[EUCO1 - form (PDF, 483KB)](http://media.slc.co.uk/sfe/1415/eu/eu_co1_1415_d.pdf) | To update your course, name and other details
 
 ^You can apply up to 9 months after the start of your course.^
 

--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_eu_ft_1415_new.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_eu_ft_1415_new.txt
@@ -4,7 +4,7 @@ To apply for a Tuition Fee Loan use form EU14N.
 
 Academic year | Form
 - | -
-2014 to 2015 | [EU14N - form and notes (PDF, 200KB)](http://www.sfengland.slc.co.uk/media/722324/eu_eu14n_1415_d.pdf)
+2014 to 2015 | [EU14N - form and notes (PDF, 200KB)](http://media.slc.co.uk/sfe/1415/eu/eu_eu14n_1415_d.pdf)
 
 
 ##Additional information
@@ -14,10 +14,10 @@ You may need to include additional information on the following forms.
 
 Form | When to use the form
 - | -
-[EUTFLR - form (PDF, 200KB)](http://www.sfengland.slc.co.uk/media/722318/eu_tlrf_1415_d.pdf) | To change the amount of loan you want to apply for 
-[Evidence factsheet (PDF, 100KB)](http://www.sfengland.slc.co.uk/media/722312/eu_evidence_factsheet_d.pdf) | List of evidence to send with your application - eg proof of identity or income 
-[Certifier checklist (PDF, 75KB)](http://www.sfengland.slc.co.uk/media/722309/eu_certifier_checklist_d.pdf) | Get the person who verifies your evidence to sign this form
-[EUCO1 - form (PDF, 100KB)](http://www.sfengland.slc.co.uk/media/722315/eu_co1_1415_d.pdf) | To update your course, name and other details
+[EUTFLR - form (PDF, 200KB)](http://media.slc.co.uk/sfe/1415/eu/eu_tlrf_1415_d.pdf) | To change the amount of loan you want to apply for 
+[Evidence factsheet (PDF, 100KB)](http://media.slc.co.uk/sfe/nysf/eu_evidence_factsheet_d.pdf) | List of evidence to send with your application - eg proof of identity or income 
+[Certifier checklist (PDF, 75KB)](http://media.slc.co.uk/sfe/nysf/eu_certifier_checklist_d.pdf) | Get the person who verifies your evidence to sign this form
+[EUCO1 - form (PDF, 100KB)](http://media.slc.co.uk/sfe/1415/eu/eu_co1_1415_d.pdf) | To update your course, name and other details
 
 ^You can apply up to 9 months after the start of your course.^
 

--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_eu_ft_1516_continuing.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_eu_ft_1516_continuing.txt
@@ -13,8 +13,8 @@ You may need to include additional information on the following forms.
 Form | When to use the form
 - | -
 [EUTFLR - form (PDF, 441KB)](http://media.slc.co.uk/sfe/1516/eu/eu_tuition_fee_loan_request_form_1516_d.pdf)  | To change the amount of loan you want to apply for
-[Evidence factsheet (PDF, 82KB)](http://www.sfengland.slc.co.uk/media/873356/eu_evidence_fact_sheet_1516_d.pdf) | List of evidence to send with your application - eg proof of identity or income
-[Certifier checklist (PDF, 60KB)](http://www.sfengland.slc.co.uk/media/873116/eu_certifier_checklist_1516_d.pdf) | Get the person who verifies your evidence to sign this form
+[Evidence factsheet (PDF, 82KB)](http://media.slc.co.uk/sfe/nysf/eu_evidence_factsheet_d.pdf) | List of evidence to send with your application - eg proof of identity or income
+[Certifier checklist (PDF, 60KB)](http://media.slc.co.uk/sfe/nysf/eu_certifier_checklist_d.pdf) | Get the person who verifies your evidence to sign this form
 [EUCO1 - form (PDF, 116KB)](http://media.slc.co.uk/sfe/1516/eu/eu_euco1_form_1516_d.pdf) | To update your course, name and other details
 
 ^You can apply up to 9 months after the start of your course.^

--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_eu_ft_1516_continuing.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_eu_ft_1516_continuing.txt
@@ -4,7 +4,7 @@ To apply for a Tuition Fee Loan use form EUPR1A.
 
 Academic year | Form
 - | -
-2015 to 2016 | [EUPR1A - form (PDF, 107KB)](http://www.sfengland.slc.co.uk/media/873477/eu_eupr1a_form_1516_d.pdf)
+2015 to 2016 | [EUPR1A - form (PDF, 107KB)](http://media.slc.co.uk/sfe/1516/eu/eu_eupr1a_form_1516_d.pdf)
 
 ##Additional information
 
@@ -12,10 +12,10 @@ You may need to include additional information on the following forms.
 
 Form | When to use the form
 - | -
-[EUTFLR - form (PDF, 441KB)](http://www.sfengland.slc.co.uk/media/873481/eu_tuition_fee_loan_request_form_1516_d.pdf)  | To change the amount of loan you want to apply for
+[EUTFLR - form (PDF, 441KB)](http://media.slc.co.uk/sfe/1516/eu/eu_tuition_fee_loan_request_form_1516_d.pdf)  | To change the amount of loan you want to apply for
 [Evidence factsheet (PDF, 82KB)](http://www.sfengland.slc.co.uk/media/873356/eu_evidence_fact_sheet_1516_d.pdf) | List of evidence to send with your application - eg proof of identity or income
 [Certifier checklist (PDF, 60KB)](http://www.sfengland.slc.co.uk/media/873116/eu_certifier_checklist_1516_d.pdf) | Get the person who verifies your evidence to sign this form
-[EUCO1 - form (PDF, 116KB)](http://www.sfengland.slc.co.uk/media/873352/eu_euco1_form_1516_d.pdf) | To update your course, name and other details
+[EUCO1 - form (PDF, 116KB)](http://media.slc.co.uk/sfe/1516/eu/eu_euco1_form_1516_d.pdf) | To update your course, name and other details
 
 ^You can apply up to 9 months after the start of your course.^
 

--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_eu_ft_1516_new.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_eu_ft_1516_new.txt
@@ -13,8 +13,8 @@ You may need to include additional information on the following forms.
 Form | When to use the form
 - | -
 [EUTFLR - form (PDF, 441KB)](http://media.slc.co.uk/sfe/1516/eu/eu_tuition_fee_loan_request_form_1516_d.pdf) | To change the amount of loan you want to apply for
-[Evidence factsheet (PDF, 82KB)](http://www.sfengland.slc.co.uk/media/873356/eu_evidence_fact_sheet_1516_d.pdf) | List of evidence to send with your application - eg proof of identity or income
-[Certifier checklist (PDF, 60KB)](http://www.sfengland.slc.co.uk/media/873116/eu_certifier_checklist_1516_d.pdf) | Get the person who verifies your evidence to sign this form
+[Evidence factsheet (PDF, 82KB)](http://media.slc.co.uk/sfe/nysf/eu_evidence_factsheet_d.pdf) | List of evidence to send with your application - eg proof of identity or income
+[Certifier checklist (PDF, 60KB)](http://media.slc.co.uk/sfe/nysf/eu_certifier_checklist_d.pdf) | Get the person who verifies your evidence to sign this form
 [EUCO1 - form (PDF, 116KB)](http://media.slc.co.uk/sfe/1516/eu/eu_euco1_form_1516_d.pdf) | To update your course, name and other details
 
 ^You can apply up to 9 months after the start of your course.^

--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_eu_ft_1516_new.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_eu_ft_1516_new.txt
@@ -4,7 +4,7 @@ To apply for a Tuition Fee Loan use form EU15N.
 
 Academic year | Form
 - | -
-2015 to 2016 | [EU15N - form and notes (PDF, 253KB)](http://www.sfengland.slc.co.uk/media/873210/eu_eu15n_form_1516_d.pdf)
+2015 to 2016 | [EU15N - form and notes (PDF, 253KB)](http://media.slc.co.uk/sfe/1516/eu/eu_eu15n_form_1516_d.pdf)
 
 ##Additional information
 
@@ -12,10 +12,10 @@ You may need to include additional information on the following forms.
 
 Form | When to use the form
 - | -
-[EUTFLR - form (PDF, 441KB)](http://www.sfengland.slc.co.uk/media/873481/eu_tuition_fee_loan_request_form_1516_d.pdf) | To change the amount of loan you want to apply for
+[EUTFLR - form (PDF, 441KB)](http://media.slc.co.uk/sfe/1516/eu/eu_tuition_fee_loan_request_form_1516_d.pdf) | To change the amount of loan you want to apply for
 [Evidence factsheet (PDF, 82KB)](http://www.sfengland.slc.co.uk/media/873356/eu_evidence_fact_sheet_1516_d.pdf) | List of evidence to send with your application - eg proof of identity or income
 [Certifier checklist (PDF, 60KB)](http://www.sfengland.slc.co.uk/media/873116/eu_certifier_checklist_1516_d.pdf) | Get the person who verifies your evidence to sign this form
-[EUCO1 - form (PDF, 116KB)](http://www.sfengland.slc.co.uk/media/873352/eu_euco1_form_1516_d.pdf) | To update your course, name and other details
+[EUCO1 - form (PDF, 116KB)](http://media.slc.co.uk/sfe/1516/eu/eu_euco1_form_1516_d.pdf) | To update your course, name and other details
 
 ^You can apply up to 9 months after the start of your course.^
 

--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_eu_pt_1415_continuing.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_eu_pt_1415_continuing.txt
@@ -4,25 +4,25 @@ If you started your course on or after 1 September 2012 you may be eligible for 
 
 Academic year | Form
 - | -
-2014 to 2015 | [EUPTLC - form (PDF, 133KB)](http://www.sfengland.slc.co.uk/media/755099/eu_ptlc_1415_d.pdf)
-2014 to 2015 | [EUPTLC - guidance notes (PDF, 96KB)](http://www.sfengland.slc.co.uk/media/755103/eu_ptlc_notes_1415_d.pdf)
+2014 to 2015 | [EUPTLC - form (PDF, 133KB)](http://media.slc.co.uk/sfe/1415/eu/eu_ptlc_1415_d.pdf)
+2014 to 2015 | [EUPTLC - guidance notes (PDF, 96KB)](http://media.slc.co.uk/sfe/1415/eu/eu_ptlc_notes_1415_d.pdf)
 
 If you started your course before 1 September 2012 you may be eligible for a Tuition Fee Grant.
 
 Academic year | Form
 - | -
-2014 to 2015 | [EUPTG1 - form (PDF, 634KB)](http://www.sfengland.slc.co.uk/media/791834/eu_ptg1_1415_d.pdf)
-2014 to 2015 | [EUPTG1 - guidance notes (PDF, 483KB)](http://www.sfengland.slc.co.uk/media/791838/eu_ptg1_notes_1415_d.pdf)
+2014 to 2015 | [EUPTG1 - form (PDF, 634KB)](http://media.slc.co.uk/sfe/1415/eu/eu_ptg1_1415_d.pdf)
+2014 to 2015 | [EUPTG1 - guidance notes (PDF, 483KB)](http://media.slc.co.uk/sfe/1415/eu/eu_ptg1_notes_1415_d.pdf)
 
 ##Additional information
 You may need to include additional information on the following forms.
 
 Form | When to use the form
 - | -
-[EUTFLR - form (PDF, 421KB)](http://www.sfengland.slc.co.uk/media/722318/eu_tlrf_1415_d.pdf) | To change the amount of loan you want to apply for
-[Evidence factsheet (PDF, 468KB)](http://www.sfengland.slc.co.uk/media/722312/eu_evidence_factsheet_d.pdf) | List of evidence to send with your application - eg proof of identity or income
+[EUTFLR - form (PDF, 421KB)](http://media.slc.co.uk/sfe/1415/eu/eu_tlrf_1415_d.pdf) | To change the amount of loan you want to apply for
+[Evidence factsheet (PDF, 468KB)](http://media.slc.co.uk/sfe/nysf/eu_evidence_factsheet_d.pdf) | List of evidence to send with your application - eg proof of identity or income
 [Certifier checklist (PDF, 75KB)](http://www.sfengland.slc.co.uk/media/560159/eu_certifier_checklist_1314_d.pdf) | Get the person who verifies your evidence to sign this form
-[EUCO1 - form (PDF, 483KB)](http://www.sfengland.slc.co.uk/media/722315/eu_co1_1415_d.pdf) | To update your course, name and other details
+[EUCO1 - form (PDF, 483KB)](http://media.slc.co.uk/sfe/1415/eu/eu_co1_1415_d.pdf) | To update your course, name and other details
 
 
 ^You can apply up to 9 months after the start of your course.^

--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_eu_pt_1415_continuing.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_eu_pt_1415_continuing.txt
@@ -21,7 +21,7 @@ Form | When to use the form
 - | -
 [EUTFLR - form (PDF, 421KB)](http://media.slc.co.uk/sfe/1415/eu/eu_tlrf_1415_d.pdf) | To change the amount of loan you want to apply for
 [Evidence factsheet (PDF, 468KB)](http://media.slc.co.uk/sfe/nysf/eu_evidence_factsheet_d.pdf) | List of evidence to send with your application - eg proof of identity or income
-[Certifier checklist (PDF, 75KB)](http://www.sfengland.slc.co.uk/media/560159/eu_certifier_checklist_1314_d.pdf) | Get the person who verifies your evidence to sign this form
+[Certifier checklist (PDF, 75KB)](http://media.slc.co.uk/sfe/nysf/eu_certifier_checklist_d.pdf) | Get the person who verifies your evidence to sign this form
 [EUCO1 - form (PDF, 483KB)](http://media.slc.co.uk/sfe/1415/eu/eu_co1_1415_d.pdf) | To update your course, name and other details
 
 

--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_eu_pt_1415_new.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_eu_pt_1415_new.txt
@@ -4,18 +4,18 @@ To apply for a Tuition Fee Loan use form EUPTL1.
 
 Academic year | Form
 - | -
-2014 to 2015 | [EUPTL1 - form (PDF, 900KB)](http://www.sfengland.slc.co.uk/media/755091/eu_ptl1_1415_d.pdf)
-2014 to 2015 | [EUPTL1 - guidance notes (PDF, 102KB)](http://www.sfengland.slc.co.uk/media/755095/eu_ptl1_notes_1415_d.pdf)
+2014 to 2015 | [EUPTL1 - form (PDF, 900KB)](http://media.slc.co.uk/sfe/1415/eu/eu_ptl1_1415_d.pdf)
+2014 to 2015 | [EUPTL1 - guidance notes (PDF, 102KB)](http://media.slc.co.uk/sfe/1415/eu/eu_ptl1_notes_1415_d.pdf)
 
 ##Additional information
 You may need to include additional information on the following forms.
 
 Form | When to use the form
 - | -
-[EUTFLR - form (PDF, 421KB)](http://www.sfengland.slc.co.uk/media/722318/eu_tlrf_1415_d.pdf) | To change the amount of loan you want to apply for
-[Evidence factsheet (PDF, 468KB)](http://www.sfengland.slc.co.uk/media/722312/eu_evidence_factsheet_d.pdf) | List of evidence to send with your application - eg proof of identity or income
+[EUTFLR - form (PDF, 421KB)](http://media.slc.co.uk/sfe/1415/eu/eu_tlrf_1415_d.pdf) | To change the amount of loan you want to apply for
+[Evidence factsheet (PDF, 468KB)](http://media.slc.co.uk/sfe/nysf/eu_evidence_factsheet_d.pdf) | List of evidence to send with your application - eg proof of identity or income
 [Certifier checklist (PDF, 75KB)](http://www.sfengland.slc.co.uk/media/560159/eu_certifier_checklist_1314_d.pdf) | Get the person who verifies your evidence to sign this form
-[EUCO1 - form (PDF, 483KB)](http://www.sfengland.slc.co.uk/media/722315/eu_co1_1415_d.pdf) | To update your course, name and other details
+[EUCO1 - form (PDF, 483KB)](http://media.slc.co.uk/sfe/1415/eu/eu_co1_1415_d.pdf) | To update your course, name and other details
 
 ^You can apply up to 9 months after the start of your course.^
 

--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_eu_pt_1415_new.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_eu_pt_1415_new.txt
@@ -14,7 +14,7 @@ Form | When to use the form
 - | -
 [EUTFLR - form (PDF, 421KB)](http://media.slc.co.uk/sfe/1415/eu/eu_tlrf_1415_d.pdf) | To change the amount of loan you want to apply for
 [Evidence factsheet (PDF, 468KB)](http://media.slc.co.uk/sfe/nysf/eu_evidence_factsheet_d.pdf) | List of evidence to send with your application - eg proof of identity or income
-[Certifier checklist (PDF, 75KB)](http://www.sfengland.slc.co.uk/media/560159/eu_certifier_checklist_1314_d.pdf) | Get the person who verifies your evidence to sign this form
+[Certifier checklist (PDF, 75KB)](http://media.slc.co.uk/sfe/nysf/eu_certifier_checklist_d.pdf) | Get the person who verifies your evidence to sign this form
 [EUCO1 - form (PDF, 483KB)](http://media.slc.co.uk/sfe/1415/eu/eu_co1_1415_d.pdf) | To update your course, name and other details
 
 ^You can apply up to 9 months after the start of your course.^

--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_eu_pt_1516_new.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_eu_pt_1516_new.txt
@@ -4,17 +4,17 @@ To apply for a Tuition Fee Loan use form EUPTL1.
 
 Academic year | Form
 - | -
-2015 to 2016 | [EUPTL1 - form (PDF, 210KB)](http://www.sfengland.slc.co.uk/media/888360/eu_ptl1_form_1516_d.pdf)
-2015 to 2016 | [EUPTL1 - guidance notes (PDF, 590KB)](http://www.sfengland.slc.co.uk/media/888364/eu_ptl1_notes_1516_d.pdf)
+2015 to 2016 | [EUPTL1 - form (PDF, 210KB)](http://media.slc.co.uk/sfe/1516/eu/eu_ptl1_form_1516_d.pdf)
+2015 to 2016 | [EUPTL1 - guidance notes (PDF, 590KB)](http://media.slc.co.uk/sfe/1516/eu/eu_ptl1_notes_1516_d.pdf)
 
 ## Additional information
 
 Form | When to use the form
 - | -
-[EUTFLR - form (PDF, 441KB)](http://www.sfengland.slc.co.uk/media/873481/eu_tuition_fee_loan_request_form_1516_d.pdf) | To change the amount of loan you want to apply for
+[EUTFLR - form (PDF, 441KB)](http://media.slc.co.uk/sfe/1516/eu/eu_tuition_fee_loan_request_form_1516_d.pdf) | To change the amount of loan you want to apply for
 [Evidence factsheet (PDF, 82KB)](http://www.sfengland.slc.co.uk/media/873356/eu_evidence_fact_sheet_1516_d.pdf) | List of evidence to send with your application, eg proof of identity or income
 [Certifier checklist (PDF, 60KB)](http://www.sfengland.slc.co.uk/media/873116/eu_certifier_checklist_1516_d.pdf) | Get the person who verifies your evidence to sign this form
-[EUCO1 - form (PDF, 116KB)](http://www.sfengland.slc.co.uk/media/873352/eu_euco1_form_1516_d.pdf) | To update your course, name and other details
+[EUCO1 - form (PDF, 116KB)](http://media.slc.co.uk/sfe/1516/eu/eu_euco1_form_1516_d.pdf) | To update your course, name and other details
 
 ^You can apply up to 9 months after the start of your course.^
 

--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_eu_pt_1516_new.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_eu_pt_1516_new.txt
@@ -12,8 +12,8 @@ Academic year | Form
 Form | When to use the form
 - | -
 [EUTFLR - form (PDF, 441KB)](http://media.slc.co.uk/sfe/1516/eu/eu_tuition_fee_loan_request_form_1516_d.pdf) | To change the amount of loan you want to apply for
-[Evidence factsheet (PDF, 82KB)](http://www.sfengland.slc.co.uk/media/873356/eu_evidence_fact_sheet_1516_d.pdf) | List of evidence to send with your application, eg proof of identity or income
-[Certifier checklist (PDF, 60KB)](http://www.sfengland.slc.co.uk/media/873116/eu_certifier_checklist_1516_d.pdf) | Get the person who verifies your evidence to sign this form
+[Evidence factsheet (PDF, 82KB)](http://media.slc.co.uk/sfe/nysf/eu_evidence_factsheet_d.pdf) | List of evidence to send with your application, eg proof of identity or income
+[Certifier checklist (PDF, 60KB)](http://media.slc.co.uk/sfe/nysf/eu_certifier_checklist_d.pdf) | Get the person who verifies your evidence to sign this form
 [EUCO1 - form (PDF, 116KB)](http://media.slc.co.uk/sfe/1516/eu/eu_euco1_form_1516_d.pdf) | To update your course, name and other details
 
 ^You can apply up to 9 months after the start of your course.^

--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_parent_partner_1415.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_parent_partner_1415.txt
@@ -11,8 +11,8 @@ If you think your income has dropped by 15% or more since the 2012 to 2013 tax y
 
 Academic year | Form
 - | -
-2014 to 2015 | [PFF2 - income details form (PDF, 579KB)](http://www.sfengland.slc.co.uk/media/682907/sfe_pff2_1415_d.pdf)
-2014 to 2015 | [CYI - current tax year income details form (PDF, 522KB)](http://www.sfengland.slc.co.uk/media/728027/sfe_cyi_1415_d.pdf)
+2014 to 2015 | [PFF2 - income details form (PDF, 579KB)](http://media.slc.co.uk/sfe/1415/ft/sfe_pff2_1415_d.pdf)
+2014 to 2015 | [CYI - current tax year income details form (PDF, 522KB)](http://media.slc.co.uk/sfe/1415/ft/sfe_cyi_1415_d.pdf)
 
 
 %Income means your [household income](/apply-for-student-finance/household-income).%

--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_parent_partner_1516.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_parent_partner_1516.txt
@@ -11,8 +11,8 @@ If you think your income has dropped by 15% or more since the 2013 to 2014 tax y
 
 Academic year | Form
 - | -
-2015 to 2016 | [PFF2 - income details form (PDF, 678KB)](http://www.sfengland.slc.co.uk/media/851499/sfe_pff2_form_1516_d.pdf)
-2015 to 2016 | [CYI - current tax year income details form (PDF, 589KB)](http://www.sfengland.slc.co.uk/media/851459/sfe_current_year_income_form_1516_d.pdf)
+2015 to 2016 | [PFF2 - income details form (PDF, 678KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_pff2_form_1516_d.pdf)
+2015 to 2016 | [CYI - current tax year income details form (PDF, 589KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_cyi_1516_d.pdf)
 
 
 %Income means your [household income](/apply-for-student-finance/household-income).%

--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_proof_identity_1415.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_proof_identity_1415.txt
@@ -4,8 +4,8 @@ If you haven’t included your UK passport details in your application, use the 
 
 Academic year | Form
 - | -
-2014 to 2015 | [UK passport details form (PDF, 428KB)](http://www.sfengland.slc.co.uk/media/685458/sfe_uk_passport_details_1415_d.pdf)
-2014 to 2015 | [Birth or adoption certificate form (PDF, 85KB)](http://www.sfengland.slc.co.uk/media/682913/sfe_birth_adopt_cert_form_1415_d.pdf)
+2014 to 2015 | [UK passport details form (PDF, 428KB)](http://media.slc.co.uk/sfe/1415/ft/sfe_uk_passport_details_1415_d.pdf)
+2014 to 2015 | [Birth or adoption certificate form (PDF, 85KB)](http://media.slc.co.uk/sfe/1415/ft/sfe_birth_adopt_cert_form_1415_d.pdf)
 
 ^Don't send your UK passport.^
 

--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_proof_identity_1516.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_proof_identity_1516.txt
@@ -4,8 +4,8 @@ If you haven’t included your UK passport details in your application, use the 
 
 Academic year | Form
 - | -
-2015 to 2016 | [UK passport details form (PDF, 67KB)](http://www.sfengland.slc.co.uk/media/860458/sfe_ukpp_details_form_1516_d.pdf)
-2015 to 2016 | [Birth or adoption certificate form (PDF, 493KB)](http://www.sfengland.slc.co.uk/media/851503/sfe_birth_adoption_form_1516_d.pdf)
+2015 to 2016 | [UK passport details form (PDF, 67KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_ukpp_details_form_1516_d.pdf)
+2015 to 2016 | [Birth or adoption certificate form (PDF, 493KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_birth_adoption_form_1516_d.pdf)
 
 ^Don't send your UK passport.^
 

--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_travel.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_travel.txt
@@ -2,7 +2,7 @@
 
 You need to complete the two forms listed below if you’re studying abroad:
 
-- [Travel Abroad Expenses Form (PDF, 110KB)](http://www.sfengland.slc.co.uk/media/851483/sfe_travel_expenses_form_1516_d.pdf) - this should be completed by you 
+- [Travel Abroad Expenses Form (PDF, 110KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_travel_expenses_form_1516_d.pdf) - this should be completed by you 
 - Course Abroad Form - your university or college will need to complete this form (or contact the Student Loans Company to confirm your study abroad details)
 
 If you’re on a clinical placement as part of your medicine or dentistry course you must complete the ‘Clinical Study Travel Expenses Form’ - this is available on request.

--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_uk_ft_1415_continuing.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_uk_ft_1415_continuing.txt
@@ -7,8 +7,8 @@ If you can't apply online, use form PR1.
 Academic Year | Form
 - | -
 2014 to 2015 | [Apply online](/apply-online-for-student-finance "Apply for student finance online")
-2014 to 2015 | [PR1 - form (PDF, 596KB)](http://www.sfengland.slc.co.uk/media/682895/sfe_pr1_form_1415_d.pdf)
-2014 to 2015 | [PR1 - guidance notes (PDF, 601KB)](http://www.sfengland.slc.co.uk/media/682919/sfe_pr1_notes_1415_d.pdf)
+2014 to 2015 | [PR1 - form (PDF, 596KB)](http://media.slc.co.uk/sfe/1415/ft/sfe_pr1_form_1415_d.pdf)
+2014 to 2015 | [PR1 - guidance notes (PDF, 601KB)](http://media.slc.co.uk/sfe/1415/ft/sfe_pr1_notes_1415_d.pdf)
 
 ^You can apply up to 9 months after the start of your course.^
 

--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_uk_ft_1415_new.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_uk_ft_1415_new.txt
@@ -7,8 +7,8 @@ If you can't apply online, use form PN1.
 Academic Year | Form
 - | -
 2014 to 2015 | [Apply online](/apply-online-for-student-finance)
-2014 to 2015 | [PN1 - form (PDF, 823KB)](http://www.sfengland.slc.co.uk/media/682892/sfe_pn1_form_1415_d.pdf)
-2014 to 2015 | [PN1 - guidance notes (PDF, 537KB)](http://www.sfengland.slc.co.uk/media/682916/sfe_pn1_notes_1415_d.pdf)
+2014 to 2015 | [PN1 - form (PDF, 823KB)](http://media.slc.co.uk/sfe/1415/ft/sfe_pn1_form_1415_d.pdf)
+2014 to 2015 | [PN1 - guidance notes (PDF, 537KB)](http://media.slc.co.uk/sfe/1415/ft/sfe_pn1_notes_1415_d.pdf)
 
 ^You can apply up to 9 months after the start of your course.^
 

--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_uk_ft_1516_continuing.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_uk_ft_1516_continuing.txt
@@ -6,8 +6,8 @@ If you can't apply online, use form PR1.
 
 Academic Year | Form
 - | -
-2015 to 2016 | [PR1 - form (PDF, 569KB)](http://www.sfengland.slc.co.uk/media/860450/sfe_pr1_form_1516_d.pdf)
-2015 to 2016 | [PR1 - guidance notes (PDF, 199KB)](http://www.sfengland.slc.co.uk/media/860454/sfe_pr1_notes_1516_d.pdf)
+2015 to 2016 | [PR1 - form (PDF, 569KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_pr1_form_1516_d.pdf)
+2015 to 2016 | [PR1 - guidance notes (PDF, 199KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_pr1_notes_1516_d.pdf)
 
 ^You can apply up to 9 months after the start of your course.^
 

--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_uk_ft_1516_new.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_uk_ft_1516_new.txt
@@ -6,8 +6,8 @@ If you can't apply online, use form PN1.
 
 Academic Year | Form
 - | -
-2015 to 2016 | [PN1 - form (PDF, 468KB)](http://www.sfengland.slc.co.uk/media/860442/sfe_pn1_form_1516_d.pdf)
-2015 to 2016 | [PN1 - guidance notes (PDF, 223KB)](http://www.sfengland.slc.co.uk/media/860446/sfe_pn1_notes_1516_d.pdf)
+2015 to 2016 | [PN1 - form (PDF, 468KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_pn1_form_1516_d.pdf)
+2015 to 2016 | [PN1 - guidance notes (PDF, 223KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_pn1_notes_1516_d.pdf)
 
 ^You can apply up to 9 months after the start of your course.^
 

--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_uk_pt_1415_continuing.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_uk_pt_1415_continuing.txt
@@ -5,8 +5,8 @@ You should [apply online](/apply-online-for-student-finance) for a Tuition Fee L
 Academic Year | Form
 - | -
 2014 to 2015 | [Apply online](/apply-online-for-student-finance)
-2014 to 2015 | [PTLC - form (PDF, 128KB)](http://www.sfengland.slc.co.uk/media/710746/sfe_ptlc_1415_d.pdf)
-2014 to 2015 | [PTLC - guidance notes (PDF, 96KB)](http://www.sfengland.slc.co.uk/media/710758/sfe_ptlc_notes_1415_d.pdf)
+2014 to 2015 | [PTLC - form (PDF, 128KB)](http://media.slc.co.uk/sfe/1415/pt/sfe_ptlc_1415_d.pdf)
+2014 to 2015 | [PTLC - guidance notes (PDF, 96KB)](http://media.slc.co.uk/sfe/1415/pt/sfe_ptlc_notes_1415_d.pdf)
 
 ^You can apply up to 9 months after the start of your course.^
 

--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_uk_pt_1415_grant.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_uk_pt_1415_grant.txt
@@ -2,10 +2,10 @@ To apply for a Fee Grant and Course Grant use form PTGC (or PTGN if you’re app
 
 Academic year | Form
 - | -
-2014 to 2015 | [PTGC - form (PDF, 400KB)](http://www.sfengland.slc.co.uk/media/710752/sfe_ptgc_1415_d.pdf)
-2014 to 2015 | [PTGC - guidance notes (PDF, 100KB)](http://www.sfengland.slc.co.uk/media/710764/sfe_ptgc_notes_1415_d.pdf)
-2014 to 2015 | [PTGN - form (PDF, 615KB)](http://www.sfengland.slc.co.uk/media/710749/sfe_ptgn_1415_d.pdf) – if you’re applying for the first time
-2014 to 2015 | [PTGN - guidance notes (PDF, 100KB)](http://www.sfengland.slc.co.uk/media/710761/sfe_ptgn_notes_1415_d.pdf)
+2014 to 2015 | [PTGC - form (PDF, 400KB)](http://media.slc.co.uk/sfe/1415/pt/sfe_ptgc_1415_d.pdf)
+2014 to 2015 | [PTGC - guidance notes (PDF, 100KB)](http://media.slc.co.uk/sfe/1415/pt/sfe_ptgc_notes_1415_d.pdf)
+2014 to 2015 | [PTGN - form (PDF, 615KB)](http://media.slc.co.uk/sfe/1415/pt/sfe_ptgn_1415_d.pdf) – if you’re applying for the first time
+2014 to 2015 | [PTGN - guidance notes (PDF, 100KB)](http://media.slc.co.uk/sfe/1415/pt/sfe_ptgn_notes_1415_d.pdf)
 
 ^You can apply up to 9 months after the start of your course.^
 
@@ -16,5 +16,5 @@ You may need to include additional information on the following forms.
 
 Form | When to use the form
 - | -
-[CO2 - change of circumstances (PDF, 98KB)](http://www.sfengland.slc.co.uk/media/755527/sfe_co2_form_1415_d.pdf) | Your course, university or contact details change
-[CB1 - benefits confirmation (PDF, 463KB)](http://www.sfengland.slc.co.uk/media/789731/sfe_cb1_1415_d.pdf) | You or your partner get certain benefits (check the form for details)
+[CO2 - change of circumstances (PDF, 98KB)](http://media.slc.co.uk/sfe/1415/pt/sfe_co2_form_1415_d.pdf ) | Your course, university or contact details change
+[CB1 - benefits confirmation (PDF, 463KB)](http://media.slc.co.uk/sfe/1415/pt/sfe_cb1_1415_d.pdf) | You or your partner get certain benefits (check the form for details)

--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_uk_pt_1415_new.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_uk_pt_1415_new.txt
@@ -5,8 +5,8 @@ You should [apply online](/apply-online-for-student-finance) for a Tuition Fee L
 Academic Year | Form
 - | -
 2014 to 2015 | [Apply online](/apply-online-for-student-finance)
-2014 to 2015 | [PTL1 - form (PDF, 237KB)](http://www.sfengland.slc.co.uk/media/710743/sfe_ptl1_1415_d.pdf)
-2014 to 2015 | [PTL1 - guidance notes (PDF, 182KB)](http://www.sfengland.slc.co.uk/media/710755/sfe_ptl1_notes_1415_d.pdf)
+2014 to 2015 | [PTL1 - form (PDF, 237KB)](http://media.slc.co.uk/sfe/1415/pt/sfe_ptl1_1415_d.pdf)
+2014 to 2015 | [PTL1 - guidance notes (PDF, 182KB)](http://media.slc.co.uk/sfe/1415/pt/sfe_ptl1_notes_1415_d.pdf)
 
 ^You can apply up to 9 months after the start of your course.^
 

--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_continuing.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_continuing.txt
@@ -5,8 +5,8 @@ You should [apply online](/apply-online-for-student-finance) for a Tuition Fee L
 Academic Year | Form
 - | -
 2015 to 2016 | [Apply online](/apply-online-for-student-finance)
-2015 to 2016 | [PTLC - form (PDF, 609KB)](http://www.sfengland.slc.co.uk/media/887066/sfe_ptlc_form_1516_d.pdf)
-2015 to 2016 | [PTLC - guidance notes (PDF, 98KB)](http://www.sfengland.slc.co.uk/media/887070/sfe_ptlc_notes_1516_d.pdf)
+2015 to 2016 | [PTLC - form (PDF, 609KB)](http://media.slc.co.uk/sfe/1516/pt/sfe_ptlc_form_1516_d.pdf)
+2015 to 2016 | [PTLC - guidance notes (PDF, 98KB)](http://media.slc.co.uk/sfe/1516/pt/sfe_ptlc_notes_1516_d.pdf)
 
 ^You can apply up to 9 months after the start of your course.^
 

--- a/lib/smartdown_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_new.txt
+++ b/lib/smartdown_flows/student-finance-forms/outcomes/outcome_uk_pt_1516_new.txt
@@ -5,8 +5,8 @@ You should [apply online](/apply-online-for-student-finance) for a Tuition Fee L
 Academic Year | Form
 - | -
 2015 to 2016 | [Apply online](/apply-online-for-student-finance)
-2015 to 2016 | [PTL1 - form (PDF, 728KB)](http://www.sfengland.slc.co.uk/media/887058/sfe_ptl1_form_1516_d.pdf)
-2015 to 2016 | [PTL1 - guidance notes (PDF, 116KB)](http://www.sfengland.slc.co.uk/media/887062/sfe_ptl1_notes_1516_d.pdf)
+2015 to 2016 | [PTL1 - form (PDF, 728KB)](http://media.slc.co.uk/sfe/1516/pt/sfe_ptl1_form_1516_d.pdf)
+2015 to 2016 | [PTL1 - guidance notes (PDF, 116KB)](http://media.slc.co.uk/sfe/1516/pt/sfe_ptl1_notes_1516_d.pdf)
 
 ^You can apply up to 9 months after the start of your course.^
 


### PR DESCRIPTION
We've been asked to update the links to student forms as the stakeholder (slc.co.uk) is changing the CMS that is serving the forms.

This has been fact-checked and needs to go live on 28th.