### PR TITLE
Convert test smart answers to use ERB templates

### DIFF
--- a/test/fixtures/smart_answer_flows/bridge-of-death.rb
+++ b/test/fixtures/smart_answer_flows/bridge-of-death.rb
@@ -34,6 +34,8 @@ module SmartAnswer
         option red: :done
       end
 
+      use_outcome_templates
+
       outcome :done
       outcome :auuuuuuuugh
     end

--- a/test/fixtures/smart_answer_flows/bridge-of-death/auuuuuuuugh.govspeak.erb
+++ b/test/fixtures/smart_answer_flows/bridge-of-death/auuuuuuuugh.govspeak.erb
@@ -1,0 +1,7 @@
+<% content_for :title do %>
+  AAAAARRRRRRRRRRRRRRRRGGGGGHHH!!!!!!!
+<% end %>
+
+<% content_for :body do %>
+  ^ <%= your_name %> is thrown into the Gorge of Eternal Peril
+<% end %>

--- a/test/fixtures/smart_answer_flows/bridge-of-death/done.govspeak.erb
+++ b/test/fixtures/smart_answer_flows/bridge-of-death/done.govspeak.erb
@@ -1,0 +1,7 @@
+<% content_for :title do %>
+  Right, off you go.
+<% end %>
+
+<% content_for :body do %>
+  Oh! Well, thank you. Thank you very much.
+<% end %>

--- a/test/fixtures/smart_answer_flows/checkbox-sample.rb
+++ b/test/fixtures/smart_answer_flows/checkbox-sample.rb
@@ -26,6 +26,8 @@ module SmartAnswer
         end
       end
 
+      use_outcome_templates
+
       outcome :margherita
       outcome :on_its_way
       outcome :no_way

--- a/test/fixtures/smart_answer_flows/checkbox-sample/margherita.govspeak.erb
+++ b/test/fixtures/smart_answer_flows/checkbox-sample/margherita.govspeak.erb
@@ -1,0 +1,3 @@
+<% content_for :title do %>
+  Ok, your margherita pizza is on its way
+<% end %>

--- a/test/fixtures/smart_answer_flows/checkbox-sample/no_way.govspeak.erb
+++ b/test/fixtures/smart_answer_flows/checkbox-sample/no_way.govspeak.erb
@@ -1,0 +1,3 @@
+<% content_for :title do %>
+  No way. That's disgusting!
+<% end %>

--- a/test/fixtures/smart_answer_flows/checkbox-sample/on_its_way.govspeak.erb
+++ b/test/fixtures/smart_answer_flows/checkbox-sample/on_its_way.govspeak.erb
@@ -1,0 +1,7 @@
+<% content_for :title do %>
+  Ok, your pizza is on its way
+<% end %>
+
+<% content_for :body do %>
+  You chose to have <%= toppings %> on your pizza.
+<% end %>

--- a/test/fixtures/smart_answer_flows/country-and-date-sample.rb
+++ b/test/fixtures/smart_answer_flows/country-and-date-sample.rb
@@ -26,6 +26,8 @@ module SmartAnswer
         next_node :ok
       end
 
+      use_outcome_templates
+
       outcome :ok
     end
   end

--- a/test/fixtures/smart_answer_flows/country-and-date-sample/ok.govspeak.erb
+++ b/test/fixtures/smart_answer_flows/country-and-date-sample/ok.govspeak.erb
@@ -1,0 +1,3 @@
+<% content_for :title do %>
+  Great - you've lived in <%= country %> for <%= years_there %> years, and were born in <%= birth_country %>!
+<% end %>

--- a/test/fixtures/smart_answer_flows/country-legacy-sample.rb
+++ b/test/fixtures/smart_answer_flows/country-legacy-sample.rb
@@ -14,6 +14,8 @@ module SmartAnswer
         next_node :ok
       end
 
+      use_outcome_templates
+
       outcome :ok
     end
   end

--- a/test/fixtures/smart_answer_flows/country-legacy-sample/ok.govspeak.erb
+++ b/test/fixtures/smart_answer_flows/country-legacy-sample/ok.govspeak.erb
@@ -1,0 +1,3 @@
+<% content_for :title do %>
+  Great - you live in <%= country %> and you were born in <%= country_of_birth %>!
+<% end %>

