### PR TITLE
Convert calculate-statutory-sick-pay to use ERB templates

### DIFF
--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -318,23 +318,11 @@ module SmartAnswer
       end
 
       # Answer 6
-      outcome :entitled_to_sick_pay do
+      outcome :entitled_to_sick_pay, use_outcome_templates: true do
         precalculate :days_paid do calculator.days_paid end
         precalculate :normal_workdays_out do calculator.normal_workdays end
         precalculate :pattern_days do calculator.pattern_days end
         precalculate :pattern_days_total do calculator.pattern_days * 28 end
-
-        precalculate :proof_of_illness do
-          PhraseList.new(:enough_notice) unless enough_notice_of_absence
-        end
-
-        precalculate :entitled_to_esa do
-          PhraseList.new(:esa) if enough_notice_of_absence
-        end
-
-        precalculate :paternity_adoption_warning do
-          PhraseList.new(:paternity_warning) if paternity_maternity_warning
-        end
       end
 
       # Answer 7

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -305,7 +305,7 @@ module SmartAnswer
       outcome :already_getting_maternity, use_outcome_templates: true
 
       # Answer 2
-      outcome :must_be_sick_for_4_days
+      outcome :must_be_sick_for_4_days, use_outcome_templates: true
 
       # Answer 4
       outcome :not_regular_schedule

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -326,7 +326,7 @@ module SmartAnswer
       end
 
       # Answer 7
-      outcome :not_entitled_3_days_not_paid do
+      outcome :not_entitled_3_days_not_paid, use_outcome_templates: true do
         precalculate :normal_workdays_out do calculator.normal_workdays end
       end
 

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -302,7 +302,7 @@ module SmartAnswer
       end
 
       # Answer 1
-      outcome :already_getting_maternity
+      outcome :already_getting_maternity, use_outcome_templates: true
 
       # Answer 2
       outcome :must_be_sick_for_4_days

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -331,7 +331,7 @@ module SmartAnswer
       end
 
       # Answer 8
-      outcome :maximum_entitlement_reached
+      outcome :maximum_entitlement_reached, use_outcome_templates: true
     end
   end
 end

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -311,7 +311,7 @@ module SmartAnswer
       outcome :not_regular_schedule, use_outcome_templates: true
 
       # Answer 5
-      outcome :not_earned_enough do
+      outcome :not_earned_enough, use_outcome_templates: true do
         precalculate :lower_earning_limit do
           Calculators::StatutorySickPayCalculator.lower_earning_limit_on(sick_start_date)
         end

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -301,24 +301,26 @@ module SmartAnswer
         next_node(:not_entitled_3_days_not_paid)
       end
 
+      use_outcome_templates
+
       # Answer 1
-      outcome :already_getting_maternity, use_outcome_templates: true
+      outcome :already_getting_maternity
 
       # Answer 2
-      outcome :must_be_sick_for_4_days, use_outcome_templates: true
+      outcome :must_be_sick_for_4_days
 
       # Answer 4
-      outcome :not_regular_schedule, use_outcome_templates: true
+      outcome :not_regular_schedule
 
       # Answer 5
-      outcome :not_earned_enough, use_outcome_templates: true do
+      outcome :not_earned_enough do
         precalculate :lower_earning_limit do
           Calculators::StatutorySickPayCalculator.lower_earning_limit_on(sick_start_date)
         end
       end
 
       # Answer 6
-      outcome :entitled_to_sick_pay, use_outcome_templates: true do
+      outcome :entitled_to_sick_pay do
         precalculate :days_paid do calculator.days_paid end
         precalculate :normal_workdays_out do calculator.normal_workdays end
         precalculate :pattern_days do calculator.pattern_days end
@@ -326,12 +328,12 @@ module SmartAnswer
       end
 
       # Answer 7
-      outcome :not_entitled_3_days_not_paid, use_outcome_templates: true do
+      outcome :not_entitled_3_days_not_paid do
         precalculate :normal_workdays_out do calculator.normal_workdays end
       end
 
       # Answer 8
-      outcome :maximum_entitlement_reached, use_outcome_templates: true
+      outcome :maximum_entitlement_reached
     end
   end
 end

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -308,7 +308,7 @@ module SmartAnswer
       outcome :must_be_sick_for_4_days, use_outcome_templates: true
 
       # Answer 4
