### PR TITLE
Consistently use synonyms_of_cp_in_nnn phrase

### DIFF
--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -1300,7 +1300,7 @@ en-GB:
           - ’union civile’, or ’civil union’ (in Quebec)
         synonyms_of_cp_in_new-zealand: |
           You may be able to get married or enter into a ‘civil union’ at the British embassy or consulate in New Zealand. Civil unions are recognised as civil partnerships under British law.
-        synonyms_of_cp_in_south_africa: |
+        synonyms_of_cp_in_south-africa: |
           Same-sex relationships in South Africa that are recognised as civil partnerships under British law are known as:
 
           - marriage

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -1348,7 +1348,7 @@ module SmartAnswer
 
         precalculate :commonwealth_countries_cp_outcome do
           phrases = PhraseList.new
-          phrases << "synonyms_of_cp_in_#{ceremony_country}".gsub('-', '_').to_sym
+          phrases << :"synonyms_of_cp_in_#{ceremony_country}"
 
           if resident_of == 'uk'
             phrases << :contact_high_comission_of_ceremony_country_in_uk_cp

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -1,6 +1,6 @@
 ---
-lib/smart_answer_flows/marriage-abroad.rb: 89bebd8c6d50ce9ce6dbc17d5db7a3fa
-lib/smart_answer_flows/locales/en/marriage-abroad.yml: 94947d71e6b90dca614b0947be813d24
+lib/smart_answer_flows/marriage-abroad.rb: 2caf364cd97a3ba2c5bb64343368ea17
+lib/smart_answer_flows/locales/en/marriage-abroad.yml: 77f39955be691a492eb72ca7538545eb
 test/data/marriage-abroad-questions-and-responses.yml: eabbd09ca91fab72a9a520d1087fb35e
 test/data/marriage-abroad-responses-and-expected-results.yml: 74f923c5f929e369f4c9a9f0b47ffcc7
 lib/smart_answer_flows/data_partials/_overseas_passports_embassies.erb: 2f521bae99c2f48b49d07bcb283a8063


### PR DESCRIPTION
The naming of multi-word countries in the `synonyms_of_cp_in_NNN` phrases was
inconsistent. Some used hyphens and one ('south-africa') used an underscore. In
addition, three outcomes were doing `:"synonyms_of_cp_in_#{ceremony_country}"`,
while one was converting hyphens to underscores
(`"synonyms_of_cp_in_#{ceremony_country}".gsub('-', '_').to_sym`).

I've renamed `synonyms_of_cp_in_south_africa` to
`synonyms_of_cp_in_south-africa` in the YAML file and removed the special case
of replacing hyphens with underscores in the
`outcome_cp_commonwealth_countries` outcome.