### PR TITLE
Simplify FlowTestHelper#setup_for_testing_flow method

### DIFF
--- a/lib/smart_answer_flows/README.md
+++ b/lib/smart_answer_flows/README.md
@@ -224,7 +224,7 @@ You used to need to use nested contexts/tests in order to test Ruby/YAML Smart A
 This test passes using the example flow above.
 
     setup do
-      setup_for_testing_flow 'example-flow'
+      setup_for_testing_flow SmartAnswer::ExampleFlow
     end
 
     should "be on question 1" do
@@ -266,7 +266,7 @@ This test passes using the example flow above.
 The same test as above in a flattened form. It passes using the example flow above.
 
     should "exercise the example flow" do
-      setup_for_testing_flow 'example-flow'
+      setup_for_testing_flow SmartAnswer::ExampleFlow
 
       assert_current_node :question_1
       add_response :A

--- a/test/integration/smart_answer_flows/calculate_redundancy_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_redundancy_pay_test.rb
@@ -2,6 +2,7 @@ require_relative '../../test_helper'
 require_relative 'flow_test_helper'
 
 require "smart_answer_flows/calculate-employee-redundancy-pay"
+require "smart_answer_flows/calculate-your-redundancy-pay"
 
 class CalculateRedundancyPayTest < ActiveSupport::TestCase
   include FlowTestHelper
@@ -240,7 +241,7 @@ class CalculateRedundancyPayTest < ActiveSupport::TestCase
 
   context "Employee" do
     setup do
-      setup_for_testing_flow 'calculate-your-redundancy-pay'
+      setup_for_testing_flow SmartAnswer::CalculateYourRedundancyPayFlow
     end
 
     should "ask when you were made redundant" do

--- a/test/integration/smart_answer_flows/check_uk_visa_test.rb
+++ b/test/integration/smart_answer_flows/check_uk_visa_test.rb
@@ -313,7 +313,7 @@ class CheckUkVisaTest < ActiveSupport::TestCase
       end
       context "Chinese passport" do
         setup do
-          setup_for_testing_flow 'check-uk-visa'
+          reset_responses
           add_response "china"
           add_response "tourism"
         end
@@ -331,7 +331,7 @@ class CheckUkVisaTest < ActiveSupport::TestCase
       end
       context "Oman passport" do
         setup do
-          setup_for_testing_flow 'check-uk-visa'
+          reset_responses
           add_response "oman"
           add_response "school"
         end
@@ -381,7 +381,7 @@ class CheckUkVisaTest < ActiveSupport::TestCase
       end
       context "Venezuelan passport" do
         setup do
-          setup_for_testing_flow 'check-uk-visa'
+          reset_responses
           add_response "venezuela"
           add_response "transit"
         end

--- a/test/integration/smart_answer_flows/flow_test_helper.rb
+++ b/test/integration/smart_answer_flows/flow_test_helper.rb
@@ -1,10 +1,6 @@
 module FlowTestHelper
-  def setup_for_testing_flow(flow_slug_or_class)
-    if flow_slug_or_class.is_a?(String)
-      @flow = SmartAnswer::FlowRegistry.instance.find(flow_slug_or_class)
-    else
-      @flow = flow_slug_or_class.build
-    end
+  def setup_for_testing_flow(klass)
+    @flow = klass.build
     reset_responses
   end
 

--- a/test/integration/smart_answer_flows/flow_test_helper.rb
+++ b/test/integration/smart_answer_flows/flow_test_helper.rb
@@ -5,6 +5,10 @@ module FlowTestHelper
     else
       @flow = flow_slug_or_class.build
     end
+    reset_responses
+  end
+
+  def reset_responses
     @responses = []
   end
 

--- a/test/integration/smart_answer_flows/marriage_abroad_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_test.rb
@@ -2,6 +2,8 @@ require_relative '../../test_helper'
 require_relative 'flow_test_helper'
 require 'gds_api/test_helpers/worldwide'
 
+require 'smart_answer_flows/marriage-abroad'
+
 class MarriageAbroadTest < ActiveSupport::TestCase
   include FlowTestHelper
   include GdsApi::TestHelpers::Worldwide
@@ -16,7 +18,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
   setup do
     @location_slugs = (OS_COUNTRIES_WITH_APPOINTMENTS + SS_COUNTRIES_WITH_APPOINTMENTS + %w(albania american-samoa anguilla argentina armenia aruba australia austria azerbaijan bahamas belarus belgium bonaire-st-eustatius-saba brazil british-indian-ocean-territory burma burundi cambodia canada china costa-rica cote-d-ivoire croatia colombia cyprus czech-republic denmark ecuador egypt estonia finland france germany greece hong-kong indonesia iran ireland italy japan jordan kazakhstan kosovo laos latvia lebanon lithuania macedonia malta mayotte mexico monaco morocco netherlands nicaragua north-korea oman guatemala paraguay peru philippines poland portugal qatar russia rwanda saint-barthelemy san-marino saudi-arabia serbia seychelles slovakia south-africa st-maarten st-martin south-korea spain sweden switzerland thailand turkey turkmenistan united-arab-emirates usa uzbekistan vietnam wallis-and-futuna yemen zimbabwe)).uniq
     worldwide_api_has_locations(@location_slugs)
-    setup_for_testing_flow 'marriage-abroad'
+    setup_for_testing_flow SmartAnswer::MarriageAbroadFlow
   end
 
   should "which country you want the ceremony to take place in" do


### PR DESCRIPTION
This finishes off the conversion to directly instantiate flows in all integration tests rather than looking them up in the registry.