### PR TITLE
Add regression test support for Smartdown flows

### DIFF
--- a/lib/smart_answer_files.rb
+++ b/lib/smart_answer_files.rb
@@ -10,10 +10,18 @@ class SmartAnswerFiles
     relative_paths.map(&:to_s).uniq
   end
 
+  def existing_paths
+    @existing_paths ||= paths.select { |path| File.exist?(path) }
+  end
+
+  def empty?
+    existing_paths.empty?
+  end
+
   private
 
   def relative_paths
-    all_paths.collect do |path|
+    @relative_paths ||= all_paths.collect do |path|
       path.relative_path_from(Rails.root)
     end
   end
@@ -24,16 +32,28 @@ class SmartAnswerFiles
       locale_path,
       questions_and_responses_test_data_path,
       responses_and_expected_results_test_data_path
-    ] + erb_template_paths + additional_files_absolute_paths
+    ] + erb_template_paths + smartdown_file_paths + additional_files_absolute_paths
   end
 
   def erb_template_directory
     Rails.root.join('lib', 'smart_answer_flows', @flow_name)
   end
 
+  def smartdown_flows_directory
+    Rails.root.join('lib', 'smartdown_flows', @flow_name)
+  end
+
   def erb_template_paths
     Dir[erb_template_directory.join('*.erb')].collect do |path|
       Pathname.new(path)
+    end
+  end
+
+  def smartdown_file_paths
+    ['outcomes/*.txt', 'questions/*.txt', 'snippets/*.txt', '*.txt'].flat_map do |pattern|
+      Dir[smartdown_flows_directory.join(pattern)].collect do |path|
+        Pathname.new(path)
+      end
     end
   end
 

--- a/lib/smart_answer_test_helper.rb
+++ b/lib/smart_answer_test_helper.rb
@@ -136,7 +136,7 @@ class SmartAnswerTestHelper
     checksum_data = read_files_checksums
     known_smart_answer_files = checksum_data.keys
     detected_smart_answer_files = SmartAnswerFiles.new(@flow_name)
-    unknown_files = detected_smart_answer_files.paths - known_smart_answer_files
+    unknown_files = detected_smart_answer_files.existing_paths - known_smart_answer_files
     unknown_files.any?
   end
 end

--- a/lib/smartdown_adapter/node_presenter.rb
+++ b/lib/smartdown_adapter/node_presenter.rb
@@ -8,16 +8,16 @@ module SmartdownAdapter
       @smartdown_node = smartdown_node
     end
 
-    def body
-      @smartdown_node.body && markdown_to_html(@smartdown_node.body)
+    def body(html: true)
+      render(@smartdown_node.body, html: html)
     end
 
     def post_body
       @smartdown_node.post_body && markdown_to_html(@smartdown_node.post_body)
     end
 
-    def next_steps
-      @smartdown_node.next_steps && markdown_to_html(@smartdown_node.next_steps)
+    def next_steps(html: true)
+      render(@smartdown_node.next_steps, html: html)
     end
 
     def has_body?
@@ -38,9 +38,13 @@ module SmartdownAdapter
 
   private
 
-    def markdown_to_html markdown
-      Govspeak::Document.new(markdown).to_html.html_safe
+    def render(smartdown, html:)
+      return unless smartdown
+      html ? markdown_to_html(smartdown) : smartdown
     end
 
+    def markdown_to_html(markdown)
+      Govspeak::Document.new(markdown).to_html.html_safe
+    end
   end
 end

--- a/script/generate-checksums-for-smart-answer.rb
+++ b/script/generate-checksums-for-smart-answer.rb
@@ -14,7 +14,9 @@ end
 additional_flow_file_paths = ARGV + existing_additional_flow_file_paths
 flow_files = SmartAnswerFiles.new(flow_name, *additional_flow_file_paths)
 
-hasher = SmartAnswerHasher.new(flow_files.paths)
+abort "No files detected, did you misspell the smartanswer name? (#{flow_name})" if flow_files.empty?
+
+hasher = SmartAnswerHasher.new(flow_files.existing_paths)
 
 flow_helper.write_files_checksum(hasher)
 

--- a/script/generate-questions-and-responses-for-smartdown-flow.rb
+++ b/script/generate-questions-and-responses-for-smartdown-flow.rb
@@ -1,0 +1,35 @@
+unless flow_name = ARGV.shift
+  puts "Usage: #{__FILE__} <flow-name>"
+  exit 1
+end
+
+smart_answer_helper = SmartAnswerTestHelper.new(flow_name)
+
+flow = SmartdownAdapter::Registry.instance.find(flow_name)
+questions_and_responses = {}
+unknown_questions = []
+
+flow.question_pages.each do |question|
+  question.questions.each do |question|
+    if question.is_a?(Smartdown::Api::MultipleChoice)
+      questions_and_responses[question.name] = question.options.map(&:value)
+    else
+      warn "Don't know how to handle questions of type: #{question.class} (Question: #{question.name})"
+
+      questions_and_responses[question.name] = [
+        "TODO: #{question.title}"
+      ]
+      unknown_questions << [question.name, question.title]
+    end
+  end
+end
+
+smart_answer_helper.write_questions_and_responses(questions_and_responses)
+
+puts "Questions and responses written to: #{smart_answer_helper.question_and_responses_path}"
+if unknown_questions.any?
+  puts "You'll need to manually add responses for:"
+  unknown_questions.each do |(question_name, question_text)|
+    puts "* #{question_text} (#{question_name})"
+  end
+end

