### PR TITLE
Update parser Gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,7 +142,7 @@ GEM
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     null_logger (0.0.1)
-    parser (2.2.0.3)
+    parser (2.2.2.6)
       ast (>= 1.1, < 3.0)
     parslet (1.6.2)
       blankslate (>= 2.0, <= 4.0)


### PR DESCRIPTION
This avoids the following warning that I've been seeing since we upgraded to
Ruby 2.1.6:

    warning: parser/current is loading parser/ruby21, which recognizes
    warning: 2.1.5-compliant syntax, but you are running 2.1.6.

I updated the Gem using:

    $ bundle update parser