### PR TITLE
Fix a bug in rendering student-finance-forms Yes/No questions

### DIFF
--- a/lib/smart_answer_flows/locales/en/student-finance-forms.yml
+++ b/lib/smart_answer_flows/locales/en/student-finance-forms.yml
@@ -65,13 +65,13 @@ en-GB:
         title: Are you a continuing student?
         hint: You’re usually a continuing student if you got student finance last year.
         options:
-          continuing-student: Yes
-          new-student: No
+          continuing-student: 'Yes'
+          new-student: 'No'
 
       pt_course_start?:
         title: Did your part-time course start before 1 September 2012?
         options:
-          course-start-before-01092012: Yes
-          course-start-after-01092012: No
+          course-start-before-01092012: 'Yes'
+          course-start-after-01092012: 'No'
 
 

--- a/test/data/student-finance-forms-files.yml
+++ b/test/data/student-finance-forms-files.yml
@@ -1,6 +1,6 @@
 ---
 lib/smart_answer_flows/student-finance-forms.rb: 8ee5bf5fc1ffb41c74bcef3972edd337
-lib/smart_answer_flows/locales/en/student-finance-forms.yml: 0ead9796bfaeb6a496a61634667703af
+lib/smart_answer_flows/locales/en/student-finance-forms.yml: 4af45b8e051978b737e78976edbbd826
 test/data/student-finance-forms-questions-and-responses.yml: ec2ad38a9df75dd2606b9f979afd5066
 test/data/student-finance-forms-responses-and-expected-results.yml: fb765941838abb1e05b2d874049c7db1
 lib/smart_answer_flows/student-finance-forms/_circumstances_changed_co2_form.govspeak.erb: 236d81f3660a1958bb0dd3a8f229baf4

--- a/test/unit/smart_answer_flows/student_finance_forms_view_test.rb
+++ b/test/unit/smart_answer_flows/student_finance_forms_view_test.rb
@@ -1,0 +1,30 @@
+require_relative '../../test_helper'
+
+require 'smart_answer_flows/student-finance-forms'
+
+module SmartAnswer
+  class StudentFinanceFormsViewTest < ActiveSupport::TestCase
+    setup do
+      @flow = StudentFinanceFormsFlow.build
+      @i18n_prefix = "flow.#{@flow.name}"
+    end
+
+    def question_presenter(question_name)
+      question = @flow.node(question_name)
+      state = SmartAnswer::State.new(question)
+      QuestionPresenter.new(@i18n_prefix, question, state)
+    end
+
+    context 'when rendering :continuing_student? question' do
+      should 'display Yes and No options' do
+        assert_equal ['No', 'Yes'], question_presenter(:continuing_student?).options.map(&:label).sort
+      end
+    end
+
+    context 'when rendering :pt_course_start? question' do
+      should 'display Yes and No options' do
+        assert_equal ['No', 'Yes'], question_presenter(:pt_course_start?).options.map(&:label).sort
+      end
+    end
+  end
+end


### PR DESCRIPTION
When rendering Yes/No questions in student-finance-forms the 'Yes/No' values in
YAML were treated as boolean 'true/false' values, which is not intended. Add
quotes around those values to ensure YAML treats them as strings.

Add regression tests for the two questions affected by this bug.