### PR TITLE
Further disambiguation of marriage in Spain process

### DIFF
--- a/lib/smart_answer_flows/locales/en/marriage-abroad.yml
+++ b/lib/smart_answer_flows/locales/en/marriage-abroad.yml
@@ -571,11 +571,11 @@ en-GB:
 
           You must sign the notice of marriage and affirmation in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you send your application to the consulate.
 
-          Send all the documents and fee by registered post to the address in the application pack.
+          Send all the documents by registered post to the address in the application pack.
 
           ###What happens next
 
-          The consulate will check your forms and documents. Once everything is approved, they’ll take your payment and display your notice of marriage for 7 days. If nobody raises an objection, they’ll then issue your CNI and send it to you with your supporting documents by registered post.
+          The consulate will check your forms and documents. Once everything is approved, they’ll take your payment and display your notice of marriage for 7 days. If nobody raises an objection, they’ll then issue your CNI and send it to you with your original documents by registered post.
 
           It takes 10 working days after payment for the consulate to process your application.
         get_maritial_status_certificate_spain: |

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_british/opposite_sex.txt
@@ -41,11 +41,11 @@ $D
 
 You must sign the notice of marriage and affirmation in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you send your application to the consulate.
 
-Send all the documents and fee by registered post to the address in the application pack.
+Send all the documents by registered post to the address in the application pack.
 
 ###What happens next
 
-The consulate will check your forms and documents. Once everything is approved, they’ll take your payment and display your notice of marriage for 7 days. If nobody raises an objection, they’ll then issue your CNI and send it to you with your supporting documents by registered post.
+The consulate will check your forms and documents. Once everything is approved, they’ll take your payment and display your notice of marriage for 7 days. If nobody raises an objection, they’ll then issue your CNI and send it to you with your original documents by registered post.
 
 It takes 10 working days after payment for the consulate to process your application.
 

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_british/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_british/same_sex.txt
@@ -41,11 +41,11 @@ $D
 
 You must sign the notice of marriage and affirmation in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you send your application to the consulate.
 
-Send all the documents and fee by registered post to the address in the application pack.
+Send all the documents by registered post to the address in the application pack.
 
 ###What happens next
 
-The consulate will check your forms and documents. Once everything is approved, they’ll take your payment and display your notice of marriage for 7 days. If nobody raises an objection, they’ll then issue your CNI and send it to you with your supporting documents by registered post.
+The consulate will check your forms and documents. Once everything is approved, they’ll take your payment and display your notice of marriage for 7 days. If nobody raises an objection, they’ll then issue your CNI and send it to you with your original documents by registered post.
 
 It takes 10 working days after payment for the consulate to process your application.
 

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_local/opposite_sex.txt
@@ -41,11 +41,11 @@ $D
 
 You must sign the notice of marriage and affirmation in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you send your application to the consulate.
 
-Send all the documents and fee by registered post to the address in the application pack.
+Send all the documents by registered post to the address in the application pack.
 
 ###What happens next
 
-The consulate will check your forms and documents. Once everything is approved, they’ll take your payment and display your notice of marriage for 7 days. If nobody raises an objection, they’ll then issue your CNI and send it to you with your supporting documents by registered post.
+The consulate will check your forms and documents. Once everything is approved, they’ll take your payment and display your notice of marriage for 7 days. If nobody raises an objection, they’ll then issue your CNI and send it to you with your original documents by registered post.
 
 It takes 10 working days after payment for the consulate to process your application.
 

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_local/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_local/same_sex.txt
@@ -41,11 +41,11 @@ $D
 
 You must sign the notice of marriage and affirmation in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you send your application to the consulate.
 
-Send all the documents and fee by registered post to the address in the application pack.
+Send all the documents by registered post to the address in the application pack.
 
 ###What happens next
 
-The consulate will check your forms and documents. Once everything is approved, they’ll take your payment and display your notice of marriage for 7 days. If nobody raises an objection, they’ll then issue your CNI and send it to you with your supporting documents by registered post.
+The consulate will check your forms and documents. Once everything is approved, they’ll take your payment and display your notice of marriage for 7 days. If nobody raises an objection, they’ll then issue your CNI and send it to you with your original documents by registered post.
 
 It takes 10 working days after payment for the consulate to process your application.
 

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_other/opposite_sex.txt
@@ -41,11 +41,11 @@ $D
 
 You must sign the notice of marriage and affirmation in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you send your application to the consulate.
 
-Send all the documents and fee by registered post to the address in the application pack.
+Send all the documents by registered post to the address in the application pack.
 
 ###What happens next
 
-The consulate will check your forms and documents. Once everything is approved, they’ll take your payment and display your notice of marriage for 7 days. If nobody raises an objection, they’ll then issue your CNI and send it to you with your supporting documents by registered post.
+The consulate will check your forms and documents. Once everything is approved, they’ll take your payment and display your notice of marriage for 7 days. If nobody raises an objection, they’ll then issue your CNI and send it to you with your original documents by registered post.
 
 It takes 10 working days after payment for the consulate to process your application.
 

--- a/test/artefacts/marriage-abroad/spain/ceremony_country/partner_other/same_sex.txt
+++ b/test/artefacts/marriage-abroad/spain/ceremony_country/partner_other/same_sex.txt
@@ -41,11 +41,11 @@ $D
 
 You must sign the notice of marriage and affirmation in front of a local [notary public](http://www.notaries-directory.eu/) in Spain before you send your application to the consulate.
 
-Send all the documents and fee by registered post to the address in the application pack.
+Send all the documents by registered post to the address in the application pack.
 
 ###What happens next
 
-The consulate will check your forms and documents. Once everything is approved, they’ll take your payment and display your notice of marriage for 7 days. If nobody raises an objection, they’ll then issue your CNI and send it to you with your supporting documents by registered post.
+The consulate will check your forms and documents. Once everything is approved, they’ll take your payment and display your notice of marriage for 7 days. If nobody raises an objection, they’ll then issue your CNI and send it to you with your original documents by registered post.
 
 It takes 10 working days after payment for the consulate to process your application.
 

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -1,6 +1,6 @@
 --- 
 lib/smart_answer_flows/marriage-abroad.rb: 89bebd8c6d50ce9ce6dbc17d5db7a3fa
-lib/smart_answer_flows/locales/en/marriage-abroad.yml: 61b86b978fc1ff985c1d113bf1848628
+lib/smart_answer_flows/locales/en/marriage-abroad.yml: 4563927852203e8c83c3590aa2771894
 test/data/marriage-abroad-questions-and-responses.yml: eabbd09ca91fab72a9a520d1087fb35e
 test/data/marriage-abroad-responses-and-expected-results.yml: 74f923c5f929e369f4c9a9f0b47ffcc7
 lib/smart_answer_flows/data_partials/_overseas_passports_embassies.erb: 2f521bae99c2f48b49d07bcb283a8063


### PR DESCRIPTION
In addition to fb5ba0d more references to 'sending fees' need to be removed as
it may be confusing, and in addition to 3c0b933 'supporting' documents need to
be replaced with 'original' documents to make it clear what needs to be sent.

Unfortunately the mentioned commits are in master already, so I can't rebase.