### PR TITLE
UK-issued CNI is now accepted by Greek town halls

### DIFF
--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -644,6 +644,10 @@ en-GB:
 
         tunisia_legalisation_and_translation: |
           You’ll need to exchange your UK-issued CNI for one that’s valid in Tunisia at the nearest British embassy to where you’re getting married.
+        uk_cni_accepted_in_townhall: |
+          Your UK-issued CNI should be accepted by the town hall.
+
+          You should also check if it needs to be:
         legisation_and_translation_intro_uk: |
           ###Legalisation and translation
 

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -696,6 +696,9 @@ module SmartAnswer
               phrases << :consular_cni_os_uk_resident_montenegro
             elsif %w(finland kazakhstan kyrgyzstan poland).include?(ceremony_country)
               phrases << :legalisation_and_translation_check_with_authorities
+            elsif ceremony_country == 'greece'
+              phrases << :legalisation_and_translation
+              phrases << :uk_cni_accepted_in_townhall
             elsif %w(italy).exclude?(ceremony_country)
               phrases << :legisation_and_translation_intro_uk
             end

--- a/test/artefacts/marriage-abroad/greece/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/greece/uk/partner_british/opposite_sex.txt
@@ -19,7 +19,8 @@ You can normally get a CNI by giving a notice of marriage at your local register
 
 ###Legalisation and translation
 
-You might need to exchange your UK-issued CNI for one that’s valid in Greece at the nearest embassy or consulate to where you’re getting married.
+
+Your UK-issued CNI should be accepted by the town hall.
 
 You should also check if it needs to be:
 

--- a/test/artefacts/marriage-abroad/greece/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/greece/uk/partner_local/opposite_sex.txt
@@ -19,7 +19,8 @@ You can normally get a CNI by giving a notice of marriage at your local register
 
 ###Legalisation and translation
 
-You might need to exchange your UK-issued CNI for one that’s valid in Greece at the nearest embassy or consulate to where you’re getting married.
+
+Your UK-issued CNI should be accepted by the town hall.
 
 You should also check if it needs to be:
 

--- a/test/artefacts/marriage-abroad/greece/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/greece/uk/partner_other/opposite_sex.txt
@@ -19,7 +19,8 @@ You can normally get a CNI by giving a notice of marriage at your local register
 
 ###Legalisation and translation
 
-You might need to exchange your UK-issued CNI for one that’s valid in Greece at the nearest embassy or consulate to where you’re getting married.
+
+Your UK-issued CNI should be accepted by the town hall.
 
 You should also check if it needs to be:
 

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -1,6 +1,6 @@
 --- 
-lib/smart_answer_flows/marriage-abroad.rb: 8808a524e477045b5a0467f2c478c30c
-lib/smart_answer_flows/locales/en/marriage-abroad.yml: 874cbc28f13517442c8d785249c12fbd
+lib/smart_answer_flows/marriage-abroad.rb: 5a6dba66d1b702a17b0e5a0b91b1d6aa
+lib/smart_answer_flows/locales/en/marriage-abroad.yml: 65395f8271ce9dc197f2ddaed4be4908
 test/data/marriage-abroad-questions-and-responses.yml: eabbd09ca91fab72a9a520d1087fb35e
 test/data/marriage-abroad-responses-and-expected-results.yml: e2a77265651bd20a9892bde75f375e82
 lib/smart_answer_flows/data_partials/_overseas_passports_embassies.erb: 2f521bae99c2f48b49d07bcb283a8063


### PR DESCRIPTION
The Greek Ministry has now agreed for Greek Town Halls to accept the Domestic
CNI issued by the UK Superintendent Registrar for marriage in Greece without
it having to be exchanged by FCO.

There is a very high volume of British nationals who marry in Greece over the
summer. This is a significant change and users should be notified that the
extra financial cost of exchanging the CNI is no longer needed.

@chrisroos unfortunately this will cause you some merge conflicts :(