### PR TITLE
Fix the value-sample test Smart Answer Flow

### DIFF
--- a/test/fixtures/smart_answer_flows/value-sample/outcome_with_template.govspeak.erb
+++ b/test/fixtures/smart_answer_flows/value-sample/outcome_with_template.govspeak.erb
@@ -1,0 +1,7 @@
+<% content_for :body do %>
+  text-before-user-input
+
+  <%= user_input %>
+
+  text-after-user-input
+<% end %>

--- a/test/fixtures/smart_answer_flows/value-sample/outcome_with_template_body.govspeak.erb
+++ b/test/fixtures/smart_answer_flows/value-sample/outcome_with_template_body.govspeak.erb
@@ -1,1 +1,0 @@
-<%= user_input %>

--- a/test/integration/engine/html_escaping_user_input_test.rb
+++ b/test/integration/engine/html_escaping_user_input_test.rb
@@ -15,7 +15,8 @@ class HtmlEscapingUserInputTest < EngineIntegrationTest
     end
 
     should "escape user input interpolated into outcome ERB template" do
-      assert page.has_css?("h2", text: "Outcome with template"), "Not on outcome page"
+      assert page.has_content?('text-before-user-input'), "Not on outcome page"
+      assert page.has_content?('text-after-user-input'), "Not on outcome page"
       refute page.has_css?("script#naughty", text: @javascript, visible: false), "Includes unsafe HTML"
     end
   end


### PR DESCRIPTION
The "escape user input interpolated into outcome ERB template" test in
html_escaping_user_input_test.rb wasn't testing anything particularly useful.

The body in the ERB template was never being rendered (because it was still
using the old style of a single template for each of the title and body
sections) which meant that refuting the presence of the malicious input would
always succeed.

I've renamed outcome_with_template_body.govspeak.erb to
outcome_with_template.govspeak.erb and added the `content_for :body` container.
I've also added text within that container so that I can assert for the
presence of that text in the test. If the text isn't there then the test will
fail fast.

NOTE. I believe the previous assertion for the `h2` was attempting to fail fast
in a similar way. Unfortunately, that would always succeed because
`NodePresenter#title` falls back to humanising the outcome name ("Outcome with
template" in this case) if no other title exists.