### PR TITLE
Marriage in Spain changes

### DIFF
--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -511,6 +511,109 @@ en-GB:
           %{country_name_uppercase_prefix} is a British overseas territory.
 
           Contact the %{ceremony_country_name} Government to find out about getting married there, including what documents you’ll need.
+# Marriage in Spain phrases
+        civil_weddings_in_spain: |
+          Civil weddings in Spain take place at a town hall, register office or district court. You must register with the local civil authorities afterwards to get an official marriage certificate if you have a religious wedding.
+        legal_restrictions_for_non_residents_spain: |
+          %There are certain legal restrictions on getting married in Spain if neither of you lives there. If you both live outside Spain, you must check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re planning to get married to find out if this is allowed.%
+        ss_process_and_recognition_in_spain: |
+          The process for same-sex marriages in Spain is the same as for opposite-sex civil marriages. Your marriage will be recognised as a civil partnership under British law.
+        what_you_need_to_do_spain_third_country: |
+          ## What you need to do
+
+          You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf) or a [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf) or both to prove you’re allowed to marry.
+
+          Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
+
+          There are 2 ways you can get these certificates:
+
+          - [go to the UK and post notice with a UK registrar](%{uk_residence_outcome_path})
+          - [go to %{country_name_lowercase_prefix} and post notice at the embassy or consulate there](%{ceremony_country_residence_outcome_path})
+
+          You need to apply for all certificates at least 3 months before the date you intend to get married.
+
+          You must be physically present in Spain for at least 3 days before you apply for a CNI.
+        what_you_need_to_do_spain: |
+          ## What you need to do
+
+          You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf), [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf), or both to prove you’re allowed to marry.
+
+          Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC)  where you’re getting married to find out what certificates you’ll need.
+
+          Your partner must follow the same process to get their own certificates.
+
+          ^You must apply for all certificates at least 3 months before you get married.^
+        get_cni_in_uk_for_spain_title: |
+          ## Getting a certificate of no impediment
+        get_cni_in_uk_for_spain: |
+          ^Your CNI will be valid for 3 months in Spain.^
+
+          You must then exchange your UK-issued CNI for one that’s valid in Spain.
+
+          Download and fill in the CNI application pack - it contains a list of the documents you’ll need.
+
+          $D
+          [Download 'CNI for UK residents application pack' (PDF, 426KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446265/UK_CNI_Pack.pdf)
+          $D
+
+          Send the documents and fee by registered post to the address in the application pack.
+        get_cni_in_spain: |
+          ## Getting a certificate of no impediment
+
+          Download and the complete the CNI application pack - it contains a list of the documents you’ll need.
+
+          $D
+          [Download 'CNI application pack' (PDF, 464KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446264/CNI_Pack.pdf)
+          $D
+
+          You must sign the notice of marriage and affirmation in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you post the other documents.
+
+          Send all the documents and fee by registered post to the address in the application pack.
+
+          ###What happens next
+
+          The consulate will check your forms and documents. Once everything is approved, they’ll take your payment and display your notice of marriage for 7 days. If nobody raises an objection, they’ll then issue your CNI and send it to you with your supporting documents by registered post.
+
+          It takes 10 working days after payment for the consulate to process your application.
+        get_maritial_status_certificate_spain: |
+          ##Getting a marital status certificate
+
+          Download and complete the marital status certificate application pack - it contains a list of the documents you’ll need.
+
+          $D
+          [Download 'Marital status certificate application pack' (PDF, 424KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446267/Marital_Status_for_Marriage_Pack.pdf)
+          $D
+
+          You must sign the affirmation in the application pack in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you post the other documents.
+
+          Send the documents and fee by registered post to the address in the application pack.
+
+          ### What happens next
+
+          The consulate will check your forms and documents, and contact you if they have any queries.
+
+          It takes 10 working days after your payment has been approved for the consulate to process your application.
+
+          They’ll send your certificate and supporting documents to you by registered post.
+        other_requirements_in_spain: |
+          ##Other requirements for Spain
+
+          The civil registrar may also ask for confirmation of your addresses for the past 2 years (‘confirmación de domicilio para casarse en España’).
+
+          You’ll need to show one of the following:
+
+          - a letter confirming your address, eg electoral roll
+          - a bank or building society statement, credit card statement
+          - a mortgage statement
+          - a council tax letter
+          - utility bills
+          - recent proof of entitlement to local or state benefits, eg tax credits, pension, education or other benefits
+
+          If you’re asked to provide a document from the British consulate, print out a copy of the [‘communication proof of address’](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/288272/Communication_re_Proof_of_Address.pdf).
+
+          ^You must get your documents translated if they’re not in English or Spanish.^
+        fees_spain: |
+
 # Marriage in a country with consular CNI phrases
         japan_intro: |
           Contact your [nearest embassy or consulate](http://www.mofa.go.jp/about/emb_cons/over/index.html) of Japan to find out about local marriage laws, including what documents you’ll need.
@@ -1823,6 +1926,13 @@ en-GB:
         title: Marriage in %{country_name_lowercase_prefix}
         body: |
           %{bot_outcome}
+      outcome_spain:
+        title: |
+          %{ceremony_type} in Spain
+        body: |
+          %{spain_body}
+
+          *[CNI]:certificate of no impediment
 
 # CNI outcome for opposite sex partners residing in third country
       outcome_consular_cni_os_residing_in_third_country:

--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -519,11 +519,17 @@ en-GB:
           %There are certain legal restrictions on getting married in Spain if neither of you lives there. If you both live outside Spain, you must check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re planning to get married to find out if this is allowed.%
         ss_process_in_spain: |
           The process for same-sex marriages in Spain is the same as for opposite-sex civil marriages.
+        cni_maritial_status_certificate_spain: |
+          You may be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
+
+          $D
+          [Download 'Certificate of no impediment' (PDF, 198KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf)
+          $D
+
+          $D
+          [Download 'Marital status certificate' (PDF, 145KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf)
+          $D
         what_you_need_to_do_spain_third_country: |
-          ## What you need to do
-
-          You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf) or a [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf) or both to prove you’re allowed to marry.
-
           Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
 
           There are 2 ways you can get these certificates:
@@ -535,10 +541,6 @@ en-GB:
 
           You must be physically present in Spain for at least 3 days before you apply for a CNI.
         what_you_need_to_do_spain: |
-          ## What you need to do
-
-          You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf), [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf), or both to prove you’re allowed to marry.
-
           ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 
           Your partner must also provide their own certificates.

--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -22,6 +22,7 @@ en-GB:
 
       phrases:
         ceremony_type_marriage: Marriage
+        ceremony_type_ss_marriage: Same-sex Marriage
         ceremony_type_civil_partnership: Civil partnership
 
         title_ss_marriage: Same-sex marriage
@@ -516,8 +517,8 @@ en-GB:
           Civil weddings in Spain take place at a town hall, register office or district court. You must register with the local civil authorities afterwards to get an official marriage certificate if you have a religious wedding.
         legal_restrictions_for_non_residents_spain: |
           %There are certain legal restrictions on getting married in Spain if neither of you lives there. If you both live outside Spain, you must check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re planning to get married to find out if this is allowed.%
-        ss_process_and_recognition_in_spain: |
-          The process for same-sex marriages in Spain is the same as for opposite-sex civil marriages. Your marriage will be recognised as a civil partnership under British law.
+        ss_process_in_spain: |
+          The process for same-sex marriages in Spain is the same as for opposite-sex civil marriages.
         what_you_need_to_do_spain_third_country: |
           ## What you need to do
 

--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -635,24 +635,12 @@ en-GB:
           You may be able to get married at the British Embassy if you’re both resident in %{country_name_lowercase_prefix} and can prove that there are no other suitable facilities.
 
           Contact the British Embassy in %{country_name_lowercase_prefix} for more information.
-        spain_os_consular_cni_opposite_sex: |
-          Civil weddings in Spain take place at a town hall, register office or district court. You need to register with the local civil authorities afterwards to get an official marriage certificate if you have a religious wedding.
-        spain_os_consular_cni_same_sex: |
-          The process for same-sex marriages in Spain is the same as for opposite-sex civil marriages. Your marriage will be recognised as a civil partnership under British law.
-        spain_os_consular_civil_registry: |
-          Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married.
-        spain_os_consular_cni_not_local_resident: |
-          %There are certain legal restrictions if neither of you is resident in Spain. If you both live outside Spain, you should check with the civil registry where you’re planning to getting married to find out if this is allowed.%
         italy_os_consular_cni_ceremony_italy: |
           Contact the local comune (town hall) before making any plans to find out about local marriage laws, including what documents you’ll need.
         consular_cni_os_ceremony_21_day_requirement: |
           You need to have been living in the country where you intend to marry for 21 full days.
         you_may_be_asked_for_cni: |
           You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
-        cni_pareja_de_hecho_requirements_spain: |
-          You may be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
-
-          ^You may also need to get a marital status certificate if you’re living with your partner and want to get a ‘[pareja de hecho](/notarial-and-documentary-services-guide-for-spain#marital-status-certificate-for-pareja-de-hecho)’ (cohabitation registration).^
         get_cni_from_uk: |
           You’ll need to get a certificate of no impediment (CNI) from the authorities in the UK to prove you’re allowed to marry.
         partner_cni_requirements_the_same: |
@@ -913,14 +901,6 @@ en-GB:
           - a copy of your partner’s identity document
         italy_consular_cni_os_partner_british: |
           You and your partner will need to provide your passports and [full birth certificate](/order-copy-birth-death-marriage-certificate/) or [naturalisation certificate](/get-replacement-citizenship-certificate).
-        consular_cni_variant_local_resident_spain: |
-          The documents you need are:
-
-          - your passport
-          - your partner’s passport or national identity document
-          - a ‘certificado de empadronamiento’ (town hall registration certificate) or Spanish police residence certificate (green document with your NIE number address) issued at least 3 days ago
-
-          ^The Civil Registry will usually ask you for a certificado de empadronamiento issued in the last 3 months.^
         consular_cni_os_not_uk_resident_ceremony_not_germany: |
           If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
 
@@ -939,18 +919,6 @@ en-GB:
 
         consular_cni_os_other_resident_ceremony_italy: |
           You’ll also need to provide evidence of nationality or residence if the divorce or dissolution took place outside the UK. You’ll need to get it [translated](/government/publications/italy-list-of-translators-and-interpreters) if it’s not in English.
-        sending_cni_and_booking_appointment_spain: |
-          Send your completed CNI service request form and copies of the supporting documents to your [nearest British consulate](/notarial-and-documentary-services-guide-for-spain#where-to-send-your-request). You can send them as scanned attachments by email or by fax. You’ll need to bring the original documents to your appointment.
-
-          To request an appointment, fill in the CNI service request form and make sure you’ve got all of the necessary supporting documents.
-
-          $D
-          [Download ’CNI service request form’ (DOC, 29KB)](/government/publications/certificate-of-no-impediment-service-request-form-spain)
-          $D
-
-          ###What happens next
-
-          The consulate will check your form and documents, and if everything’s in order they’ll send you details of how to book your appointment to give official notice of your marriage. They’ll then display your notice publicly for 7 days, and if nobody has raised an objection, they’ll issue your CNI. There’s an additional fee for this.
 
         download_and_fill_notice_and_affidavit_but_not_sign: |
           You’ll need to fill in forms for your notice of marriage, and an oath or affidavit (written statement of facts) stating that you’re free to marry.
@@ -1034,45 +1002,6 @@ en-GB:
           %The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
         check_if_cni_needs_to_be_legalised: |
           You should check if your CNI needs to be legalised (certified as genuine) by the local authorities in %{country_name_lowercase_prefix}.
-        consular_cni_os_ceremony_spain: |
-          ###Getting a marital status certificate
-
-          In some parts of Spain you may need to to get a ‘marital status certificate’ (‘certificado de estado civil’) instead of, or as well as, a CNI (’certificado de no impedimento’).
-
-          Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married. If you need one, ask a [solicitor](/government/publications/spain-list-of-lawyers) (‘abogado’) to draw up a declaration for you printed on their headed paper.
-
-          ^If it’s on blank, non-headed paper, they’ll need to give you a separate letter including their contact details, confirming that they’ve drawn up the declaration.^
-
-          You’ll then need to make an appointment at the consulate to make the declaration and sign the document in front of a consular officer - so don’t sign it beforehand.
-
-          Download instructions in English and Spanish on what the declaration needs to include.
-
-          $D
-          [Download ‘Marital status declaration instructions in English’ (PDF, 363KB)](/government/uploads/system/uploads/attachment_data/file/136832/marital-status-declaration-instruction-en.pdf)
-          [Download ‘Declaración de estado civil instrucciones en Español’ (PDF, 236KB)](/government/uploads/system/uploads/attachment_data/file/136833/marital-status-declaration-instruction-sp.pdf)
-          $D
-
-          You’ll also need a completed marital status certificate application form, as well as the supporting documents and the fee (see below).
-
-          $D
-          [Download ’Marital status certificate appointment request form’ (DOC, 53KB)](/government/uploads/system/uploads/attachment_data/file/182249/Appointment_request_form_marital_status_marriage.doc)
-          $D
-        consular_cni_os_ceremony_spain_partner_british: |
-          Your partner will also need to get a marital status certificate from the consulate and pay the fees if the civil registry have told you that they need one.
-        other_requirements_for_spain: |
-          ###Other requirements for Spain
-
-          The civil registrar may also ask for confirmation of your addresses for the past 2 years (‘confirmación de domicilio para casarse en España’).
-
-          You’ll need to show one of the following:
-
-          - a letter confirming your address, eg electoral roll
-          - a bank or building society statement, credit card statement
-          - a mortgage statement
-          - a council tax letter
-          - utility bills
-          - recent proof of entitlement to local or state benefits, eg tax credits, pension, education or other benefits
-
         consular_cni_os_fees_incl_null_osta_oath_consular_letter: |
           ##Fees
 
@@ -1930,7 +1859,7 @@ en-GB:
         title: |
           %{ceremony_type} in Spain
         body: |
-          %{spain_body}
+          %{body}
 
           *[CNI]:certificate of no impediment
 

--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -556,7 +556,7 @@ en-GB:
           [Download 'CNI for UK residents application pack' (PDF, 426KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446265/UK_CNI_Pack.pdf)
           $D
 
-          Send the documents and fee by registered post to the address in the application pack.
+          Send the documents by registered post to the address in the application pack.
         get_cni_in_spain: |
           ## Getting a certificate of no impediment
 
@@ -586,7 +586,7 @@ en-GB:
 
           You must sign the affirmation in the application pack in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you post the other documents.
 
-          Send the documents and fee by registered post to the address in the application pack.
+          Send the documents by registered post to the address in the application pack.
 
           ### What happens next
 

--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -595,11 +595,17 @@ en-GB:
           It takes 10 working days after your payment has been approved for the consulate to process your application.
 
           They’ll send your certificate and supporting documents to you by registered post.
-        other_requirements_in_spain: |
+        other_requirements_in_spain_intro: |
           ##Other requirements for Spain
 
           The civil registrar may also ask for confirmation of your addresses for the past 2 years (‘confirmación de domicilio para casarse en España’).
 
+        other_requirements_in_spain_for_residents_intro: |
+          ##Other requirements for Spain
+
+          If you’ve been living in Spain for less than 2 years, the civil registrar may also ask for confirmation of your addresses for the past 2 years (‘confirmación de domicilio para casarse en España’).
+
+        other_requirements_in_spain: |
           You’ll need to show one of the following:
 
           - a letter confirming your address, eg electoral roll

--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -934,7 +934,7 @@ en-GB:
           - a [decree absolute or final order](/copy-decree-absolute-final-order)
           - a civil partnership dissolution or annulment certificate
           - your (or your partner’s) former spouse or civil partner’s [death certificate](/order-copy-birth-death-marriage-certificate/)
-        consular_cni_os_other_resident_ceremony_not_germany_or_spain: |
+        evidence_if_divorced_outside_uk: |
           ^You’ll also need to provide evidence of nationality or residence if the divorce or dissolution took place outside the UK. You’ll need to get it [translated](/government/collections/list-of-lawyers) if it’s not in English.^
 
         consular_cni_os_other_resident_ceremony_italy: |

--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -592,6 +592,7 @@ en-GB:
         cni_at_local_register_office: |
           You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+        cni_issued_locally_validity: |
           ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in %{country_name_lowercase_prefix} to find out how long a CNI is valid under local law.^
 
         cni_subject_to_objection_14_days:

--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -538,11 +538,11 @@ en-GB:
 
           You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf), [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf), or both to prove you’re allowed to marry.
 
-          Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC)  where you’re getting married to find out what certificates you’ll need.
+          ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 
-          Your partner must follow the same process to get their own certificates.
+          Your partner must also provide their own certificates.
 
-          ^You must apply for all certificates at least 3 months before you get married.^
+          You must apply for all certificates at least 3 months before you get married.
         get_cni_in_uk_for_spain_title: |
           ## Getting a certificate of no impediment
         get_cni_in_uk_for_spain: |

--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -566,7 +566,7 @@ en-GB:
           [Download 'CNI application pack' (PDF, 464KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446264/CNI_Pack.pdf)
           $D
 
-          You must sign the notice of marriage and affirmation in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you post the other documents.
+          You must sign the notice of marriage and affirmation in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you send your application to the consulate.
 
           Send all the documents and fee by registered post to the address in the application pack.
 
@@ -584,7 +584,7 @@ en-GB:
           [Download 'Marital status certificate application pack' (PDF, 424KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446267/Marital_Status_for_Marriage_Pack.pdf)
           $D
 
-          You must sign the affirmation in the application pack in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you post the other documents.
+          You must sign the affirmation in the application pack in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you send your application to the consulate.
 
           Send the documents by registered post to the address in the application pack.
 
@@ -594,7 +594,7 @@ en-GB:
 
           It takes 10 working days after your payment has been approved for the consulate to process your application.
 
-          They’ll send your certificate and supporting documents to you by registered post.
+          They’ll send your certificate and original documents to you by registered post.
         other_requirements_in_spain_intro: |
           ##Other requirements for Spain
 

--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -688,7 +688,6 @@ en-GB:
           - [go to %{country_name_lowercase_prefix} and swear an affidavit (written statement of facts) that you’re free to marry](%{ceremony_country_residence_outcome_path})
         cni_at_local_register_office: |
           You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
-
         cni_issued_locally_validity: |
           ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in %{country_name_lowercase_prefix} to find out how long a CNI is valid under local law.^
 

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -466,7 +466,7 @@ module SmartAnswer
           current_path.gsub('third_country', 'ceremony_country')
         end
 
-        precalculate :spain_body do
+        precalculate :body do
           phrases = PhraseList.new
           if resident_of != 'uk'
             if sex_of_your_partner == 'opposite_sex'
@@ -636,14 +636,13 @@ module SmartAnswer
       outcome :outcome_os_consular_cni do
         precalculate :consular_cni_os_start do
           phrases = PhraseList.new
-          three_day_residency_requirement_applies = %w(albania algeria angola armenia austria azerbaijan bahrain belarus bolivia bosnia-and-herzegovina bulgaria chile croatia cuba democratic-republic-of-congo denmark dominican-republic el-salvador estonia ethiopia georgia greece guatemala honduras hungary iceland italy kazakhstan kosovo kuwait kyrgyzstan latvia lithuania luxembourg macedonia mexico moldova montenegro nepal panama poland romania russia serbia slovenia spain sudan sweden tajikistan tunisia turkmenistan ukraine uzbekistan venezuela)
-          three_day_residency_handled_by_exception = %w(croatia italy spain russia)
+          three_day_residency_requirement_applies = %w(albania algeria angola armenia austria azerbaijan bahrain belarus bolivia bosnia-and-herzegovina bulgaria chile croatia cuba democratic-republic-of-congo denmark dominican-republic el-salvador estonia ethiopia georgia greece guatemala honduras hungary iceland italy kazakhstan kosovo kuwait kyrgyzstan latvia lithuania luxembourg macedonia mexico moldova montenegro nepal panama poland romania russia serbia slovenia sudan sweden tajikistan tunisia turkmenistan ukraine uzbekistan venezuela)
+          three_day_residency_handled_by_exception = %w(croatia italy russia)
           no_birth_cert_requirement = three_day_residency_requirement_applies - ['italy']
           cni_notary_public_countries = %w(albania algeria angola armenia austria azerbaijan bahrain bolivia bosnia-and-herzegovina bulgaria croatia cuba estonia georgia greece iceland kazakhstan kuwait kyrgyzstan libya lithuania luxembourg mexico moldova montenegro poland russia serbia sweden tajikistan tunisia turkmenistan ukraine uzbekistan venezuela)
-          no_document_download_link_if_os_resident_of_uk_countries = %w(albania algeria angola armenia austria azerbaijan bahrain bolivia bosnia-and-herzegovina bulgaria croatia cuba estonia georgia greece iceland italy japan kazakhstan kuwait kyrgyzstan libya lithuania luxembourg macedonia mexico moldova montenegro nicaragua poland russia spain serbia sweden tajikistan tunisia turkmenistan ukraine uzbekistan venezuela)
+          no_document_download_link_if_os_resident_of_uk_countries = %w(albania algeria angola armenia austria azerbaijan bahrain bolivia bosnia-and-herzegovina bulgaria croatia cuba estonia georgia greece iceland italy japan kazakhstan kuwait kyrgyzstan libya lithuania luxembourg macedonia mexico moldova montenegro nicaragua poland russia serbia sweden tajikistan tunisia turkmenistan ukraine uzbekistan venezuela)
 
           cni_posted_after_14_days_countries = %w(oman jordan qatar saudi-arabia united-arab-emirates yemen)
-          not_italy_or_spain = %w(italy spain).exclude?(ceremony_country)
           ceremony_not_germany_or_not_resident_other = (ceremony_country != 'germany' || resident_of == 'uk') # TODO verify this is ok
           ceremony_and_residency_in_croatia = (ceremony_country == 'croatia' && resident_of == 'ceremony_country')
 
@@ -670,7 +669,7 @@ module SmartAnswer
             end
           end
 
-          if %(japan italy spain).exclude?(ceremony_country)
+          if %(japan italy).exclude?(ceremony_country)
             if resident_of == 'ceremony_country'
               phrases << :get_legal_advice
             else
@@ -678,17 +677,7 @@ module SmartAnswer
             end
           end
 
-          if ceremony_country == 'spain'
-            if sex_of_your_partner == 'opposite_sex'
-              phrases << :spain_os_consular_cni_opposite_sex
-            else
-              phrases << :spain_os_consular_cni_same_sex
-            end
-            phrases << :spain_os_consular_civil_registry
-            unless resident_of == 'ceremony_country'
-              phrases << :spain_os_consular_cni_not_local_resident
-            end
-          elsif ceremony_country == 'italy'
+          if ceremony_country == 'italy'
             phrases << :italy_os_consular_cni_ceremony_italy
           end
 
@@ -703,13 +692,11 @@ module SmartAnswer
           elsif data_query.os_21_days_residency_required_countries?(ceremony_country)
             phrases << :consular_cni_os_ceremony_21_day_requirement
             phrases << :you_may_be_asked_for_cni
-          elsif not_italy_or_spain && ceremony_not_germany_or_not_resident_other
+          elsif ceremony_country != 'italy' && ceremony_not_germany_or_not_resident_other
             phrases << :you_may_be_asked_for_cni
           end
 
-          if ceremony_country == 'spain'
-            phrases << :cni_pareja_de_hecho_requirements_spain
-          elsif ceremony_country == 'italy'
+          if ceremony_country == 'italy'
             if resident_of == 'uk'
               phrases << :get_cni_from_uk
             end
@@ -796,7 +783,7 @@ module SmartAnswer
               phrases << :russia_os_local_resident
             end
 
-            unless %w(germany italy japan spain).include?(ceremony_country)
+            unless %w(germany italy japan).include?(ceremony_country)
               if ceremony_country == 'macedonia'
                 phrases << :consular_cni_os_foreign_resident_3_days_macedonia
               else
@@ -810,12 +797,12 @@ module SmartAnswer
 
           if resident_of != 'uk' && data_query.phrase_exists?("required_supporting_documents_#{ceremony_country}")
             phrases << :"required_supporting_documents_#{ceremony_country}"
-          elsif resident_of == 'ceremony_country' && %w(germany italy japan spain).exclude?(ceremony_country)
+          elsif resident_of == 'ceremony_country' && %w(germany italy japan).exclude?(ceremony_country)
             birth_cert_inclusion = if no_birth_cert_requirement.exclude?(ceremony_country)
               '_incl_birth_cert'
             end
 
-            notary_public_inclusion = if cni_notary_public_countries.include?(ceremony_country) || %w(japan macedonia spain).include?(ceremony_country)
+            notary_public_inclusion = if cni_notary_public_countries.include?(ceremony_country) || %w(japan macedonia).include?(ceremony_country)
               '_notary_public'
             end
             phrases << "required_supporting_documents#{birth_cert_inclusion}#{notary_public_inclusion}".to_sym
@@ -836,8 +823,6 @@ module SmartAnswer
               else
                 phrases << :italy_consular_cni_os_partner_not_british
               end
-            elsif ceremony_country == 'spain'
-              phrases << :consular_cni_variant_local_resident_spain
             end
           end
 
@@ -852,13 +837,9 @@ module SmartAnswer
           if resident_of != 'uk'
             if ceremony_country == 'italy' && resident_of != 'uk'
               phrases << :consular_cni_os_other_resident_ceremony_italy
-            elsif %(germany spain).exclude?(ceremony_country)
-              phrases << :consular_cni_os_other_resident_ceremony_not_germany_or_spain
+            elsif %(germany).exclude?(ceremony_country)
+              phrases << :evidence_if_divorced_outside_uk
             end
-          end
-
-          if resident_of == 'ceremony_country' && ceremony_country == 'spain'
-            phrases << :sending_cni_and_booking_appointment_spain
           end
 
           if ceremony_country == 'italy' && resident_of != 'uk'
@@ -866,11 +847,11 @@ module SmartAnswer
           end
 
           if resident_of == 'ceremony_country'
-            if %w(spain germany).exclude?(ceremony_country)
+            if %w(germany).exclude?(ceremony_country)
               phrases << :download_and_fill_notice_and_affidavit_but_not_sign
             end
           else
-            if sex_of_your_partner == 'same_sex' || no_document_download_link_if_os_resident_of_uk_countries.exclude?(ceremony_country) && (cni_notary_public_countries + %w(italy japan macedonia spain) - %w(greece tunisia)).include?(ceremony_country)
+            if sex_of_your_partner == 'same_sex' || no_document_download_link_if_os_resident_of_uk_countries.exclude?(ceremony_country) && (cni_notary_public_countries + %w(italy japan macedonia) - %w(greece tunisia)).include?(ceremony_country)
               phrases << :download_and_fill_notice_and_affidavit_but_not_sign
             end
           end
@@ -884,7 +865,7 @@ module SmartAnswer
               phrases << :consular_cni_os_foreign_resident_ceremony_notary_public_greece
             elsif cni_notary_public_countries.include?(ceremony_country) || ceremony_country == 'japan'
               phrases << :consular_cni_os_foreign_resident_ceremony_notary_public
-            elsif %w(germany spain).exclude?(ceremony_country)
+            elsif %w(germany).exclude?(ceremony_country)
               phrases << :display_notice_of_marriage_7_days
             end
           elsif data_query.requires_7_day_notice?(ceremony_country)
@@ -908,16 +889,8 @@ module SmartAnswer
             phrases << :names_on_documents_must_match
           end
 
-          if resident_of != 'uk' && %w(italy spain germany).exclude?(ceremony_country)
+          if resident_of != 'uk' && %w(italy germany).exclude?(ceremony_country)
             phrases << :check_if_cni_needs_to_be_legalised
-          end
-
-          if ceremony_country == 'spain'
-            phrases << :consular_cni_os_ceremony_spain
-            if partner_nationality == 'partner_british'
-              phrases << :consular_cni_os_ceremony_spain_partner_british
-            end
-            phrases << :other_requirements_for_spain
           end
 
           if resident_of == 'ceremony_country'

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -495,6 +495,8 @@ module SmartAnswer
             phrases << :legal_restrictions_for_non_residents_spain
           end
 
+          phrases << :what_you_need_to_do
+          phrases << :cni_maritial_status_certificate_spain
           if resident_of == 'third_country'
             phrases << :what_you_need_to_do_spain_third_country
           else

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -454,6 +454,14 @@ module SmartAnswer
       end
 
       outcome :outcome_spain do
+        precalculate :ceremony_type do
+          if sex_of_your_partner == 'opposite_sex'
+            PhraseList.new(:ceremony_type_marriage)
+          else
+            PhraseList.new(:ceremony_type_ss_marriage)
+          end
+        end
+
         precalculate :current_path do
           (['/marriage-abroad/y'] + responses).join('/')
         end
@@ -469,11 +477,7 @@ module SmartAnswer
         precalculate :body do
           phrases = PhraseList.new
           if resident_of != 'uk'
-            if sex_of_your_partner == 'opposite_sex'
-              phrases << :contact_local_authorities_in_country_marriage
-            else
-              phrases << :contact_local_authorities_in_country_cp
-            end
+            phrases << :contact_local_authorities_in_country_marriage
           end
 
           if resident_of != 'third_country' && sex_of_your_partner == 'opposite_sex'
@@ -481,7 +485,7 @@ module SmartAnswer
           end
 
           if sex_of_your_partner == 'same_sex'
-            phrases << :ss_process_and_recognition_in_spain
+            phrases << :ss_process_in_spain
           end
 
           if resident_of == 'ceremony_country'

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -667,6 +667,7 @@ module SmartAnswer
 
           if resident_of == 'uk'
             phrases << :cni_at_local_register_office
+            phrases << :cni_issued_locally_validity
             if cni_posted_after_14_days_countries.include?(ceremony_country)
               phrases << :cni_subject_to_objection_14_days
             end
@@ -1224,7 +1225,7 @@ module SmartAnswer
 
           unless ceremony_country == 'czech-republic' && sex_of_your_partner == 'same_sex'
             if ceremony_country == 'brazil' && sex_of_your_partner == 'same_sex' && resident_of == 'uk'
-              phrases << :what_you_need_to_do_cni_cp << :cni_at_local_register_office << :legisation_and_translation_intro_uk << :legalise_translate_and_check_with_authorities << :names_on_documents_must_match
+              phrases << :what_you_need_to_do_cni_cp << :cni_at_local_register_office << :cni_issued_locally_validity << :legisation_and_translation_intro_uk << :legalise_translate_and_check_with_authorities << :names_on_documents_must_match
             else
               phrases << :cp_or_equivalent_cp_what_you_need_to_do
               phrases << contact_method_key

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -507,7 +507,14 @@ module SmartAnswer
 
           if resident_of != 'third_country'
             phrases << :get_maritial_status_certificate_spain
+
+            if resident_of == 'ceremony_country'
+              phrases << :other_requirements_in_spain_for_residents_intro
+            else
+              phrases << :other_requirements_in_spain_intro
+            end
             phrases << :other_requirements_in_spain
+
             phrases << :names_on_documents_must_match
 
             unless partner_nationality == 'partner_british'

--- a/test/artefacts/marriage-abroad/albania/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/albania/uk/partner_british/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Albania to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/albania/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/albania/uk/partner_local/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Albania to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/albania/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/albania/uk/partner_other/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Albania to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/american-samoa/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/american-samoa/uk/partner_british/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in American Samoa to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/american-samoa/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/american-samoa/uk/partner_local/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in American Samoa to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/american-samoa/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/american-samoa/uk/partner_other/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in American Samoa to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/armenia/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/armenia/uk/partner_british/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Armenia to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/armenia/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/armenia/uk/partner_local/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Armenia to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/armenia/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/armenia/uk/partner_other/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Armenia to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/aruba/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/aruba/uk/partner_british/opposite_sex.txt
@@ -16,6 +16,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Aruba to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/aruba/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/aruba/uk/partner_local/opposite_sex.txt
@@ -16,6 +16,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Aruba to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/aruba/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/aruba/uk/partner_other/opposite_sex.txt
@@ -16,6 +16,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Aruba to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/austria/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/austria/uk/partner_british/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Austria to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/austria/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/austria/uk/partner_local/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Austria to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/austria/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/austria/uk/partner_other/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Austria to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/azerbaijan/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/azerbaijan/uk/partner_british/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Azerbaijan to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/azerbaijan/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/azerbaijan/uk/partner_local/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Azerbaijan to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/azerbaijan/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/azerbaijan/uk/partner_other/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Azerbaijan to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/belarus/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/belarus/uk/partner_british/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Belarus to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/belarus/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/belarus/uk/partner_local/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Belarus to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/belarus/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/belarus/uk/partner_other/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Belarus to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/bonaire-st-eustatius-saba/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/bonaire-st-eustatius-saba/uk/partner_british/opposite_sex.txt
@@ -16,6 +16,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Bonaire St Eustatius Saba to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/bonaire-st-eustatius-saba/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/bonaire-st-eustatius-saba/uk/partner_local/opposite_sex.txt
@@ -16,6 +16,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Bonaire St Eustatius Saba to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/bonaire-st-eustatius-saba/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/bonaire-st-eustatius-saba/uk/partner_other/opposite_sex.txt
@@ -16,6 +16,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Bonaire St Eustatius Saba to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/brazil/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/brazil/uk/partner_british/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Brazil to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/brazil/uk/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/brazil/uk/partner_british/same_sex.txt
@@ -16,6 +16,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Brazil to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/brazil/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/brazil/uk/partner_local/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Brazil to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/brazil/uk/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/brazil/uk/partner_local/same_sex.txt
@@ -16,6 +16,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Brazil to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/brazil/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/brazil/uk/partner_other/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Brazil to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/brazil/uk/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/brazil/uk/partner_other/same_sex.txt
@@ -16,6 +16,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Brazil to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/burundi/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/burundi/uk/partner_british/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Burundi to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/burundi/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/burundi/uk/partner_local/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Burundi to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/burundi/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/burundi/uk/partner_other/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Burundi to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/costa-rica/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/costa-rica/uk/partner_british/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Costa Rica to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/costa-rica/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/costa-rica/uk/partner_local/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Costa Rica to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/costa-rica/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/costa-rica/uk/partner_other/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Costa Rica to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/cote-d-ivoire/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/cote-d-ivoire/uk/partner_british/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Cote d'Ivoire to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/cote-d-ivoire/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/cote-d-ivoire/uk/partner_local/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Cote d'Ivoire to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/cote-d-ivoire/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/cote-d-ivoire/uk/partner_other/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Cote d'Ivoire to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/croatia/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/croatia/uk/partner_british/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Croatia to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/croatia/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/croatia/uk/partner_local/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Croatia to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/croatia/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/croatia/uk/partner_other/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Croatia to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/denmark/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/denmark/uk/partner_british/opposite_sex.txt
@@ -17,6 +17,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Denmark to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/denmark/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/denmark/uk/partner_local/opposite_sex.txt
@@ -17,6 +17,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Denmark to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/denmark/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/denmark/uk/partner_other/opposite_sex.txt
@@ -17,6 +17,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Denmark to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/estonia/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/estonia/uk/partner_british/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Estonia to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/estonia/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/estonia/uk/partner_local/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Estonia to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/estonia/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/estonia/uk/partner_other/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Estonia to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/finland/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/finland/uk/partner_british/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Finland to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/finland/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/finland/uk/partner_local/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Finland to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/finland/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/finland/uk/partner_other/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Finland to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/germany/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/germany/uk/partner_british/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Germany to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/germany/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/germany/uk/partner_local/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Germany to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/germany/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/germany/uk/partner_other/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Germany to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/greece/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/greece/uk/partner_british/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Greece to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/greece/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/greece/uk/partner_local/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Greece to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/greece/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/greece/uk/partner_other/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Greece to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/guatemala/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/guatemala/uk/partner_british/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Guatemala to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/guatemala/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/guatemala/uk/partner_local/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Guatemala to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/guatemala/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/guatemala/uk/partner_other/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Guatemala to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/iceland/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/iceland/uk/partner_british/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Iceland to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/iceland/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/iceland/uk/partner_local/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Iceland to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/iceland/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/iceland/uk/partner_other/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Iceland to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/italy/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/italy/uk/partner_british/opposite_sex.txt
@@ -14,6 +14,7 @@ You’ll need to get a certificate of no impediment (CNI) from the authorities i
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Italy to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/italy/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/italy/uk/partner_local/opposite_sex.txt
@@ -11,6 +11,7 @@ You’ll need to get a certificate of no impediment (CNI) from the authorities i
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Italy to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/italy/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/italy/uk/partner_other/opposite_sex.txt
@@ -11,6 +11,7 @@ You’ll need to get a certificate of no impediment (CNI) from the authorities i
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Italy to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/japan/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/japan/uk/partner_british/opposite_sex.txt
@@ -13,6 +13,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Japan to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/japan/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/japan/uk/partner_local/opposite_sex.txt
@@ -13,6 +13,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Japan to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/japan/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/japan/uk/partner_other/opposite_sex.txt
@@ -13,6 +13,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Japan to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/jordan/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/jordan/uk/partner_british/opposite_sex.txt
@@ -25,6 +25,7 @@ For non-Islamic marriages, you may be asked to provide a certificate of no imped
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Jordan to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/jordan/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/jordan/uk/partner_local/opposite_sex.txt
@@ -25,6 +25,7 @@ For non-Islamic marriages, you may be asked to provide a certificate of no imped
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Jordan to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/jordan/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/jordan/uk/partner_other/opposite_sex.txt
@@ -25,6 +25,7 @@ For non-Islamic marriages, you may be asked to provide a certificate of no imped
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Jordan to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/kazakhstan/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/kazakhstan/uk/partner_british/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Kazakhstan to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/kazakhstan/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/kazakhstan/uk/partner_local/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Kazakhstan to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/kazakhstan/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/kazakhstan/uk/partner_other/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Kazakhstan to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/kuwait/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/kuwait/uk/partner_british/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Kuwait to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/kuwait/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/kuwait/uk/partner_local/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Kuwait to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/kuwait/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/kuwait/uk/partner_other/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Kuwait to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/kyrgyzstan/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/kyrgyzstan/uk/partner_british/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Kyrgyzstan to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/kyrgyzstan/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/kyrgyzstan/uk/partner_local/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Kyrgyzstan to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/kyrgyzstan/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/kyrgyzstan/uk/partner_other/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Kyrgyzstan to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/latvia/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/latvia/uk/partner_british/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Latvia to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/latvia/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/latvia/uk/partner_local/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Latvia to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/latvia/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/latvia/uk/partner_other/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Latvia to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/lithuania/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/lithuania/uk/partner_british/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Lithuania to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/lithuania/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/lithuania/uk/partner_local/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Lithuania to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/lithuania/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/lithuania/uk/partner_other/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Lithuania to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/luxembourg/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/luxembourg/uk/partner_british/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Luxembourg to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/luxembourg/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/luxembourg/uk/partner_local/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Luxembourg to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/luxembourg/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/luxembourg/uk/partner_other/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Luxembourg to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/macedonia/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/macedonia/uk/partner_british/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Macedonia to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/macedonia/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/macedonia/uk/partner_local/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Macedonia to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/macedonia/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/macedonia/uk/partner_other/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Macedonia to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/mexico/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/mexico/uk/partner_british/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Mexico to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/mexico/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/mexico/uk/partner_local/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Mexico to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/mexico/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/mexico/uk/partner_other/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Mexico to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/montenegro/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/montenegro/uk/partner_british/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Montenegro to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/montenegro/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/montenegro/uk/partner_local/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Montenegro to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/montenegro/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/montenegro/uk/partner_other/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Montenegro to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/nicaragua/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/nicaragua/uk/partner_british/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Nicaragua to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/nicaragua/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/nicaragua/uk/partner_local/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Nicaragua to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/nicaragua/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/nicaragua/uk/partner_other/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Nicaragua to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/norway/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/norway/uk/partner_british/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Norway to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/norway/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/norway/uk/partner_local/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Norway to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/norway/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/norway/uk/partner_other/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Norway to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/oman/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/oman/uk/partner_british/opposite_sex.txt
@@ -20,6 +20,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Oman to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/oman/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/oman/uk/partner_local/opposite_sex.txt
@@ -20,6 +20,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Oman to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/oman/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/oman/uk/partner_other/opposite_sex.txt
@@ -20,6 +20,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Oman to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/paraguay/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/paraguay/uk/partner_british/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Paraguay to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/paraguay/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/paraguay/uk/partner_local/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Paraguay to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/paraguay/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/paraguay/uk/partner_other/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Paraguay to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/poland/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/poland/uk/partner_british/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Poland to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/poland/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/poland/uk/partner_local/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Poland to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/poland/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/poland/uk/partner_other/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Poland to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/russia/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/russia/uk/partner_british/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Russia to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/russia/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/russia/uk/partner_local/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Russia to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/russia/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/russia/uk/partner_other/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Russia to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/rwanda/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/rwanda/uk/partner_british/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Rwanda to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/rwanda/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/rwanda/uk/partner_local/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Rwanda to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/rwanda/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/rwanda/uk/partner_other/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Rwanda to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/san-marino/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/san-marino/uk/partner_british/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in San Marino to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/san-marino/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/san-marino/uk/partner_local/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in San Marino to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/san-marino/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/san-marino/uk/partner_other/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in San Marino to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/serbia/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/serbia/uk/partner_british/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Serbia to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/serbia/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/serbia/uk/partner_local/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Serbia to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/serbia/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/serbia/uk/partner_other/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Serbia to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_british/opposite_sex.txt
@@ -1,89 +1,70 @@
 Marriage in Spain
 
+
 Contact the relevant local authorities in Spain to find out about local marriage laws, including what documents you’ll need.
 
 
-Civil weddings in Spain take place at a town hall, register office or district court. You need to register with the local civil authorities afterwards to get an official marriage certificate if you have a religious wedding.
+Civil weddings in Spain take place at a town hall, register office or district court. You must register with the local civil authorities afterwards to get an official marriage certificate if you have a religious wedding.
 
 
-Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married.
+^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
 
 
-##What you need to do
+## What you need to do
+
+You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf), [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf), or both to prove you’re allowed to marry.
+
+Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC)  where you’re getting married to find out what certificates you’ll need.
+
+Your partner must follow the same process to get their own certificates.
+
+^You must apply for all certificates at least 3 months before you get married.^
 
 
-You may be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
+## Getting a certificate of no impediment
 
-^You may also need to get a marital status certificate if you’re living with your partner and want to get a ‘[pareja de hecho](/notarial-and-documentary-services-guide-for-spain#marital-status-certificate-for-pareja-de-hecho)’ (cohabitation registration).^
-
-
-If you need a CNI, you must give notice of your intended marriage in Spain. You must do this at the British embassy or in front of a notary public in that country.
-
-
-The documents you need are:
-
-- your passport
-- your partner’s passport or national identity document
-- a ‘certificado de empadronamiento’ (town hall registration certificate) or Spanish police residence certificate (green document with your NIE number address) issued at least 3 days ago
-
-^The Civil Registry will usually ask you for a certificado de empadronamiento issued in the last 3 months.^
-
-
-If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
-
-- a [decree absolute or final order](/copy-decree-absolute-final-order)
-- a civil partnership dissolution or annulment certificate
-- your (or your partner’s) former spouse or civil partner’s [death certificate](/order-copy-birth-death-marriage-certificate/)
-
-
-Send your completed CNI service request form and copies of the supporting documents to your [nearest British consulate](/notarial-and-documentary-services-guide-for-spain#where-to-send-your-request). You can send them as scanned attachments by email or by fax. You’ll need to bring the original documents to your appointment.
-
-To request an appointment, fill in the CNI service request form and make sure you’ve got all of the necessary supporting documents.
+Download and the complete the CNI application pack - it contains a list of the documents you’ll need.
 
 $D
-[Download ’CNI service request form’ (DOC, 29KB)](/government/publications/certificate-of-no-impediment-service-request-form-spain)
+[Download 'CNI application pack' (PDF, 464KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446264/CNI_Pack.pdf)
 $D
+
+You must sign the notice of marriage and affirmation in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you post the other documents.
+
+Send all the documents and fee by registered post to the address in the application pack.
 
 ###What happens next
 
-The consulate will check your form and documents, and if everything’s in order they’ll send you details of how to book your appointment to give official notice of your marriage. They’ll then display your notice publicly for 7 days, and if nobody has raised an objection, they’ll issue your CNI. There’s an additional fee for this.
+The consulate will check your forms and documents. Once everything is approved, they’ll take your payment and display your notice of marriage for 7 days. If nobody raises an objection, they’ll then issue your CNI and send it to you with your supporting documents by registered post.
 
-^Your partner will need to follow the same process and pay the fees to get their own CNI.^
-
-
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
+It takes 10 working days after payment for the consulate to process your application.
 
 
-###Getting a marital status certificate
+##Getting a marital status certificate
 
-In some parts of Spain you may need to to get a ‘marital status certificate’ (‘certificado de estado civil’) instead of, or as well as, a CNI (’certificado de no impedimento’).
-
-Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married. If you need one, ask a [solicitor](/government/publications/spain-list-of-lawyers) (‘abogado’) to draw up a declaration for you printed on their headed paper.
-
-^If it’s on blank, non-headed paper, they’ll need to give you a separate letter including their contact details, confirming that they’ve drawn up the declaration.^
-
-You’ll then need to make an appointment at the consulate to make the declaration and sign the document in front of a consular officer - so don’t sign it beforehand.
-
-Download instructions in English and Spanish on what the declaration needs to include.
+Download and complete the marital status certificate application pack - it contains a list of the documents you’ll need.
 
 $D
-[Download ‘Marital status declaration instructions in English’ (PDF, 363KB)](/government/uploads/system/uploads/attachment_data/file/136832/marital-status-declaration-instruction-en.pdf)
-[Download ‘Declaración de estado civil instrucciones en Español’ (PDF, 236KB)](/government/uploads/system/uploads/attachment_data/file/136833/marital-status-declaration-instruction-sp.pdf)
+[Download 'Marital status certificate application pack' (PDF, 424KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446267/Marital_Status_for_Marriage_Pack.pdf)
 $D
 
-You’ll also need a completed marital status certificate application form, as well as the supporting documents and the fee (see below).
+You must sign the affirmation in the application pack in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you post the other documents.
 
-$D
-[Download ’Marital status certificate appointment request form’ (DOC, 53KB)](/government/uploads/system/uploads/attachment_data/file/182249/Appointment_request_form_marital_status_marriage.doc)
-$D
+Send the documents and fee by registered post to the address in the application pack.
+
+### What happens next
+
+The consulate will check your forms and documents, and contact you if they have any queries.
+
+It takes 10 working days after your payment has been approved for the consulate to process your application.
+
+They’ll send your certificate and supporting documents to you by registered post.
 
 
-Your partner will also need to get a marital status certificate from the consulate and pay the fees if the civil registry have told you that they need one.
+##Other requirements for Spain
 
+If you’ve been living in Spain for less than 2 years, the civil registrar may also ask for confirmation of your addresses for the past 2 years (‘confirmación de domicilio para casarse en España’).
 
-###Other requirements for Spain
-
-The civil registrar may also ask for confirmation of your addresses for the past 2 years (‘confirmación de domicilio para casarse en España’).
 
 You’ll need to show one of the following:
 
@@ -94,8 +75,12 @@ You’ll need to show one of the following:
 - utility bills
 - recent proof of entitlement to local or state benefits, eg tax credits, pension, education or other benefits
 
+If you’re asked to provide a document from the British consulate, print out a copy of the [‘communication proof of address’](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/288272/Communication_re_Proof_of_Address.pdf).
 
-^You don't need to stay in the country while your notice is posted.^
+^You must get your documents translated if they’re not in English or Spanish.^
+
+
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
 
 
 ##Fees
@@ -112,10 +97,8 @@ Administering an oath or making a declaration | £55
 You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Spain](/government/publications/spain-consular-fees).
 
 
-You can pay by cash or credit card, but not by personal cheque.
+You can pay by credit card (Visa, Visa Electron or MasterCard), but not by personal cheque.
 
 
 *[CNI]:certificate of no impediment
-*[GRO]:General Register Office
-*[FCO]:Foreign &amp; Commonwealth Office
 

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_british/opposite_sex.txt
@@ -10,9 +10,19 @@ Civil weddings in Spain take place at a town hall, register office or district c
 ^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
 
 
-## What you need to do
+##What you need to do
 
-You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf), [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf), or both to prove you’re allowed to marry.
+
+You may be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
+
+$D
+[Download 'Certificate of no impediment' (PDF, 198KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf)
+$D
+
+$D
+[Download 'Marital status certificate' (PDF, 145KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf)
+$D
+
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 
@@ -29,7 +39,7 @@ $D
 [Download 'CNI application pack' (PDF, 464KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446264/CNI_Pack.pdf)
 $D
 
-You must sign the notice of marriage and affirmation in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you post the other documents.
+You must sign the notice of marriage and affirmation in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you send your application to the consulate.
 
 Send all the documents and fee by registered post to the address in the application pack.
 
@@ -48,9 +58,9 @@ $D
 [Download 'Marital status certificate application pack' (PDF, 424KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446267/Marital_Status_for_Marriage_Pack.pdf)
 $D
 
-You must sign the affirmation in the application pack in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you post the other documents.
+You must sign the affirmation in the application pack in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you send your application to the consulate.
 
-Send the documents and fee by registered post to the address in the application pack.
+Send the documents by registered post to the address in the application pack.
 
 ### What happens next
 
@@ -58,7 +68,7 @@ The consulate will check your forms and documents, and contact you if they have 
 
 It takes 10 working days after your payment has been approved for the consulate to process your application.
 
-They’ll send your certificate and supporting documents to you by registered post.
+They’ll send your certificate and original documents to you by registered post.
 
 
 ##Other requirements for Spain

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_british/opposite_sex.txt
@@ -14,11 +14,11 @@ Civil weddings in Spain take place at a town hall, register office or district c
 
 You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf), [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf), or both to prove you’re allowed to marry.
 
-Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC)  where you’re getting married to find out what certificates you’ll need.
+^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 
-Your partner must follow the same process to get their own certificates.
+Your partner must also provide their own certificates.
 
-^You must apply for all certificates at least 3 months before you get married.^
+You must apply for all certificates at least 3 months before you get married.
 
 
 ## Getting a certificate of no impediment

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_british/same_sex.txt
@@ -1,89 +1,70 @@
-Marriage in Spain
+Civil partnership in Spain
 
-Contact the relevant local authorities in Spain to find out about local marriage laws, including what documents you’ll need.
+
+Contact the relevant local authorities in Spain to find out about local laws, including what documents you’ll need.
 
 
 The process for same-sex marriages in Spain is the same as for opposite-sex civil marriages. Your marriage will be recognised as a civil partnership under British law.
 
 
-Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married.
+^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
 
 
-##What you need to do
+## What you need to do
+
+You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf), [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf), or both to prove you’re allowed to marry.
+
+Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC)  where you’re getting married to find out what certificates you’ll need.
+
+Your partner must follow the same process to get their own certificates.
+
+^You must apply for all certificates at least 3 months before you get married.^
 
 
-You may be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
+## Getting a certificate of no impediment
 
-^You may also need to get a marital status certificate if you’re living with your partner and want to get a ‘[pareja de hecho](/notarial-and-documentary-services-guide-for-spain#marital-status-certificate-for-pareja-de-hecho)’ (cohabitation registration).^
-
-
-If you need a CNI, you must give notice of your intended marriage in Spain. You must do this at the British embassy or in front of a notary public in that country.
-
-
-The documents you need are:
-
-- your passport
-- your partner’s passport or national identity document
-- a ‘certificado de empadronamiento’ (town hall registration certificate) or Spanish police residence certificate (green document with your NIE number address) issued at least 3 days ago
-
-^The Civil Registry will usually ask you for a certificado de empadronamiento issued in the last 3 months.^
-
-
-If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
-
-- a [decree absolute or final order](/copy-decree-absolute-final-order)
-- a civil partnership dissolution or annulment certificate
-- your (or your partner’s) former spouse or civil partner’s [death certificate](/order-copy-birth-death-marriage-certificate/)
-
-
-Send your completed CNI service request form and copies of the supporting documents to your [nearest British consulate](/notarial-and-documentary-services-guide-for-spain#where-to-send-your-request). You can send them as scanned attachments by email or by fax. You’ll need to bring the original documents to your appointment.
-
-To request an appointment, fill in the CNI service request form and make sure you’ve got all of the necessary supporting documents.
+Download and the complete the CNI application pack - it contains a list of the documents you’ll need.
 
 $D
-[Download ’CNI service request form’ (DOC, 29KB)](/government/publications/certificate-of-no-impediment-service-request-form-spain)
+[Download 'CNI application pack' (PDF, 464KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446264/CNI_Pack.pdf)
 $D
+
+You must sign the notice of marriage and affirmation in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you post the other documents.
+
+Send all the documents and fee by registered post to the address in the application pack.
 
 ###What happens next
 
-The consulate will check your form and documents, and if everything’s in order they’ll send you details of how to book your appointment to give official notice of your marriage. They’ll then display your notice publicly for 7 days, and if nobody has raised an objection, they’ll issue your CNI. There’s an additional fee for this.
+The consulate will check your forms and documents. Once everything is approved, they’ll take your payment and display your notice of marriage for 7 days. If nobody raises an objection, they’ll then issue your CNI and send it to you with your supporting documents by registered post.
 
-^Your partner will need to follow the same process and pay the fees to get their own CNI.^
-
-
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
+It takes 10 working days after payment for the consulate to process your application.
 
 
-###Getting a marital status certificate
+##Getting a marital status certificate
 
-In some parts of Spain you may need to to get a ‘marital status certificate’ (‘certificado de estado civil’) instead of, or as well as, a CNI (’certificado de no impedimento’).
-
-Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married. If you need one, ask a [solicitor](/government/publications/spain-list-of-lawyers) (‘abogado’) to draw up a declaration for you printed on their headed paper.
-
-^If it’s on blank, non-headed paper, they’ll need to give you a separate letter including their contact details, confirming that they’ve drawn up the declaration.^
-
-You’ll then need to make an appointment at the consulate to make the declaration and sign the document in front of a consular officer - so don’t sign it beforehand.
-
-Download instructions in English and Spanish on what the declaration needs to include.
+Download and complete the marital status certificate application pack - it contains a list of the documents you’ll need.
 
 $D
-[Download ‘Marital status declaration instructions in English’ (PDF, 363KB)](/government/uploads/system/uploads/attachment_data/file/136832/marital-status-declaration-instruction-en.pdf)
-[Download ‘Declaración de estado civil instrucciones en Español’ (PDF, 236KB)](/government/uploads/system/uploads/attachment_data/file/136833/marital-status-declaration-instruction-sp.pdf)
+[Download 'Marital status certificate application pack' (PDF, 424KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446267/Marital_Status_for_Marriage_Pack.pdf)
 $D
 
-You’ll also need a completed marital status certificate application form, as well as the supporting documents and the fee (see below).
+You must sign the affirmation in the application pack in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you post the other documents.
 
-$D
-[Download ’Marital status certificate appointment request form’ (DOC, 53KB)](/government/uploads/system/uploads/attachment_data/file/182249/Appointment_request_form_marital_status_marriage.doc)
-$D
+Send the documents and fee by registered post to the address in the application pack.
+
+### What happens next
+
+The consulate will check your forms and documents, and contact you if they have any queries.
+
+It takes 10 working days after your payment has been approved for the consulate to process your application.
+
+They’ll send your certificate and supporting documents to you by registered post.
 
 
-Your partner will also need to get a marital status certificate from the consulate and pay the fees if the civil registry have told you that they need one.
+##Other requirements for Spain
 
+If you’ve been living in Spain for less than 2 years, the civil registrar may also ask for confirmation of your addresses for the past 2 years (‘confirmación de domicilio para casarse en España’).
 
-###Other requirements for Spain
-
-The civil registrar may also ask for confirmation of your addresses for the past 2 years (‘confirmación de domicilio para casarse en España’).
 
 You’ll need to show one of the following:
 
@@ -94,8 +75,12 @@ You’ll need to show one of the following:
 - utility bills
 - recent proof of entitlement to local or state benefits, eg tax credits, pension, education or other benefits
 
+If you’re asked to provide a document from the British consulate, print out a copy of the [‘communication proof of address’](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/288272/Communication_re_Proof_of_Address.pdf).
 
-^You don't need to stay in the country while your notice is posted.^
+^You must get your documents translated if they’re not in English or Spanish.^
+
+
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
 
 
 ##Fees
@@ -112,10 +97,8 @@ Administering an oath or making a declaration | £55
 You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Spain](/government/publications/spain-consular-fees).
 
 
-You can pay by cash or credit card, but not by personal cheque.
+You can pay by credit card (Visa, Visa Electron or MasterCard), but not by personal cheque.
 
 
 *[CNI]:certificate of no impediment
-*[GRO]:General Register Office
-*[FCO]:Foreign &amp; Commonwealth Office
 

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_british/same_sex.txt
@@ -14,11 +14,11 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf), [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf), or both to prove you’re allowed to marry.
 
-Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC)  where you’re getting married to find out what certificates you’ll need.
+^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 
-Your partner must follow the same process to get their own certificates.
+Your partner must also provide their own certificates.
 
-^You must apply for all certificates at least 3 months before you get married.^
+You must apply for all certificates at least 3 months before you get married.
 
 
 ## Getting a certificate of no impediment

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_british/same_sex.txt
@@ -1,18 +1,28 @@
-Civil partnership in Spain
+Same-sex Marriage in Spain
 
 
-Contact the relevant local authorities in Spain to find out about local laws, including what documents you’ll need.
+Contact the relevant local authorities in Spain to find out about local marriage laws, including what documents you’ll need.
 
 
-The process for same-sex marriages in Spain is the same as for opposite-sex civil marriages. Your marriage will be recognised as a civil partnership under British law.
+The process for same-sex marriages in Spain is the same as for opposite-sex civil marriages.
 
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
 
 
-## What you need to do
+##What you need to do
 
-You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf), [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf), or both to prove you’re allowed to marry.
+
+You may be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
+
+$D
+[Download 'Certificate of no impediment' (PDF, 198KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf)
+$D
+
+$D
+[Download 'Marital status certificate' (PDF, 145KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf)
+$D
+
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 
@@ -29,7 +39,7 @@ $D
 [Download 'CNI application pack' (PDF, 464KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446264/CNI_Pack.pdf)
 $D
 
-You must sign the notice of marriage and affirmation in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you post the other documents.
+You must sign the notice of marriage and affirmation in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you send your application to the consulate.
 
 Send all the documents and fee by registered post to the address in the application pack.
 
@@ -48,9 +58,9 @@ $D
 [Download 'Marital status certificate application pack' (PDF, 424KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446267/Marital_Status_for_Marriage_Pack.pdf)
 $D
 
-You must sign the affirmation in the application pack in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you post the other documents.
+You must sign the affirmation in the application pack in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you send your application to the consulate.
 
-Send the documents and fee by registered post to the address in the application pack.
+Send the documents by registered post to the address in the application pack.
 
 ### What happens next
 
@@ -58,7 +68,7 @@ The consulate will check your forms and documents, and contact you if they have 
 
 It takes 10 working days after your payment has been approved for the consulate to process your application.
 
-They’ll send your certificate and supporting documents to you by registered post.
+They’ll send your certificate and original documents to you by registered post.
 
 
 ##Other requirements for Spain

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_local/opposite_sex.txt
@@ -10,9 +10,19 @@ Civil weddings in Spain take place at a town hall, register office or district c
 ^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
 
 
-## What you need to do
+##What you need to do
 
-You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf), [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf), or both to prove you’re allowed to marry.
+
+You may be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
+
+$D
+[Download 'Certificate of no impediment' (PDF, 198KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf)
+$D
+
+$D
+[Download 'Marital status certificate' (PDF, 145KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf)
+$D
+
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 
@@ -29,7 +39,7 @@ $D
 [Download 'CNI application pack' (PDF, 464KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446264/CNI_Pack.pdf)
 $D
 
-You must sign the notice of marriage and affirmation in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you post the other documents.
+You must sign the notice of marriage and affirmation in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you send your application to the consulate.
 
 Send all the documents and fee by registered post to the address in the application pack.
 
@@ -48,9 +58,9 @@ $D
 [Download 'Marital status certificate application pack' (PDF, 424KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446267/Marital_Status_for_Marriage_Pack.pdf)
 $D
 
-You must sign the affirmation in the application pack in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you post the other documents.
+You must sign the affirmation in the application pack in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you send your application to the consulate.
 
-Send the documents and fee by registered post to the address in the application pack.
+Send the documents by registered post to the address in the application pack.
 
 ### What happens next
 
@@ -58,7 +68,7 @@ The consulate will check your forms and documents, and contact you if they have 
 
 It takes 10 working days after your payment has been approved for the consulate to process your application.
 
-They’ll send your certificate and supporting documents to you by registered post.
+They’ll send your certificate and original documents to you by registered post.
 
 
 ##Other requirements for Spain

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_local/opposite_sex.txt
@@ -1,83 +1,70 @@
 Marriage in Spain
 
+
 Contact the relevant local authorities in Spain to find out about local marriage laws, including what documents you’ll need.
 
 
-Civil weddings in Spain take place at a town hall, register office or district court. You need to register with the local civil authorities afterwards to get an official marriage certificate if you have a religious wedding.
+Civil weddings in Spain take place at a town hall, register office or district court. You must register with the local civil authorities afterwards to get an official marriage certificate if you have a religious wedding.
 
 
-Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married.
+^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
 
 
-##What you need to do
+## What you need to do
+
+You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf), [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf), or both to prove you’re allowed to marry.
+
+Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC)  where you’re getting married to find out what certificates you’ll need.
+
+Your partner must follow the same process to get their own certificates.
+
+^You must apply for all certificates at least 3 months before you get married.^
 
 
-You may be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
+## Getting a certificate of no impediment
 
-^You may also need to get a marital status certificate if you’re living with your partner and want to get a ‘[pareja de hecho](/notarial-and-documentary-services-guide-for-spain#marital-status-certificate-for-pareja-de-hecho)’ (cohabitation registration).^
-
-
-If you need a CNI, you must give notice of your intended marriage in Spain. You must do this at the British embassy or in front of a notary public in that country.
-
-
-The documents you need are:
-
-- your passport
-- your partner’s passport or national identity document
-- a ‘certificado de empadronamiento’ (town hall registration certificate) or Spanish police residence certificate (green document with your NIE number address) issued at least 3 days ago
-
-^The Civil Registry will usually ask you for a certificado de empadronamiento issued in the last 3 months.^
-
-
-If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
-
-- a [decree absolute or final order](/copy-decree-absolute-final-order)
-- a civil partnership dissolution or annulment certificate
-- your (or your partner’s) former spouse or civil partner’s [death certificate](/order-copy-birth-death-marriage-certificate/)
-
-
-Send your completed CNI service request form and copies of the supporting documents to your [nearest British consulate](/notarial-and-documentary-services-guide-for-spain#where-to-send-your-request). You can send them as scanned attachments by email or by fax. You’ll need to bring the original documents to your appointment.
-
-To request an appointment, fill in the CNI service request form and make sure you’ve got all of the necessary supporting documents.
+Download and the complete the CNI application pack - it contains a list of the documents you’ll need.
 
 $D
-[Download ’CNI service request form’ (DOC, 29KB)](/government/publications/certificate-of-no-impediment-service-request-form-spain)
+[Download 'CNI application pack' (PDF, 464KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446264/CNI_Pack.pdf)
 $D
+
+You must sign the notice of marriage and affirmation in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you post the other documents.
+
+Send all the documents and fee by registered post to the address in the application pack.
 
 ###What happens next
 
-The consulate will check your form and documents, and if everything’s in order they’ll send you details of how to book your appointment to give official notice of your marriage. They’ll then display your notice publicly for 7 days, and if nobody has raised an objection, they’ll issue your CNI. There’s an additional fee for this.
+The consulate will check your forms and documents. Once everything is approved, they’ll take your payment and display your notice of marriage for 7 days. If nobody raises an objection, they’ll then issue your CNI and send it to you with your supporting documents by registered post.
 
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
+It takes 10 working days after payment for the consulate to process your application.
 
 
-###Getting a marital status certificate
+##Getting a marital status certificate
 
-In some parts of Spain you may need to to get a ‘marital status certificate’ (‘certificado de estado civil’) instead of, or as well as, a CNI (’certificado de no impedimento’).
-
-Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married. If you need one, ask a [solicitor](/government/publications/spain-list-of-lawyers) (‘abogado’) to draw up a declaration for you printed on their headed paper.
-
-^If it’s on blank, non-headed paper, they’ll need to give you a separate letter including their contact details, confirming that they’ve drawn up the declaration.^
-
-You’ll then need to make an appointment at the consulate to make the declaration and sign the document in front of a consular officer - so don’t sign it beforehand.
-
-Download instructions in English and Spanish on what the declaration needs to include.
+Download and complete the marital status certificate application pack - it contains a list of the documents you’ll need.
 
 $D
-[Download ‘Marital status declaration instructions in English’ (PDF, 363KB)](/government/uploads/system/uploads/attachment_data/file/136832/marital-status-declaration-instruction-en.pdf)
-[Download ‘Declaración de estado civil instrucciones en Español’ (PDF, 236KB)](/government/uploads/system/uploads/attachment_data/file/136833/marital-status-declaration-instruction-sp.pdf)
+[Download 'Marital status certificate application pack' (PDF, 424KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446267/Marital_Status_for_Marriage_Pack.pdf)
 $D
 
-You’ll also need a completed marital status certificate application form, as well as the supporting documents and the fee (see below).
+You must sign the affirmation in the application pack in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you post the other documents.
 
-$D
-[Download ’Marital status certificate appointment request form’ (DOC, 53KB)](/government/uploads/system/uploads/attachment_data/file/182249/Appointment_request_form_marital_status_marriage.doc)
-$D
+Send the documents and fee by registered post to the address in the application pack.
+
+### What happens next
+
+The consulate will check your forms and documents, and contact you if they have any queries.
+
+It takes 10 working days after your payment has been approved for the consulate to process your application.
+
+They’ll send your certificate and supporting documents to you by registered post.
 
 
-###Other requirements for Spain
+##Other requirements for Spain
 
-The civil registrar may also ask for confirmation of your addresses for the past 2 years (‘confirmación de domicilio para casarse en España’).
+If you’ve been living in Spain for less than 2 years, the civil registrar may also ask for confirmation of your addresses for the past 2 years (‘confirmación de domicilio para casarse en España’).
+
 
 You’ll need to show one of the following:
 
@@ -88,8 +75,12 @@ You’ll need to show one of the following:
 - utility bills
 - recent proof of entitlement to local or state benefits, eg tax credits, pension, education or other benefits
 
+If you’re asked to provide a document from the British consulate, print out a copy of the [‘communication proof of address’](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/288272/Communication_re_Proof_of_Address.pdf).
 
-^You don't need to stay in the country while your notice is posted.^
+^You must get your documents translated if they’re not in English or Spanish.^
+
+
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
 
 
 ##Naturalisation of your partner if they move to the UK
@@ -111,10 +102,8 @@ Administering an oath or making a declaration | £55
 You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Spain](/government/publications/spain-consular-fees).
 
 
-You can pay by cash or credit card, but not by personal cheque.
+You can pay by credit card (Visa, Visa Electron or MasterCard), but not by personal cheque.
 
 
 *[CNI]:certificate of no impediment
-*[GRO]:General Register Office
-*[FCO]:Foreign &amp; Commonwealth Office
 

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_local/opposite_sex.txt
@@ -14,11 +14,11 @@ Civil weddings in Spain take place at a town hall, register office or district c
 
 You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf), [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf), or both to prove you’re allowed to marry.
 
-Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC)  where you’re getting married to find out what certificates you’ll need.
+^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 
-Your partner must follow the same process to get their own certificates.
+Your partner must also provide their own certificates.
 
-^You must apply for all certificates at least 3 months before you get married.^
+You must apply for all certificates at least 3 months before you get married.
 
 
 ## Getting a certificate of no impediment

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_local/same_sex.txt
@@ -1,83 +1,70 @@
-Marriage in Spain
+Civil partnership in Spain
 
-Contact the relevant local authorities in Spain to find out about local marriage laws, including what documents you’ll need.
+
+Contact the relevant local authorities in Spain to find out about local laws, including what documents you’ll need.
 
 
 The process for same-sex marriages in Spain is the same as for opposite-sex civil marriages. Your marriage will be recognised as a civil partnership under British law.
 
 
-Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married.
+^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
 
 
-##What you need to do
+## What you need to do
+
+You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf), [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf), or both to prove you’re allowed to marry.
+
+Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC)  where you’re getting married to find out what certificates you’ll need.
+
+Your partner must follow the same process to get their own certificates.
+
+^You must apply for all certificates at least 3 months before you get married.^
 
 
-You may be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
+## Getting a certificate of no impediment
 
-^You may also need to get a marital status certificate if you’re living with your partner and want to get a ‘[pareja de hecho](/notarial-and-documentary-services-guide-for-spain#marital-status-certificate-for-pareja-de-hecho)’ (cohabitation registration).^
-
-
-If you need a CNI, you must give notice of your intended marriage in Spain. You must do this at the British embassy or in front of a notary public in that country.
-
-
-The documents you need are:
-
-- your passport
-- your partner’s passport or national identity document
-- a ‘certificado de empadronamiento’ (town hall registration certificate) or Spanish police residence certificate (green document with your NIE number address) issued at least 3 days ago
-
-^The Civil Registry will usually ask you for a certificado de empadronamiento issued in the last 3 months.^
-
-
-If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
-
-- a [decree absolute or final order](/copy-decree-absolute-final-order)
-- a civil partnership dissolution or annulment certificate
-- your (or your partner’s) former spouse or civil partner’s [death certificate](/order-copy-birth-death-marriage-certificate/)
-
-
-Send your completed CNI service request form and copies of the supporting documents to your [nearest British consulate](/notarial-and-documentary-services-guide-for-spain#where-to-send-your-request). You can send them as scanned attachments by email or by fax. You’ll need to bring the original documents to your appointment.
-
-To request an appointment, fill in the CNI service request form and make sure you’ve got all of the necessary supporting documents.
+Download and the complete the CNI application pack - it contains a list of the documents you’ll need.
 
 $D
-[Download ’CNI service request form’ (DOC, 29KB)](/government/publications/certificate-of-no-impediment-service-request-form-spain)
+[Download 'CNI application pack' (PDF, 464KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446264/CNI_Pack.pdf)
 $D
+
+You must sign the notice of marriage and affirmation in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you post the other documents.
+
+Send all the documents and fee by registered post to the address in the application pack.
 
 ###What happens next
 
-The consulate will check your form and documents, and if everything’s in order they’ll send you details of how to book your appointment to give official notice of your marriage. They’ll then display your notice publicly for 7 days, and if nobody has raised an objection, they’ll issue your CNI. There’s an additional fee for this.
+The consulate will check your forms and documents. Once everything is approved, they’ll take your payment and display your notice of marriage for 7 days. If nobody raises an objection, they’ll then issue your CNI and send it to you with your supporting documents by registered post.
 
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
+It takes 10 working days after payment for the consulate to process your application.
 
 
-###Getting a marital status certificate
+##Getting a marital status certificate
 
-In some parts of Spain you may need to to get a ‘marital status certificate’ (‘certificado de estado civil’) instead of, or as well as, a CNI (’certificado de no impedimento’).
-
-Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married. If you need one, ask a [solicitor](/government/publications/spain-list-of-lawyers) (‘abogado’) to draw up a declaration for you printed on their headed paper.
-
-^If it’s on blank, non-headed paper, they’ll need to give you a separate letter including their contact details, confirming that they’ve drawn up the declaration.^
-
-You’ll then need to make an appointment at the consulate to make the declaration and sign the document in front of a consular officer - so don’t sign it beforehand.
-
-Download instructions in English and Spanish on what the declaration needs to include.
+Download and complete the marital status certificate application pack - it contains a list of the documents you’ll need.
 
 $D
-[Download ‘Marital status declaration instructions in English’ (PDF, 363KB)](/government/uploads/system/uploads/attachment_data/file/136832/marital-status-declaration-instruction-en.pdf)
-[Download ‘Declaración de estado civil instrucciones en Español’ (PDF, 236KB)](/government/uploads/system/uploads/attachment_data/file/136833/marital-status-declaration-instruction-sp.pdf)
+[Download 'Marital status certificate application pack' (PDF, 424KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446267/Marital_Status_for_Marriage_Pack.pdf)
 $D
 
-You’ll also need a completed marital status certificate application form, as well as the supporting documents and the fee (see below).
+You must sign the affirmation in the application pack in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you post the other documents.
 
-$D
-[Download ’Marital status certificate appointment request form’ (DOC, 53KB)](/government/uploads/system/uploads/attachment_data/file/182249/Appointment_request_form_marital_status_marriage.doc)
-$D
+Send the documents and fee by registered post to the address in the application pack.
+
+### What happens next
+
+The consulate will check your forms and documents, and contact you if they have any queries.
+
+It takes 10 working days after your payment has been approved for the consulate to process your application.
+
+They’ll send your certificate and supporting documents to you by registered post.
 
 
-###Other requirements for Spain
+##Other requirements for Spain
 
-The civil registrar may also ask for confirmation of your addresses for the past 2 years (‘confirmación de domicilio para casarse en España’).
+If you’ve been living in Spain for less than 2 years, the civil registrar may also ask for confirmation of your addresses for the past 2 years (‘confirmación de domicilio para casarse en España’).
+
 
 You’ll need to show one of the following:
 
@@ -88,8 +75,12 @@ You’ll need to show one of the following:
 - utility bills
 - recent proof of entitlement to local or state benefits, eg tax credits, pension, education or other benefits
 
+If you’re asked to provide a document from the British consulate, print out a copy of the [‘communication proof of address’](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/288272/Communication_re_Proof_of_Address.pdf).
 
-^You don't need to stay in the country while your notice is posted.^
+^You must get your documents translated if they’re not in English or Spanish.^
+
+
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
 
 
 ##Naturalisation of your partner if they move to the UK
@@ -111,10 +102,8 @@ Administering an oath or making a declaration | £55
 You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Spain](/government/publications/spain-consular-fees).
 
 
-You can pay by cash or credit card, but not by personal cheque.
+You can pay by credit card (Visa, Visa Electron or MasterCard), but not by personal cheque.
 
 
 *[CNI]:certificate of no impediment
-*[GRO]:General Register Office
-*[FCO]:Foreign &amp; Commonwealth Office
 

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_local/same_sex.txt
@@ -14,11 +14,11 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf), [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf), or both to prove you’re allowed to marry.
 
-Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC)  where you’re getting married to find out what certificates you’ll need.
+^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 
-Your partner must follow the same process to get their own certificates.
+Your partner must also provide their own certificates.
 
-^You must apply for all certificates at least 3 months before you get married.^
+You must apply for all certificates at least 3 months before you get married.
 
 
 ## Getting a certificate of no impediment

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_local/same_sex.txt
@@ -1,18 +1,28 @@
-Civil partnership in Spain
+Same-sex Marriage in Spain
 
 
-Contact the relevant local authorities in Spain to find out about local laws, including what documents you’ll need.
+Contact the relevant local authorities in Spain to find out about local marriage laws, including what documents you’ll need.
 
 
-The process for same-sex marriages in Spain is the same as for opposite-sex civil marriages. Your marriage will be recognised as a civil partnership under British law.
+The process for same-sex marriages in Spain is the same as for opposite-sex civil marriages.
 
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
 
 
-## What you need to do
+##What you need to do
 
-You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf), [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf), or both to prove you’re allowed to marry.
+
+You may be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
+
+$D
+[Download 'Certificate of no impediment' (PDF, 198KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf)
+$D
+
+$D
+[Download 'Marital status certificate' (PDF, 145KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf)
+$D
+
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 
@@ -29,7 +39,7 @@ $D
 [Download 'CNI application pack' (PDF, 464KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446264/CNI_Pack.pdf)
 $D
 
-You must sign the notice of marriage and affirmation in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you post the other documents.
+You must sign the notice of marriage and affirmation in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you send your application to the consulate.
 
 Send all the documents and fee by registered post to the address in the application pack.
 
@@ -48,9 +58,9 @@ $D
 [Download 'Marital status certificate application pack' (PDF, 424KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446267/Marital_Status_for_Marriage_Pack.pdf)
 $D
 
-You must sign the affirmation in the application pack in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you post the other documents.
+You must sign the affirmation in the application pack in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you send your application to the consulate.
 
-Send the documents and fee by registered post to the address in the application pack.
+Send the documents by registered post to the address in the application pack.
 
 ### What happens next
 
@@ -58,7 +68,7 @@ The consulate will check your forms and documents, and contact you if they have 
 
 It takes 10 working days after your payment has been approved for the consulate to process your application.
 
-They’ll send your certificate and supporting documents to you by registered post.
+They’ll send your certificate and original documents to you by registered post.
 
 
 ##Other requirements for Spain

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_other/opposite_sex.txt
@@ -10,9 +10,19 @@ Civil weddings in Spain take place at a town hall, register office or district c
 ^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
 
 
-## What you need to do
+##What you need to do
 
-You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf), [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf), or both to prove you’re allowed to marry.
+
+You may be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
+
+$D
+[Download 'Certificate of no impediment' (PDF, 198KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf)
+$D
+
+$D
+[Download 'Marital status certificate' (PDF, 145KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf)
+$D
+
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 
@@ -29,7 +39,7 @@ $D
 [Download 'CNI application pack' (PDF, 464KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446264/CNI_Pack.pdf)
 $D
 
-You must sign the notice of marriage and affirmation in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you post the other documents.
+You must sign the notice of marriage and affirmation in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you send your application to the consulate.
 
 Send all the documents and fee by registered post to the address in the application pack.
 
@@ -48,9 +58,9 @@ $D
 [Download 'Marital status certificate application pack' (PDF, 424KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446267/Marital_Status_for_Marriage_Pack.pdf)
 $D
 
-You must sign the affirmation in the application pack in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you post the other documents.
+You must sign the affirmation in the application pack in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you send your application to the consulate.
 
-Send the documents and fee by registered post to the address in the application pack.
+Send the documents by registered post to the address in the application pack.
 
 ### What happens next
 
@@ -58,7 +68,7 @@ The consulate will check your forms and documents, and contact you if they have 
 
 It takes 10 working days after your payment has been approved for the consulate to process your application.
 
-They’ll send your certificate and supporting documents to you by registered post.
+They’ll send your certificate and original documents to you by registered post.
 
 
 ##Other requirements for Spain

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_other/opposite_sex.txt
@@ -1,83 +1,70 @@
 Marriage in Spain
 
+
 Contact the relevant local authorities in Spain to find out about local marriage laws, including what documents you’ll need.
 
 
-Civil weddings in Spain take place at a town hall, register office or district court. You need to register with the local civil authorities afterwards to get an official marriage certificate if you have a religious wedding.
+Civil weddings in Spain take place at a town hall, register office or district court. You must register with the local civil authorities afterwards to get an official marriage certificate if you have a religious wedding.
 
 
-Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married.
+^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
 
 
-##What you need to do
+## What you need to do
+
+You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf), [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf), or both to prove you’re allowed to marry.
+
+Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC)  where you’re getting married to find out what certificates you’ll need.
+
+Your partner must follow the same process to get their own certificates.
+
+^You must apply for all certificates at least 3 months before you get married.^
 
 
-You may be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
+## Getting a certificate of no impediment
 
-^You may also need to get a marital status certificate if you’re living with your partner and want to get a ‘[pareja de hecho](/notarial-and-documentary-services-guide-for-spain#marital-status-certificate-for-pareja-de-hecho)’ (cohabitation registration).^
-
-
-If you need a CNI, you must give notice of your intended marriage in Spain. You must do this at the British embassy or in front of a notary public in that country.
-
-
-The documents you need are:
-
-- your passport
-- your partner’s passport or national identity document
-- a ‘certificado de empadronamiento’ (town hall registration certificate) or Spanish police residence certificate (green document with your NIE number address) issued at least 3 days ago
-
-^The Civil Registry will usually ask you for a certificado de empadronamiento issued in the last 3 months.^
-
-
-If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
-
-- a [decree absolute or final order](/copy-decree-absolute-final-order)
-- a civil partnership dissolution or annulment certificate
-- your (or your partner’s) former spouse or civil partner’s [death certificate](/order-copy-birth-death-marriage-certificate/)
-
-
-Send your completed CNI service request form and copies of the supporting documents to your [nearest British consulate](/notarial-and-documentary-services-guide-for-spain#where-to-send-your-request). You can send them as scanned attachments by email or by fax. You’ll need to bring the original documents to your appointment.
-
-To request an appointment, fill in the CNI service request form and make sure you’ve got all of the necessary supporting documents.
+Download and the complete the CNI application pack - it contains a list of the documents you’ll need.
 
 $D
-[Download ’CNI service request form’ (DOC, 29KB)](/government/publications/certificate-of-no-impediment-service-request-form-spain)
+[Download 'CNI application pack' (PDF, 464KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446264/CNI_Pack.pdf)
 $D
+
+You must sign the notice of marriage and affirmation in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you post the other documents.
+
+Send all the documents and fee by registered post to the address in the application pack.
 
 ###What happens next
 
-The consulate will check your form and documents, and if everything’s in order they’ll send you details of how to book your appointment to give official notice of your marriage. They’ll then display your notice publicly for 7 days, and if nobody has raised an objection, they’ll issue your CNI. There’s an additional fee for this.
+The consulate will check your forms and documents. Once everything is approved, they’ll take your payment and display your notice of marriage for 7 days. If nobody raises an objection, they’ll then issue your CNI and send it to you with your supporting documents by registered post.
 
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
+It takes 10 working days after payment for the consulate to process your application.
 
 
-###Getting a marital status certificate
+##Getting a marital status certificate
 
-In some parts of Spain you may need to to get a ‘marital status certificate’ (‘certificado de estado civil’) instead of, or as well as, a CNI (’certificado de no impedimento’).
-
-Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married. If you need one, ask a [solicitor](/government/publications/spain-list-of-lawyers) (‘abogado’) to draw up a declaration for you printed on their headed paper.
-
-^If it’s on blank, non-headed paper, they’ll need to give you a separate letter including their contact details, confirming that they’ve drawn up the declaration.^
-
-You’ll then need to make an appointment at the consulate to make the declaration and sign the document in front of a consular officer - so don’t sign it beforehand.
-
-Download instructions in English and Spanish on what the declaration needs to include.
+Download and complete the marital status certificate application pack - it contains a list of the documents you’ll need.
 
 $D
-[Download ‘Marital status declaration instructions in English’ (PDF, 363KB)](/government/uploads/system/uploads/attachment_data/file/136832/marital-status-declaration-instruction-en.pdf)
-[Download ‘Declaración de estado civil instrucciones en Español’ (PDF, 236KB)](/government/uploads/system/uploads/attachment_data/file/136833/marital-status-declaration-instruction-sp.pdf)
+[Download 'Marital status certificate application pack' (PDF, 424KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446267/Marital_Status_for_Marriage_Pack.pdf)
 $D
 
-You’ll also need a completed marital status certificate application form, as well as the supporting documents and the fee (see below).
+You must sign the affirmation in the application pack in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you post the other documents.
 
-$D
-[Download ’Marital status certificate appointment request form’ (DOC, 53KB)](/government/uploads/system/uploads/attachment_data/file/182249/Appointment_request_form_marital_status_marriage.doc)
-$D
+Send the documents and fee by registered post to the address in the application pack.
+
+### What happens next
+
+The consulate will check your forms and documents, and contact you if they have any queries.
+
+It takes 10 working days after your payment has been approved for the consulate to process your application.
+
+They’ll send your certificate and supporting documents to you by registered post.
 
 
-###Other requirements for Spain
+##Other requirements for Spain
 
-The civil registrar may also ask for confirmation of your addresses for the past 2 years (‘confirmación de domicilio para casarse en España’).
+If you’ve been living in Spain for less than 2 years, the civil registrar may also ask for confirmation of your addresses for the past 2 years (‘confirmación de domicilio para casarse en España’).
+
 
 You’ll need to show one of the following:
 
@@ -88,8 +75,12 @@ You’ll need to show one of the following:
 - utility bills
 - recent proof of entitlement to local or state benefits, eg tax credits, pension, education or other benefits
 
+If you’re asked to provide a document from the British consulate, print out a copy of the [‘communication proof of address’](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/288272/Communication_re_Proof_of_Address.pdf).
 
-^You don't need to stay in the country while your notice is posted.^
+^You must get your documents translated if they’re not in English or Spanish.^
+
+
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
 
 
 ##Naturalisation of your partner if they move to the UK
@@ -111,10 +102,8 @@ Administering an oath or making a declaration | £55
 You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Spain](/government/publications/spain-consular-fees).
 
 
-You can pay by cash or credit card, but not by personal cheque.
+You can pay by credit card (Visa, Visa Electron or MasterCard), but not by personal cheque.
 
 
 *[CNI]:certificate of no impediment
-*[GRO]:General Register Office
-*[FCO]:Foreign &amp; Commonwealth Office
 

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_other/opposite_sex.txt
@@ -14,11 +14,11 @@ Civil weddings in Spain take place at a town hall, register office or district c
 
 You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf), [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf), or both to prove you’re allowed to marry.
 
-Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC)  where you’re getting married to find out what certificates you’ll need.
+^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 
-Your partner must follow the same process to get their own certificates.
+Your partner must also provide their own certificates.
 
-^You must apply for all certificates at least 3 months before you get married.^
+You must apply for all certificates at least 3 months before you get married.
 
 
 ## Getting a certificate of no impediment

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_other/same_sex.txt
@@ -1,83 +1,70 @@
-Marriage in Spain
+Civil partnership in Spain
 
-Contact the relevant local authorities in Spain to find out about local marriage laws, including what documents you’ll need.
+
+Contact the relevant local authorities in Spain to find out about local laws, including what documents you’ll need.
 
 
 The process for same-sex marriages in Spain is the same as for opposite-sex civil marriages. Your marriage will be recognised as a civil partnership under British law.
 
 
-Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married.
+^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
 
 
-##What you need to do
+## What you need to do
+
+You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf), [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf), or both to prove you’re allowed to marry.
+
+Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC)  where you’re getting married to find out what certificates you’ll need.
+
+Your partner must follow the same process to get their own certificates.
+
+^You must apply for all certificates at least 3 months before you get married.^
 
 
-You may be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
+## Getting a certificate of no impediment
 
-^You may also need to get a marital status certificate if you’re living with your partner and want to get a ‘[pareja de hecho](/notarial-and-documentary-services-guide-for-spain#marital-status-certificate-for-pareja-de-hecho)’ (cohabitation registration).^
-
-
-If you need a CNI, you must give notice of your intended marriage in Spain. You must do this at the British embassy or in front of a notary public in that country.
-
-
-The documents you need are:
-
-- your passport
-- your partner’s passport or national identity document
-- a ‘certificado de empadronamiento’ (town hall registration certificate) or Spanish police residence certificate (green document with your NIE number address) issued at least 3 days ago
-
-^The Civil Registry will usually ask you for a certificado de empadronamiento issued in the last 3 months.^
-
-
-If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
-
-- a [decree absolute or final order](/copy-decree-absolute-final-order)
-- a civil partnership dissolution or annulment certificate
-- your (or your partner’s) former spouse or civil partner’s [death certificate](/order-copy-birth-death-marriage-certificate/)
-
-
-Send your completed CNI service request form and copies of the supporting documents to your [nearest British consulate](/notarial-and-documentary-services-guide-for-spain#where-to-send-your-request). You can send them as scanned attachments by email or by fax. You’ll need to bring the original documents to your appointment.
-
-To request an appointment, fill in the CNI service request form and make sure you’ve got all of the necessary supporting documents.
+Download and the complete the CNI application pack - it contains a list of the documents you’ll need.
 
 $D
-[Download ’CNI service request form’ (DOC, 29KB)](/government/publications/certificate-of-no-impediment-service-request-form-spain)
+[Download 'CNI application pack' (PDF, 464KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446264/CNI_Pack.pdf)
 $D
+
+You must sign the notice of marriage and affirmation in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you post the other documents.
+
+Send all the documents and fee by registered post to the address in the application pack.
 
 ###What happens next
 
-The consulate will check your form and documents, and if everything’s in order they’ll send you details of how to book your appointment to give official notice of your marriage. They’ll then display your notice publicly for 7 days, and if nobody has raised an objection, they’ll issue your CNI. There’s an additional fee for this.
+The consulate will check your forms and documents. Once everything is approved, they’ll take your payment and display your notice of marriage for 7 days. If nobody raises an objection, they’ll then issue your CNI and send it to you with your supporting documents by registered post.
 
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
+It takes 10 working days after payment for the consulate to process your application.
 
 
-###Getting a marital status certificate
+##Getting a marital status certificate
 
-In some parts of Spain you may need to to get a ‘marital status certificate’ (‘certificado de estado civil’) instead of, or as well as, a CNI (’certificado de no impedimento’).
-
-Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married. If you need one, ask a [solicitor](/government/publications/spain-list-of-lawyers) (‘abogado’) to draw up a declaration for you printed on their headed paper.
-
-^If it’s on blank, non-headed paper, they’ll need to give you a separate letter including their contact details, confirming that they’ve drawn up the declaration.^
-
-You’ll then need to make an appointment at the consulate to make the declaration and sign the document in front of a consular officer - so don’t sign it beforehand.
-
-Download instructions in English and Spanish on what the declaration needs to include.
+Download and complete the marital status certificate application pack - it contains a list of the documents you’ll need.
 
 $D
-[Download ‘Marital status declaration instructions in English’ (PDF, 363KB)](/government/uploads/system/uploads/attachment_data/file/136832/marital-status-declaration-instruction-en.pdf)
-[Download ‘Declaración de estado civil instrucciones en Español’ (PDF, 236KB)](/government/uploads/system/uploads/attachment_data/file/136833/marital-status-declaration-instruction-sp.pdf)
+[Download 'Marital status certificate application pack' (PDF, 424KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446267/Marital_Status_for_Marriage_Pack.pdf)
 $D
 
-You’ll also need a completed marital status certificate application form, as well as the supporting documents and the fee (see below).
+You must sign the affirmation in the application pack in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you post the other documents.
 
-$D
-[Download ’Marital status certificate appointment request form’ (DOC, 53KB)](/government/uploads/system/uploads/attachment_data/file/182249/Appointment_request_form_marital_status_marriage.doc)
-$D
+Send the documents and fee by registered post to the address in the application pack.
+
+### What happens next
+
+The consulate will check your forms and documents, and contact you if they have any queries.
+
+It takes 10 working days after your payment has been approved for the consulate to process your application.
+
+They’ll send your certificate and supporting documents to you by registered post.
 
 
-###Other requirements for Spain
+##Other requirements for Spain
 
-The civil registrar may also ask for confirmation of your addresses for the past 2 years (‘confirmación de domicilio para casarse en España’).
+If you’ve been living in Spain for less than 2 years, the civil registrar may also ask for confirmation of your addresses for the past 2 years (‘confirmación de domicilio para casarse en España’).
+
 
 You’ll need to show one of the following:
 
@@ -88,8 +75,12 @@ You’ll need to show one of the following:
 - utility bills
 - recent proof of entitlement to local or state benefits, eg tax credits, pension, education or other benefits
 
+If you’re asked to provide a document from the British consulate, print out a copy of the [‘communication proof of address’](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/288272/Communication_re_Proof_of_Address.pdf).
 
-^You don't need to stay in the country while your notice is posted.^
+^You must get your documents translated if they’re not in English or Spanish.^
+
+
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
 
 
 ##Naturalisation of your partner if they move to the UK
@@ -111,10 +102,8 @@ Administering an oath or making a declaration | £55
 You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Spain](/government/publications/spain-consular-fees).
 
 
-You can pay by cash or credit card, but not by personal cheque.
+You can pay by credit card (Visa, Visa Electron or MasterCard), but not by personal cheque.
 
 
 *[CNI]:certificate of no impediment
-*[GRO]:General Register Office
-*[FCO]:Foreign &amp; Commonwealth Office
 

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_other/same_sex.txt
@@ -14,11 +14,11 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf), [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf), or both to prove you’re allowed to marry.
 
-Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC)  where you’re getting married to find out what certificates you’ll need.
+^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 
-Your partner must follow the same process to get their own certificates.
+Your partner must also provide their own certificates.
 
-^You must apply for all certificates at least 3 months before you get married.^
+You must apply for all certificates at least 3 months before you get married.
 
 
 ## Getting a certificate of no impediment

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_other/same_sex.txt
@@ -1,18 +1,28 @@
-Civil partnership in Spain
+Same-sex Marriage in Spain
 
 
-Contact the relevant local authorities in Spain to find out about local laws, including what documents you’ll need.
+Contact the relevant local authorities in Spain to find out about local marriage laws, including what documents you’ll need.
 
 
-The process for same-sex marriages in Spain is the same as for opposite-sex civil marriages. Your marriage will be recognised as a civil partnership under British law.
+The process for same-sex marriages in Spain is the same as for opposite-sex civil marriages.
 
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
 
 
-## What you need to do
+##What you need to do
 
-You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf), [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf), or both to prove you’re allowed to marry.
+
+You may be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
+
+$D
+[Download 'Certificate of no impediment' (PDF, 198KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf)
+$D
+
+$D
+[Download 'Marital status certificate' (PDF, 145KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf)
+$D
+
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 
@@ -29,7 +39,7 @@ $D
 [Download 'CNI application pack' (PDF, 464KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446264/CNI_Pack.pdf)
 $D
 
-You must sign the notice of marriage and affirmation in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you post the other documents.
+You must sign the notice of marriage and affirmation in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you send your application to the consulate.
 
 Send all the documents and fee by registered post to the address in the application pack.
 
@@ -48,9 +58,9 @@ $D
 [Download 'Marital status certificate application pack' (PDF, 424KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446267/Marital_Status_for_Marriage_Pack.pdf)
 $D
 
-You must sign the affirmation in the application pack in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you post the other documents.
+You must sign the affirmation in the application pack in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you send your application to the consulate.
 
-Send the documents and fee by registered post to the address in the application pack.
+Send the documents by registered post to the address in the application pack.
 
 ### What happens next
 
@@ -58,7 +68,7 @@ The consulate will check your forms and documents, and contact you if they have 
 
 It takes 10 working days after your payment has been approved for the consulate to process your application.
 
-They’ll send your certificate and supporting documents to you by registered post.
+They’ll send your certificate and original documents to you by registered post.
 
 
 ##Other requirements for Spain

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_british/opposite_sex.txt
@@ -1,24 +1,30 @@
 Marriage in Spain
 
+
 Contact the relevant local authorities in Spain to find out about local marriage laws, including what documents you’ll need.
 
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Spain](/foreign-travel-advice/spain) before making any plans.
 
 
-##What you need to do
+%There are certain legal restrictions on getting married in Spain if neither of you lives there. If you both live outside Spain, you must check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re planning to get married to find out if this is allowed.%
 
 
-You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
+## What you need to do
 
+You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf) or a [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf) or both to prove you’re allowed to marry.
 
-There are 2 ways you can get a CNI:
+Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
+
+There are 2 ways you can get these certificates:
 
 - [go to the UK and post notice with a UK registrar](/marriage-abroad/y/spain/uk/partner_british/opposite_sex)
 - [go to Spain and post notice at the embassy or consulate there](/marriage-abroad/y/spain/ceremony_country/partner_british/opposite_sex)
 
-%If you choose to post notice in Spain, you’ll normally have to wait at least 10 days before you can get married.%
+You need to apply for all certificates at least 3 months before the date you intend to get married.
+
+You must be physically present in Spain for at least 3 days before you apply for a CNI.
 
 
-*[CNI]:Certificate of no impediment
+*[CNI]:certificate of no impediment
 

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_british/opposite_sex.txt
@@ -10,9 +10,19 @@ Contact the relevant local authorities in Spain to find out about local marriage
 %There are certain legal restrictions on getting married in Spain if neither of you lives there. If you both live outside Spain, you must check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re planning to get married to find out if this is allowed.%
 
 
-## What you need to do
+##What you need to do
 
-You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf) or a [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf) or both to prove you’re allowed to marry.
+
+You may be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
+
+$D
+[Download 'Certificate of no impediment' (PDF, 198KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf)
+$D
+
+$D
+[Download 'Marital status certificate' (PDF, 145KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf)
+$D
+
 
 Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
 

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_british/same_sex.txt
@@ -1,10 +1,10 @@
-Civil partnership in Spain
+Same-sex Marriage in Spain
 
 
-Contact the relevant local authorities in Spain to find out about local laws, including what documents you’ll need.
+Contact the relevant local authorities in Spain to find out about local marriage laws, including what documents you’ll need.
 
 
-The process for same-sex marriages in Spain is the same as for opposite-sex civil marriages. Your marriage will be recognised as a civil partnership under British law.
+The process for same-sex marriages in Spain is the same as for opposite-sex civil marriages.
 
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Spain](/foreign-travel-advice/spain) before making any plans.
@@ -13,9 +13,19 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 %There are certain legal restrictions on getting married in Spain if neither of you lives there. If you both live outside Spain, you must check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re planning to get married to find out if this is allowed.%
 
 
-## What you need to do
+##What you need to do
 
-You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf) or a [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf) or both to prove you’re allowed to marry.
+
+You may be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
+
+$D
+[Download 'Certificate of no impediment' (PDF, 198KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf)
+$D
+
+$D
+[Download 'Marital status certificate' (PDF, 145KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf)
+$D
+
 
 Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
 

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_british/same_sex.txt
@@ -1,24 +1,33 @@
-Marriage in Spain
+Civil partnership in Spain
 
-Contact the relevant local authorities in Spain to find out about local marriage laws, including what documents you’ll need.
+
+Contact the relevant local authorities in Spain to find out about local laws, including what documents you’ll need.
+
+
+The process for same-sex marriages in Spain is the same as for opposite-sex civil marriages. Your marriage will be recognised as a civil partnership under British law.
 
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Spain](/foreign-travel-advice/spain) before making any plans.
 
 
-##What you need to do
+%There are certain legal restrictions on getting married in Spain if neither of you lives there. If you both live outside Spain, you must check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re planning to get married to find out if this is allowed.%
 
 
-You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
+## What you need to do
 
+You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf) or a [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf) or both to prove you’re allowed to marry.
 
-There are 2 ways you can get a CNI:
+Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
+
+There are 2 ways you can get these certificates:
 
 - [go to the UK and post notice with a UK registrar](/marriage-abroad/y/spain/uk/partner_british/same_sex)
 - [go to Spain and post notice at the embassy or consulate there](/marriage-abroad/y/spain/ceremony_country/partner_british/same_sex)
 
-%If you choose to post notice in Spain, you’ll normally have to wait at least 10 days before you can get married.%
+You need to apply for all certificates at least 3 months before the date you intend to get married.
+
+You must be physically present in Spain for at least 3 days before you apply for a CNI.
 
 
-*[CNI]:Certificate of no impediment
+*[CNI]:certificate of no impediment
 

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_local/opposite_sex.txt
@@ -1,24 +1,30 @@
 Marriage in Spain
 
+
 Contact the relevant local authorities in Spain to find out about local marriage laws, including what documents you’ll need.
 
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Spain](/foreign-travel-advice/spain) before making any plans.
 
 
-##What you need to do
+%There are certain legal restrictions on getting married in Spain if neither of you lives there. If you both live outside Spain, you must check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re planning to get married to find out if this is allowed.%
 
 
-You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
+## What you need to do
 
+You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf) or a [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf) or both to prove you’re allowed to marry.
 
-There are 2 ways you can get a CNI:
+Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
+
+There are 2 ways you can get these certificates:
 
 - [go to the UK and post notice with a UK registrar](/marriage-abroad/y/spain/uk/partner_local/opposite_sex)
 - [go to Spain and post notice at the embassy or consulate there](/marriage-abroad/y/spain/ceremony_country/partner_local/opposite_sex)
 
-%If you choose to post notice in Spain, you’ll normally have to wait at least 10 days before you can get married.%
+You need to apply for all certificates at least 3 months before the date you intend to get married.
+
+You must be physically present in Spain for at least 3 days before you apply for a CNI.
 
 
-*[CNI]:Certificate of no impediment
+*[CNI]:certificate of no impediment
 

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_local/opposite_sex.txt
@@ -10,9 +10,19 @@ Contact the relevant local authorities in Spain to find out about local marriage
 %There are certain legal restrictions on getting married in Spain if neither of you lives there. If you both live outside Spain, you must check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re planning to get married to find out if this is allowed.%
 
 
-## What you need to do
+##What you need to do
 
-You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf) or a [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf) or both to prove you’re allowed to marry.
+
+You may be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
+
+$D
+[Download 'Certificate of no impediment' (PDF, 198KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf)
+$D
+
+$D
+[Download 'Marital status certificate' (PDF, 145KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf)
+$D
+
 
 Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
 

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_local/same_sex.txt
@@ -1,10 +1,10 @@
-Civil partnership in Spain
+Same-sex Marriage in Spain
 
 
-Contact the relevant local authorities in Spain to find out about local laws, including what documents you’ll need.
+Contact the relevant local authorities in Spain to find out about local marriage laws, including what documents you’ll need.
 
 
-The process for same-sex marriages in Spain is the same as for opposite-sex civil marriages. Your marriage will be recognised as a civil partnership under British law.
+The process for same-sex marriages in Spain is the same as for opposite-sex civil marriages.
 
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Spain](/foreign-travel-advice/spain) before making any plans.
@@ -13,9 +13,19 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 %There are certain legal restrictions on getting married in Spain if neither of you lives there. If you both live outside Spain, you must check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re planning to get married to find out if this is allowed.%
 
 
-## What you need to do
+##What you need to do
 
-You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf) or a [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf) or both to prove you’re allowed to marry.
+
+You may be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
+
+$D
+[Download 'Certificate of no impediment' (PDF, 198KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf)
+$D
+
+$D
+[Download 'Marital status certificate' (PDF, 145KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf)
+$D
+
 
 Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
 

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_local/same_sex.txt
@@ -1,24 +1,33 @@
-Marriage in Spain
+Civil partnership in Spain
 
-Contact the relevant local authorities in Spain to find out about local marriage laws, including what documents you’ll need.
+
+Contact the relevant local authorities in Spain to find out about local laws, including what documents you’ll need.
+
+
+The process for same-sex marriages in Spain is the same as for opposite-sex civil marriages. Your marriage will be recognised as a civil partnership under British law.
 
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Spain](/foreign-travel-advice/spain) before making any plans.
 
 
-##What you need to do
+%There are certain legal restrictions on getting married in Spain if neither of you lives there. If you both live outside Spain, you must check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re planning to get married to find out if this is allowed.%
 
 
-You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
+## What you need to do
 
+You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf) or a [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf) or both to prove you’re allowed to marry.
 
-There are 2 ways you can get a CNI:
+Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
+
+There are 2 ways you can get these certificates:
 
 - [go to the UK and post notice with a UK registrar](/marriage-abroad/y/spain/uk/partner_local/same_sex)
 - [go to Spain and post notice at the embassy or consulate there](/marriage-abroad/y/spain/ceremony_country/partner_local/same_sex)
 
-%If you choose to post notice in Spain, you’ll normally have to wait at least 10 days before you can get married.%
+You need to apply for all certificates at least 3 months before the date you intend to get married.
+
+You must be physically present in Spain for at least 3 days before you apply for a CNI.
 
 
-*[CNI]:Certificate of no impediment
+*[CNI]:certificate of no impediment
 

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_other/opposite_sex.txt
@@ -1,24 +1,30 @@
 Marriage in Spain
 
+
 Contact the relevant local authorities in Spain to find out about local marriage laws, including what documents you’ll need.
 
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Spain](/foreign-travel-advice/spain) before making any plans.
 
 
-##What you need to do
+%There are certain legal restrictions on getting married in Spain if neither of you lives there. If you both live outside Spain, you must check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re planning to get married to find out if this is allowed.%
 
 
-You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
+## What you need to do
 
+You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf) or a [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf) or both to prove you’re allowed to marry.
 
-There are 2 ways you can get a CNI:
+Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
+
+There are 2 ways you can get these certificates:
 
 - [go to the UK and post notice with a UK registrar](/marriage-abroad/y/spain/uk/partner_other/opposite_sex)
 - [go to Spain and post notice at the embassy or consulate there](/marriage-abroad/y/spain/ceremony_country/partner_other/opposite_sex)
 
-%If you choose to post notice in Spain, you’ll normally have to wait at least 10 days before you can get married.%
+You need to apply for all certificates at least 3 months before the date you intend to get married.
+
+You must be physically present in Spain for at least 3 days before you apply for a CNI.
 
 
-*[CNI]:Certificate of no impediment
+*[CNI]:certificate of no impediment
 

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_other/opposite_sex.txt
@@ -10,9 +10,19 @@ Contact the relevant local authorities in Spain to find out about local marriage
 %There are certain legal restrictions on getting married in Spain if neither of you lives there. If you both live outside Spain, you must check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re planning to get married to find out if this is allowed.%
 
 
-## What you need to do
+##What you need to do
 
-You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf) or a [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf) or both to prove you’re allowed to marry.
+
+You may be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
+
+$D
+[Download 'Certificate of no impediment' (PDF, 198KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf)
+$D
+
+$D
+[Download 'Marital status certificate' (PDF, 145KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf)
+$D
+
 
 Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
 

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_other/same_sex.txt
@@ -1,10 +1,10 @@
-Civil partnership in Spain
+Same-sex Marriage in Spain
 
 
-Contact the relevant local authorities in Spain to find out about local laws, including what documents you’ll need.
+Contact the relevant local authorities in Spain to find out about local marriage laws, including what documents you’ll need.
 
 
-The process for same-sex marriages in Spain is the same as for opposite-sex civil marriages. Your marriage will be recognised as a civil partnership under British law.
+The process for same-sex marriages in Spain is the same as for opposite-sex civil marriages.
 
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Spain](/foreign-travel-advice/spain) before making any plans.
@@ -13,9 +13,19 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 %There are certain legal restrictions on getting married in Spain if neither of you lives there. If you both live outside Spain, you must check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re planning to get married to find out if this is allowed.%
 
 
-## What you need to do
+##What you need to do
 
-You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf) or a [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf) or both to prove you’re allowed to marry.
+
+You may be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
+
+$D
+[Download 'Certificate of no impediment' (PDF, 198KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf)
+$D
+
+$D
+[Download 'Marital status certificate' (PDF, 145KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf)
+$D
+
 
 Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
 

--- a/test/artefacts/marriage-abroad/spain/third_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/third_country/partner_other/same_sex.txt
@@ -1,24 +1,33 @@
-Marriage in Spain
+Civil partnership in Spain
 
-Contact the relevant local authorities in Spain to find out about local marriage laws, including what documents you’ll need.
+
+Contact the relevant local authorities in Spain to find out about local laws, including what documents you’ll need.
+
+
+The process for same-sex marriages in Spain is the same as for opposite-sex civil marriages. Your marriage will be recognised as a civil partnership under British law.
 
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Spain](/foreign-travel-advice/spain) before making any plans.
 
 
-##What you need to do
+%There are certain legal restrictions on getting married in Spain if neither of you lives there. If you both live outside Spain, you must check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re planning to get married to find out if this is allowed.%
 
 
-You may be asked to provide a certificate of no impediment (CNI) or a similar document to prove you’re allowed to marry.
+## What you need to do
 
+You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf) or a [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf) or both to prove you’re allowed to marry.
 
-There are 2 ways you can get a CNI:
+Check with the civil registry  where you’re getting married to find out what certificate you’ll need.
+
+There are 2 ways you can get these certificates:
 
 - [go to the UK and post notice with a UK registrar](/marriage-abroad/y/spain/uk/partner_other/same_sex)
 - [go to Spain and post notice at the embassy or consulate there](/marriage-abroad/y/spain/ceremony_country/partner_other/same_sex)
 
-%If you choose to post notice in Spain, you’ll normally have to wait at least 10 days before you can get married.%
+You need to apply for all certificates at least 3 months before the date you intend to get married.
+
+You must be physically present in Spain for at least 3 days before you apply for a CNI.
 
 
-*[CNI]:Certificate of no impediment
+*[CNI]:certificate of no impediment
 

--- a/test/artefacts/marriage-abroad/spain/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_british/opposite_sex.txt
@@ -10,9 +10,19 @@ Civil weddings in Spain take place at a town hall, register office or district c
 %There are certain legal restrictions on getting married in Spain if neither of you lives there. If you both live outside Spain, you must check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re planning to get married to find out if this is allowed.%
 
 
-## What you need to do
+##What you need to do
 
-You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf), [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf), or both to prove you’re allowed to marry.
+
+You may be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
+
+$D
+[Download 'Certificate of no impediment' (PDF, 198KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf)
+$D
+
+$D
+[Download 'Marital status certificate' (PDF, 145KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf)
+$D
+
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 
@@ -37,7 +47,7 @@ $D
 [Download 'CNI for UK residents application pack' (PDF, 426KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446265/UK_CNI_Pack.pdf)
 $D
 
-Send the documents and fee by registered post to the address in the application pack.
+Send the documents by registered post to the address in the application pack.
 
 
 ##Getting a marital status certificate
@@ -48,9 +58,9 @@ $D
 [Download 'Marital status certificate application pack' (PDF, 424KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446267/Marital_Status_for_Marriage_Pack.pdf)
 $D
 
-You must sign the affirmation in the application pack in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you post the other documents.
+You must sign the affirmation in the application pack in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you send your application to the consulate.
 
-Send the documents and fee by registered post to the address in the application pack.
+Send the documents by registered post to the address in the application pack.
 
 ### What happens next
 
@@ -58,7 +68,7 @@ The consulate will check your forms and documents, and contact you if they have 
 
 It takes 10 working days after your payment has been approved for the consulate to process your application.
 
-They’ll send your certificate and supporting documents to you by registered post.
+They’ll send your certificate and original documents to you by registered post.
 
 
 ##Other requirements for Spain

--- a/test/artefacts/marriage-abroad/spain/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_british/opposite_sex.txt
@@ -1,78 +1,70 @@
 Marriage in Spain
 
-Contact the [Embassy of Spain](/government/publications/foreign-embassies-in-the-uk) before making any plans to find out about local marriage laws, including what documents you’ll need.
+
+Civil weddings in Spain take place at a town hall, register office or district court. You must register with the local civil authorities afterwards to get an official marriage certificate if you have a religious wedding.
 
 
-Civil weddings in Spain take place at a town hall, register office or district court. You need to register with the local civil authorities afterwards to get an official marriage certificate if you have a religious wedding.
+^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Spain](/foreign-travel-advice/spain) before making any plans.
 
 
-Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married.
+%There are certain legal restrictions on getting married in Spain if neither of you lives there. If you both live outside Spain, you must check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re planning to get married to find out if this is allowed.%
 
 
-%There are certain legal restrictions if neither of you is resident in Spain. If you both live outside Spain, you should check with the civil registry where you’re planning to getting married to find out if this is allowed.%
+## What you need to do
+
+You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf), [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf), or both to prove you’re allowed to marry.
+
+Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC)  where you’re getting married to find out what certificates you’ll need.
+
+Your partner must follow the same process to get their own certificates.
+
+^You must apply for all certificates at least 3 months before you get married.^
 
 
-##What you need to do
-
-
-You may be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
-
-^You may also need to get a marital status certificate if you’re living with your partner and want to get a ‘[pareja de hecho](/notarial-and-documentary-services-guide-for-spain#marital-status-certificate-for-pareja-de-hecho)’ (cohabitation registration).^
+## Getting a certificate of no impediment
 
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
-^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Spain to find out how long a CNI is valid under local law.^
 
+^Your CNI will be valid for 3 months in Spain.^
 
-###Legalisation and translation
+You must then exchange your UK-issued CNI for one that’s valid in Spain.
 
-You might need to exchange your UK-issued CNI for one that’s valid in Spain at the nearest embassy or consulate to where you’re getting married.
-
-You should also check if it needs to be:
-
-
-- ‘[legalised](/get-document-legalised)’ (certified as genuine)
-- translated - [find a translator abroad](/government/collections/list-of-lawyers), or in the UK through the [Institute of Linguists](http://www.iol.org.uk/linguist/translator1.asp?r=PCTXYL10046)
-
-You should also check with the local authorities in Spain to find out if you need to provide legalised and translated copies of any other documents.
-
-^Your partner will need to follow the same process and pay the fees to get their own CNI.^
-
-
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
-
-
-###Getting a marital status certificate
-
-In some parts of Spain you may need to to get a ‘marital status certificate’ (‘certificado de estado civil’) instead of, or as well as, a CNI (’certificado de no impedimento’).
-
-Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married. If you need one, ask a [solicitor](/government/publications/spain-list-of-lawyers) (‘abogado’) to draw up a declaration for you printed on their headed paper.
-
-^If it’s on blank, non-headed paper, they’ll need to give you a separate letter including their contact details, confirming that they’ve drawn up the declaration.^
-
-You’ll then need to make an appointment at the consulate to make the declaration and sign the document in front of a consular officer - so don’t sign it beforehand.
-
-Download instructions in English and Spanish on what the declaration needs to include.
+Download and fill in the CNI application pack - it contains a list of the documents you’ll need.
 
 $D
-[Download ‘Marital status declaration instructions in English’ (PDF, 363KB)](/government/uploads/system/uploads/attachment_data/file/136832/marital-status-declaration-instruction-en.pdf)
-[Download ‘Declaración de estado civil instrucciones en Español’ (PDF, 236KB)](/government/uploads/system/uploads/attachment_data/file/136833/marital-status-declaration-instruction-sp.pdf)
+[Download 'CNI for UK residents application pack' (PDF, 426KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446265/UK_CNI_Pack.pdf)
 $D
 
-You’ll also need a completed marital status certificate application form, as well as the supporting documents and the fee (see below).
+Send the documents and fee by registered post to the address in the application pack.
+
+
+##Getting a marital status certificate
+
+Download and complete the marital status certificate application pack - it contains a list of the documents you’ll need.
 
 $D
-[Download ’Marital status certificate appointment request form’ (DOC, 53KB)](/government/uploads/system/uploads/attachment_data/file/182249/Appointment_request_form_marital_status_marriage.doc)
+[Download 'Marital status certificate application pack' (PDF, 424KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446267/Marital_Status_for_Marriage_Pack.pdf)
 $D
 
+You must sign the affirmation in the application pack in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you post the other documents.
 
-Your partner will also need to get a marital status certificate from the consulate and pay the fees if the civil registry have told you that they need one.
+Send the documents and fee by registered post to the address in the application pack.
+
+### What happens next
+
+The consulate will check your forms and documents, and contact you if they have any queries.
+
+It takes 10 working days after your payment has been approved for the consulate to process your application.
+
+They’ll send your certificate and supporting documents to you by registered post.
 
 
-###Other requirements for Spain
+##Other requirements for Spain
 
 The civil registrar may also ask for confirmation of your addresses for the past 2 years (‘confirmación de domicilio para casarse en España’).
+
 
 You’ll need to show one of the following:
 
@@ -82,6 +74,13 @@ You’ll need to show one of the following:
 - a council tax letter
 - utility bills
 - recent proof of entitlement to local or state benefits, eg tax credits, pension, education or other benefits
+
+If you’re asked to provide a document from the British consulate, print out a copy of the [‘communication proof of address’](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/288272/Communication_re_Proof_of_Address.pdf).
+
+^You must get your documents translated if they’re not in English or Spanish.^
+
+
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
 
 
 ##Fees
@@ -98,10 +97,8 @@ Administering an oath or making a declaration | £55
 You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Spain](/government/publications/spain-consular-fees).
 
 
-You can pay by cash or credit card, but not by personal cheque.
+You can pay by credit card (Visa, Visa Electron or MasterCard), but not by personal cheque.
 
 
 *[CNI]:certificate of no impediment
-*[GRO]:General Register Office
-*[FCO]:Foreign &amp; Commonwealth Office
 

--- a/test/artefacts/marriage-abroad/spain/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_british/opposite_sex.txt
@@ -14,11 +14,11 @@ Civil weddings in Spain take place at a town hall, register office or district c
 
 You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf), [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf), or both to prove you’re allowed to marry.
 
-Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC)  where you’re getting married to find out what certificates you’ll need.
+^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 
-Your partner must follow the same process to get their own certificates.
+Your partner must also provide their own certificates.
 
-^You must apply for all certificates at least 3 months before you get married.^
+You must apply for all certificates at least 3 months before you get married.
 
 
 ## Getting a certificate of no impediment

--- a/test/artefacts/marriage-abroad/spain/uk/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_british/same_sex.txt
@@ -1,7 +1,7 @@
-Civil partnership in Spain
+Same-sex Marriage in Spain
 
 
-The process for same-sex marriages in Spain is the same as for opposite-sex civil marriages. Your marriage will be recognised as a civil partnership under British law.
+The process for same-sex marriages in Spain is the same as for opposite-sex civil marriages.
 
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Spain](/foreign-travel-advice/spain) before making any plans.
@@ -10,9 +10,19 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 %There are certain legal restrictions on getting married in Spain if neither of you lives there. If you both live outside Spain, you must check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re planning to get married to find out if this is allowed.%
 
 
-## What you need to do
+##What you need to do
 
-You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf), [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf), or both to prove you’re allowed to marry.
+
+You may be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
+
+$D
+[Download 'Certificate of no impediment' (PDF, 198KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf)
+$D
+
+$D
+[Download 'Marital status certificate' (PDF, 145KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf)
+$D
+
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 
@@ -37,7 +47,7 @@ $D
 [Download 'CNI for UK residents application pack' (PDF, 426KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446265/UK_CNI_Pack.pdf)
 $D
 
-Send the documents and fee by registered post to the address in the application pack.
+Send the documents by registered post to the address in the application pack.
 
 
 ##Getting a marital status certificate
@@ -48,9 +58,9 @@ $D
 [Download 'Marital status certificate application pack' (PDF, 424KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446267/Marital_Status_for_Marriage_Pack.pdf)
 $D
 
-You must sign the affirmation in the application pack in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you post the other documents.
+You must sign the affirmation in the application pack in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you send your application to the consulate.
 
-Send the documents and fee by registered post to the address in the application pack.
+Send the documents by registered post to the address in the application pack.
 
 ### What happens next
 
@@ -58,7 +68,7 @@ The consulate will check your forms and documents, and contact you if they have 
 
 It takes 10 working days after your payment has been approved for the consulate to process your application.
 
-They’ll send your certificate and supporting documents to you by registered post.
+They’ll send your certificate and original documents to you by registered post.
 
 
 ##Other requirements for Spain

--- a/test/artefacts/marriage-abroad/spain/uk/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_british/same_sex.txt
@@ -1,90 +1,70 @@
-Marriage in Spain
-
-Contact the [Embassy of Spain](/government/publications/foreign-embassies-in-the-uk) before making any plans to find out about local marriage laws, including what documents you’ll need.
+Civil partnership in Spain
 
 
 The process for same-sex marriages in Spain is the same as for opposite-sex civil marriages. Your marriage will be recognised as a civil partnership under British law.
 
 
-Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married.
+^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Spain](/foreign-travel-advice/spain) before making any plans.
 
 
-%There are certain legal restrictions if neither of you is resident in Spain. If you both live outside Spain, you should check with the civil registry where you’re planning to getting married to find out if this is allowed.%
+%There are certain legal restrictions on getting married in Spain if neither of you lives there. If you both live outside Spain, you must check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re planning to get married to find out if this is allowed.%
 
 
-##What you need to do
+## What you need to do
+
+You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf), [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf), or both to prove you’re allowed to marry.
+
+Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC)  where you’re getting married to find out what certificates you’ll need.
+
+Your partner must follow the same process to get their own certificates.
+
+^You must apply for all certificates at least 3 months before you get married.^
 
 
-You may be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
-
-^You may also need to get a marital status certificate if you’re living with your partner and want to get a ‘[pareja de hecho](/notarial-and-documentary-services-guide-for-spain#marital-status-certificate-for-pareja-de-hecho)’ (cohabitation registration).^
+## Getting a certificate of no impediment
 
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
-^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Spain to find out how long a CNI is valid under local law.^
 
+^Your CNI will be valid for 3 months in Spain.^
 
-###Legalisation and translation
+You must then exchange your UK-issued CNI for one that’s valid in Spain.
 
-You might need to exchange your UK-issued CNI for one that’s valid in Spain at the nearest embassy or consulate to where you’re getting married.
-
-You should also check if it needs to be:
-
-
-- ‘[legalised](/get-document-legalised)’ (certified as genuine)
-- translated - [find a translator abroad](/government/collections/list-of-lawyers), or in the UK through the [Institute of Linguists](http://www.iol.org.uk/linguist/translator1.asp?r=PCTXYL10046)
-
-You should also check with the local authorities in Spain to find out if you need to provide legalised and translated copies of any other documents.
-
-
-You’ll need to fill in forms for your notice of marriage, and an oath or affidavit (written statement of facts) stating that you’re free to marry.
-
-You can download and fill in (but not sign) the forms in advance.
-
+Download and fill in the CNI application pack - it contains a list of the documents you’ll need.
 
 $D
-[Download ‘Notice of marriage’](/government/publications/notice-of-marriage-form--2)
-
-[Download ‘Affidavit for marriage’](/government/publications/affirmationaffidavit-of-marital-status-form)
+[Download 'CNI for UK residents application pack' (PDF, 426KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446265/UK_CNI_Pack.pdf)
 $D
 
-^Your partner will need to follow the same process and pay the fees to get their own CNI.^
+Send the documents and fee by registered post to the address in the application pack.
 
 
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
+##Getting a marital status certificate
 
-
-###Getting a marital status certificate
-
-In some parts of Spain you may need to to get a ‘marital status certificate’ (‘certificado de estado civil’) instead of, or as well as, a CNI (’certificado de no impedimento’).
-
-Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married. If you need one, ask a [solicitor](/government/publications/spain-list-of-lawyers) (‘abogado’) to draw up a declaration for you printed on their headed paper.
-
-^If it’s on blank, non-headed paper, they’ll need to give you a separate letter including their contact details, confirming that they’ve drawn up the declaration.^
-
-You’ll then need to make an appointment at the consulate to make the declaration and sign the document in front of a consular officer - so don’t sign it beforehand.
-
-Download instructions in English and Spanish on what the declaration needs to include.
+Download and complete the marital status certificate application pack - it contains a list of the documents you’ll need.
 
 $D
-[Download ‘Marital status declaration instructions in English’ (PDF, 363KB)](/government/uploads/system/uploads/attachment_data/file/136832/marital-status-declaration-instruction-en.pdf)
-[Download ‘Declaración de estado civil instrucciones en Español’ (PDF, 236KB)](/government/uploads/system/uploads/attachment_data/file/136833/marital-status-declaration-instruction-sp.pdf)
+[Download 'Marital status certificate application pack' (PDF, 424KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446267/Marital_Status_for_Marriage_Pack.pdf)
 $D
 
-You’ll also need a completed marital status certificate application form, as well as the supporting documents and the fee (see below).
+You must sign the affirmation in the application pack in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you post the other documents.
 
-$D
-[Download ’Marital status certificate appointment request form’ (DOC, 53KB)](/government/uploads/system/uploads/attachment_data/file/182249/Appointment_request_form_marital_status_marriage.doc)
-$D
+Send the documents and fee by registered post to the address in the application pack.
+
+### What happens next
+
+The consulate will check your forms and documents, and contact you if they have any queries.
+
+It takes 10 working days after your payment has been approved for the consulate to process your application.
+
+They’ll send your certificate and supporting documents to you by registered post.
 
 
-Your partner will also need to get a marital status certificate from the consulate and pay the fees if the civil registry have told you that they need one.
-
-
-###Other requirements for Spain
+##Other requirements for Spain
 
 The civil registrar may also ask for confirmation of your addresses for the past 2 years (‘confirmación de domicilio para casarse en España’).
+
 
 You’ll need to show one of the following:
 
@@ -94,6 +74,13 @@ You’ll need to show one of the following:
 - a council tax letter
 - utility bills
 - recent proof of entitlement to local or state benefits, eg tax credits, pension, education or other benefits
+
+If you’re asked to provide a document from the British consulate, print out a copy of the [‘communication proof of address’](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/288272/Communication_re_Proof_of_Address.pdf).
+
+^You must get your documents translated if they’re not in English or Spanish.^
+
+
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
 
 
 ##Fees
@@ -110,10 +97,8 @@ Administering an oath or making a declaration | £55
 You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Spain](/government/publications/spain-consular-fees).
 
 
-You can pay by cash or credit card, but not by personal cheque.
+You can pay by credit card (Visa, Visa Electron or MasterCard), but not by personal cheque.
 
 
 *[CNI]:certificate of no impediment
-*[GRO]:General Register Office
-*[FCO]:Foreign &amp; Commonwealth Office
 

--- a/test/artefacts/marriage-abroad/spain/uk/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_british/same_sex.txt
@@ -14,11 +14,11 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf), [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf), or both to prove you’re allowed to marry.
 
-Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC)  where you’re getting married to find out what certificates you’ll need.
+^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 
-Your partner must follow the same process to get their own certificates.
+Your partner must also provide their own certificates.
 
-^You must apply for all certificates at least 3 months before you get married.^
+You must apply for all certificates at least 3 months before you get married.
 
 
 ## Getting a certificate of no impediment

--- a/test/artefacts/marriage-abroad/spain/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_local/opposite_sex.txt
@@ -10,9 +10,19 @@ Civil weddings in Spain take place at a town hall, register office or district c
 %There are certain legal restrictions on getting married in Spain if neither of you lives there. If you both live outside Spain, you must check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re planning to get married to find out if this is allowed.%
 
 
-## What you need to do
+##What you need to do
 
-You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf), [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf), or both to prove you’re allowed to marry.
+
+You may be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
+
+$D
+[Download 'Certificate of no impediment' (PDF, 198KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf)
+$D
+
+$D
+[Download 'Marital status certificate' (PDF, 145KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf)
+$D
+
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 
@@ -37,7 +47,7 @@ $D
 [Download 'CNI for UK residents application pack' (PDF, 426KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446265/UK_CNI_Pack.pdf)
 $D
 
-Send the documents and fee by registered post to the address in the application pack.
+Send the documents by registered post to the address in the application pack.
 
 
 ##Getting a marital status certificate
@@ -48,9 +58,9 @@ $D
 [Download 'Marital status certificate application pack' (PDF, 424KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446267/Marital_Status_for_Marriage_Pack.pdf)
 $D
 
-You must sign the affirmation in the application pack in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you post the other documents.
+You must sign the affirmation in the application pack in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you send your application to the consulate.
 
-Send the documents and fee by registered post to the address in the application pack.
+Send the documents by registered post to the address in the application pack.
 
 ### What happens next
 
@@ -58,7 +68,7 @@ The consulate will check your forms and documents, and contact you if they have 
 
 It takes 10 working days after your payment has been approved for the consulate to process your application.
 
-They’ll send your certificate and supporting documents to you by registered post.
+They’ll send your certificate and original documents to you by registered post.
 
 
 ##Other requirements for Spain

--- a/test/artefacts/marriage-abroad/spain/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_local/opposite_sex.txt
@@ -1,72 +1,70 @@
 Marriage in Spain
 
-Contact the [Embassy of Spain](/government/publications/foreign-embassies-in-the-uk) before making any plans to find out about local marriage laws, including what documents you’ll need.
+
+Civil weddings in Spain take place at a town hall, register office or district court. You must register with the local civil authorities afterwards to get an official marriage certificate if you have a religious wedding.
 
 
-Civil weddings in Spain take place at a town hall, register office or district court. You need to register with the local civil authorities afterwards to get an official marriage certificate if you have a religious wedding.
+^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Spain](/foreign-travel-advice/spain) before making any plans.
 
 
-Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married.
+%There are certain legal restrictions on getting married in Spain if neither of you lives there. If you both live outside Spain, you must check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re planning to get married to find out if this is allowed.%
 
 
-%There are certain legal restrictions if neither of you is resident in Spain. If you both live outside Spain, you should check with the civil registry where you’re planning to getting married to find out if this is allowed.%
+## What you need to do
+
+You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf), [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf), or both to prove you’re allowed to marry.
+
+Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC)  where you’re getting married to find out what certificates you’ll need.
+
+Your partner must follow the same process to get their own certificates.
+
+^You must apply for all certificates at least 3 months before you get married.^
 
 
-##What you need to do
-
-
-You may be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
-
-^You may also need to get a marital status certificate if you’re living with your partner and want to get a ‘[pareja de hecho](/notarial-and-documentary-services-guide-for-spain#marital-status-certificate-for-pareja-de-hecho)’ (cohabitation registration).^
+## Getting a certificate of no impediment
 
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
-^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Spain to find out how long a CNI is valid under local law.^
 
+^Your CNI will be valid for 3 months in Spain.^
 
-###Legalisation and translation
+You must then exchange your UK-issued CNI for one that’s valid in Spain.
 
-You might need to exchange your UK-issued CNI for one that’s valid in Spain at the nearest embassy or consulate to where you’re getting married.
-
-You should also check if it needs to be:
-
-
-- ‘[legalised](/get-document-legalised)’ (certified as genuine)
-- translated - [find a translator abroad](/government/collections/list-of-lawyers), or in the UK through the [Institute of Linguists](http://www.iol.org.uk/linguist/translator1.asp?r=PCTXYL10046)
-
-You should also check with the local authorities in Spain to find out if you need to provide legalised and translated copies of any other documents.
-
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
-
-
-###Getting a marital status certificate
-
-In some parts of Spain you may need to to get a ‘marital status certificate’ (‘certificado de estado civil’) instead of, or as well as, a CNI (’certificado de no impedimento’).
-
-Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married. If you need one, ask a [solicitor](/government/publications/spain-list-of-lawyers) (‘abogado’) to draw up a declaration for you printed on their headed paper.
-
-^If it’s on blank, non-headed paper, they’ll need to give you a separate letter including their contact details, confirming that they’ve drawn up the declaration.^
-
-You’ll then need to make an appointment at the consulate to make the declaration and sign the document in front of a consular officer - so don’t sign it beforehand.
-
-Download instructions in English and Spanish on what the declaration needs to include.
+Download and fill in the CNI application pack - it contains a list of the documents you’ll need.
 
 $D
-[Download ‘Marital status declaration instructions in English’ (PDF, 363KB)](/government/uploads/system/uploads/attachment_data/file/136832/marital-status-declaration-instruction-en.pdf)
-[Download ‘Declaración de estado civil instrucciones en Español’ (PDF, 236KB)](/government/uploads/system/uploads/attachment_data/file/136833/marital-status-declaration-instruction-sp.pdf)
+[Download 'CNI for UK residents application pack' (PDF, 426KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446265/UK_CNI_Pack.pdf)
 $D
 
-You’ll also need a completed marital status certificate application form, as well as the supporting documents and the fee (see below).
+Send the documents and fee by registered post to the address in the application pack.
+
+
+##Getting a marital status certificate
+
+Download and complete the marital status certificate application pack - it contains a list of the documents you’ll need.
 
 $D
-[Download ’Marital status certificate appointment request form’ (DOC, 53KB)](/government/uploads/system/uploads/attachment_data/file/182249/Appointment_request_form_marital_status_marriage.doc)
+[Download 'Marital status certificate application pack' (PDF, 424KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446267/Marital_Status_for_Marriage_Pack.pdf)
 $D
 
+You must sign the affirmation in the application pack in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you post the other documents.
 
-###Other requirements for Spain
+Send the documents and fee by registered post to the address in the application pack.
+
+### What happens next
+
+The consulate will check your forms and documents, and contact you if they have any queries.
+
+It takes 10 working days after your payment has been approved for the consulate to process your application.
+
+They’ll send your certificate and supporting documents to you by registered post.
+
+
+##Other requirements for Spain
 
 The civil registrar may also ask for confirmation of your addresses for the past 2 years (‘confirmación de domicilio para casarse en España’).
+
 
 You’ll need to show one of the following:
 
@@ -76,6 +74,13 @@ You’ll need to show one of the following:
 - a council tax letter
 - utility bills
 - recent proof of entitlement to local or state benefits, eg tax credits, pension, education or other benefits
+
+If you’re asked to provide a document from the British consulate, print out a copy of the [‘communication proof of address’](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/288272/Communication_re_Proof_of_Address.pdf).
+
+^You must get your documents translated if they’re not in English or Spanish.^
+
+
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
 
 
 ##Naturalisation of your partner if they move to the UK
@@ -97,10 +102,8 @@ Administering an oath or making a declaration | £55
 You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Spain](/government/publications/spain-consular-fees).
 
 
-You can pay by cash or credit card, but not by personal cheque.
+You can pay by credit card (Visa, Visa Electron or MasterCard), but not by personal cheque.
 
 
 *[CNI]:certificate of no impediment
-*[GRO]:General Register Office
-*[FCO]:Foreign &amp; Commonwealth Office
 

--- a/test/artefacts/marriage-abroad/spain/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_local/opposite_sex.txt
@@ -14,11 +14,11 @@ Civil weddings in Spain take place at a town hall, register office or district c
 
 You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf), [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf), or both to prove you’re allowed to marry.
 
-Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC)  where you’re getting married to find out what certificates you’ll need.
+^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 
-Your partner must follow the same process to get their own certificates.
+Your partner must also provide their own certificates.
 
-^You must apply for all certificates at least 3 months before you get married.^
+You must apply for all certificates at least 3 months before you get married.
 
 
 ## Getting a certificate of no impediment

--- a/test/artefacts/marriage-abroad/spain/uk/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_local/same_sex.txt
@@ -1,7 +1,7 @@
-Civil partnership in Spain
+Same-sex Marriage in Spain
 
 
-The process for same-sex marriages in Spain is the same as for opposite-sex civil marriages. Your marriage will be recognised as a civil partnership under British law.
+The process for same-sex marriages in Spain is the same as for opposite-sex civil marriages.
 
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Spain](/foreign-travel-advice/spain) before making any plans.
@@ -10,9 +10,19 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 %There are certain legal restrictions on getting married in Spain if neither of you lives there. If you both live outside Spain, you must check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re planning to get married to find out if this is allowed.%
 
 
-## What you need to do
+##What you need to do
 
-You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf), [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf), or both to prove you’re allowed to marry.
+
+You may be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
+
+$D
+[Download 'Certificate of no impediment' (PDF, 198KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf)
+$D
+
+$D
+[Download 'Marital status certificate' (PDF, 145KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf)
+$D
+
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 
@@ -37,7 +47,7 @@ $D
 [Download 'CNI for UK residents application pack' (PDF, 426KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446265/UK_CNI_Pack.pdf)
 $D
 
-Send the documents and fee by registered post to the address in the application pack.
+Send the documents by registered post to the address in the application pack.
 
 
 ##Getting a marital status certificate
@@ -48,9 +58,9 @@ $D
 [Download 'Marital status certificate application pack' (PDF, 424KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446267/Marital_Status_for_Marriage_Pack.pdf)
 $D
 
-You must sign the affirmation in the application pack in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you post the other documents.
+You must sign the affirmation in the application pack in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you send your application to the consulate.
 
-Send the documents and fee by registered post to the address in the application pack.
+Send the documents by registered post to the address in the application pack.
 
 ### What happens next
 
@@ -58,7 +68,7 @@ The consulate will check your forms and documents, and contact you if they have 
 
 It takes 10 working days after your payment has been approved for the consulate to process your application.
 
-They’ll send your certificate and supporting documents to you by registered post.
+They’ll send your certificate and original documents to you by registered post.
 
 
 ##Other requirements for Spain

--- a/test/artefacts/marriage-abroad/spain/uk/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_local/same_sex.txt
@@ -1,84 +1,70 @@
-Marriage in Spain
-
-Contact the [Embassy of Spain](/government/publications/foreign-embassies-in-the-uk) before making any plans to find out about local marriage laws, including what documents you’ll need.
+Civil partnership in Spain
 
 
 The process for same-sex marriages in Spain is the same as for opposite-sex civil marriages. Your marriage will be recognised as a civil partnership under British law.
 
 
-Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married.
+^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Spain](/foreign-travel-advice/spain) before making any plans.
 
 
-%There are certain legal restrictions if neither of you is resident in Spain. If you both live outside Spain, you should check with the civil registry where you’re planning to getting married to find out if this is allowed.%
+%There are certain legal restrictions on getting married in Spain if neither of you lives there. If you both live outside Spain, you must check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re planning to get married to find out if this is allowed.%
 
 
-##What you need to do
+## What you need to do
+
+You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf), [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf), or both to prove you’re allowed to marry.
+
+Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC)  where you’re getting married to find out what certificates you’ll need.
+
+Your partner must follow the same process to get their own certificates.
+
+^You must apply for all certificates at least 3 months before you get married.^
 
 
-You may be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
-
-^You may also need to get a marital status certificate if you’re living with your partner and want to get a ‘[pareja de hecho](/notarial-and-documentary-services-guide-for-spain#marital-status-certificate-for-pareja-de-hecho)’ (cohabitation registration).^
+## Getting a certificate of no impediment
 
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
-^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Spain to find out how long a CNI is valid under local law.^
 
+^Your CNI will be valid for 3 months in Spain.^
 
-###Legalisation and translation
+You must then exchange your UK-issued CNI for one that’s valid in Spain.
 
-You might need to exchange your UK-issued CNI for one that’s valid in Spain at the nearest embassy or consulate to where you’re getting married.
-
-You should also check if it needs to be:
-
-
-- ‘[legalised](/get-document-legalised)’ (certified as genuine)
-- translated - [find a translator abroad](/government/collections/list-of-lawyers), or in the UK through the [Institute of Linguists](http://www.iol.org.uk/linguist/translator1.asp?r=PCTXYL10046)
-
-You should also check with the local authorities in Spain to find out if you need to provide legalised and translated copies of any other documents.
-
-
-You’ll need to fill in forms for your notice of marriage, and an oath or affidavit (written statement of facts) stating that you’re free to marry.
-
-You can download and fill in (but not sign) the forms in advance.
-
+Download and fill in the CNI application pack - it contains a list of the documents you’ll need.
 
 $D
-[Download ‘Notice of marriage’](/government/publications/notice-of-marriage-form--2)
-
-[Download ‘Affidavit for marriage’](/government/publications/affirmationaffidavit-of-marital-status-form)
+[Download 'CNI for UK residents application pack' (PDF, 426KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446265/UK_CNI_Pack.pdf)
 $D
 
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
+Send the documents and fee by registered post to the address in the application pack.
 
 
-###Getting a marital status certificate
+##Getting a marital status certificate
 
-In some parts of Spain you may need to to get a ‘marital status certificate’ (‘certificado de estado civil’) instead of, or as well as, a CNI (’certificado de no impedimento’).
-
-Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married. If you need one, ask a [solicitor](/government/publications/spain-list-of-lawyers) (‘abogado’) to draw up a declaration for you printed on their headed paper.
-
-^If it’s on blank, non-headed paper, they’ll need to give you a separate letter including their contact details, confirming that they’ve drawn up the declaration.^
-
-You’ll then need to make an appointment at the consulate to make the declaration and sign the document in front of a consular officer - so don’t sign it beforehand.
-
-Download instructions in English and Spanish on what the declaration needs to include.
+Download and complete the marital status certificate application pack - it contains a list of the documents you’ll need.
 
 $D
-[Download ‘Marital status declaration instructions in English’ (PDF, 363KB)](/government/uploads/system/uploads/attachment_data/file/136832/marital-status-declaration-instruction-en.pdf)
-[Download ‘Declaración de estado civil instrucciones en Español’ (PDF, 236KB)](/government/uploads/system/uploads/attachment_data/file/136833/marital-status-declaration-instruction-sp.pdf)
+[Download 'Marital status certificate application pack' (PDF, 424KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446267/Marital_Status_for_Marriage_Pack.pdf)
 $D
 
-You’ll also need a completed marital status certificate application form, as well as the supporting documents and the fee (see below).
+You must sign the affirmation in the application pack in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you post the other documents.
 
-$D
-[Download ’Marital status certificate appointment request form’ (DOC, 53KB)](/government/uploads/system/uploads/attachment_data/file/182249/Appointment_request_form_marital_status_marriage.doc)
-$D
+Send the documents and fee by registered post to the address in the application pack.
+
+### What happens next
+
+The consulate will check your forms and documents, and contact you if they have any queries.
+
+It takes 10 working days after your payment has been approved for the consulate to process your application.
+
+They’ll send your certificate and supporting documents to you by registered post.
 
 
-###Other requirements for Spain
+##Other requirements for Spain
 
 The civil registrar may also ask for confirmation of your addresses for the past 2 years (‘confirmación de domicilio para casarse en España’).
+
 
 You’ll need to show one of the following:
 
@@ -88,6 +74,13 @@ You’ll need to show one of the following:
 - a council tax letter
 - utility bills
 - recent proof of entitlement to local or state benefits, eg tax credits, pension, education or other benefits
+
+If you’re asked to provide a document from the British consulate, print out a copy of the [‘communication proof of address’](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/288272/Communication_re_Proof_of_Address.pdf).
+
+^You must get your documents translated if they’re not in English or Spanish.^
+
+
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
 
 
 ##Naturalisation of your partner if they move to the UK
@@ -109,10 +102,8 @@ Administering an oath or making a declaration | £55
 You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Spain](/government/publications/spain-consular-fees).
 
 
-You can pay by cash or credit card, but not by personal cheque.
+You can pay by credit card (Visa, Visa Electron or MasterCard), but not by personal cheque.
 
 
 *[CNI]:certificate of no impediment
-*[GRO]:General Register Office
-*[FCO]:Foreign &amp; Commonwealth Office
 

--- a/test/artefacts/marriage-abroad/spain/uk/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_local/same_sex.txt
@@ -14,11 +14,11 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf), [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf), or both to prove you’re allowed to marry.
 
-Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC)  where you’re getting married to find out what certificates you’ll need.
+^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 
-Your partner must follow the same process to get their own certificates.
+Your partner must also provide their own certificates.
 
-^You must apply for all certificates at least 3 months before you get married.^
+You must apply for all certificates at least 3 months before you get married.
 
 
 ## Getting a certificate of no impediment

--- a/test/artefacts/marriage-abroad/spain/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_other/opposite_sex.txt
@@ -10,9 +10,19 @@ Civil weddings in Spain take place at a town hall, register office or district c
 %There are certain legal restrictions on getting married in Spain if neither of you lives there. If you both live outside Spain, you must check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re planning to get married to find out if this is allowed.%
 
 
-## What you need to do
+##What you need to do
 
-You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf), [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf), or both to prove you’re allowed to marry.
+
+You may be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
+
+$D
+[Download 'Certificate of no impediment' (PDF, 198KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf)
+$D
+
+$D
+[Download 'Marital status certificate' (PDF, 145KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf)
+$D
+
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 
@@ -37,7 +47,7 @@ $D
 [Download 'CNI for UK residents application pack' (PDF, 426KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446265/UK_CNI_Pack.pdf)
 $D
 
-Send the documents and fee by registered post to the address in the application pack.
+Send the documents by registered post to the address in the application pack.
 
 
 ##Getting a marital status certificate
@@ -48,9 +58,9 @@ $D
 [Download 'Marital status certificate application pack' (PDF, 424KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446267/Marital_Status_for_Marriage_Pack.pdf)
 $D
 
-You must sign the affirmation in the application pack in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you post the other documents.
+You must sign the affirmation in the application pack in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you send your application to the consulate.
 
-Send the documents and fee by registered post to the address in the application pack.
+Send the documents by registered post to the address in the application pack.
 
 ### What happens next
 
@@ -58,7 +68,7 @@ The consulate will check your forms and documents, and contact you if they have 
 
 It takes 10 working days after your payment has been approved for the consulate to process your application.
 
-They’ll send your certificate and supporting documents to you by registered post.
+They’ll send your certificate and original documents to you by registered post.
 
 
 ##Other requirements for Spain

--- a/test/artefacts/marriage-abroad/spain/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_other/opposite_sex.txt
@@ -1,72 +1,70 @@
 Marriage in Spain
 
-Contact the [Embassy of Spain](/government/publications/foreign-embassies-in-the-uk) before making any plans to find out about local marriage laws, including what documents you’ll need.
+
+Civil weddings in Spain take place at a town hall, register office or district court. You must register with the local civil authorities afterwards to get an official marriage certificate if you have a religious wedding.
 
 
-Civil weddings in Spain take place at a town hall, register office or district court. You need to register with the local civil authorities afterwards to get an official marriage certificate if you have a religious wedding.
+^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Spain](/foreign-travel-advice/spain) before making any plans.
 
 
-Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married.
+%There are certain legal restrictions on getting married in Spain if neither of you lives there. If you both live outside Spain, you must check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re planning to get married to find out if this is allowed.%
 
 
-%There are certain legal restrictions if neither of you is resident in Spain. If you both live outside Spain, you should check with the civil registry where you’re planning to getting married to find out if this is allowed.%
+## What you need to do
+
+You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf), [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf), or both to prove you’re allowed to marry.
+
+Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC)  where you’re getting married to find out what certificates you’ll need.
+
+Your partner must follow the same process to get their own certificates.
+
+^You must apply for all certificates at least 3 months before you get married.^
 
 
-##What you need to do
-
-
-You may be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
-
-^You may also need to get a marital status certificate if you’re living with your partner and want to get a ‘[pareja de hecho](/notarial-and-documentary-services-guide-for-spain#marital-status-certificate-for-pareja-de-hecho)’ (cohabitation registration).^
+## Getting a certificate of no impediment
 
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
-^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Spain to find out how long a CNI is valid under local law.^
 
+^Your CNI will be valid for 3 months in Spain.^
 
-###Legalisation and translation
+You must then exchange your UK-issued CNI for one that’s valid in Spain.
 
-You might need to exchange your UK-issued CNI for one that’s valid in Spain at the nearest embassy or consulate to where you’re getting married.
-
-You should also check if it needs to be:
-
-
-- ‘[legalised](/get-document-legalised)’ (certified as genuine)
-- translated - [find a translator abroad](/government/collections/list-of-lawyers), or in the UK through the [Institute of Linguists](http://www.iol.org.uk/linguist/translator1.asp?r=PCTXYL10046)
-
-You should also check with the local authorities in Spain to find out if you need to provide legalised and translated copies of any other documents.
-
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
-
-
-###Getting a marital status certificate
-
-In some parts of Spain you may need to to get a ‘marital status certificate’ (‘certificado de estado civil’) instead of, or as well as, a CNI (’certificado de no impedimento’).
-
-Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married. If you need one, ask a [solicitor](/government/publications/spain-list-of-lawyers) (‘abogado’) to draw up a declaration for you printed on their headed paper.
-
-^If it’s on blank, non-headed paper, they’ll need to give you a separate letter including their contact details, confirming that they’ve drawn up the declaration.^
-
-You’ll then need to make an appointment at the consulate to make the declaration and sign the document in front of a consular officer - so don’t sign it beforehand.
-
-Download instructions in English and Spanish on what the declaration needs to include.
+Download and fill in the CNI application pack - it contains a list of the documents you’ll need.
 
 $D
-[Download ‘Marital status declaration instructions in English’ (PDF, 363KB)](/government/uploads/system/uploads/attachment_data/file/136832/marital-status-declaration-instruction-en.pdf)
-[Download ‘Declaración de estado civil instrucciones en Español’ (PDF, 236KB)](/government/uploads/system/uploads/attachment_data/file/136833/marital-status-declaration-instruction-sp.pdf)
+[Download 'CNI for UK residents application pack' (PDF, 426KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446265/UK_CNI_Pack.pdf)
 $D
 
-You’ll also need a completed marital status certificate application form, as well as the supporting documents and the fee (see below).
+Send the documents and fee by registered post to the address in the application pack.
+
+
+##Getting a marital status certificate
+
+Download and complete the marital status certificate application pack - it contains a list of the documents you’ll need.
 
 $D
-[Download ’Marital status certificate appointment request form’ (DOC, 53KB)](/government/uploads/system/uploads/attachment_data/file/182249/Appointment_request_form_marital_status_marriage.doc)
+[Download 'Marital status certificate application pack' (PDF, 424KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446267/Marital_Status_for_Marriage_Pack.pdf)
 $D
 
+You must sign the affirmation in the application pack in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you post the other documents.
 
-###Other requirements for Spain
+Send the documents and fee by registered post to the address in the application pack.
+
+### What happens next
+
+The consulate will check your forms and documents, and contact you if they have any queries.
+
+It takes 10 working days after your payment has been approved for the consulate to process your application.
+
+They’ll send your certificate and supporting documents to you by registered post.
+
+
+##Other requirements for Spain
 
 The civil registrar may also ask for confirmation of your addresses for the past 2 years (‘confirmación de domicilio para casarse en España’).
+
 
 You’ll need to show one of the following:
 
@@ -76,6 +74,13 @@ You’ll need to show one of the following:
 - a council tax letter
 - utility bills
 - recent proof of entitlement to local or state benefits, eg tax credits, pension, education or other benefits
+
+If you’re asked to provide a document from the British consulate, print out a copy of the [‘communication proof of address’](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/288272/Communication_re_Proof_of_Address.pdf).
+
+^You must get your documents translated if they’re not in English or Spanish.^
+
+
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
 
 
 ##Naturalisation of your partner if they move to the UK
@@ -97,10 +102,8 @@ Administering an oath or making a declaration | £55
 You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Spain](/government/publications/spain-consular-fees).
 
 
-You can pay by cash or credit card, but not by personal cheque.
+You can pay by credit card (Visa, Visa Electron or MasterCard), but not by personal cheque.
 
 
 *[CNI]:certificate of no impediment
-*[GRO]:General Register Office
-*[FCO]:Foreign &amp; Commonwealth Office
 

--- a/test/artefacts/marriage-abroad/spain/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_other/opposite_sex.txt
@@ -14,11 +14,11 @@ Civil weddings in Spain take place at a town hall, register office or district c
 
 You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf), [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf), or both to prove you’re allowed to marry.
 
-Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC)  where you’re getting married to find out what certificates you’ll need.
+^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 
-Your partner must follow the same process to get their own certificates.
+Your partner must also provide their own certificates.
 
-^You must apply for all certificates at least 3 months before you get married.^
+You must apply for all certificates at least 3 months before you get married.
 
 
 ## Getting a certificate of no impediment

--- a/test/artefacts/marriage-abroad/spain/uk/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_other/same_sex.txt
@@ -1,7 +1,7 @@
-Civil partnership in Spain
+Same-sex Marriage in Spain
 
 
-The process for same-sex marriages in Spain is the same as for opposite-sex civil marriages. Your marriage will be recognised as a civil partnership under British law.
+The process for same-sex marriages in Spain is the same as for opposite-sex civil marriages.
 
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Spain](/foreign-travel-advice/spain) before making any plans.
@@ -10,9 +10,19 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 %There are certain legal restrictions on getting married in Spain if neither of you lives there. If you both live outside Spain, you must check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re planning to get married to find out if this is allowed.%
 
 
-## What you need to do
+##What you need to do
 
-You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf), [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf), or both to prove you’re allowed to marry.
+
+You may be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
+
+$D
+[Download 'Certificate of no impediment' (PDF, 198KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf)
+$D
+
+$D
+[Download 'Marital status certificate' (PDF, 145KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf)
+$D
+
 
 ^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 
@@ -37,7 +47,7 @@ $D
 [Download 'CNI for UK residents application pack' (PDF, 426KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446265/UK_CNI_Pack.pdf)
 $D
 
-Send the documents and fee by registered post to the address in the application pack.
+Send the documents by registered post to the address in the application pack.
 
 
 ##Getting a marital status certificate
@@ -48,9 +58,9 @@ $D
 [Download 'Marital status certificate application pack' (PDF, 424KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446267/Marital_Status_for_Marriage_Pack.pdf)
 $D
 
-You must sign the affirmation in the application pack in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you post the other documents.
+You must sign the affirmation in the application pack in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you send your application to the consulate.
 
-Send the documents and fee by registered post to the address in the application pack.
+Send the documents by registered post to the address in the application pack.
 
 ### What happens next
 
@@ -58,7 +68,7 @@ The consulate will check your forms and documents, and contact you if they have 
 
 It takes 10 working days after your payment has been approved for the consulate to process your application.
 
-They’ll send your certificate and supporting documents to you by registered post.
+They’ll send your certificate and original documents to you by registered post.
 
 
 ##Other requirements for Spain

--- a/test/artefacts/marriage-abroad/spain/uk/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_other/same_sex.txt
@@ -1,84 +1,70 @@
-Marriage in Spain
-
-Contact the [Embassy of Spain](/government/publications/foreign-embassies-in-the-uk) before making any plans to find out about local marriage laws, including what documents you’ll need.
+Civil partnership in Spain
 
 
 The process for same-sex marriages in Spain is the same as for opposite-sex civil marriages. Your marriage will be recognised as a civil partnership under British law.
 
 
-Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married.
+^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Spain](/foreign-travel-advice/spain) before making any plans.
 
 
-%There are certain legal restrictions if neither of you is resident in Spain. If you both live outside Spain, you should check with the civil registry where you’re planning to getting married to find out if this is allowed.%
+%There are certain legal restrictions on getting married in Spain if neither of you lives there. If you both live outside Spain, you must check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re planning to get married to find out if this is allowed.%
 
 
-##What you need to do
+## What you need to do
+
+You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf), [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf), or both to prove you’re allowed to marry.
+
+Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC)  where you’re getting married to find out what certificates you’ll need.
+
+Your partner must follow the same process to get their own certificates.
+
+^You must apply for all certificates at least 3 months before you get married.^
 
 
-You may be asked to provide a certificate of no impediment (CNI), marital status certificate or both to prove you’re allowed to marry.
-
-^You may also need to get a marital status certificate if you’re living with your partner and want to get a ‘[pareja de hecho](/notarial-and-documentary-services-guide-for-spain#marital-status-certificate-for-pareja-de-hecho)’ (cohabitation registration).^
+## Getting a certificate of no impediment
 
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
-^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Spain to find out how long a CNI is valid under local law.^
 
+^Your CNI will be valid for 3 months in Spain.^
 
-###Legalisation and translation
+You must then exchange your UK-issued CNI for one that’s valid in Spain.
 
-You might need to exchange your UK-issued CNI for one that’s valid in Spain at the nearest embassy or consulate to where you’re getting married.
-
-You should also check if it needs to be:
-
-
-- ‘[legalised](/get-document-legalised)’ (certified as genuine)
-- translated - [find a translator abroad](/government/collections/list-of-lawyers), or in the UK through the [Institute of Linguists](http://www.iol.org.uk/linguist/translator1.asp?r=PCTXYL10046)
-
-You should also check with the local authorities in Spain to find out if you need to provide legalised and translated copies of any other documents.
-
-
-You’ll need to fill in forms for your notice of marriage, and an oath or affidavit (written statement of facts) stating that you’re free to marry.
-
-You can download and fill in (but not sign) the forms in advance.
-
+Download and fill in the CNI application pack - it contains a list of the documents you’ll need.
 
 $D
-[Download ‘Notice of marriage’](/government/publications/notice-of-marriage-form--2)
-
-[Download ‘Affidavit for marriage’](/government/publications/affirmationaffidavit-of-marital-status-form)
+[Download 'CNI for UK residents application pack' (PDF, 426KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446265/UK_CNI_Pack.pdf)
 $D
 
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
+Send the documents and fee by registered post to the address in the application pack.
 
 
-###Getting a marital status certificate
+##Getting a marital status certificate
 
-In some parts of Spain you may need to to get a ‘marital status certificate’ (‘certificado de estado civil’) instead of, or as well as, a CNI (’certificado de no impedimento’).
-
-Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married. If you need one, ask a [solicitor](/government/publications/spain-list-of-lawyers) (‘abogado’) to draw up a declaration for you printed on their headed paper.
-
-^If it’s on blank, non-headed paper, they’ll need to give you a separate letter including their contact details, confirming that they’ve drawn up the declaration.^
-
-You’ll then need to make an appointment at the consulate to make the declaration and sign the document in front of a consular officer - so don’t sign it beforehand.
-
-Download instructions in English and Spanish on what the declaration needs to include.
+Download and complete the marital status certificate application pack - it contains a list of the documents you’ll need.
 
 $D
-[Download ‘Marital status declaration instructions in English’ (PDF, 363KB)](/government/uploads/system/uploads/attachment_data/file/136832/marital-status-declaration-instruction-en.pdf)
-[Download ‘Declaración de estado civil instrucciones en Español’ (PDF, 236KB)](/government/uploads/system/uploads/attachment_data/file/136833/marital-status-declaration-instruction-sp.pdf)
+[Download 'Marital status certificate application pack' (PDF, 424KB)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/446267/Marital_Status_for_Marriage_Pack.pdf)
 $D
 
-You’ll also need a completed marital status certificate application form, as well as the supporting documents and the fee (see below).
+You must sign the affirmation in the application pack in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you post the other documents.
 
-$D
-[Download ’Marital status certificate appointment request form’ (DOC, 53KB)](/government/uploads/system/uploads/attachment_data/file/182249/Appointment_request_form_marital_status_marriage.doc)
-$D
+Send the documents and fee by registered post to the address in the application pack.
+
+### What happens next
+
+The consulate will check your forms and documents, and contact you if they have any queries.
+
+It takes 10 working days after your payment has been approved for the consulate to process your application.
+
+They’ll send your certificate and supporting documents to you by registered post.
 
 
-###Other requirements for Spain
+##Other requirements for Spain
 
 The civil registrar may also ask for confirmation of your addresses for the past 2 years (‘confirmación de domicilio para casarse en España’).
+
 
 You’ll need to show one of the following:
 
@@ -88,6 +74,13 @@ You’ll need to show one of the following:
 - a council tax letter
 - utility bills
 - recent proof of entitlement to local or state benefits, eg tax credits, pension, education or other benefits
+
+If you’re asked to provide a document from the British consulate, print out a copy of the [‘communication proof of address’](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/288272/Communication_re_Proof_of_Address.pdf).
+
+^You must get your documents translated if they’re not in English or Spanish.^
+
+
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (eg marriage certificate or deed poll).%
 
 
 ##Naturalisation of your partner if they move to the UK
@@ -109,10 +102,8 @@ Administering an oath or making a declaration | £55
 You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Spain](/government/publications/spain-consular-fees).
 
 
-You can pay by cash or credit card, but not by personal cheque.
+You can pay by credit card (Visa, Visa Electron or MasterCard), but not by personal cheque.
 
 
 *[CNI]:certificate of no impediment
-*[GRO]:General Register Office
-*[FCO]:Foreign &amp; Commonwealth Office
 

--- a/test/artefacts/marriage-abroad/spain/uk/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/uk/partner_other/same_sex.txt
@@ -14,11 +14,11 @@ The process for same-sex marriages in Spain is the same as for opposite-sex civi
 
 You may be asked to provide a [certificate of no impediment (CNI)](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/315447/EXAMPLE_CERT_Certificate_of_No_Impediment_CNI__1_.pdf), [marital status certificate](https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/420038/Marital_Status_example.pdf), or both to prove you’re allowed to marry.
 
-Check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC)  where you’re getting married to find out what certificates you’ll need.
+^Document requirements vary across Spain - check with the [civil registry](http://www.mjusticia.gob.es/BUSCADIR/ServletControlador?apartado=buscadorGeneral&tipo=RC) where you’re getting married to find out what you’ll need.^
 
-Your partner must follow the same process to get their own certificates.
+Your partner must also provide their own certificates.
 
-^You must apply for all certificates at least 3 months before you get married.^
+You must apply for all certificates at least 3 months before you get married.
 
 
 ## Getting a certificate of no impediment

--- a/test/artefacts/marriage-abroad/st-maarten/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/st-maarten/uk/partner_british/opposite_sex.txt
@@ -16,6 +16,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in St Maarten to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/st-maarten/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/st-maarten/uk/partner_local/opposite_sex.txt
@@ -16,6 +16,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in St Maarten to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/st-maarten/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/st-maarten/uk/partner_other/opposite_sex.txt
@@ -16,6 +16,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in St Maarten to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/sweden/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/sweden/uk/partner_british/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Sweden to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/sweden/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/sweden/uk/partner_local/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Sweden to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/sweden/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/sweden/uk/partner_other/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Sweden to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/tunisia/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/tunisia/uk/partner_british/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Tunisia to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/tunisia/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/tunisia/uk/partner_local/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Tunisia to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/tunisia/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/tunisia/uk/partner_other/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Tunisia to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/turkmenistan/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/turkmenistan/uk/partner_british/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Turkmenistan to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/turkmenistan/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/turkmenistan/uk/partner_local/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Turkmenistan to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/turkmenistan/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/turkmenistan/uk/partner_other/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Turkmenistan to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/uzbekistan/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/uzbekistan/uk/partner_british/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Uzbekistan to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/uzbekistan/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/uzbekistan/uk/partner_local/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Uzbekistan to find out how long a CNI is valid under local law.^
 
 

--- a/test/artefacts/marriage-abroad/uzbekistan/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/uzbekistan/uk/partner_other/opposite_sex.txt
@@ -14,6 +14,7 @@ You may be asked to provide a certificate of no impediment (CNI) or a similar do
 
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
+
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Uzbekistan to find out how long a CNI is valid under local law.^
 
 

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -1,6 +1,6 @@
 --- 
 lib/smart_answer_flows/marriage-abroad.rb: f7e1e56615bdb0ac0ff2a2ca41707793
-lib/smart_answer_flows/locales/en/marriage-abroad.yml: d4634c7bd51cdb193d274d73fbaf37d9
+lib/smart_answer_flows/locales/en/marriage-abroad.yml: 8f79055a72905d5ec1469a6694bba270
 test/data/marriage-abroad-questions-and-responses.yml: eabbd09ca91fab72a9a520d1087fb35e
 test/data/marriage-abroad-responses-and-expected-results.yml: 74f923c5f929e369f4c9a9f0b47ffcc7
 lib/smart_answer_flows/data_partials/_overseas_passports_embassies.erb: 2f521bae99c2f48b49d07bcb283a8063

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -1,6 +1,6 @@
 --- 
-lib/smart_answer_flows/marriage-abroad.rb: f7e1e56615bdb0ac0ff2a2ca41707793
-lib/smart_answer_flows/locales/en/marriage-abroad.yml: 8f79055a72905d5ec1469a6694bba270
+lib/smart_answer_flows/marriage-abroad.rb: 89bebd8c6d50ce9ce6dbc17d5db7a3fa
+lib/smart_answer_flows/locales/en/marriage-abroad.yml: 61b86b978fc1ff985c1d113bf1848628
 test/data/marriage-abroad-questions-and-responses.yml: eabbd09ca91fab72a9a520d1087fb35e
 test/data/marriage-abroad-responses-and-expected-results.yml: 74f923c5f929e369f4c9a9f0b47ffcc7
 lib/smart_answer_flows/data_partials/_overseas_passports_embassies.erb: 2f521bae99c2f48b49d07bcb283a8063

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -1,8 +1,8 @@
 --- 
-lib/smart_answer_flows/marriage-abroad.rb: 5a6dba66d1b702a17b0e5a0b91b1d6aa
-lib/smart_answer_flows/locales/en/marriage-abroad.yml: 65395f8271ce9dc197f2ddaed4be4908
+lib/smart_answer_flows/marriage-abroad.rb: f7e1e56615bdb0ac0ff2a2ca41707793
+lib/smart_answer_flows/locales/en/marriage-abroad.yml: d4634c7bd51cdb193d274d73fbaf37d9
 test/data/marriage-abroad-questions-and-responses.yml: eabbd09ca91fab72a9a520d1087fb35e
-test/data/marriage-abroad-responses-and-expected-results.yml: e2a77265651bd20a9892bde75f375e82
+test/data/marriage-abroad-responses-and-expected-results.yml: 74f923c5f929e369f4c9a9f0b47ffcc7
 lib/smart_answer_flows/data_partials/_overseas_passports_embassies.erb: 2f521bae99c2f48b49d07bcb283a8063
 lib/smart_answer/calculators/marriage_abroad_data_query.rb: ce67dce87d17b77e1edd2cb5c630ca89
 lib/smart_answer/calculators/country_name_formatter.rb: 0cb274748f0daf3965451b6230c183fd

--- a/test/data/marriage-abroad-responses-and-expected-results.yml
+++ b/test/data/marriage-abroad-responses-and-expected-results.yml
@@ -18939,7 +18939,7 @@
   - uk
   - partner_british
   - opposite_sex
-  :next_node: :outcome_os_consular_cni
+  :next_node: :outcome_spain
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses: 
@@ -18947,7 +18947,7 @@
   - uk
   - partner_british
   - same_sex
-  :next_node: :outcome_os_consular_cni
+  :next_node: :outcome_spain
   :outcome_node: true
 - :current_node: :what_is_your_partners_nationality?
   :responses: 
@@ -18962,7 +18962,7 @@
   - uk
   - partner_local
   - opposite_sex
-  :next_node: :outcome_os_consular_cni
+  :next_node: :outcome_spain
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses: 
@@ -18970,7 +18970,7 @@
   - uk
   - partner_local
   - same_sex
-  :next_node: :outcome_os_consular_cni
+  :next_node: :outcome_spain
   :outcome_node: true
 - :current_node: :what_is_your_partners_nationality?
   :responses: 
@@ -18985,7 +18985,7 @@
   - uk
   - partner_other
   - opposite_sex
-  :next_node: :outcome_os_consular_cni
+  :next_node: :outcome_spain
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses: 
@@ -18993,7 +18993,7 @@
   - uk
   - partner_other
   - same_sex
-  :next_node: :outcome_os_consular_cni
+  :next_node: :outcome_spain
   :outcome_node: true
 - :current_node: :legal_residency?
   :responses: 
@@ -19014,7 +19014,7 @@
   - ceremony_country
   - partner_british
   - opposite_sex
-  :next_node: :outcome_os_consular_cni
+  :next_node: :outcome_spain
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses: 
@@ -19022,7 +19022,7 @@
   - ceremony_country
   - partner_british
   - same_sex
-  :next_node: :outcome_os_consular_cni
+  :next_node: :outcome_spain
   :outcome_node: true
 - :current_node: :what_is_your_partners_nationality?
   :responses: 
@@ -19037,7 +19037,7 @@
   - ceremony_country
   - partner_local
   - opposite_sex
-  :next_node: :outcome_os_consular_cni
+  :next_node: :outcome_spain
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses: 
@@ -19045,7 +19045,7 @@
   - ceremony_country
   - partner_local
   - same_sex
-  :next_node: :outcome_os_consular_cni
+  :next_node: :outcome_spain
   :outcome_node: true
 - :current_node: :what_is_your_partners_nationality?
   :responses: 
@@ -19060,7 +19060,7 @@
   - ceremony_country
   - partner_other
   - opposite_sex
-  :next_node: :outcome_os_consular_cni
+  :next_node: :outcome_spain
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses: 
@@ -19068,7 +19068,7 @@
   - ceremony_country
   - partner_other
   - same_sex
-  :next_node: :outcome_os_consular_cni
+  :next_node: :outcome_spain
   :outcome_node: true
 - :current_node: :legal_residency?
   :responses: 
@@ -19089,7 +19089,7 @@
   - third_country
   - partner_british
   - opposite_sex
-  :next_node: :outcome_consular_cni_os_residing_in_third_country
+  :next_node: :outcome_spain
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses: 
@@ -19097,7 +19097,7 @@
   - third_country
   - partner_british
   - same_sex
-  :next_node: :outcome_consular_cni_os_residing_in_third_country
+  :next_node: :outcome_spain
   :outcome_node: true
 - :current_node: :what_is_your_partners_nationality?
   :responses: 
@@ -19112,7 +19112,7 @@
   - third_country
   - partner_local
   - opposite_sex
-  :next_node: :outcome_consular_cni_os_residing_in_third_country
+  :next_node: :outcome_spain
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses: 
@@ -19120,7 +19120,7 @@
   - third_country
   - partner_local
   - same_sex
-  :next_node: :outcome_consular_cni_os_residing_in_third_country
+  :next_node: :outcome_spain
   :outcome_node: true
 - :current_node: :what_is_your_partners_nationality?
   :responses: 
@@ -19135,7 +19135,7 @@
   - third_country
   - partner_other
   - opposite_sex
-  :next_node: :outcome_consular_cni_os_residing_in_third_country
+  :next_node: :outcome_spain
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses: 
@@ -19143,7 +19143,7 @@
   - third_country
   - partner_other
   - same_sex
-  :next_node: :outcome_consular_cni_os_residing_in_third_country
+  :next_node: :outcome_spain
   :outcome_node: true
 - :current_node: :country_of_ceremony?
   :responses: 

--- a/test/integration/smart_answer_flows/marriage_abroad_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_test.rb
@@ -608,7 +608,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
       end
       should "go to outcome_spain with UK/OS specific phrases" do
         assert_current_node :outcome_spain
-        assert_phrase_list :body, [:civil_weddings_in_spain, :get_legal_and_travel_advice, :legal_restrictions_for_non_residents_spain, :what_you_need_to_do_spain, :get_cni_in_uk_for_spain_title, :cni_at_local_register_office, :get_cni_in_uk_for_spain, :get_maritial_status_certificate_spain, :other_requirements_in_spain_intro, :other_requirements_in_spain, :names_on_documents_must_match, :consular_cni_os_fees_incl_null_osta_oath_consular_letter, :link_to_consular_fees, :pay_by_visas_or_mastercard]
+        assert_phrase_list :body, [:civil_weddings_in_spain, :get_legal_and_travel_advice, :legal_restrictions_for_non_residents_spain, :what_you_need_to_do, :cni_maritial_status_certificate_spain, :what_you_need_to_do_spain, :get_cni_in_uk_for_spain_title, :cni_at_local_register_office, :get_cni_in_uk_for_spain, :get_maritial_status_certificate_spain, :other_requirements_in_spain_intro, :other_requirements_in_spain, :names_on_documents_must_match, :consular_cni_os_fees_incl_null_osta_oath_consular_letter, :link_to_consular_fees, :pay_by_visas_or_mastercard]
       end
     end
 
@@ -620,7 +620,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
       end
       should "go to outcome_spain with ceremony country OS specific phrases" do
         assert_current_node :outcome_spain
-        assert_phrase_list :body, [:contact_local_authorities_in_country_marriage, :civil_weddings_in_spain, :get_legal_advice, :what_you_need_to_do_spain, :get_cni_in_spain, :get_maritial_status_certificate_spain, :other_requirements_in_spain_for_residents_intro, :other_requirements_in_spain, :names_on_documents_must_match, :partner_naturalisation_in_uk, :consular_cni_os_fees_incl_null_osta_oath_consular_letter, :link_to_consular_fees, :pay_by_visas_or_mastercard]
+        assert_phrase_list :body, [:contact_local_authorities_in_country_marriage, :civil_weddings_in_spain, :get_legal_advice, :what_you_need_to_do, :cni_maritial_status_certificate_spain, :what_you_need_to_do_spain, :get_cni_in_spain, :get_maritial_status_certificate_spain, :other_requirements_in_spain_for_residents_intro, :other_requirements_in_spain, :names_on_documents_must_match, :partner_naturalisation_in_uk, :consular_cni_os_fees_incl_null_osta_oath_consular_letter, :link_to_consular_fees, :pay_by_visas_or_mastercard]
       end
     end
 
@@ -633,7 +633,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
 
       should "go to outcome_spain with third country OS specific phrases" do
         assert_current_node :outcome_spain
-        assert_phrase_list :body, [:contact_local_authorities_in_country_marriage, :get_legal_and_travel_advice, :legal_restrictions_for_non_residents_spain, :what_you_need_to_do_spain_third_country]
+        assert_phrase_list :body, [:contact_local_authorities_in_country_marriage, :get_legal_and_travel_advice, :legal_restrictions_for_non_residents_spain, :what_you_need_to_do, :cni_maritial_status_certificate_spain, :what_you_need_to_do_spain_third_country]
         assert_state_variable :ceremony_country_residence_outcome_path, "/marriage-abroad/y/spain/ceremony_country/partner_other/opposite_sex"
         assert_state_variable :uk_residence_outcome_path, "/marriage-abroad/y/spain/uk/partner_other/opposite_sex"
       end
@@ -648,7 +648,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
 
       should "go to outcome_spain with UK/SS specific phrases" do
         assert_current_node :outcome_spain
-        assert_phrase_list :body, [:ss_process_in_spain, :get_legal_and_travel_advice, :legal_restrictions_for_non_residents_spain, :what_you_need_to_do_spain, :get_cni_in_uk_for_spain_title, :cni_at_local_register_office, :get_cni_in_uk_for_spain, :get_maritial_status_certificate_spain, :other_requirements_in_spain_intro, :other_requirements_in_spain, :names_on_documents_must_match, :consular_cni_os_fees_incl_null_osta_oath_consular_letter, :link_to_consular_fees, :pay_by_visas_or_mastercard]
+        assert_phrase_list :body, [:ss_process_in_spain, :get_legal_and_travel_advice, :legal_restrictions_for_non_residents_spain, :what_you_need_to_do, :cni_maritial_status_certificate_spain, :what_you_need_to_do_spain, :get_cni_in_uk_for_spain_title, :cni_at_local_register_office, :get_cni_in_uk_for_spain, :get_maritial_status_certificate_spain, :other_requirements_in_spain_intro, :other_requirements_in_spain, :names_on_documents_must_match, :consular_cni_os_fees_incl_null_osta_oath_consular_letter, :link_to_consular_fees, :pay_by_visas_or_mastercard]
       end
     end
 
@@ -661,7 +661,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
 
       should "go to outcome_spain with third country SS specific phrases" do
         assert_current_node :outcome_spain
-        assert_phrase_list :body, [:contact_local_authorities_in_country_marriage, :ss_process_in_spain, :get_legal_and_travel_advice, :legal_restrictions_for_non_residents_spain, :what_you_need_to_do_spain_third_country]
+        assert_phrase_list :body, [:contact_local_authorities_in_country_marriage, :ss_process_in_spain, :get_legal_and_travel_advice, :legal_restrictions_for_non_residents_spain, :what_you_need_to_do, :cni_maritial_status_certificate_spain, :what_you_need_to_do_spain_third_country]
         assert_state_variable :ceremony_country_residence_outcome_path, "/marriage-abroad/y/spain/ceremony_country/partner_other/same_sex"
         assert_state_variable :uk_residence_outcome_path, "/marriage-abroad/y/spain/uk/partner_other/same_sex"
       end

--- a/test/integration/smart_answer_flows/marriage_abroad_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_test.rb
@@ -606,10 +606,9 @@ class MarriageAbroadTest < ActiveSupport::TestCase
         add_response 'partner_british'
         add_response 'opposite_sex'
       end
-      should "go to consular cni os outcome" do
-        assert_current_node :outcome_os_consular_cni
-        assert_phrase_list :consular_cni_os_start, [:contact_embassy_of_ceremony_country_in_uk_marriage, :spain_os_consular_cni_opposite_sex, :spain_os_consular_civil_registry, :spain_os_consular_cni_not_local_resident, :what_you_need_to_do, :cni_pareja_de_hecho_requirements_spain, :cni_at_local_register_office, :legisation_and_translation_intro_uk, :legalise_translate_and_check_with_authorities]
-        assert_phrase_list :consular_cni_os_remainder, [:same_cni_process_and_fees_for_partner, :names_on_documents_must_match, :consular_cni_os_ceremony_spain, :consular_cni_os_ceremony_spain_partner_british, :other_requirements_for_spain, :consular_cni_os_fees_incl_null_osta_oath_consular_letter, :link_to_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+      should "go to outcome_spain with UK/OS specific phrases" do
+        assert_current_node :outcome_spain
+        assert_phrase_list :body, [:civil_weddings_in_spain, :get_legal_and_travel_advice, :legal_restrictions_for_non_residents_spain, :what_you_need_to_do_spain, :get_cni_in_uk_for_spain_title, :cni_at_local_register_office, :get_cni_in_uk_for_spain, :get_maritial_status_certificate_spain, :other_requirements_in_spain, :names_on_documents_must_match, :consular_cni_os_fees_incl_null_osta_oath_consular_letter, :link_to_consular_fees, :pay_by_visas_or_mastercard]
       end
     end
 
@@ -619,10 +618,9 @@ class MarriageAbroadTest < ActiveSupport::TestCase
         add_response 'partner_local'
         add_response 'opposite_sex'
       end
-      should "go to consular cni os outcome" do
-        assert_current_node :outcome_os_consular_cni
-        assert_phrase_list :consular_cni_os_start, [:contact_local_authorities_in_country_marriage, :spain_os_consular_cni_opposite_sex, :spain_os_consular_civil_registry, :what_you_need_to_do, :cni_pareja_de_hecho_requirements_spain, :consular_cni_os_giving_notice_in_ceremony_country, :consular_cni_variant_local_resident_spain, :consular_cni_os_not_uk_resident_ceremony_not_germany, :sending_cni_and_booking_appointment_spain]
-        assert_phrase_list :consular_cni_os_remainder, [:names_on_documents_must_match, :consular_cni_os_ceremony_spain, :other_requirements_for_spain, :no_need_to_stay_after_posting_notice, :partner_naturalisation_in_uk, :consular_cni_os_fees_incl_null_osta_oath_consular_letter, :link_to_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+      should "go to outcome_spain with ceremony country OS specific phrases" do
+        assert_current_node :outcome_spain
+        assert_phrase_list :body, [:contact_local_authorities_in_country_marriage, :civil_weddings_in_spain, :get_legal_advice, :what_you_need_to_do_spain, :get_cni_in_spain, :get_maritial_status_certificate_spain, :other_requirements_in_spain, :names_on_documents_must_match, :partner_naturalisation_in_uk, :consular_cni_os_fees_incl_null_osta_oath_consular_letter, :link_to_consular_fees, :pay_by_visas_or_mastercard]
       end
     end
 
@@ -633,9 +631,9 @@ class MarriageAbroadTest < ActiveSupport::TestCase
         add_response 'opposite_sex'
       end
 
-      should "go to outcome_consular_cni_os_residing_in_third_country" do
-        assert_current_node :outcome_consular_cni_os_residing_in_third_country
-        assert_phrase_list :body, [:contact_local_authorities_in_country_marriage, :get_legal_and_travel_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :standard_ways_to_get_cni_in_third_country]
+      should "go to outcome_spain with third country OS specific phrases" do
+        assert_current_node :outcome_spain
+        assert_phrase_list :body, [:contact_local_authorities_in_country_marriage, :get_legal_and_travel_advice, :legal_restrictions_for_non_residents_spain, :what_you_need_to_do_spain_third_country]
         assert_state_variable :ceremony_country_residence_outcome_path, "/marriage-abroad/y/spain/ceremony_country/partner_other/opposite_sex"
         assert_state_variable :uk_residence_outcome_path, "/marriage-abroad/y/spain/uk/partner_other/opposite_sex"
       end
@@ -648,10 +646,9 @@ class MarriageAbroadTest < ActiveSupport::TestCase
         add_response 'same_sex'
       end
 
-      should "go to cp or equivalent outcome" do
-        assert_current_node :outcome_os_consular_cni
-        assert_phrase_list :consular_cni_os_start, [:contact_embassy_of_ceremony_country_in_uk_marriage, :spain_os_consular_cni_same_sex, :spain_os_consular_civil_registry, :spain_os_consular_cni_not_local_resident, :what_you_need_to_do, :cni_pareja_de_hecho_requirements_spain, :cni_at_local_register_office, :legisation_and_translation_intro_uk, :legalise_translate_and_check_with_authorities, :download_and_fill_notice_and_affidavit_but_not_sign]
-        assert_phrase_list :consular_cni_os_remainder, [:same_cni_process_and_fees_for_partner, :names_on_documents_must_match, :consular_cni_os_ceremony_spain, :consular_cni_os_ceremony_spain_partner_british, :other_requirements_for_spain, :consular_cni_os_fees_incl_null_osta_oath_consular_letter, :link_to_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
+      should "go to outcome_spain with UK/SS specific phrases" do
+        assert_current_node :outcome_spain
+        assert_phrase_list :body, [:ss_process_and_recognition_in_spain, :get_legal_and_travel_advice, :legal_restrictions_for_non_residents_spain, :what_you_need_to_do_spain, :get_cni_in_uk_for_spain_title, :cni_at_local_register_office, :get_cni_in_uk_for_spain, :get_maritial_status_certificate_spain, :other_requirements_in_spain, :names_on_documents_must_match, :consular_cni_os_fees_incl_null_osta_oath_consular_letter, :link_to_consular_fees, :pay_by_visas_or_mastercard]
       end
     end
 
@@ -662,9 +659,9 @@ class MarriageAbroadTest < ActiveSupport::TestCase
         add_response 'same_sex'
       end
 
-      should "go to outcome_consular_cni_os_residing_in_third_country" do
-        assert_current_node :outcome_consular_cni_os_residing_in_third_country
-        assert_phrase_list :body, [:contact_local_authorities_in_country_marriage, :get_legal_and_travel_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :standard_ways_to_get_cni_in_third_country]
+      should "go to outcome_spain with third country SS specific phrases" do
+        assert_current_node :outcome_spain
+        assert_phrase_list :body, [:contact_local_authorities_in_country_cp, :ss_process_and_recognition_in_spain, :get_legal_and_travel_advice, :legal_restrictions_for_non_residents_spain, :what_you_need_to_do_spain_third_country]
         assert_state_variable :ceremony_country_residence_outcome_path, "/marriage-abroad/y/spain/ceremony_country/partner_other/same_sex"
         assert_state_variable :uk_residence_outcome_path, "/marriage-abroad/y/spain/uk/partner_other/same_sex"
       end
@@ -774,7 +771,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "go to consular cni os outcome" do
       assert_current_node :outcome_os_consular_cni
-      assert_phrase_list :consular_cni_os_start, [:contact_embassy_of_ceremony_country_in_uk_marriage, :get_legal_and_travel_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :cni_at_local_register_office, :legisation_and_translation_intro_uk, :legalise_translate_and_check_with_authorities]
+      assert_phrase_list :consular_cni_os_start, [:contact_embassy_of_ceremony_country_in_uk_marriage, :get_legal_and_travel_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :cni_at_local_register_office, :cni_issued_locally_validity, :legisation_and_translation_intro_uk, :legalise_translate_and_check_with_authorities]
       assert_phrase_list :consular_cni_os_remainder, [:names_on_documents_must_match, :partner_naturalisation_in_uk, :consular_cni_os_fees_incl_null_osta_oath_consular_letter, :link_to_consular_fees, :pay_in_local_currency_ceremony_country_name]
     end
   end
@@ -1580,7 +1577,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
 
       should "have a japan-specific intro" do
         assert_current_node :outcome_os_consular_cni
-        assert_phrase_list :consular_cni_os_start, [:japan_intro, :what_you_need_to_do, :you_may_be_asked_for_cni, :cni_at_local_register_office, :legisation_and_translation_intro_uk, :legalise_translate_and_check_with_authorities]
+        assert_phrase_list :consular_cni_os_start, [:japan_intro, :what_you_need_to_do, :you_may_be_asked_for_cni, :cni_at_local_register_office, :cni_issued_locally_validity, :legisation_and_translation_intro_uk, :legalise_translate_and_check_with_authorities]
       end
     end
 

--- a/test/integration/smart_answer_flows/marriage_abroad_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_test.rb
@@ -608,7 +608,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
       end
       should "go to outcome_spain with UK/OS specific phrases" do
         assert_current_node :outcome_spain
-        assert_phrase_list :body, [:civil_weddings_in_spain, :get_legal_and_travel_advice, :legal_restrictions_for_non_residents_spain, :what_you_need_to_do_spain, :get_cni_in_uk_for_spain_title, :cni_at_local_register_office, :get_cni_in_uk_for_spain, :get_maritial_status_certificate_spain, :other_requirements_in_spain, :names_on_documents_must_match, :consular_cni_os_fees_incl_null_osta_oath_consular_letter, :link_to_consular_fees, :pay_by_visas_or_mastercard]
+        assert_phrase_list :body, [:civil_weddings_in_spain, :get_legal_and_travel_advice, :legal_restrictions_for_non_residents_spain, :what_you_need_to_do_spain, :get_cni_in_uk_for_spain_title, :cni_at_local_register_office, :get_cni_in_uk_for_spain, :get_maritial_status_certificate_spain, :other_requirements_in_spain_intro, :other_requirements_in_spain, :names_on_documents_must_match, :consular_cni_os_fees_incl_null_osta_oath_consular_letter, :link_to_consular_fees, :pay_by_visas_or_mastercard]
       end
     end
 
@@ -620,7 +620,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
       end
       should "go to outcome_spain with ceremony country OS specific phrases" do
         assert_current_node :outcome_spain
-        assert_phrase_list :body, [:contact_local_authorities_in_country_marriage, :civil_weddings_in_spain, :get_legal_advice, :what_you_need_to_do_spain, :get_cni_in_spain, :get_maritial_status_certificate_spain, :other_requirements_in_spain, :names_on_documents_must_match, :partner_naturalisation_in_uk, :consular_cni_os_fees_incl_null_osta_oath_consular_letter, :link_to_consular_fees, :pay_by_visas_or_mastercard]
+        assert_phrase_list :body, [:contact_local_authorities_in_country_marriage, :civil_weddings_in_spain, :get_legal_advice, :what_you_need_to_do_spain, :get_cni_in_spain, :get_maritial_status_certificate_spain, :other_requirements_in_spain_for_residents_intro, :other_requirements_in_spain, :names_on_documents_must_match, :partner_naturalisation_in_uk, :consular_cni_os_fees_incl_null_osta_oath_consular_letter, :link_to_consular_fees, :pay_by_visas_or_mastercard]
       end
     end
 
@@ -648,7 +648,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
 
       should "go to outcome_spain with UK/SS specific phrases" do
         assert_current_node :outcome_spain
-        assert_phrase_list :body, [:ss_process_and_recognition_in_spain, :get_legal_and_travel_advice, :legal_restrictions_for_non_residents_spain, :what_you_need_to_do_spain, :get_cni_in_uk_for_spain_title, :cni_at_local_register_office, :get_cni_in_uk_for_spain, :get_maritial_status_certificate_spain, :other_requirements_in_spain, :names_on_documents_must_match, :consular_cni_os_fees_incl_null_osta_oath_consular_letter, :link_to_consular_fees, :pay_by_visas_or_mastercard]
+        assert_phrase_list :body, [:ss_process_and_recognition_in_spain, :get_legal_and_travel_advice, :legal_restrictions_for_non_residents_spain, :what_you_need_to_do_spain, :get_cni_in_uk_for_spain_title, :cni_at_local_register_office, :get_cni_in_uk_for_spain, :get_maritial_status_certificate_spain, :other_requirements_in_spain_intro, :other_requirements_in_spain, :names_on_documents_must_match, :consular_cni_os_fees_incl_null_osta_oath_consular_letter, :link_to_consular_fees, :pay_by_visas_or_mastercard]
       end
     end
 

--- a/test/integration/smart_answer_flows/marriage_abroad_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_test.rb
@@ -648,7 +648,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
 
       should "go to outcome_spain with UK/SS specific phrases" do
         assert_current_node :outcome_spain
-        assert_phrase_list :body, [:ss_process_and_recognition_in_spain, :get_legal_and_travel_advice, :legal_restrictions_for_non_residents_spain, :what_you_need_to_do_spain, :get_cni_in_uk_for_spain_title, :cni_at_local_register_office, :get_cni_in_uk_for_spain, :get_maritial_status_certificate_spain, :other_requirements_in_spain_intro, :other_requirements_in_spain, :names_on_documents_must_match, :consular_cni_os_fees_incl_null_osta_oath_consular_letter, :link_to_consular_fees, :pay_by_visas_or_mastercard]
+        assert_phrase_list :body, [:ss_process_in_spain, :get_legal_and_travel_advice, :legal_restrictions_for_non_residents_spain, :what_you_need_to_do_spain, :get_cni_in_uk_for_spain_title, :cni_at_local_register_office, :get_cni_in_uk_for_spain, :get_maritial_status_certificate_spain, :other_requirements_in_spain_intro, :other_requirements_in_spain, :names_on_documents_must_match, :consular_cni_os_fees_incl_null_osta_oath_consular_letter, :link_to_consular_fees, :pay_by_visas_or_mastercard]
       end
     end
 
@@ -661,7 +661,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
 
       should "go to outcome_spain with third country SS specific phrases" do
         assert_current_node :outcome_spain
-        assert_phrase_list :body, [:contact_local_authorities_in_country_cp, :ss_process_and_recognition_in_spain, :get_legal_and_travel_advice, :legal_restrictions_for_non_residents_spain, :what_you_need_to_do_spain_third_country]
+        assert_phrase_list :body, [:contact_local_authorities_in_country_marriage, :ss_process_in_spain, :get_legal_and_travel_advice, :legal_restrictions_for_non_residents_spain, :what_you_need_to_do_spain_third_country]
         assert_state_variable :ceremony_country_residence_outcome_path, "/marriage-abroad/y/spain/ceremony_country/partner_other/same_sex"
         assert_state_variable :uk_residence_outcome_path, "/marriage-abroad/y/spain/uk/partner_other/same_sex"
       end

--- a/test/integration/smart_answer_flows/marriage_abroad_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_test.rb
@@ -370,7 +370,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "go to consular cni os outcome" do
       assert_current_node :outcome_os_consular_cni
-      assert_phrase_list :consular_cni_os_start, [:contact_local_authorities_in_country_marriage, :get_legal_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :consular_cni_os_giving_notice_in_ceremony_country, :living_in_ceremony_country_3_days, :cni_exception_for_permanent_residents_estonia, "appointment_links.opposite_sex.estonia", :required_supporting_documents_notary_public, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :download_and_fill_notice_and_affidavit_but_not_sign, :consular_cni_os_foreign_resident_ceremony_notary_public]
+      assert_phrase_list :consular_cni_os_start, [:contact_local_authorities_in_country_marriage, :get_legal_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :consular_cni_os_giving_notice_in_ceremony_country, :living_in_ceremony_country_3_days, :cni_exception_for_permanent_residents_estonia, "appointment_links.opposite_sex.estonia", :required_supporting_documents_notary_public, :consular_cni_os_not_uk_resident_ceremony_not_germany, :evidence_if_divorced_outside_uk, :download_and_fill_notice_and_affidavit_but_not_sign, :consular_cni_os_foreign_resident_ceremony_notary_public]
       assert_phrase_list :consular_cni_os_remainder, [:names_on_documents_must_match, :check_if_cni_needs_to_be_legalised, :no_need_to_stay_after_posting_notice, :partner_naturalisation_in_uk, :consular_cni_os_fees_incl_null_osta_oath_consular_letter, :link_to_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
     end
   end
@@ -401,7 +401,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "go to consular cni os outcome" do
       assert_current_node :outcome_os_consular_cni
-      assert_phrase_list :consular_cni_os_start, [:contact_local_authorities_in_country_marriage, :gulf_states_os_consular_cni, :gulf_states_os_consular_cni_local_resident, :get_legal_advice, :what_you_need_to_do, :consular_cni_os_foreign_resident_21_days_jordan, :consular_cni_os_giving_notice_in_ceremony_country, :embassies_data, :required_supporting_documents_incl_birth_cert, :documents_must_be_originals_when_in_sharia_court, :consular_cni_os_not_uk_resident_ceremony_jordan, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :download_and_fill_notice_and_affidavit_but_not_sign, :display_notice_of_marriage_7_days]
+      assert_phrase_list :consular_cni_os_start, [:contact_local_authorities_in_country_marriage, :gulf_states_os_consular_cni, :gulf_states_os_consular_cni_local_resident, :get_legal_advice, :what_you_need_to_do, :consular_cni_os_foreign_resident_21_days_jordan, :consular_cni_os_giving_notice_in_ceremony_country, :embassies_data, :required_supporting_documents_incl_birth_cert, :documents_must_be_originals_when_in_sharia_court, :consular_cni_os_not_uk_resident_ceremony_jordan, :evidence_if_divorced_outside_uk, :download_and_fill_notice_and_affidavit_but_not_sign, :display_notice_of_marriage_7_days]
       assert_phrase_list :consular_cni_os_remainder, [:same_cni_process_and_fees_for_partner, :names_on_documents_must_match, :check_if_cni_needs_to_be_legalised, :no_need_to_stay_after_posting_notice, :consular_cni_os_fees_incl_null_osta_oath_consular_letter, :link_to_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
     end
   end
@@ -557,7 +557,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "go to consular cni os outcome" do
       assert_current_node :outcome_os_consular_cni
-      assert_phrase_list :consular_cni_os_start, [:contact_local_authorities_in_country_marriage, :get_legal_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :consular_cni_os_giving_notice_in_ceremony_country, :living_in_ceremony_country_3_days, "appointment_links.opposite_sex.azerbaijan", :required_supporting_documents_notary_public, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :download_and_fill_notice_and_affidavit_but_not_sign, :consular_cni_os_foreign_resident_ceremony_notary_public]
+      assert_phrase_list :consular_cni_os_start, [:contact_local_authorities_in_country_marriage, :get_legal_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :consular_cni_os_giving_notice_in_ceremony_country, :living_in_ceremony_country_3_days, "appointment_links.opposite_sex.azerbaijan", :required_supporting_documents_notary_public, :consular_cni_os_not_uk_resident_ceremony_not_germany, :evidence_if_divorced_outside_uk, :download_and_fill_notice_and_affidavit_but_not_sign, :consular_cni_os_foreign_resident_ceremony_notary_public]
       assert_phrase_list :consular_cni_os_remainder, [:names_on_documents_must_match, :check_if_cni_needs_to_be_legalised, :no_need_to_stay_after_posting_notice, :partner_naturalisation_in_uk, :consular_cni_os_fees_incl_null_osta_oath_consular_letter, :link_to_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
     end
   end
@@ -589,7 +589,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "go to consular cni os outcome" do
       assert_current_node :outcome_os_consular_cni
-      assert_phrase_list :consular_cni_os_start, [:contact_local_authorities_in_country_marriage, :get_legal_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :consular_cni_os_denmark, :consular_cni_os_giving_notice_in_ceremony_country, :living_in_ceremony_country_3_days, "appointment_links.opposite_sex.denmark", :required_supporting_documents, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :download_and_fill_notice_and_affidavit_but_not_sign, :display_notice_of_marriage_7_days]
+      assert_phrase_list :consular_cni_os_start, [:contact_local_authorities_in_country_marriage, :get_legal_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :consular_cni_os_denmark, :consular_cni_os_giving_notice_in_ceremony_country, :living_in_ceremony_country_3_days, "appointment_links.opposite_sex.denmark", :required_supporting_documents, :consular_cni_os_not_uk_resident_ceremony_not_germany, :evidence_if_divorced_outside_uk, :download_and_fill_notice_and_affidavit_but_not_sign, :display_notice_of_marriage_7_days]
       assert_phrase_list :consular_cni_os_remainder, [:names_on_documents_must_match, :check_if_cni_needs_to_be_legalised, :no_need_to_stay_after_posting_notice, :partner_naturalisation_in_uk, :consular_cni_os_fees_incl_null_osta_oath_consular_letter, :link_to_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
     end
   end
@@ -678,7 +678,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "go to consular cni os outcome" do
       assert_current_node :outcome_os_consular_cni
-      assert_phrase_list :consular_cni_os_start, [:contact_local_authorities_in_country_marriage, :get_legal_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :consular_cni_os_giving_notice_in_ceremony_country, :living_in_ceremony_country_3_days, "appointment_links.opposite_sex.poland", :required_supporting_documents_notary_public, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :download_and_fill_notice_and_affidavit_but_not_sign, :consular_cni_os_foreign_resident_ceremony_notary_public]
+      assert_phrase_list :consular_cni_os_start, [:contact_local_authorities_in_country_marriage, :get_legal_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :consular_cni_os_giving_notice_in_ceremony_country, :living_in_ceremony_country_3_days, "appointment_links.opposite_sex.poland", :required_supporting_documents_notary_public, :consular_cni_os_not_uk_resident_ceremony_not_germany, :evidence_if_divorced_outside_uk, :download_and_fill_notice_and_affidavit_but_not_sign, :consular_cni_os_foreign_resident_ceremony_notary_public]
       assert_phrase_list :consular_cni_os_remainder, [:names_on_documents_must_match, :check_if_cni_needs_to_be_legalised, :no_need_to_stay_after_posting_notice, :partner_naturalisation_in_uk, :consular_cni_os_fees_incl_null_osta_oath_consular_letter, :link_to_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
     end
   end
@@ -693,7 +693,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "go to consular cni os outcome" do
       assert_current_node :outcome_os_consular_cni
-      assert_phrase_list :consular_cni_os_start, [:contact_local_authorities_in_country_marriage, :get_legal_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :consular_cni_os_giving_notice_in_ceremony_country, :living_in_ceremony_country_3_days, "appointment_links.opposite_sex.azerbaijan", :required_supporting_documents_notary_public, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :download_and_fill_notice_and_affidavit_but_not_sign, :consular_cni_os_foreign_resident_ceremony_notary_public]
+      assert_phrase_list :consular_cni_os_start, [:contact_local_authorities_in_country_marriage, :get_legal_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :consular_cni_os_giving_notice_in_ceremony_country, :living_in_ceremony_country_3_days, "appointment_links.opposite_sex.azerbaijan", :required_supporting_documents_notary_public, :consular_cni_os_not_uk_resident_ceremony_not_germany, :evidence_if_divorced_outside_uk, :download_and_fill_notice_and_affidavit_but_not_sign, :consular_cni_os_foreign_resident_ceremony_notary_public]
       assert_phrase_list :consular_cni_os_remainder, [:names_on_documents_must_match, :check_if_cni_needs_to_be_legalised, :no_need_to_stay_after_posting_notice, :partner_naturalisation_in_uk, :consular_cni_os_fees_incl_null_osta_oath_consular_letter, :link_to_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
     end
   end
@@ -880,7 +880,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "go to os affirmation outcome" do
       assert_current_node :outcome_os_consular_cni
-      assert_phrase_list :consular_cni_os_start, [:contact_local_authorities_in_country_marriage, :gulf_states_os_consular_cni, :gulf_states_os_consular_cni_local_resident, :get_legal_advice, :what_you_need_to_do, :consular_cni_os_ceremony_21_day_requirement, :you_may_be_asked_for_cni, :consular_cni_os_giving_notice_in_ceremony_country, :embassies_data, :required_supporting_documents_incl_birth_cert, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :download_and_fill_notice_and_affidavit_but_not_sign, :display_notice_of_marriage_7_days]
+      assert_phrase_list :consular_cni_os_start, [:contact_local_authorities_in_country_marriage, :gulf_states_os_consular_cni, :gulf_states_os_consular_cni_local_resident, :get_legal_advice, :what_you_need_to_do, :consular_cni_os_ceremony_21_day_requirement, :you_may_be_asked_for_cni, :consular_cni_os_giving_notice_in_ceremony_country, :embassies_data, :required_supporting_documents_incl_birth_cert, :consular_cni_os_not_uk_resident_ceremony_not_germany, :evidence_if_divorced_outside_uk, :download_and_fill_notice_and_affidavit_but_not_sign, :display_notice_of_marriage_7_days]
     end
   end
 
@@ -1081,7 +1081,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "go to consular cni os outcome" do
       assert_current_node :outcome_os_consular_cni
-      assert_phrase_list :consular_cni_os_start, [:contact_local_authorities_in_country_marriage, :get_legal_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :living_in_ceremony_country_3_days, :consular_cni_os_foreign_resident_3_days_macedonia, :required_supporting_documents_notary_public, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :download_and_fill_notice_and_affidavit_but_not_sign, :display_notice_of_marriage_7_days]
+      assert_phrase_list :consular_cni_os_start, [:contact_local_authorities_in_country_marriage, :get_legal_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :living_in_ceremony_country_3_days, :consular_cni_os_foreign_resident_3_days_macedonia, :required_supporting_documents_notary_public, :consular_cni_os_not_uk_resident_ceremony_not_germany, :evidence_if_divorced_outside_uk, :download_and_fill_notice_and_affidavit_but_not_sign, :display_notice_of_marriage_7_days]
     end
   end
 
@@ -1235,7 +1235,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "go to russia CNI outcome" do
       assert_current_node :outcome_os_consular_cni
-      assert_phrase_list :consular_cni_os_start, [:contact_local_authorities_in_country_marriage, :get_legal_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :russia_os_local_resident, "appointment_links.opposite_sex.russia", :required_supporting_documents_notary_public, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :download_and_fill_notice_and_affidavit_but_not_sign, :consular_cni_os_foreign_resident_ceremony_notary_public]
+      assert_phrase_list :consular_cni_os_start, [:contact_local_authorities_in_country_marriage, :get_legal_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :russia_os_local_resident, "appointment_links.opposite_sex.russia", :required_supporting_documents_notary_public, :consular_cni_os_not_uk_resident_ceremony_not_germany, :evidence_if_divorced_outside_uk, :download_and_fill_notice_and_affidavit_but_not_sign, :consular_cni_os_foreign_resident_ceremony_notary_public]
       assert_phrase_list :consular_cni_os_remainder, [:names_on_documents_must_match, :check_if_cni_needs_to_be_legalised, :no_need_to_stay_after_posting_notice, :partner_naturalisation_in_uk, :consular_cni_os_fees_incl_null_osta_oath_consular_letter, :link_to_consular_fees, :pay_by_mastercard_or_visa]
     end
   end
@@ -1467,7 +1467,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
       add_response 'partner_other'
       add_response 'opposite_sex'
       assert_current_node :outcome_os_consular_cni
-      assert_phrase_list :consular_cni_os_start, [:contact_local_authorities_in_country_marriage, :get_legal_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :arrange_cni_via_costa_rica, :embassies_data, :required_supporting_documents_incl_birth_cert, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :download_and_fill_notice_and_affidavit_but_not_sign, :display_notice_of_marriage_7_days]
+      assert_phrase_list :consular_cni_os_start, [:contact_local_authorities_in_country_marriage, :get_legal_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :arrange_cni_via_costa_rica, :embassies_data, :required_supporting_documents_incl_birth_cert, :consular_cni_os_not_uk_resident_ceremony_not_germany, :evidence_if_divorced_outside_uk, :download_and_fill_notice_and_affidavit_but_not_sign, :display_notice_of_marriage_7_days]
       assert_equal "British Embassy San Jose", current_state.organisation.title
     end
 
@@ -1590,7 +1590,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
 
       should "give CNI outcome when marrying to an opposite sex non-local partner" do
         assert_current_node :outcome_os_consular_cni
-        assert_phrase_list :consular_cni_os_start, [:japan_intro, :what_you_need_to_do, :you_may_be_asked_for_cni, :consular_cni_os_giving_notice_in_ceremony_country, :embassies_data, :japan_consular_cni_os_local_resident, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :download_and_fill_notice_and_affidavit_but_not_sign, :consular_cni_os_foreign_resident_ceremony_notary_public]
+        assert_phrase_list :consular_cni_os_start, [:japan_intro, :what_you_need_to_do, :you_may_be_asked_for_cni, :consular_cni_os_giving_notice_in_ceremony_country, :embassies_data, :japan_consular_cni_os_local_resident, :consular_cni_os_not_uk_resident_ceremony_not_germany, :evidence_if_divorced_outside_uk, :download_and_fill_notice_and_affidavit_but_not_sign, :consular_cni_os_foreign_resident_ceremony_notary_public]
         assert_phrase_list :consular_cni_os_remainder, [:names_on_documents_must_match, :check_if_cni_needs_to_be_legalised, :no_need_to_stay_after_posting_notice, :partner_naturalisation_in_uk, :consular_cni_os_fees_incl_null_osta_oath_consular_letter, :link_to_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
       end
     end
@@ -1957,7 +1957,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "go to outcome_os_consular_cni and show specific phraselist" do
       assert_current_node :outcome_os_consular_cni
-      assert_phrase_list :consular_cni_os_start, [:contact_local_authorities_in_country_marriage, :get_legal_advice, :what_you_need_to_do, :what_to_do_croatia, :consular_cni_os_local_resident_table, "appointment_links.opposite_sex.croatia", :required_supporting_documents_notary_public, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :download_and_fill_notice_and_affidavit_but_not_sign, :consular_cni_os_foreign_resident_ceremony_notary_public]
+      assert_phrase_list :consular_cni_os_start, [:contact_local_authorities_in_country_marriage, :get_legal_advice, :what_you_need_to_do, :what_to_do_croatia, :consular_cni_os_local_resident_table, "appointment_links.opposite_sex.croatia", :required_supporting_documents_notary_public, :consular_cni_os_not_uk_resident_ceremony_not_germany, :evidence_if_divorced_outside_uk, :download_and_fill_notice_and_affidavit_but_not_sign, :consular_cni_os_foreign_resident_ceremony_notary_public]
     end
   end
 
@@ -2276,7 +2276,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
       end
       should "lead to outcome_os_consular_cni with Greece-specific appoitnment link and document requirements" do
         assert_current_node :outcome_os_consular_cni
-        assert_phrase_list :consular_cni_os_start, [:contact_local_authorities_in_country_marriage, :get_legal_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :consular_cni_os_giving_notice_in_ceremony_country, :living_in_ceremony_country_3_days, "appointment_links.opposite_sex.greece", :required_supporting_documents_greece, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :download_and_fill_notice_and_affidavit_but_not_sign, :consular_cni_os_foreign_resident_ceremony_notary_public_greece]
+        assert_phrase_list :consular_cni_os_start, [:contact_local_authorities_in_country_marriage, :get_legal_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :consular_cni_os_giving_notice_in_ceremony_country, :living_in_ceremony_country_3_days, "appointment_links.opposite_sex.greece", :required_supporting_documents_greece, :consular_cni_os_not_uk_resident_ceremony_not_germany, :evidence_if_divorced_outside_uk, :download_and_fill_notice_and_affidavit_but_not_sign, :consular_cni_os_foreign_resident_ceremony_notary_public_greece]
       end
     end
   end
@@ -2573,7 +2573,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
       add_response 'opposite_sex'
       assert_current_node :outcome_os_consular_cni
 
-      assert_phrase_list :consular_cni_os_start,  [:contact_local_authorities_in_country_marriage, :get_legal_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :consular_cni_os_giving_notice_in_ceremony_country, :living_in_ceremony_country_3_days, :kazakhstan_os_local_resident, "appointment_links.opposite_sex.kyrgyzstan", :required_supporting_documents_notary_public, :consular_cni_os_not_uk_resident_ceremony_not_germany, :consular_cni_os_other_resident_ceremony_not_germany_or_spain, :download_and_fill_notice_and_affidavit_but_not_sign, :consular_cni_os_foreign_resident_ceremony_notary_public]
+      assert_phrase_list :consular_cni_os_start,  [:contact_local_authorities_in_country_marriage, :get_legal_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :consular_cni_os_giving_notice_in_ceremony_country, :living_in_ceremony_country_3_days, :kazakhstan_os_local_resident, "appointment_links.opposite_sex.kyrgyzstan", :required_supporting_documents_notary_public, :consular_cni_os_not_uk_resident_ceremony_not_germany, :evidence_if_divorced_outside_uk, :download_and_fill_notice_and_affidavit_but_not_sign, :consular_cni_os_foreign_resident_ceremony_notary_public]
       assert_phrase_list :consular_cni_os_remainder, [:same_cni_process_and_fees_for_partner, :names_on_documents_must_match, :check_if_cni_needs_to_be_legalised, :no_need_to_stay_after_posting_notice, :consular_cni_os_fees_incl_null_osta_oath_consular_letter, :list_of_consular_kazakhstan, :pay_in_local_currency_ceremony_in_kazakhstan]
     end
   end

--- a/test/integration/smart_answer_flows/marriage_abroad_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_test.rb
@@ -355,7 +355,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "go to consular cni os outcome" do
       assert_current_node :outcome_os_consular_cni
-      assert_phrase_list :consular_cni_os_start, [:contact_embassy_of_ceremony_country_in_uk_marriage, :get_legal_and_travel_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :cni_at_local_register_office, :legisation_and_translation_intro_uk, :legalise_translate_and_check_with_authorities]
+      assert_phrase_list :consular_cni_os_start, [:contact_embassy_of_ceremony_country_in_uk_marriage, :get_legal_and_travel_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :cni_at_local_register_office, :cni_issued_locally_validity, :legisation_and_translation_intro_uk, :legalise_translate_and_check_with_authorities]
       assert_phrase_list :consular_cni_os_remainder, [:same_cni_process_and_fees_for_partner, :names_on_documents_must_match, :consular_cni_os_fees_incl_null_osta_oath_consular_letter, :link_to_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
     end
   end
@@ -416,7 +416,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "go to consular cni os outcome" do
       assert_current_node :outcome_os_consular_cni
-      assert_phrase_list :consular_cni_os_start, [:italy_os_consular_cni_ceremony_italy, :what_you_need_to_do, :get_cni_from_uk, :partner_cni_requirements_the_same, :cni_at_local_register_office, :getting_statutory_declaration_for_italy_partner_british, :bilingual_statutory_declaration_download_for_italy, :legalising_italian_statutory_declaration]
+      assert_phrase_list :consular_cni_os_start, [:italy_os_consular_cni_ceremony_italy, :what_you_need_to_do, :get_cni_from_uk, :partner_cni_requirements_the_same, :cni_at_local_register_office, :cni_issued_locally_validity, :getting_statutory_declaration_for_italy_partner_british, :bilingual_statutory_declaration_download_for_italy, :legalising_italian_statutory_declaration]
       assert_phrase_list :consular_cni_os_remainder, [:names_on_documents_must_match]
     end
   end
@@ -506,7 +506,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "go to consular cni os outcome" do
       assert_current_node :outcome_os_consular_cni
-      assert_phrase_list :consular_cni_os_start, [:contact_embassy_of_ceremony_country_in_uk_marriage, :get_legal_and_travel_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :cni_at_local_register_office, :legisation_and_translation_intro_uk, :legalise_translate_and_check_with_authorities]
+      assert_phrase_list :consular_cni_os_start, [:contact_embassy_of_ceremony_country_in_uk_marriage, :get_legal_and_travel_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :cni_at_local_register_office, :cni_issued_locally_validity, :legisation_and_translation_intro_uk, :legalise_translate_and_check_with_authorities]
       assert_phrase_list :consular_cni_os_remainder, [:names_on_documents_must_match, :partner_naturalisation_in_uk, :consular_cni_os_fees_incl_null_osta_oath_consular_letter, :link_to_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
     end
   end
@@ -521,7 +521,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "go to consular cni os outcome" do
       assert_current_node :outcome_os_consular_cni
-      assert_phrase_list :consular_cni_os_start, [:contact_embassy_of_ceremony_country_in_uk_marriage, :get_legal_and_travel_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :cni_at_local_register_office, :legisation_and_translation_intro_uk, :legalise_translate_and_check_with_authorities]
+      assert_phrase_list :consular_cni_os_start, [:contact_embassy_of_ceremony_country_in_uk_marriage, :get_legal_and_travel_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :cni_at_local_register_office, :cni_issued_locally_validity, :legisation_and_translation_intro_uk, :legalise_translate_and_check_with_authorities]
       assert_phrase_list :consular_cni_os_remainder, [:names_on_documents_must_match, :partner_naturalisation_in_uk, :consular_cni_os_fees_incl_null_osta_oath_consular_letter, :link_to_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
     end
   end
@@ -536,7 +536,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     should "go to consular cni os outcome for opposite sex marriage" do
       add_response 'opposite_sex'
       assert_current_node :outcome_os_consular_cni
-      assert_phrase_list :consular_cni_os_start, [:contact_embassy_of_ceremony_country_in_uk_marriage, :get_legal_and_travel_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :cni_at_local_register_office, :legisation_and_translation_intro_uk, :legalise_translate_and_check_with_authorities]
+      assert_phrase_list :consular_cni_os_start, [:contact_embassy_of_ceremony_country_in_uk_marriage, :get_legal_and_travel_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :cni_at_local_register_office, :cni_issued_locally_validity, :legisation_and_translation_intro_uk, :legalise_translate_and_check_with_authorities]
       assert_phrase_list :consular_cni_os_remainder, [:names_on_documents_must_match, :partner_naturalisation_in_uk, :consular_cni_os_fees_incl_null_osta_oath_consular_letter, :link_to_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
     end
 
@@ -971,7 +971,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "go to consular cni os outcome" do
       assert_current_node :outcome_os_consular_cni
-      assert_phrase_list :consular_cni_os_start, [:contact_dutch_embassy_for_dutch_caribbean_islands, :get_legal_and_travel_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :cni_at_local_register_office, :legisation_and_translation_intro_uk, :legalise_translate_and_check_with_authorities]
+      assert_phrase_list :consular_cni_os_start, [:contact_dutch_embassy_for_dutch_caribbean_islands, :get_legal_and_travel_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :cni_at_local_register_office, :cni_issued_locally_validity, :legisation_and_translation_intro_uk, :legalise_translate_and_check_with_authorities]
       assert_phrase_list :consular_cni_os_remainder, [:names_on_documents_must_match, :partner_naturalisation_in_uk, :consular_cni_os_fees_incl_null_osta_oath_consular_letter]
     end
   end
@@ -1014,7 +1014,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "go to consular cni os outcome" do
       assert_current_node :outcome_os_consular_cni
-      assert_phrase_list :consular_cni_os_start, [:contact_embassy_of_ceremony_country_in_uk_marriage, :get_legal_and_travel_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :cni_at_local_register_office, :legisation_and_translation_intro_uk, :legalise_translate_and_check_with_authorities]
+      assert_phrase_list :consular_cni_os_start, [:contact_embassy_of_ceremony_country_in_uk_marriage, :get_legal_and_travel_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :cni_at_local_register_office, :cni_issued_locally_validity, :legisation_and_translation_intro_uk, :legalise_translate_and_check_with_authorities]
       assert_phrase_list :consular_cni_os_remainder, [:same_cni_process_and_fees_for_partner, :names_on_documents_must_match, :consular_cni_os_fees_incl_null_osta_oath_consular_letter]
       assert_state_variable :pay_by_cash_or_credit_card_no_cheque, nil
     end
@@ -1705,7 +1705,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     should "go to cni outcome" do
       assert_current_node :outcome_os_consular_cni
       assert_phrase_list :consular_cni_os_remainder, [:names_on_documents_must_match, :consular_cni_os_fees_incl_null_osta_oath_consular_letter, :link_to_consular_fees, :pay_in_euros_or_visa_electron]
-      assert_phrase_list :consular_cni_os_start, [:contact_embassy_of_ceremony_country_in_uk_marriage, :get_legal_and_travel_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :cni_at_local_register_office, :legalisation_and_translation_check_with_authorities, :legalise_translate_and_check_with_authorities]
+      assert_phrase_list :consular_cni_os_start, [:contact_embassy_of_ceremony_country_in_uk_marriage, :get_legal_and_travel_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :cni_at_local_register_office, :cni_issued_locally_validity, :legalisation_and_translation_check_with_authorities, :legalise_translate_and_check_with_authorities]
      end
   end
 
@@ -1720,7 +1720,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     should "go to cni outcome" do
       assert_current_node :outcome_os_consular_cni
       assert_phrase_list :consular_cni_os_remainder, [:names_on_documents_must_match, :partner_naturalisation_in_uk, :consular_cni_os_fees_incl_null_osta_oath_consular_letter, :link_to_consular_fees, :pay_in_euros_or_visa_electron]
-      assert_phrase_list :consular_cni_os_start, [:contact_embassy_of_ceremony_country_in_uk_marriage, :get_legal_and_travel_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :cni_at_local_register_office, :legalisation_and_translation_check_with_authorities, :legalise_translate_and_check_with_authorities]
+      assert_phrase_list :consular_cni_os_start, [:contact_embassy_of_ceremony_country_in_uk_marriage, :get_legal_and_travel_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :cni_at_local_register_office, :cni_issued_locally_validity, :legalisation_and_translation_check_with_authorities, :legalise_translate_and_check_with_authorities]
      end
   end
 
@@ -1749,7 +1749,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     should "go to outcome cni with specific fee table" do
       assert_current_node :outcome_os_consular_cni
       assert_phrase_list :consular_cni_os_remainder, [:callout_partner_equivalent_document, :names_on_documents_must_match, :partner_naturalisation_in_uk, :consular_cni_os_fees_incl_null_osta_oath_consular_letter, :link_to_consular_fees, :pay_in_euros_or_visa_electron]
-      assert_phrase_list :consular_cni_os_start, [:contact_embassy_of_ceremony_country_in_uk_marriage, :get_legal_and_travel_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :cni_at_local_register_office, :legalisation_and_translation_check_with_authorities, :legalise_translate_and_check_with_authorities]
+      assert_phrase_list :consular_cni_os_start, [:contact_embassy_of_ceremony_country_in_uk_marriage, :get_legal_and_travel_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :cni_at_local_register_office, :cni_issued_locally_validity, :legalisation_and_translation_check_with_authorities, :legalise_translate_and_check_with_authorities]
     end
   end
 
@@ -2138,7 +2138,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "show outcome_os_consular_cni" do
       assert_current_node :outcome_os_consular_cni
-      assert_phrase_list :consular_cni_os_start, [:contact_embassy_of_ceremony_country_in_uk_marriage, :get_legal_and_travel_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :cni_at_local_register_office, :legisation_and_translation_intro_uk, :legalise_translate_and_check_with_authorities]
+      assert_phrase_list :consular_cni_os_start, [:contact_embassy_of_ceremony_country_in_uk_marriage, :get_legal_and_travel_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :cni_at_local_register_office, :cni_issued_locally_validity, :legisation_and_translation_intro_uk, :legalise_translate_and_check_with_authorities]
       assert_phrase_list :consular_cni_os_remainder, [:same_cni_process_and_fees_for_partner, :names_on_documents_must_match, :consular_cni_os_fees_incl_null_osta_oath_consular_letter, :link_to_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
     end
   end
@@ -2153,7 +2153,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "show outcome_os_consular_cni" do
       assert_current_node :outcome_os_consular_cni
-      assert_phrase_list :consular_cni_os_start, [:contact_embassy_of_ceremony_country_in_uk_marriage, :get_legal_and_travel_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :cni_at_local_register_office, :legisation_and_translation_intro_uk, :legalise_translate_and_check_with_authorities]
+      assert_phrase_list :consular_cni_os_start, [:contact_embassy_of_ceremony_country_in_uk_marriage, :get_legal_and_travel_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :cni_at_local_register_office, :cni_issued_locally_validity, :legisation_and_translation_intro_uk, :legalise_translate_and_check_with_authorities]
       assert_phrase_list :consular_cni_os_remainder, [:same_cni_process_and_fees_for_partner, :names_on_documents_must_match, :consular_cni_os_fees_incl_null_osta_oath_consular_letter, :link_to_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
     end
   end
@@ -2294,7 +2294,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
     should "not include the links to download documents" do
       assert_current_node :outcome_os_consular_cni
-      assert_phrase_list :consular_cni_os_start, [:contact_embassy_of_ceremony_country_in_uk_marriage, :get_legal_and_travel_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :cni_at_local_register_office, :legisation_and_translation_intro_uk, :legalise_translate_and_check_with_authorities]
+      assert_phrase_list :consular_cni_os_start, [:contact_embassy_of_ceremony_country_in_uk_marriage, :get_legal_and_travel_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :cni_at_local_register_office, :cni_issued_locally_validity, :legisation_and_translation_intro_uk, :legalise_translate_and_check_with_authorities]
     end
   end
 
@@ -2533,7 +2533,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
       add_response 'partner_british'
       add_response 'opposite_sex'
       assert_current_node :outcome_os_consular_cni
-      assert_phrase_list :consular_cni_os_start, [:contact_embassy_of_ceremony_country_in_uk_marriage, :get_legal_and_travel_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :cni_at_local_register_office, :legisation_and_translation_intro_uk, :legalise_translate_and_check_with_authorities]
+      assert_phrase_list :consular_cni_os_start, [:contact_embassy_of_ceremony_country_in_uk_marriage, :get_legal_and_travel_advice, :what_you_need_to_do, :you_may_be_asked_for_cni, :cni_at_local_register_office, :cni_issued_locally_validity, :legisation_and_translation_intro_uk, :legalise_translate_and_check_with_authorities]
       assert_phrase_list :consular_cni_os_remainder, [:same_cni_process_and_fees_for_partner, :names_on_documents_must_match, :consular_cni_os_fees_incl_null_osta_oath_consular_letter, :link_to_consular_fees, :pay_by_cash_or_credit_card_no_cheque]
     end
 


### PR DESCRIPTION
Marriage abroad tool outcomes in Spain are getting a brand new custom outcome.

Technically Spain is a CNI country, however I have decided to create a new outcome for Spain as the majority of the phrases are Spain-specific. It used to be the case before as well, thus making the CNI outcome a bit convoluted (the other two most prominent culprits are Italy and Germany).

This is currently out for fact check.