### PR TITLE
Configure Mocha to prevent stubbing non-existent methods

### DIFF
--- a/lib/smart_answer/calculators/holiday_entitlement.rb
+++ b/lib/smart_answer/calculators/holiday_entitlement.rb
@@ -85,16 +85,25 @@ module SmartAnswer::Calculators
       number.to_s.sub(/\.0+$/, '')
     end
 
-    def method_missing(*args)
+    def method_missing(symbol, *args)
       # formatted_foo calls format_number on foo
-      if args.first.to_s =~ /\Aformatted_(.*)\z/
-        format_number(self.send($1.to_sym), args[1] || 1)
+      if formatting_method = formatting_method(symbol)
+        format_number(send(formatting_method), args.first || 1)
       else
         super
       end
     end
 
+    def respond_to?(symbol, include_all = false)
+      formatting_method(symbol).present?
+    end
+
   private
+
+    def formatting_method(symbol)
+      matches = symbol.to_s.match(/\Aformatted_(.*)\z/)
+      matches ? matches[1].to_sym : nil
+    end
 
     def leave_year_start_end
       if self.leave_year_start_date

--- a/test/data/calculate-your-holiday-entitlement-files.yml
+++ b/test/data/calculate-your-holiday-entitlement-files.yml
@@ -10,4 +10,4 @@ lib/smart_answer_flows/calculate-your-holiday-entitlement/compressed_hours_done.
 lib/smart_answer_flows/calculate-your-holiday-entitlement/days_per_week_done.govspeak.erb: 214a138b7dbedc186662ea2df1389864
 lib/smart_answer_flows/calculate-your-holiday-entitlement/hours_per_week_done.govspeak.erb: 096f7b9741d693cdab7295300b8cfa0d
 lib/smart_answer_flows/calculate-your-holiday-entitlement/shift_worker_done.govspeak.erb: 22ab0c04098de9e46ab3dc6207fb8756
-lib/smart_answer/calculators/holiday_entitlement.rb: ada0652ba9b2a4538e0ac2a6c09699d1
+lib/smart_answer/calculators/holiday_entitlement.rb: 790123490288361297bfb64099e84816

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,6 +15,7 @@ FLOW_REGISTRY_OPTIONS[:preload_flows] = true
 require 'rails/test_help'
 
 require 'mocha/setup'
+Mocha::Configuration.prevent(:stubbing_non_existent_method)
 
 require 'webmock/minitest'
 WebMock.disable_net_connect!(allow_localhost: true, net_http_connect_on_start: true)

--- a/test/unit/calculators/holiday_entitlement_test.rb
+++ b/test/unit/calculators/holiday_entitlement_test.rb
@@ -378,6 +378,9 @@ module SmartAnswer::Calculators
       # implemented with method_missing
       setup do
         @calc = HolidayEntitlement.new
+        class << @calc
+          def foo; end
+        end
       end
 
       should "return foo to 1 dp by default" do

--- a/test/unit/smartdown_adapter/presenter_test.rb
+++ b/test/unit/smartdown_adapter/presenter_test.rb
@@ -19,8 +19,8 @@ module SmartdownAdapter
       end
       context "an unstarted flow" do
         setup do
-          request = { started: false }
-          request.stubs(:query_parameters).returns({})
+          request = ActionDispatch::TestRequest.new
+          request[:started] = false
           @presenter = SmartdownAdapter::Presenter.new(@flow, request)
         end
         should "initialize sets internal state" do
@@ -32,8 +32,9 @@ module SmartdownAdapter
       end
       context "a started flow with a response" do
         setup do
-          request = { started: true, response: 'lion', params: "" }
-          request.stubs(:query_parameters).returns({})
+          request = ActionDispatch::TestRequest.new
+          request[:started] = true
+          request[:response] = 'lion'
           @presenter = SmartdownAdapter::Presenter.new(@flow, request)
         end
         should "initialize sets internal state" do
@@ -45,7 +46,10 @@ module SmartdownAdapter
       end
       context "a started flow with responses" do
         setup do
-          request = { started: true, responses: 'lion', params: "", next: "y" }
+          request = ActionDispatch::TestRequest.new
+          request[:started] = true
+          request[:responses] = 'lion'
+          request[:next] = 'y'
           request.stubs(:query_parameters).returns({ 'response_1' => "no" })
           @presenter = SmartdownAdapter::Presenter.new(@flow, request)
         end
@@ -58,7 +62,10 @@ module SmartdownAdapter
       end
       context "a flow with an empty response" do
         setup do
-          request = { started: true, responses: "lion", params: "", next: "y" }
+          request = ActionDispatch::TestRequest.new
+          request[:started] = true
+          request[:responses] = 'lion'
+          request[:next] = 'y'
           request.stubs(:query_parameters).returns({ "response_1" => "" })
           @presenter = SmartdownAdapter::Presenter.new(@flow, request)
         end

--- a/test/unit/test_helpers/flow_test_helper_test.rb
+++ b/test/unit/test_helpers/flow_test_helper_test.rb
@@ -15,7 +15,7 @@ class FlowTestHelperTest < ActiveSupport::TestCase
 
 
   test "caches current_state" do
-    flow = Object.new
+    flow = mock('flow')
     flow.expects(:process).once.returns(:state)
     includer = FlowTestHelperIncluder.new(flow, [:yes, :no])
     includer.current_state
@@ -23,7 +23,7 @@ class FlowTestHelperTest < ActiveSupport::TestCase
   end
 
   test "busts current_state cache when responses change" do
-    flow = Object.new
+    flow = mock('flow')
     flow.expects(:process).twice.returns(:state)
     responses = [:yes, :no]
     includer = FlowTestHelperIncluder.new(flow, responses)


### PR DESCRIPTION
I wanted to enable [this option](http://gofreerange.com/mocha/docs/Mocha/Configuration.html) in the tests I'm adding for a new smart answer, but it seems more sensible to enable it for *all* tests rather than just the ones I'm working on.

The commits in this PR fix a few tests that failed when I enabled the option. The final commit enables the option.