### PR TITLE
Change the way Certificate of freesale can be legalised

### DIFF
--- a/lib/data/legalisation_documents_data.yml
+++ b/lib/data/legalisation_documents_data.yml
@@ -30,7 +30,7 @@ certificate-of-incorporation:
 certificate-of-freesale:
   heading: Certificate of freesale
   type: certificate of freesale
-  group: government_companies
+  group: certificate_of_freesale
 certificate-of-memorandum:
   heading: Certificate of memorandum
   type: certificate of memorandum

--- a/lib/smart_answer_flows/legalisation-document-checker/outcome_results.govspeak.erb
+++ b/lib/smart_answer_flows/legalisation-document-checker/outcome_results.govspeak.erb
@@ -88,6 +88,15 @@
       - certified
 
       ^A photocopy of your document can be legalised, but it must be certified.^
+    <% when 'certificate_of_freesale' %>
+      ##<%= heading %>
+      Your <%= type %> can only be legalised if either:
+
+      - it’s been signed by an official from the issuing authority
+      - it says ‘signature valid’ next to a tick
+      - it’s certified
+
+      ^A photocopy of your document can be legalised, but it must be certified.^
     <% when 'marriage_document' %>
       ##<%= heading %>
 

--- a/test/artefacts/legalisation-document-checker/certificate-of-freesale.txt
+++ b/test/artefacts/legalisation-document-checker/certificate-of-freesale.txt
@@ -1,0 +1,40 @@
+
+
+##Certificate of freesale
+Your certificate of freesale can only be legalised if either:
+
+- it’s been signed by an official from the issuing authority
+- it says ‘signature valid’ next to a tick
+- it’s certified
+
+^A photocopy of your document can be legalised, but it must be certified.^
+
+##Certifying documents
+
+If you provide a certified document, it must be certified in the UK by a solicitor or ‘notary public’.
+
+When the solicitor or notary public signs the document, they must:
+
+- note the type of certification they have done (eg the document is a true copy of the original)
+- use their personal signature, not a company signature
+- include the date of certification
+- include their company address
+
+If they add a notarial certificate, it must be attached to the document. The certificate must also  contain a specific reference to the document they have certified.
+
+If a notary public from England, Wales or Northern Ireland signs a document for legalisation, they must also stamp or emboss the document with their notarial seal.
+
+You can find:
+
+- [solicitors in England and Wales](http://www.lawsociety.org.uk/home.law)
+
+- [notaries public in England and Wales](http://www.facultyoffice.org.uk/notary/find-a-notary/)
+
+- [solicitors and notaries public in Scotland](http://www.lawscot.org.uk/)
+
+- [solicitors and notaries public in Northern Ireland](http://www.lawsoc-ni.org/)
+
+##Get your documents legalised
+
+You can [get your documents legalised](/get-document-legalised) by the Legalisation Office if they meet the standards above.
+

--- a/test/data/legalisation-document-checker-files.yml
+++ b/test/data/legalisation-document-checker-files.yml
@@ -1,8 +1,8 @@
 --- 
 lib/smart_answer_flows/legalisation-document-checker.rb: 14b4efc9ab0774ae55ffe26ad65b5755
 lib/smart_answer_flows/locales/en/legalisation-document-checker.yml: 04490ae627332eeb5c83a769e10c6496
-test/data/legalisation-document-checker-questions-and-responses.yml: 4837cd9c9064d026e9a2b343b8d1a475
-test/data/legalisation-document-checker-responses-and-expected-results.yml: 8d683093a2b1a4839ca33235639175f9
-lib/smart_answer_flows/legalisation-document-checker/outcome_results.govspeak.erb: 3ec34b0285eaf60f9a12d1a17e28be88
+test/data/legalisation-document-checker-questions-and-responses.yml: 37c99c68ba04e459447622b01938ce0b
+test/data/legalisation-document-checker-responses-and-expected-results.yml: a6de7673704ef7ff4348546128f52b75
+lib/smart_answer_flows/legalisation-document-checker/outcome_results.govspeak.erb: 00c464b05564abf1824e3da37bca1d24
 lib/smart_answer/calculators/legalisation_documents_data_query.rb: 31d5eec29a4cf4e27a4204e8f08132f9
-lib/data/legalisation_documents_data.yml: 8438e7aa64db7ac8f8cb23ba9b84ed83
+lib/data/legalisation_documents_data.yml: 788f0f6cbd9b35be712f9aca7c871591

--- a/test/data/legalisation-document-checker-questions-and-responses.yml
+++ b/test/data/legalisation-document-checker-questions-and-responses.yml
@@ -1,5 +1,5 @@
---- 
-:which_documents_do_you_want_legalised?: 
+---
+:which_documents_do_you_want_legalised?:
 - acro-police-certificate # police_disclosure
 - affidavit # solicitors_notaries
 - articles-of-association # government_companies
@@ -12,3 +12,4 @@
 - marriage-certificate # marriage_document
 - passport-copy-only # solicitors_notaries_copy_passport
 - pet-export-document # vet_health
+- certificate-of-freesale # its own certificate_of_freesale group

--- a/test/data/legalisation-document-checker-responses-and-expected-results.yml
+++ b/test/data/legalisation-document-checker-responses-and-expected-results.yml
@@ -59,3 +59,8 @@
   - pet-export-document
   :next_node: :outcome_results
   :outcome_node: true
+- :current_node: :which_documents_do_you_want_legalised?
+  :responses: 
+  - certificate-of-freesale
+  :next_node: :outcome_results
+  :outcome_node: true


### PR DESCRIPTION
BIS have informed us that these certificates are no longer signed but must bear the “Signature Valid” text along with a “Tick” on the certificate.

Rules have changed for this document only, so I had to create a new "group" for it. Not sure it's the least confusing way of making this change.