--- a/script/generate-responses-and-expected-results-for-smartdown-flow.rb
+++ b/script/generate-responses-and-expected-results-for-smartdown-flow.rb
@@ -1,0 +1,51 @@
+require 'timecop'
+
+Timecop.freeze(Date.parse('2015-01-01'))
+
+unless flow_name = ARGV.shift
+  puts "Usage: #{__FILE__} <flow-name>"
+  exit 1
+end
+
+smart_answer_helper = SmartAnswerTestHelper.new(flow_name)
+
+questions_and_responses_path = smart_answer_helper.question_and_responses_path
+unless File.exists?(questions_and_responses_path)
+  puts "Questions and responses file doesn't exist."
+  puts "Generate it using the generate-responses-for-smart-answer script."
+  exit 1
+end
+
+questions_and_responses_yaml = File.read(questions_and_responses_path)
+QUESTIONS_AND_RESPONSES = YAML.load(questions_and_responses_yaml)
+
+flow = SmartdownAdapter::Registry.instance.find(flow_name)
+RESPONSES_AND_EXPECTED_RESULTS = []
+
+def answer_question(flow, state)
+  question_name      = state.current_node.questions.first.name # This will break when there are multiple questions per page
+  existing_responses = state.accepted_responses
+
+  QUESTIONS_AND_RESPONSES[question_name].each do |response|
+    responses = existing_responses + [response]
+    state     = flow.state(started = true, responses)
+    next_node = state.current_node
+
+    RESPONSES_AND_EXPECTED_RESULTS << {
+      current_node: question_name,
+      responses: responses.map(&:to_s),
+      next_node: next_node.name,
+      outcome_node: next_node.is_a?(Smartdown::Api::Outcome)
+    }
+
+    unless next_node.is_a?(Smartdown::Api::Outcome) #|| state.error
+      answer_question(flow, state)
+    end
+  end
+end
+
+state = flow.state(started = true, responses = [])
+answer_question(flow, state)
+
+smart_answer_helper.write_responses_and_expected_results(RESPONSES_AND_EXPECTED_RESULTS)
+puts "Responses and expected results written to #{smart_answer_helper.responses_and_expected_results_path}"

--- a/test/regression/smart_answers_regression_test.rb
+++ b/test/regression/smart_answers_regression_test.rb
@@ -76,7 +76,11 @@ class SmartAnswersRegressionTest < ActionController::TestCase
       end
 
       should "ensure all nodes are being exercised" do
-        flow = SmartAnswer::FlowRegistry.instance.find(flow_name)
+        flow = begin
+          SmartAnswer::FlowRegistry.instance.find(flow_name)
+        rescue SmartAnswer::FlowRegistry::NotFound
+          SmartdownAdapter::Registry.instance.find(flow_name)
+        end
 
         nodes_exercised_in_test = responses_and_expected_results.inject([]) do |array, responses_and_expected_results|
           current_node = responses_and_expected_results[:current_node]

--- a/test/regression/smart_answers_regression_test.rb
+++ b/test/regression/smart_answers_regression_test.rb
@@ -96,7 +96,7 @@ class SmartAnswersRegressionTest < ActionController::TestCase
 
         if outcome_node
           should "render and save output for responses: #{responses.join(', ')}" do
-            get :show, id: flow_name, started: 'y', responses: responses, format: 'txt'
+            get :show, id: flow_name, started: 'y', responses: responses.join('/'), format: 'txt'
 
             path_to_output = smart_answer_helper.save_output(responses, response)
 

--- a/test/unit/smart_answer_test_helper_test.rb
+++ b/test/unit/smart_answer_test_helper_test.rb
@@ -5,7 +5,7 @@ class SmartAnswerTestHelperTest < ActiveSupport::TestCase
     setup do
       @flow_name = 'flow-name'
       @temp_file = Tempfile.new('filename')
-      @smart_answer_files = stub(paths: [@temp_file.path])
+      @smart_answer_files = stub(existing_paths: [@temp_file.path], paths: [@temp_file.path])
       SmartAnswerFiles.stubs(:new).with(@flow_name).returns(@smart_answer_files)
       @hasher = SmartAnswerHasher.new(@smart_answer_files.paths)
       @test_helper = SmartAnswerTestHelper.new(@flow_name)


### PR DESCRIPTION
We have 4 Smartdown-based smartanswers that we intend to convert to the standard ruby-based ones. This branch adds support for creating [regression tests](https://github.com/alphagov/smart-answers/blob/960500ffb4b1cd57a2f158e88a0a1955762ef6c0/README.md#adding-regression-tests-to-smart-answers) for Smartdown Smart Answers.

I'm not very happy with the changes in the "Add Smartdown support for the `generate-checksums-for-smart-answer` command" and "Support Smartdown in the "ensure all nodes are being exercised" regression test" commits, but given everything Smartdown-related goes away once we convert 4 Smartdown flows I'd be happy for this to get merged.

Original work by @chrisroos included some student-finance-forms related commits, but I'll submit them as a part of another PR