### PR TITLE
Fail regression tests if new outcome files are generated

### DIFF
--- a/test/regression/smart_answers_regression_test.rb
+++ b/test/regression/smart_answers_regression_test.rb
@@ -107,8 +107,8 @@ class SmartAnswersRegressionTest < ActionController::TestCase
       end
 
       should "#{RUN_ME_LAST} and generate the same set of output files" do
-        diff_output = `git diff --stat -- #{smart_answer_helper.path_to_outputs_for_flow}`
-        assert diff_output.blank?, "Unexpected difference in outputs for flow:\n#{diff_output}"
+        diff_output = `git status --short -- #{smart_answer_helper.path_to_outputs_for_flow}`
+        assert diff_output.blank?, "Changes in outcome page artefacts have been detected:\n#{diff_output}\nIf these changes are expected then re-generate the checksums, re-run the regression test, and commit all the changes."
       end
     end
   end


### PR DESCRIPTION
Currently the tests fail if outcome files have been removed or changed. This
is because `git diff --stat` is used in the implementation. `git diff` does not
list untracked files.

~~This commit adds a check for newly generated outcome files using
`git ls-files --others --exclude-standard -- <path>`~~

~~git ls-files shows information about files in the index and the working tree
--others shows other (i.e. untracked) files in the output
--exclude-standard adds the standard Git exclusions: .git/info/exclude,
.gitignore in each directory, and the user’s global exclusion file.~~

~~The original request suggests that the test failure should help point out what you need to do with the removed/changed/added files. What would be the best thing to advise?~~

This commit adds a check for newly generated outcome files using
`git status --short -- <path>` and explains what needs to be done to resolve
this test failure.

```
Changes in outcome page artefacts have been detected:
<git status --short output>
If these changes are expected then re-generate the checksums, re-run the regression test, and commit all the changes.
```


