### PR TITLE
Preload entire app before forking Unicorn workers.

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -4,3 +4,6 @@ end
 load_file_if_exists(self, "/etc/govuk/unicorn.rb")
 working_directory File.dirname(File.dirname(__FILE__))
 worker_processes 4
+
+# Load application in master process before forking workers
+preload_app true


### PR DESCRIPTION
smart-answers is CPU hungry, especially during app
startup. It's preloading the answers and some of
them take a long time to load. We have seen an
issue where application was slow to start.

Setting this to true reduces the start up time for
starting up the Unicorn worker processes. This
uses CoW to preload the application before forking
other worker processes. However, there is a big
gotcha. We must take special care that any sockets
(such as database connections) are properly closed
and reopened. We do this using before_fork and
after_fork.