-      outcome :not_regular_schedule
+      outcome :not_regular_schedule, use_outcome_templates: true
 
       # Answer 5
       outcome :not_earned_enough do

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/_esa.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/_esa.govspeak.erb
@@ -1,0 +1,3 @@
+<% if enough_notice_of_absence %>
+They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).
+<% end %>

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/already_getting_maternity.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/already_getting_maternity.govspeak.erb
@@ -1,0 +1,3 @@
+<% content_for :body do %>
+  Your employee isn’t entitled to statutory sick pay because they’re already receiving Statutory Maternity Pay or Maternity Allowance.
+<% end %>

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/entitled_to_sick_pay.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/entitled_to_sick_pay.govspeak.erb
@@ -1,0 +1,31 @@
+<% content_for :body do %>
+  ##Statutory Sick Pay (SSP)
+
+  Your employee is entitled to SSP for <%= days_paid %> days out of <%= normal_workdays_out %> working days taken off sick between <%= format_date(sick_start_date) %> and <%= format_date(sick_end_date) %>
+
+  <% unless enough_notice_of_absence %>
+    You don’t have to pay until your employee tells you that they’re ill. You’ll have to pay any withheld amounts by the end of your employee's entitlement to sick pay if your employee is sick for more than 28 weeks.
+  <% end %>
+
+
+  Week ending | SSP amount
+  -|-
+  <%= formatted_sick_pay_weekly_amounts %>
+   | **Total SSP: <%= format_money(ssp_payment) %>**
+
+  ##What you need to know
+
+  <% if paternity_maternity_warning %>
+    ^ Your employee will not be able to collect Ordinary Statutory Paternity Pay or Statutory Adoption Pay while collecting Statutory Sick Pay. ^
+
+  <% end %>
+
+  SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of <%= pattern_days_total %> days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. <%= render partial: 'esa.govspeak.erb', locals: {enough_notice_of_absence: enough_notice_of_absence} -%>
+
+
+  There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
+
+  You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
+
+  *[SSP]: Statutory Sick Pay
+<% end %>

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/maximum_entitlement_reached.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/maximum_entitlement_reached.govspeak.erb
@@ -1,0 +1,5 @@
+<% content_for :body do %>
+  Your employee isn’t entitled to Statutory Sick Pay because they’ve already received the maximum amount of SSP (28 weeks).
+
+  You must send them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of them going off sick. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).
+<% end %>

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/must_be_sick_for_4_days.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/must_be_sick_for_4_days.govspeak.erb
@@ -1,0 +1,3 @@
+<% content_for :body do %>
+  Your employee must be sick for at least 4 days in a row to get Statutory Sick Pay.
+<% end %>

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/not_earned_enough.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/not_earned_enough.govspeak.erb
@@ -1,0 +1,5 @@
+<% content_for :body do %>
+  Your employee isn’t entitled to Statutory Sick Pay because their average weekly earnings must be at least £<%= lower_earning_limit %>. Their average weekly earnings are £<%= employee_average_weekly_earnings %>.
+
+  You must send them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) no more than 7 days after they’ve told you they’re sick. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).
+<% end %>

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/not_entitled_3_days_not_paid.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/not_entitled_3_days_not_paid.govspeak.erb
@@ -1,0 +1,5 @@
+<% content_for :body do %>
+  Your employee isn’t entitled to Statutory Sick Pay because the first 3 days of illness aren’t paid.
+
+  This employee has taken <%= normal_workdays_out %> working days off sick between <%= format_date(sick_start_date) %> and <%= format_date(sick_end_date) %>.
+<% end %>

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/not_regular_schedule.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/not_regular_schedule.govspeak.erb
@@ -1,0 +1,3 @@
+<% content_for :body do %>
+  If your employee has an irregular work schedule, you’ll need to [work out Statutory Sick Pay manually](/statutory-sick-pay-manually-calculate-your-employees-payments).
+<% end %>

--- a/lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml
+++ b/lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml
@@ -150,14 +150,6 @@ en-GB:
           "6": Saturday
           "0": Sunday
 
-      # Answer 5
-      not_earned_enough:
-        body: |
-          Your employee isn’t entitled to Statutory Sick Pay because their average weekly earnings must be at least £%{lower_earning_limit}. Their average weekly earnings are £%{employee_average_weekly_earnings}.
-
-          You must send them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) no more than 7 days after they’ve told you they’re sick. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).
-
-
       # Answer 6
       entitled_to_sick_pay:
         body: |

--- a/lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml
+++ b/lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml
@@ -150,11 +150,6 @@ en-GB:
           "6": Saturday
           "0": Sunday
 
