### PR TITLE
Reduce unicorn workers from 6 to 4

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -3,4 +3,4 @@ def load_file_if_exists(config, file)
 end
 load_file_if_exists(self, "/etc/govuk/unicorn.rb")
 working_directory File.dirname(File.dirname(__FILE__))
-worker_processes 6
+worker_processes 4


### PR DESCRIPTION
On our new environment with slightly less powerful CPUs we see smartanswers maxing out the 4 CPUs on the machine.

This problem can be mitigated by increasing the number of CPUs from 4 to 8, but only if the number of unicorn workers is reduced at the same time.

If necessary we'll build a 4th calculators-frontend machine to account for the workers that will be lost from this change.

/cc @jennyd @joshmyers @alphagov/team-infrastructure-admins 