### PR TITLE
Remove unused phrases from calculate-state-pension

### DIFF
--- a/lib/smart_answer_flows/calculate-state-pension.rb
+++ b/lib/smart_answer_flows/calculate-state-pension.rb
@@ -27,15 +27,6 @@ module SmartAnswer
         option :male
         option :female
 
-        # optional text to include in a hint for a later question
-        calculate :if_married_woman do |response|
-          if response.eql? 'female'
-            PhraseList.new(:married_woman_text)
-          else
-            ''
-          end
-        end
-
         next_node_if(:dob_age?, variable_matches(:calculate_age_or_amount, "age"))
         next_node :dob_amount?
       end

--- a/lib/smart_answer_flows/calculate-state-pension.rb
+++ b/lib/smart_answer_flows/calculate-state-pension.rb
@@ -541,14 +541,6 @@ module SmartAnswer
           sprintf("%.2f", calculator.what_you_would_get_if_not_full)
         end
 
-        precalculate :pension_summary do
-          if calculator.pension_loss > 0
-            PhraseList.new(:this_is_n_below_the_full_state_pension)
-          else
-            PhraseList.new(:this_is_the_full_state_pension)
-          end
-        end
-
         precalculate :enough_qualifying_years do
           qualifying_years_total >= 30
         end

--- a/lib/smart_answer_flows/locales/en/calculate-state-pension.yml
+++ b/lib/smart_answer_flows/locales/en/calculate-state-pension.yml
@@ -26,8 +26,6 @@ en-GB:
         "no": "No"
         none: "None of the above"
       phrases:
-        this_is_the_full_state_pension: This is the full State Pension.
-        this_is_n_below_the_full_state_pension: This is £%{pension_loss} per week below the full State Pension.
         married_woman_text: If you are a married woman paying reduced National Insurance, don’t count any years before 2010.
         carers_allowance_women_hint: Don’t count years when you opted for the reduced National Insurance rate for married women and widows.
         carers_allowance_women_ni_reduced_years_before_2010: Don’t count years before April 2010 when you opted for the reduced National Insurance rate for married women and widows.

--- a/lib/smart_answer_flows/locales/en/calculate-state-pension.yml
+++ b/lib/smart_answer_flows/locales/en/calculate-state-pension.yml
@@ -26,16 +26,11 @@ en-GB:
         "no": "No"
         none: "None of the above"
       phrases:
-        only_enter_years_from_nineteen: You can only enter years from 19.
         this_is_the_full_state_pension: This is the full State Pension.
         this_is_n_below_the_full_state_pension: This is £%{pension_loss} per week below the full State Pension.
         married_woman_text: If you are a married woman paying reduced National Insurance, don’t count any years before 2010.
         carers_allowance_women_hint: Don’t count years when you opted for the reduced National Insurance rate for married women and widows.
         carers_allowance_women_ni_reduced_years_before_2010: Don’t count years before April 2010 when you opted for the reduced National Insurance rate for married women and widows.
-        remaining_contributions_years_callout: |
-          You still need to pay National Insurance contributions for %{remaining_contribution_years} to get the full State Pension.
-        full_contribution_years_callout: You get the full State Pension.
-        amount_disclaimer: |
 
       ## Q1
       which_calculation?:

--- a/lib/smart_answer_flows/locales/en/calculate-state-pension.yml
+++ b/lib/smart_answer_flows/locales/en/calculate-state-pension.yml
@@ -26,7 +26,6 @@ en-GB:
         "no": "No"
         none: "None of the above"
       phrases:
-        married_woman_text: If you are a married woman paying reduced National Insurance, don’t count any years before 2010.
         carers_allowance_women_hint: Don’t count years when you opted for the reduced National Insurance rate for married women and widows.
         carers_allowance_women_ni_reduced_years_before_2010: Don’t count years before April 2010 when you opted for the reduced National Insurance rate for married women and widows.
 

--- a/test/data/calculate-state-pension-files.yml
+++ b/test/data/calculate-state-pension-files.yml
@@ -1,6 +1,6 @@
 ---
-lib/smart_answer_flows/calculate-state-pension.rb: 4dd65f17b2009898d50fcee8d028d76e
-lib/smart_answer_flows/locales/en/calculate-state-pension.yml: 6f62df90b89c231de683dc716d6fd5b3
+lib/smart_answer_flows/calculate-state-pension.rb: e0d85de87409ebc72db6dfc260ec0c35
+lib/smart_answer_flows/locales/en/calculate-state-pension.yml: aaadd5749253fa1fea73f168e6783818
 test/data/calculate-state-pension-questions-and-responses.yml: 62d1841ee3292988bcec43d8bbf21ea7
 test/data/calculate-state-pension-responses-and-expected-results.yml: d467d2445671cb21151d59d9dd004d9f
 lib/smart_answer_flows/calculate-state-pension/age_result.govspeak.erb: 09497f3940d7a32cc51d06a5964d005b


### PR DESCRIPTION
This just leaves the "carers_allowance_women_hint" and "carers_allowance_women_ni_reduced_years_before_2010" phrases, which are used in the hint text for a couple of questions.