--- a/test/fixtures/smart_answer_flows/custom-errors-sample.rb
+++ b/test/fixtures/smart_answer_flows/custom-errors-sample.rb
@@ -11,6 +11,8 @@ module SmartAnswer
         end
       end
 
+      use_outcome_templates
+
       outcome :done
     end
   end

--- a/test/fixtures/smart_answer_flows/data-partial-sample.rb
+++ b/test/fixtures/smart_answer_flows/data-partial-sample.rb
@@ -9,6 +9,8 @@ module SmartAnswer
         option data_partial_with_array: :done_array
       end
 
+      use_outcome_templates
+
       outcome :done_scalar do
         precalculate :sample_data do
           {

--- a/test/fixtures/smart_answer_flows/data-partial-sample/done_array.govspeak.erb
+++ b/test/fixtures/smart_answer_flows/data-partial-sample/done_array.govspeak.erb
@@ -1,0 +1,14 @@
+<% content_for :title do %>
+  Data partial with array data
+<% end %>
+
+<% content_for :body do %>
+  Some data that was passed through
+
+  <%= render partial: '../data_partials/array_partial.erb',
+             locals: {
+               sample_data: sample_data
+             } %>
+
+  More markdown afterwards
+<% end %>

--- a/test/fixtures/smart_answer_flows/data-partial-sample/done_scalar.govspeak.erb
+++ b/test/fixtures/smart_answer_flows/data-partial-sample/done_scalar.govspeak.erb
@@ -1,0 +1,14 @@
+<% content_for :title do %>
+  Data partial with scalar data
+<% end %>
+
+<% content_for :body do %>
+  Some data that was passed through
+
+  <%= render partial: '../data_partials/scalar_partial.erb',
+             locals: {
+               sample_data: sample_data
+             } %>
+
+  More markdown afterwards
+<% end %>

--- a/test/fixtures/smart_answer_flows/locales/en/bridge-of-death.yml
+++ b/test/fixtures/smart_answer_flows/locales/en/bridge-of-death.yml
@@ -39,13 +39,3 @@ en-GB:
       what_is_the_capital_of_assyria?:
         title: "What...is the capital of Assyria?"
         label: "Answer:"
-
-      done:
-        title: "Right, off you go."
-        body: |
-          Oh! Well, thank you. Thank you very much.
-
-      auuuuuuuugh:
-        title: "AAAAARRRRRRRRRRRRRRRRGGGGGHHH!!!!!!!"
-        body: |
-          ^ %{your_name} is thrown into the Gorge of Eternal Peril

--- a/test/fixtures/smart_answer_flows/locales/en/checkbox-sample.yml
+++ b/test/fixtures/smart_answer_flows/locales/en/checkbox-sample.yml
@@ -8,14 +8,3 @@ en-GB:
           peppers: "Peppers"
           ice_cream: "Ice Cream!!!"
           pepperoni: "Pepperoni"
-
-      on_its_way:
-        title: "Ok, your pizza is on its way"
-        body: |
-          You chose to have %{toppings} on your pizza.
-
-      margherita:
-        title: "Ok, your margherita pizza is on its way"
-
-      no_way:
-        title: "No way. That's disgusting!"

--- a/test/fixtures/smart_answer_flows/locales/en/country-and-date-sample.yml
+++ b/test/fixtures/smart_answer_flows/locales/en/country-and-date-sample.yml
@@ -1,5 +1,4 @@
 en-GB:
   flow:
     country-and-date-sample:
-      ok:
-        title: "Great - you've lived in %{country} for %{years_there} years, and were born in %{birth_country}!"
+

--- a/test/fixtures/smart_answer_flows/locales/en/country-legacy-sample.yml
+++ b/test/fixtures/smart_answer_flows/locales/en/country-legacy-sample.yml
@@ -1,5 +1,3 @@
 en-GB:
   flow:
     country-legacy-sample:
-      ok:
-        title: "Great - you live in %{country} and you were born in %{country_of_birth}!"

--- a/test/fixtures/smart_answer_flows/locales/en/data-partial-sample.yml
+++ b/test/fixtures/smart_answer_flows/locales/en/data-partial-sample.yml
@@ -1,19 +1,3 @@
 en-GB:
   flow:
     data-partial-sample:
-      done_scalar:
-        title: "Data partial with scalar data"
-        body: |
-          Some data that was passed through
-
-          +[data_partial:scalar_partial:sample_data]
-
-          More markdown afterwards
-      done_array:
-        title: "Data partial with array data"
-        body: |
-          Some data that was passed through
-
-          +[data_partial:array_partial:sample_data]
-
-          More markdown afterwards

--- a/test/fixtures/smart_answer_flows/locales/en/money-and-salary-sample.yml
+++ b/test/fixtures/smart_answer_flows/locales/en/money-and-salary-sample.yml
@@ -4,8 +4,3 @@ en-GB:
 
       what_size_bonus_do_you_want?:
         error_message: "%{error}"
-
-      ok:
-        title: "OK, here you go."
-        body: |
-          ^ This is allowed because %{requested_bonus} is more than your annual salary of %{annual_salary}

--- a/test/fixtures/smart_answer_flows/locales/en/precalculation-sample.yml
+++ b/test/fixtures/smart_answer_flows/locales/en/precalculation-sample.yml
@@ -5,7 +5,3 @@ en-GB:
         label: "Amount:"
       how_many_woodchucks_do_you_have?:
         label: "Amount:"
-      done:
-        title: "%{formatted_amount_of_wood} would be chucked."
-        body: |
-          ^ %{formatted_number_of_woodchucks}, each chucking %{formatted_capacity_of_woodchucks} = %{formatted_amount_of_wood} being chucked.

--- a/test/fixtures/smart_answer_flows/money-and-salary-sample.rb
+++ b/test/fixtures/smart_answer_flows/money-and-salary-sample.rb
@@ -23,6 +23,8 @@ module SmartAnswer
         next_node :ok
       end
 
+      use_outcome_templates
+
       outcome :ok
     end
   end

--- a/test/fixtures/smart_answer_flows/money-and-salary-sample/ok.govspeak.erb
+++ b/test/fixtures/smart_answer_flows/money-and-salary-sample/ok.govspeak.erb
@@ -1,0 +1,7 @@
+<% content_for :title do %>
+  OK, here you go.
+<% end %>
+
+<% content_for :body do %>
+  ^ This is allowed because <%= format_money(requested_bonus) %> is more than your annual salary of <%= format_money(annual_salary) %>
+<% end %>

--- a/test/fixtures/smart_answer_flows/precalculation-sample.rb
+++ b/test/fixtures/smart_answer_flows/precalculation-sample.rb
@@ -16,6 +16,8 @@ module SmartAnswer
         next_node :done
       end
 
+      use_outcome_templates
+
       outcome :done do
         precalculate :amount_of_wood do
           woodchuck_capacity.to_i * number_of_woodchucks.to_i

--- a/test/fixtures/smart_answer_flows/precalculation-sample/done.govspeak.erb
+++ b/test/fixtures/smart_answer_flows/precalculation-sample/done.govspeak.erb
@@ -1,0 +1,7 @@
+<% content_for :title do %>
+  <%= formatted_amount_of_wood %> would be chucked.
+<% end %>
+
+<% content_for :body do %>
+  ^ <%= formatted_number_of_woodchucks %>, each chucking <%= formatted_capacity_of_woodchucks %> = <%= formatted_amount_of_wood %> being chucked.
+<% end %>

--- a/test/fixtures/smart_answer_flows/value-sample.rb
+++ b/test/fixtures/smart_answer_flows/value-sample.rb
@@ -10,7 +10,9 @@ module SmartAnswer
         next_node :outcome_with_template
       end
 
-      outcome :outcome_with_template, use_outcome_templates: true
+      use_outcome_templates
+
+      outcome :outcome_with_template
     end
   end
 end


### PR DESCRIPTION
I'm planning to remove support for rendering Outcomes using data stored in YAML locale files.

Before I can do that I need to ensure _all_ Smart Answers are using ERB templates, including these test fixture flows.