-      # Answer 4
-      not_regular_schedule:
-        body: |
-          If your employee has an irregular work schedule, you’ll need to [work out Statutory Sick Pay manually](/statutory-sick-pay-manually-calculate-your-employees-payments).
-
       # Answer 5
       not_earned_enough:
         body: |

--- a/lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml
+++ b/lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml
@@ -144,13 +144,6 @@ en-GB:
           "6": Saturday
           "0": Sunday
 
-      # Answer 7
-      not_entitled_3_days_not_paid:
-        body: |
-          Your employee isn’t entitled to Statutory Sick Pay because the first 3 days of illness aren’t paid.
-
-          This employee has taken %{normal_workdays_out} working days off sick between %{sick_start_date} and %{sick_end_date}.
-
       # Answer 8
       maximum_entitlement_reached:
         body: |

--- a/lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml
+++ b/lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml
@@ -150,11 +150,6 @@ en-GB:
           "6": Saturday
           "0": Sunday
 
-      # Answer 1
-      already_getting_maternity:
-        body: |
-          Your employee isn’t entitled to statutory sick pay because they’re already receiving Statutory Maternity Pay or Maternity Allowance.
-
       # Answer 2
       must_be_sick_for_4_days:
         body: |

--- a/lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml
+++ b/lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml
@@ -143,10 +143,3 @@ en-GB:
           "5": Friday
           "6": Saturday
           "0": Sunday
-
-      # Answer 8
-      maximum_entitlement_reached:
-        body: |
-          Your employee isn’t entitled to Statutory Sick Pay because they’ve already received the maximum amount of SSP (28 weeks).
-
-          You must send them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of them going off sick. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml
+++ b/lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml
@@ -5,12 +5,6 @@ en-GB:
         description: Statutory Sick Pay (SSP) calculator -  calculate SSP for an employee
       title: Calculate your employee's statutory sick pay
       phrases:
-        paternity_warning: |
-          ^ Your employee will not be able to collect Ordinary Statutory Paternity Pay or Statutory Adoption Pay while collecting Statutory Sick Pay. ^
-        enough_notice: |
-          You don’t have to pay until your employee tells you that they’re ill. You’ll have to pay any withheld amounts by the end of your employee's entitlement to sick pay if your employee is sick for more than 28 weeks.
-        esa: |
-          They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).
         ssp_link: |
 
 
@@ -150,31 +144,6 @@ en-GB:
           "6": Saturday
           "0": Sunday
 
