### PR TITLE
Add 6 week deadline for sending supporting documents

### DIFF
--- a/lib/smart_answer_flows/overseas-passports.rb
+++ b/lib/smart_answer_flows/overseas-passports.rb
@@ -109,10 +109,6 @@ module SmartAnswer
           passport_data['optimistic_processing_time?']
         end
 
-        calculate :incomplete_deadline_countries do
-          %w(afghanistan australia austria bahrain bangladesh barbados belgium brazil canada china denmark egypt ethiopia finland france germany ghana greece hong-kong india indonesia iraq ireland israel italy jamaica japan kenya lebanon malawi malaysia netherlands new-zealand nigeria norway pakistan philippines portugal qatar russia saudi-arabia sierra-leone singapore south-africa spain sri-lanka sudan sweden switzerland thailand trinidad-and-tobago turkey uganda united-arab-emirates usa venezuela vietnam zambia zimbabwe)
-        end
-
         next_node :child_or_adult_passport?
       end
 

--- a/lib/smart_answer_flows/overseas-passports/ips_application_result.govspeak.erb
+++ b/lib/smart_answer_flows/overseas-passports/ips_application_result.govspeak.erb
@@ -148,9 +148,7 @@
     <% end %>
   <% end %>
 
-  <% if incomplete_deadline_countries.include?(current_location) %>
-    %You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
-  <% end %>
+  %You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
   <% uk_visa_application_centre_countries = %w(afghanistan algeria azerbaijan bangladesh belarus burundi burma china gaza georgia india indonesia kazakhstan kyrgyzstan laos lebanon mauritania morocco nepal pakistan russia tajikistan thailand turkmenistan ukraine uzbekistan western-sahara vietnam venezuela) %>
   <% uk_visa_application_with_colour_pictures = %w(azerbaijan algeria bangladesh belarus burma china georgia india indonesia kazakhstan kyrgyzstan laos lebanon mauritania morocco nepal pakistan tajikistan thailand turkmenistan ukraine uzbekistan russia vietnam venezuela western-sahara) %>

--- a/lib/smart_answer_flows/overseas-passports/ips_application_result_online.govspeak.erb
+++ b/lib/smart_answer_flows/overseas-passports/ips_application_result_online.govspeak.erb
@@ -94,9 +94,7 @@
 
   [Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
 
-  <% if incomplete_deadline_countries.include?(current_location) %>
-    %You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
-  <% end %>
+  %You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
   ## Getting your passport
 

--- a/test/artefacts/overseas-passports/algeria/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/algeria/applying/adult/afghanistan.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/algeria/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/algeria/applying/adult/south-africa.txt
@@ -43,6 +43,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/algeria/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/algeria/applying/child/afghanistan.txt
@@ -41,6 +41,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/algeria/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/algeria/applying/child/south-africa.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/algeria/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/algeria/renewing_new/adult.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/algeria/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/algeria/renewing_new/child.txt
@@ -41,6 +41,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/algeria/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/algeria/renewing_old/adult/afghanistan.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/algeria/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/algeria/renewing_old/adult/south-africa.txt
@@ -43,6 +43,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/algeria/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/algeria/renewing_old/child/afghanistan.txt
@@ -41,6 +41,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/algeria/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/algeria/renewing_old/child/south-africa.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/algeria/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/algeria/replacing/adult.txt
@@ -44,6 +44,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/algeria/replacing/child.txt
+++ b/test/artefacts/overseas-passports/algeria/replacing/child.txt
@@ -43,6 +43,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/american-samoa/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/american-samoa/applying/adult/afghanistan.txt
@@ -41,6 +41,7 @@ You will need to print, sign and post your declaration form at the end.
 
 [Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 ## Getting your passport
 

--- a/test/artefacts/overseas-passports/american-samoa/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/american-samoa/applying/adult/south-africa.txt
@@ -42,6 +42,7 @@ You will need to print, sign and post your declaration form at the end.
 
 [Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 ## Getting your passport
 

--- a/test/artefacts/overseas-passports/american-samoa/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/american-samoa/applying/child/afghanistan.txt
@@ -40,6 +40,7 @@ You will need to print, sign and post your declaration form at the end.
 
 [Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 ## Getting your passport
 

--- a/test/artefacts/overseas-passports/american-samoa/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/american-samoa/applying/child/south-africa.txt
@@ -41,6 +41,7 @@ You will need to print, sign and post your declaration form at the end.
 
 [Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 ## Getting your passport
 

--- a/test/artefacts/overseas-passports/american-samoa/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/american-samoa/renewing_new/adult.txt
@@ -41,6 +41,7 @@ You will need to print, sign and post your declaration form at the end.
 
 [Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 ## Getting your passport
 

--- a/test/artefacts/overseas-passports/american-samoa/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/american-samoa/renewing_new/child.txt
@@ -40,6 +40,7 @@ You will need to print, sign and post your declaration form at the end.
 
 [Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 ## Getting your passport
 

--- a/test/artefacts/overseas-passports/american-samoa/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/american-samoa/renewing_old/adult/afghanistan.txt
@@ -41,6 +41,7 @@ You will need to print, sign and post your declaration form at the end.
 
 [Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 ## Getting your passport
 

--- a/test/artefacts/overseas-passports/american-samoa/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/american-samoa/renewing_old/adult/south-africa.txt
@@ -42,6 +42,7 @@ You will need to print, sign and post your declaration form at the end.
 
 [Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 ## Getting your passport
 

--- a/test/artefacts/overseas-passports/american-samoa/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/american-samoa/renewing_old/child/afghanistan.txt
@@ -40,6 +40,7 @@ You will need to print, sign and post your declaration form at the end.
 
 [Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 ## Getting your passport
 

--- a/test/artefacts/overseas-passports/american-samoa/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/american-samoa/renewing_old/child/south-africa.txt
@@ -41,6 +41,7 @@ You will need to print, sign and post your declaration form at the end.
 
 [Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 ## Getting your passport
 

--- a/test/artefacts/overseas-passports/american-samoa/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/american-samoa/replacing/adult.txt
@@ -41,6 +41,7 @@ You will need to print, sign and post your declaration form at the end.
 
 [Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 ## Getting your passport
 

--- a/test/artefacts/overseas-passports/american-samoa/replacing/child.txt
+++ b/test/artefacts/overseas-passports/american-samoa/replacing/child.txt
@@ -40,6 +40,7 @@ You will need to print, sign and post your declaration form at the end.
 
 [Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 ## Getting your passport
 

--- a/test/artefacts/overseas-passports/benin/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/benin/applying/adult/afghanistan.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Send your application

--- a/test/artefacts/overseas-passports/benin/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/benin/applying/adult/south-africa.txt
@@ -43,6 +43,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Send your application

--- a/test/artefacts/overseas-passports/benin/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/benin/applying/child/afghanistan.txt
@@ -41,6 +41,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Send your application

--- a/test/artefacts/overseas-passports/benin/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/benin/applying/child/south-africa.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Send your application

--- a/test/artefacts/overseas-passports/benin/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/benin/renewing_new/adult.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Send your application

--- a/test/artefacts/overseas-passports/benin/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/benin/renewing_new/child.txt
@@ -41,6 +41,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Send your application

--- a/test/artefacts/overseas-passports/benin/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/benin/renewing_old/adult/afghanistan.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Send your application

--- a/test/artefacts/overseas-passports/benin/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/benin/renewing_old/adult/south-africa.txt
@@ -43,6 +43,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Send your application

--- a/test/artefacts/overseas-passports/benin/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/benin/renewing_old/child/afghanistan.txt
@@ -41,6 +41,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Send your application

--- a/test/artefacts/overseas-passports/benin/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/benin/renewing_old/child/south-africa.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Send your application

--- a/test/artefacts/overseas-passports/benin/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/benin/replacing/adult.txt
@@ -44,6 +44,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Send your application

--- a/test/artefacts/overseas-passports/benin/replacing/child.txt
+++ b/test/artefacts/overseas-passports/benin/replacing/child.txt
@@ -43,6 +43,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Send your application

--- a/test/artefacts/overseas-passports/burundi/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/burundi/applying/adult/afghanistan.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/burundi/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/burundi/applying/adult/south-africa.txt
@@ -43,6 +43,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/burundi/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/burundi/applying/child/afghanistan.txt
@@ -41,6 +41,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/burundi/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/burundi/applying/child/south-africa.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/burundi/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/burundi/renewing_new/adult.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/burundi/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/burundi/renewing_new/child.txt
@@ -41,6 +41,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/burundi/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/burundi/renewing_old/adult/afghanistan.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/burundi/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/burundi/renewing_old/adult/south-africa.txt
@@ -43,6 +43,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/burundi/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/burundi/renewing_old/child/afghanistan.txt
@@ -41,6 +41,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/burundi/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/burundi/renewing_old/child/south-africa.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/burundi/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/burundi/replacing/adult.txt
@@ -44,6 +44,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/burundi/replacing/child.txt
+++ b/test/artefacts/overseas-passports/burundi/replacing/child.txt
@@ -43,6 +43,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/cambodia/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/cambodia/applying/adult/afghanistan.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/cambodia/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/cambodia/applying/adult/south-africa.txt
@@ -43,6 +43,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/cambodia/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/cambodia/applying/child/afghanistan.txt
@@ -41,6 +41,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/cambodia/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/cambodia/applying/child/south-africa.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/cambodia/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/cambodia/renewing_new/adult.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/cambodia/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/cambodia/renewing_new/child.txt
@@ -41,6 +41,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/cambodia/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/cambodia/renewing_old/adult/afghanistan.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/cambodia/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/cambodia/renewing_old/adult/south-africa.txt
@@ -43,6 +43,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/cambodia/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/cambodia/renewing_old/child/afghanistan.txt
@@ -41,6 +41,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/cambodia/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/cambodia/renewing_old/child/south-africa.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/cambodia/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/cambodia/replacing/adult.txt
@@ -44,6 +44,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/cambodia/replacing/child.txt
+++ b/test/artefacts/overseas-passports/cambodia/replacing/child.txt
@@ -43,6 +43,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/cuba/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/cuba/applying/adult/afghanistan.txt
@@ -38,6 +38,7 @@ You must pay in cash using local currency - the prices above will be converted a
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/cuba/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/cuba/applying/adult/south-africa.txt
@@ -39,6 +39,7 @@ You must pay in cash using local currency - the prices above will be converted a
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/cuba/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/cuba/applying/child/afghanistan.txt
@@ -37,6 +37,7 @@ You must pay in cash using local currency - the prices above will be converted a
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/cuba/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/cuba/applying/child/south-africa.txt
@@ -38,6 +38,7 @@ You must pay in cash using local currency - the prices above will be converted a
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/cuba/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/cuba/renewing_new/adult.txt
@@ -38,6 +38,7 @@ You must pay in cash using local currency - the prices above will be converted a
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-2)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/cuba/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/cuba/renewing_new/child.txt
@@ -37,6 +37,7 @@ You must pay in cash using local currency - the prices above will be converted a
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-2)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/cuba/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/cuba/renewing_old/adult/afghanistan.txt
@@ -38,6 +38,7 @@ You must pay in cash using local currency - the prices above will be converted a
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/cuba/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/cuba/renewing_old/adult/south-africa.txt
@@ -39,6 +39,7 @@ You must pay in cash using local currency - the prices above will be converted a
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/cuba/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/cuba/renewing_old/child/afghanistan.txt
@@ -37,6 +37,7 @@ You must pay in cash using local currency - the prices above will be converted a
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/cuba/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/cuba/renewing_old/child/south-africa.txt
@@ -38,6 +38,7 @@ You must pay in cash using local currency - the prices above will be converted a
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/cuba/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/cuba/replacing/adult.txt
@@ -40,6 +40,7 @@ You must pay in cash using local currency - the prices above will be converted a
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-2)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/cuba/replacing/child.txt
+++ b/test/artefacts/overseas-passports/cuba/replacing/child.txt
@@ -39,6 +39,7 @@ You must pay in cash using local currency - the prices above will be converted a
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-2)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/falkland-islands/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/falkland-islands/applying/adult/afghanistan.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/falkland-islands/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/falkland-islands/applying/adult/south-africa.txt
@@ -43,6 +43,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/falkland-islands/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/falkland-islands/applying/child/afghanistan.txt
@@ -41,6 +41,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/falkland-islands/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/falkland-islands/applying/child/south-africa.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/falkland-islands/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/falkland-islands/renewing_new/adult.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-applications-supporting-documents-guidance)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/falkland-islands/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/falkland-islands/renewing_new/child.txt
@@ -41,6 +41,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-applications-supporting-documents-guidance)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/falkland-islands/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/falkland-islands/renewing_old/adult/afghanistan.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/falkland-islands/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/falkland-islands/renewing_old/adult/south-africa.txt
@@ -43,6 +43,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/falkland-islands/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/falkland-islands/renewing_old/child/afghanistan.txt
@@ -41,6 +41,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/falkland-islands/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/falkland-islands/renewing_old/child/south-africa.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/falkland-islands/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/falkland-islands/replacing/adult.txt
@@ -43,6 +43,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-applications-supporting-documents-guidance)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/falkland-islands/replacing/child.txt
+++ b/test/artefacts/overseas-passports/falkland-islands/replacing/child.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-applications-supporting-documents-guidance)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/laos/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/laos/applying/adult/afghanistan.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/laos/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/laos/applying/adult/south-africa.txt
@@ -43,6 +43,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/laos/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/laos/applying/child/afghanistan.txt
@@ -41,6 +41,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/laos/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/laos/applying/child/south-africa.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/laos/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/laos/renewing_new/adult.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/laos/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/laos/renewing_new/child.txt
@@ -41,6 +41,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/laos/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/laos/renewing_old/adult/afghanistan.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/laos/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/laos/renewing_old/adult/south-africa.txt
@@ -43,6 +43,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/laos/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/laos/renewing_old/child/afghanistan.txt
@@ -41,6 +41,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/laos/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/laos/renewing_old/child/south-africa.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/laos/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/laos/replacing/adult.txt
@@ -44,6 +44,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/laos/replacing/child.txt
+++ b/test/artefacts/overseas-passports/laos/replacing/child.txt
@@ -43,6 +43,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/pitcairn-island/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/pitcairn-island/applying/adult/afghanistan.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/pitcairn-island/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/pitcairn-island/applying/adult/south-africa.txt
@@ -43,6 +43,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/pitcairn-island/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/pitcairn-island/applying/child/afghanistan.txt
@@ -41,6 +41,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/pitcairn-island/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/pitcairn-island/applying/child/south-africa.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/pitcairn-island/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/pitcairn-island/renewing_new/adult.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-applications-supporting-documents-guidance)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/pitcairn-island/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/pitcairn-island/renewing_new/child.txt
@@ -41,6 +41,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-applications-supporting-documents-guidance)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/pitcairn-island/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/pitcairn-island/renewing_old/adult/afghanistan.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/pitcairn-island/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/pitcairn-island/renewing_old/adult/south-africa.txt
@@ -43,6 +43,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/pitcairn-island/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/pitcairn-island/renewing_old/child/afghanistan.txt
@@ -41,6 +41,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/pitcairn-island/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/pitcairn-island/renewing_old/child/south-africa.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/pitcairn-island/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/pitcairn-island/replacing/adult.txt
@@ -44,6 +44,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-applications-supporting-documents-guidance)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/pitcairn-island/replacing/child.txt
+++ b/test/artefacts/overseas-passports/pitcairn-island/replacing/child.txt
@@ -43,6 +43,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-applications-supporting-documents-guidance)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/st-helena-ascension-and-tristan-da-cunha/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/st-helena-ascension-and-tristan-da-cunha/applying/adult/afghanistan.txt
@@ -36,6 +36,7 @@ You must pay in cash. In addition to the passport fee you’ll need to pay any l
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/st-helena-ascension-and-tristan-da-cunha/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/st-helena-ascension-and-tristan-da-cunha/applying/adult/south-africa.txt
@@ -37,6 +37,7 @@ You must pay in cash. In addition to the passport fee you’ll need to pay any l
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/st-helena-ascension-and-tristan-da-cunha/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/st-helena-ascension-and-tristan-da-cunha/applying/child/afghanistan.txt
@@ -35,6 +35,7 @@ You must pay in cash. In addition to the passport fee you’ll need to pay any l
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/st-helena-ascension-and-tristan-da-cunha/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/st-helena-ascension-and-tristan-da-cunha/applying/child/south-africa.txt
@@ -36,6 +36,7 @@ You must pay in cash. In addition to the passport fee you’ll need to pay any l
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/st-helena-ascension-and-tristan-da-cunha/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/st-helena-ascension-and-tristan-da-cunha/renewing_new/adult.txt
@@ -36,6 +36,7 @@ You must pay in cash. In addition to the passport fee you’ll need to pay any l
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-applications-supporting-documents-guidance)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/st-helena-ascension-and-tristan-da-cunha/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/st-helena-ascension-and-tristan-da-cunha/renewing_new/child.txt
@@ -35,6 +35,7 @@ You must pay in cash. In addition to the passport fee you’ll need to pay any l
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-applications-supporting-documents-guidance)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/st-helena-ascension-and-tristan-da-cunha/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/st-helena-ascension-and-tristan-da-cunha/renewing_old/adult/afghanistan.txt
@@ -36,6 +36,7 @@ You must pay in cash. In addition to the passport fee you’ll need to pay any l
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/st-helena-ascension-and-tristan-da-cunha/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/st-helena-ascension-and-tristan-da-cunha/renewing_old/adult/south-africa.txt
@@ -37,6 +37,7 @@ You must pay in cash. In addition to the passport fee you’ll need to pay any l
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/st-helena-ascension-and-tristan-da-cunha/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/st-helena-ascension-and-tristan-da-cunha/renewing_old/child/afghanistan.txt
@@ -35,6 +35,7 @@ You must pay in cash. In addition to the passport fee you’ll need to pay any l
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/st-helena-ascension-and-tristan-da-cunha/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/st-helena-ascension-and-tristan-da-cunha/renewing_old/child/south-africa.txt
@@ -36,6 +36,7 @@ You must pay in cash. In addition to the passport fee you’ll need to pay any l
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/st-helena-ascension-and-tristan-da-cunha/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/st-helena-ascension-and-tristan-da-cunha/replacing/adult.txt
@@ -38,6 +38,7 @@ You must pay in cash. In addition to the passport fee you’ll need to pay any l
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-applications-supporting-documents-guidance)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/st-helena-ascension-and-tristan-da-cunha/replacing/child.txt
+++ b/test/artefacts/overseas-passports/st-helena-ascension-and-tristan-da-cunha/replacing/child.txt
@@ -37,6 +37,7 @@ You must pay in cash. In addition to the passport fee you’ll need to pay any l
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-applications-supporting-documents-guidance)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/st-martin/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/st-martin/applying/adult/afghanistan.txt
@@ -41,6 +41,7 @@ You will need to print, sign and post your declaration form at the end.
 
 [Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 ## Getting your passport
 

--- a/test/artefacts/overseas-passports/st-martin/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/st-martin/applying/adult/south-africa.txt
@@ -42,6 +42,7 @@ You will need to print, sign and post your declaration form at the end.
 
 [Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 ## Getting your passport
 

--- a/test/artefacts/overseas-passports/st-martin/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/st-martin/applying/child/afghanistan.txt
@@ -40,6 +40,7 @@ You will need to print, sign and post your declaration form at the end.
 
 [Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 ## Getting your passport
 

--- a/test/artefacts/overseas-passports/st-martin/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/st-martin/applying/child/south-africa.txt
@@ -41,6 +41,7 @@ You will need to print, sign and post your declaration form at the end.
 
 [Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 ## Getting your passport
 

--- a/test/artefacts/overseas-passports/st-martin/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/st-martin/renewing_new/adult.txt
@@ -41,6 +41,7 @@ You will need to print, sign and post your declaration form at the end.
 
 [Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 ## Getting your passport
 

--- a/test/artefacts/overseas-passports/st-martin/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/st-martin/renewing_new/child.txt
@@ -40,6 +40,7 @@ You will need to print, sign and post your declaration form at the end.
 
 [Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 ## Getting your passport
 

--- a/test/artefacts/overseas-passports/st-martin/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/st-martin/renewing_old/adult/afghanistan.txt
@@ -41,6 +41,7 @@ You will need to print, sign and post your declaration form at the end.
 
 [Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 ## Getting your passport
 

--- a/test/artefacts/overseas-passports/st-martin/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/st-martin/renewing_old/adult/south-africa.txt
@@ -42,6 +42,7 @@ You will need to print, sign and post your declaration form at the end.
 
 [Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 ## Getting your passport
 

--- a/test/artefacts/overseas-passports/st-martin/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/st-martin/renewing_old/child/afghanistan.txt
@@ -40,6 +40,7 @@ You will need to print, sign and post your declaration form at the end.
 
 [Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 ## Getting your passport
 

--- a/test/artefacts/overseas-passports/st-martin/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/st-martin/renewing_old/child/south-africa.txt
@@ -41,6 +41,7 @@ You will need to print, sign and post your declaration form at the end.
 
 [Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 ## Getting your passport
 

--- a/test/artefacts/overseas-passports/st-martin/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/st-martin/replacing/adult.txt
@@ -41,6 +41,7 @@ You will need to print, sign and post your declaration form at the end.
 
 [Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 ## Getting your passport
 

--- a/test/artefacts/overseas-passports/st-martin/replacing/child.txt
+++ b/test/artefacts/overseas-passports/st-martin/replacing/child.txt
@@ -40,6 +40,7 @@ You will need to print, sign and post your declaration form at the end.
 
 [Start your application on Her Majesty’s Passport Office website](https://passportapplication.service.gov.uk/)
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 ## Getting your passport
 

--- a/test/artefacts/overseas-passports/tajikistan/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/tajikistan/applying/adult/afghanistan.txt
@@ -43,6 +43,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/tajikistan/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/tajikistan/applying/adult/south-africa.txt
@@ -44,6 +44,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/tajikistan/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/tajikistan/applying/child/afghanistan.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/tajikistan/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/tajikistan/applying/child/south-africa.txt
@@ -43,6 +43,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/tajikistan/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/tajikistan/renewing_new/adult.txt
@@ -43,6 +43,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/tajikistan/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/tajikistan/renewing_new/child.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/tajikistan/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/tajikistan/renewing_old/adult/afghanistan.txt
@@ -43,6 +43,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/tajikistan/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/tajikistan/renewing_old/adult/south-africa.txt
@@ -44,6 +44,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/tajikistan/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/tajikistan/renewing_old/child/afghanistan.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/tajikistan/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/tajikistan/renewing_old/child/south-africa.txt
@@ -43,6 +43,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/tajikistan/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/tajikistan/replacing/adult.txt
@@ -45,6 +45,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/tajikistan/replacing/child.txt
+++ b/test/artefacts/overseas-passports/tajikistan/replacing/child.txt
@@ -44,6 +44,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/applying/adult/afghanistan.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/applying/adult/south-africa.txt
@@ -43,6 +43,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/applying/child/afghanistan.txt
@@ -41,6 +41,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/applying/child/south-africa.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/renewing_new/adult.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-applications-supporting-documents-guidance)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/renewing_new/child.txt
@@ -41,6 +41,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-applications-supporting-documents-guidance)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/renewing_old/adult/afghanistan.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/renewing_old/adult/south-africa.txt
@@ -43,6 +43,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/renewing_old/child/afghanistan.txt
@@ -41,6 +41,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/renewing_old/child/south-africa.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/replacing/adult.txt
@@ -44,6 +44,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-applications-supporting-documents-guidance)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/replacing/child.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/gaza/replacing/child.txt
@@ -43,6 +43,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-applications-supporting-documents-guidance)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/applying/adult/afghanistan.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Send your application

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/applying/adult/south-africa.txt
@@ -43,6 +43,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Send your application

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/applying/child/afghanistan.txt
@@ -41,6 +41,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Send your application

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/applying/child/south-africa.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Send your application

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/renewing_new/adult.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-applications-supporting-documents-guidance)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Send your application

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/renewing_new/child.txt
@@ -41,6 +41,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-applications-supporting-documents-guidance)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Send your application

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/renewing_old/adult/afghanistan.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Send your application

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/renewing_old/adult/south-africa.txt
@@ -43,6 +43,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Send your application

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/renewing_old/child/afghanistan.txt
@@ -41,6 +41,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Send your application

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/renewing_old/child/south-africa.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Send your application

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/replacing/adult.txt
@@ -43,6 +43,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-applications-supporting-documents-guidance)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Send your application

--- a/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/replacing/child.txt
+++ b/test/artefacts/overseas-passports/the-occupied-palestinian-territories/jerusalem-or-westbank/replacing/child.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-applications-supporting-documents-guidance)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Send your application

--- a/test/artefacts/overseas-passports/timor-leste/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/timor-leste/applying/adult/afghanistan.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/timor-leste/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/timor-leste/applying/adult/south-africa.txt
@@ -43,6 +43,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/timor-leste/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/timor-leste/applying/child/afghanistan.txt
@@ -41,6 +41,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/timor-leste/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/timor-leste/applying/child/south-africa.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/timor-leste/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/timor-leste/renewing_new/adult.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/timor-leste/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/timor-leste/renewing_new/child.txt
@@ -41,6 +41,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/timor-leste/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/timor-leste/renewing_old/adult/afghanistan.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/timor-leste/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/timor-leste/renewing_old/adult/south-africa.txt
@@ -43,6 +43,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/timor-leste/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/timor-leste/renewing_old/child/afghanistan.txt
@@ -41,6 +41,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/timor-leste/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/timor-leste/renewing_old/child/south-africa.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/timor-leste/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/timor-leste/replacing/adult.txt
@@ -44,6 +44,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/timor-leste/replacing/child.txt
+++ b/test/artefacts/overseas-passports/timor-leste/replacing/child.txt
@@ -43,6 +43,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/western-sahara/applying/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/western-sahara/applying/adult/afghanistan.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/western-sahara/applying/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/western-sahara/applying/adult/south-africa.txt
@@ -43,6 +43,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/western-sahara/applying/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/western-sahara/applying/child/afghanistan.txt
@@ -41,6 +41,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/western-sahara/applying/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/western-sahara/applying/child/south-africa.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/western-sahara/renewing_new/adult.txt
+++ b/test/artefacts/overseas-passports/western-sahara/renewing_new/adult.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/western-sahara/renewing_new/child.txt
+++ b/test/artefacts/overseas-passports/western-sahara/renewing_new/child.txt
@@ -41,6 +41,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/western-sahara/renewing_old/adult/afghanistan.txt
+++ b/test/artefacts/overseas-passports/western-sahara/renewing_old/adult/afghanistan.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/western-sahara/renewing_old/adult/south-africa.txt
+++ b/test/artefacts/overseas-passports/western-sahara/renewing_old/adult/south-africa.txt
@@ -43,6 +43,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/western-sahara/renewing_old/child/afghanistan.txt
+++ b/test/artefacts/overseas-passports/western-sahara/renewing_old/child/afghanistan.txt
@@ -41,6 +41,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/western-sahara/renewing_old/child/south-africa.txt
+++ b/test/artefacts/overseas-passports/western-sahara/renewing_old/child/south-africa.txt
@@ -42,6 +42,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 
 ^You must include your Vault birth certificate with your application – a photocopy won’t be accepted.^
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/western-sahara/replacing/adult.txt
+++ b/test/artefacts/overseas-passports/western-sahara/replacing/adult.txt
@@ -44,6 +44,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/artefacts/overseas-passports/western-sahara/replacing/child.txt
+++ b/test/artefacts/overseas-passports/western-sahara/replacing/child.txt
@@ -43,6 +43,7 @@ You can use Mastercard, Visa, Electron, Diners Club and JCB.
 ^[Supporting documents you must send with your application](/government/publications/overseas-passport-supporting-documents-group-3)^
 
 
+%You must include all your supporting documents with your application. You’ll get 6 weeks to provide any that are missing. Your application will be cancelled and you won’t get a refund if you don’t provide them in time.%
 
 
 ## Making your application

--- a/test/data/overseas-passports-files.yml
+++ b/test/data/overseas-passports-files.yml
@@ -1,5 +1,5 @@
 --- 
-lib/smart_answer_flows/overseas-passports.rb: e7b6eb4414fde9d4248ebd3c0b4df577
+lib/smart_answer_flows/overseas-passports.rb: a411122229c4205a3de5c9c9d850ad6b
 lib/smart_answer_flows/locales/en/overseas-passports.yml: 818310a24be17db580977c560c009265
 test/data/overseas-passports-questions-and-responses.yml: dc6c103245cab8e2f33aee73d7c46556
 test/data/overseas-passports-responses-and-expected-results.yml: 13d8f1d2d9ac2d996e8f337702593417
@@ -21,8 +21,8 @@ lib/smart_answer_flows/overseas-passports/_send_application_non_uk_visa_apply_re
 lib/smart_answer_flows/overseas-passports/_send_application_non_uk_visa_renew_new_colour.govspeak.erb: b0b1ef521ee34bfe78ae23da7952c9e1
 lib/smart_answer_flows/overseas-passports/apply_in_neighbouring_country.govspeak.erb: 15cd9b890f53c2158637042249abcf1c
 lib/smart_answer_flows/overseas-passports/cannot_apply.govspeak.erb: 7dd7460c2cb988931e7d354ddd122e4d
-lib/smart_answer_flows/overseas-passports/ips_application_result.govspeak.erb: 44b0254e9f6002129c5dc99f56c90e81
-lib/smart_answer_flows/overseas-passports/ips_application_result_online.govspeak.erb: 83fcafeb75a2dc447f4d8b12de839638
+lib/smart_answer_flows/overseas-passports/ips_application_result.govspeak.erb: 836b3e86e1fb1fe96bc7a31eface3974
+lib/smart_answer_flows/overseas-passports/ips_application_result_online.govspeak.erb: 1a477e722a84a78e0f003085c5c2f726
 lib/smart_answer/overseas_passports_helper.rb: 07df4cd921e62464c2dc9534b4d8cdf8
 lib/smart_answer_flows/data_partials/_overseas_passports_embassies.erb: 2f521bae99c2f48b49d07bcb283a8063
 lib/smart_answer/calculators/passport_and_embassy_data_query.rb: ae758ea00c73edec5e7b3e6432a645b1


### PR DESCRIPTION
The deadline used to apply to a certain list of countries, now it applies to all countries, except for the ones where you can't use the service. There are handled by non IPS outcomes.