-      # Answer 6
-      entitled_to_sick_pay:
-        body: |
-          ##Statutory Sick Pay (SSP)
-
-          Your employee is entitled to SSP for %{days_paid} days out of %{normal_workdays_out} working days taken off sick between %{sick_start_date} and %{sick_end_date}
-
-          %{proof_of_illness}
-
-          Week ending | SSP amount
-          -|-
-          %{formatted_sick_pay_weekly_amounts}
-           | **Total SSP: %{ssp_payment}**
-
-          ##What you need to know
-
-          %{paternity_adoption_warning}
-
-          SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of %{pattern_days_total} days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. %{entitled_to_esa}
-
-          There are also [records you must keep](/sick-leave-pay-employees/entitlement) and rules on [proof of illness](/sick-leave-pay-employees/notice-and-fit-notes) you can ask for.
-
-          You can [claim back sick pay](http://www.hmrc.gov.uk/payerti/employee/statutory-pay/ssp-calc.htm) paid before 5 April 2014. You must do this by 6 April 2016.
-
-          *[SSP]: Statutory Sick Pay
       # Answer 7
       not_entitled_3_days_not_paid:
         body: |

--- a/lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml
+++ b/lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml
@@ -150,11 +150,6 @@ en-GB:
           "6": Saturday
           "0": Sunday
 
-      # Answer 2
-      must_be_sick_for_4_days:
-        body: |
-          Your employee must be sick for at least 4 days in a row to get Statutory Sick Pay.
-
       # Answer 4
       not_regular_schedule:
         body: |

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -9,16 +9,16 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -9,16 +9,16 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -9,16 +9,16 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -9,16 +9,16 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -9,16 +9,16 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -9,16 +9,16 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -9,16 +9,16 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,16 +9,16 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,16 +9,16 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,16 +9,16 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,16 +9,16 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,16 +9,16 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 4 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 4 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 4 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 4 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 4 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 4 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 4 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 4 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 4 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 4 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 4 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 4 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 66 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 66 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 66 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 66 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 66 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 66 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 66 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 66 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 66 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 66 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 66 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 66 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 28 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 28 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 28 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 28 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 28 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 28 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 28 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 28 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 28 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 28 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 28 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 28 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -8,16 +8,16 @@ Your employee is entitled to SSP for 16 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -8,16 +8,16 @@ Your employee is entitled to SSP for 16 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -8,16 +8,16 @@ Your employee is entitled to SSP for 16 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -8,16 +8,16 @@ Your employee is entitled to SSP for 16 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -8,16 +8,16 @@ Your employee is entitled to SSP for 16 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -8,16 +8,16 @@ Your employee is entitled to SSP for 16 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -8,16 +8,16 @@ Your employee is entitled to SSP for 16 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,16 +8,16 @@ Your employee is entitled to SSP for 16 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,16 +8,16 @@ Your employee is entitled to SSP for 16 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,16 +8,16 @@ Your employee is entitled to SSP for 16 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,16 +8,16 @@ Your employee is entitled to SSP for 16 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,16 +8,16 @@ Your employee is entitled to SSP for 16 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/additional_statutory_paternity_pay,ordinary_statutory_paternity_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,12 +9,11 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -9,25 +9,24 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -9,25 +9,24 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/0,6.txt
@@ -9,25 +9,24 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/0,6.txt
@@ -9,25 +9,24 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/0,6.txt
@@ -9,25 +9,24 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/0,6.txt
@@ -9,25 +9,24 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/0,6.txt
@@ -9,25 +9,24 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,25 +9,24 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,25 +9,24 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,25 +9,24 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,25 +9,24 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,25 +9,24 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -9,25 +9,24 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -9,25 +9,24 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -9,25 +9,24 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -9,25 +9,24 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -9,25 +9,24 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -9,25 +9,24 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -9,25 +9,24 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,25 +9,24 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,25 +9,24 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,25 +9,24 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,25 +9,24 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,25 +9,24 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -9,19 +9,18 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -9,19 +9,18 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -9,19 +9,18 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -9,19 +9,18 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -9,19 +9,18 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -9,19 +9,18 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -9,19 +9,18 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,19 +9,18 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,19 +9,18 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,19 +9,18 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,19 +9,18 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,19 +9,18 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,24 +9,23 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. 

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 4 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 4 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 4 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 4 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 4 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 4 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 4 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 4 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 4 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 4 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 4 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 4 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,12 +8,11 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -8,25 +8,24 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 66 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -8,25 +8,24 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 66 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/0,6.txt
@@ -8,25 +8,24 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 66 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/0,6.txt
@@ -8,25 +8,24 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 66 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/0,6.txt
@@ -8,25 +8,24 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 66 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/0,6.txt
@@ -8,25 +8,24 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 66 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/0,6.txt
@@ -8,25 +8,24 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 66 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,25 +8,24 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 66 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,25 +8,24 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 66 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,25 +8,24 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 66 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,25 +8,24 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 66 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,25 +8,24 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 66 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -8,25 +8,24 @@ Your employee is entitled to SSP for 28 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -8,25 +8,24 @@ Your employee is entitled to SSP for 28 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -8,25 +8,24 @@ Your employee is entitled to SSP for 28 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -8,25 +8,24 @@ Your employee is entitled to SSP for 28 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -8,25 +8,24 @@ Your employee is entitled to SSP for 28 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -8,25 +8,24 @@ Your employee is entitled to SSP for 28 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -8,25 +8,24 @@ Your employee is entitled to SSP for 28 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,25 +8,24 @@ Your employee is entitled to SSP for 28 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,25 +8,24 @@ Your employee is entitled to SSP for 28 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,25 +8,24 @@ Your employee is entitled to SSP for 28 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,25 +8,24 @@ Your employee is entitled to SSP for 28 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,25 +8,24 @@ Your employee is entitled to SSP for 28 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -8,19 +8,18 @@ Your employee is entitled to SSP for 16 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -8,19 +8,18 @@ Your employee is entitled to SSP for 16 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -8,19 +8,18 @@ Your employee is entitled to SSP for 16 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -8,19 +8,18 @@ Your employee is entitled to SSP for 16 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -8,19 +8,18 @@ Your employee is entitled to SSP for 16 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -8,19 +8,18 @@ Your employee is entitled to SSP for 16 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -8,19 +8,18 @@ Your employee is entitled to SSP for 16 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,19 +8,18 @@ Your employee is entitled to SSP for 16 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,19 +8,18 @@ Your employee is entitled to SSP for 16 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,19 +8,18 @@ Your employee is entitled to SSP for 16 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,19 +8,18 @@ Your employee is entitled to SSP for 16 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,19 +8,18 @@ Your employee is entitled to SSP for 16 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 56 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 140 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/none/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,24 +8,23 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
-
 
 
 SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of 84 days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,9 +9,9 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,22 +9,22 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -9,16 +9,16 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -9,16 +9,16 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -9,16 +9,16 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -9,16 +9,16 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -9,16 +9,16 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -9,16 +9,16 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -9,16 +9,16 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,16 +9,16 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,16 +9,16 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,16 +9,16 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,16 +9,16 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -9,16 +9,16 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/no/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -9,21 +9,21 @@ You don’t have to pay until your employee tells you that they’re ill. You’
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 4 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 4 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 4 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 4 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 4 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 4 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 4 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 4 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 4 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 4 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 4 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 4 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£52.02
- | **Total SSP: £69.19**
+| **Total SSP: £69.19**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
- | **Total SSP: £57.80**
+| **Total SSP: £57.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 2 days out of 2 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£43.35
- | **Total SSP: £86.70**
+| **Total SSP: £86.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 7 days out of 7 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£52.02
- | **Total SSP: £120.70**
+| **Total SSP: £120.70**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-04-10/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,9 +8,9 @@ Your employee is entitled to SSP for 5 days out of 5 working days taken off sick
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
- | **Total SSP: £143.94**
+| **Total SSP: £143.94**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 66 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 66 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 66 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 66 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 66 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 66 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 66 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 66 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 66 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 66 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 66 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 25 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£0.00
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,083.75**
+| **Total SSP: £1,083.75**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 66 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£17.17
+6 April 2013|£17.17
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,144.27**
+6 July 2013|£86.70
+| **Total SSP: £1,144.27**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/no/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 38 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£0.00
+6 April 2013|£0.00
 13 April 2013|£57.80
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,098.20**
+6 July 2013|£86.70
+| **Total SSP: £1,098.20**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 28 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 28 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 28 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 28 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 28 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 28 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 28 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 28 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 28 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 28 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 28 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,22 +8,22 @@ Your employee is entitled to SSP for 28 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
+6 July 2013|£86.70
 13 July 2013|£43.35
- | **Total SSP: £1,213.80**
+| **Total SSP: £1,213.80**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-02-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/0,6.txt
@@ -8,16 +8,16 @@ Your employee is entitled to SSP for 16 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/every_4_weeks/2000.0/30/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/0,6.txt
@@ -8,16 +8,16 @@ Your employee is entitled to SSP for 16 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/fortnightly/2000.0/30/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/0,6.txt
@@ -8,16 +8,16 @@ Your employee is entitled to SSP for 16 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/irregularly/2000.0/30/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/0,6.txt
@@ -8,16 +8,16 @@ Your employee is entitled to SSP for 16 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/monthly/2000.0/30/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/0,6.txt
@@ -8,16 +8,16 @@ Your employee is entitled to SSP for 16 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/before_payday/weekly/2000.0/30/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/0,6.txt
@@ -8,16 +8,16 @@ Your employee is entitled to SSP for 16 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/30/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/0,6.txt
@@ -8,16 +8,16 @@ Your employee is entitled to SSP for 16 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_less/3000.0/35/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,16 +8,16 @@ Your employee is entitled to SSP for 16 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/every_4_weeks/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,16 +8,16 @@ Your employee is entitled to SSP for 16 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/fortnightly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,16 +8,16 @@ Your employee is entitled to SSP for 16 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/irregularly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,16 +8,16 @@ Your employee is entitled to SSP for 16 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/monthly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/0,6.txt
@@ -8,16 +8,16 @@ Your employee is entitled to SSP for 16 days out of 28 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£43.35
+6 April 2013|£43.35
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£43.35
- | **Total SSP: £693.60**
+1 June 2013|£43.35
+| **Total SSP: £693.60**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3,4,5.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 69 days out of 69 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£68.68
+6 April 2013|£68.68
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,195.78**
+6 July 2013|£86.70
+| **Total SSP: £1,195.78**
 
 ##What you need to know
 

--- a/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/ordinary_statutory_paternity_pay,statutory_adoption_pay/yes/no/2013-04-02/2013-07-07/yes/2013-02-01/2013-03-15/eight_weeks_more/weekly/2013-03-31/2013-01-31/4000.0/1,2,3.txt
@@ -8,21 +8,21 @@ Your employee is entitled to SSP for 41 days out of 41 working days taken off si
 
 Week ending | SSP amount
 -|-
- 6 April 2013|£57.24
+6 April 2013|£57.24
 13 April 2013|£86.70
 20 April 2013|£86.70
 27 April 2013|£86.70
- 4 May 2013|£86.70
+4 May 2013|£86.70
 11 May 2013|£86.70
 18 May 2013|£86.70
 25 May 2013|£86.70
- 1 June 2013|£86.70
- 8 June 2013|£86.70
+1 June 2013|£86.70
+8 June 2013|£86.70
 15 June 2013|£86.70
 22 June 2013|£86.70
 29 June 2013|£86.70
- 6 July 2013|£86.70
- | **Total SSP: £1,184.34**
+6 July 2013|£86.70
+| **Total SSP: £1,184.34**
 
 ##What you need to know
 

--- a/test/data/calculate-statutory-sick-pay-files.yml
+++ b/test/data/calculate-statutory-sick-pay-files.yml
@@ -1,8 +1,16 @@
 --- 
-lib/smart_answer_flows/calculate-statutory-sick-pay.rb: 553f7bb3f72ac2871671900e1fce34b4
-lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml: 426b7883ddca0ace2bd0fedc1cd6f700
+lib/smart_answer_flows/calculate-statutory-sick-pay.rb: 9c1e703af03a20302cd8d5b626c97081
+lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml: 99127d932672eba7aef80e5aa6945e94
 test/data/calculate-statutory-sick-pay-questions-and-responses.yml: 225bf0303e9d1c7fa1a929c24b543db3
 test/data/calculate-statutory-sick-pay-responses-and-expected-results.yml: 171dcf9d94ad17c5c64d6e776c73c69b
+lib/smart_answer_flows/calculate-statutory-sick-pay/_esa.govspeak.erb: 660031398fda690ed7b3e2186ba64060
+lib/smart_answer_flows/calculate-statutory-sick-pay/already_getting_maternity.govspeak.erb: 258fd4422c4ae665c83d5ee1e061bbff
+lib/smart_answer_flows/calculate-statutory-sick-pay/entitled_to_sick_pay.govspeak.erb: b8b73c19346e4a8e6143ea87ecc7f92a
+lib/smart_answer_flows/calculate-statutory-sick-pay/maximum_entitlement_reached.govspeak.erb: eb12d5290c873df20fd23ff9eb06c273
+lib/smart_answer_flows/calculate-statutory-sick-pay/must_be_sick_for_4_days.govspeak.erb: 17b34a7463bcbbf7e2a5c417ec5452f9
+lib/smart_answer_flows/calculate-statutory-sick-pay/not_earned_enough.govspeak.erb: 1e5cd1c6d99b6bd3145578416d62e7c5
+lib/smart_answer_flows/calculate-statutory-sick-pay/not_entitled_3_days_not_paid.govspeak.erb: 98dc338280df70b2b6032a7a9dcba428
+lib/smart_answer_flows/calculate-statutory-sick-pay/not_regular_schedule.govspeak.erb: 98b6f0d902fabae8fda39c1859cd2a46
 lib/smart_answer/calculators/statutory_sick_pay_calculator.rb: d1b53da112834359536fe7ecdfff667a
 lib/smart_answer/calculators/rates_query.rb: c9568eac2742cad26f93458ed2276876
 lib/data/rates/statutory_sick_pay.yml: de2d34118e3016d1137c394745d33280

--- a/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
@@ -75,8 +75,6 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
         assert_current_node :usual_work_days?
         add_response '1,2,3,4,5'
         assert_current_node :entitled_to_sick_pay
-        assert_phrase_list :proof_of_illness, [:enough_notice]
-        assert_phrase_list :paternity_adoption_warning, [:paternity_warning]
       end
     end
 
@@ -163,8 +161,6 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
           assert_current_node :usual_work_days?
           add_response '1,2,3,4,5'
           assert_current_node :entitled_to_sick_pay
-          assert_phrase_list :entitled_to_esa, [:esa]
-          assert_phrase_list :paternity_adoption_warning, [:paternity_warning]
         end
 
         should "lead to entitled_to_sick_pay if worker got sick before payday and had linked sickness" do


### PR DESCRIPTION
This was a fairly straight forward conversion, although the conversion of the 'entitled_to_sick_pay' outcome did require to update a number of test artefacts due to whitespace changes.
