### PR TITLE
Remove support for non ERB outcome templates

### DIFF
--- a/app/presenters/outcome_presenter.rb
+++ b/app/presenters/outcome_presenter.rb
@@ -14,8 +14,6 @@ class OutcomePresenter < NodePresenter
       render_erb_template
       title = @view.content_for(:title) || ''
       strip_leading_spaces(title.chomp)
-    else
-      translate!('title')
     end
   end
 

--- a/app/presenters/outcome_presenter.rb
+++ b/app/presenters/outcome_presenter.rb
@@ -34,8 +34,6 @@ class OutcomePresenter < NodePresenter
       govspeak = @view.content_for(:body) || ''
       govspeak = strip_leading_spaces(govspeak.to_str)
       html ? GovspeakPresenter.new(govspeak).html : govspeak
-    else
-      super
     end
   end
 

--- a/app/presenters/outcome_presenter.rb
+++ b/app/presenters/outcome_presenter.rb
@@ -43,8 +43,6 @@ class OutcomePresenter < NodePresenter
       govspeak = @view.content_for(:next_steps) || ''
       govspeak = strip_leading_spaces(govspeak.to_str)
       html ? GovspeakPresenter.new(govspeak).html : govspeak
-    else
-      super
     end
   end
 

--- a/app/presenters/outcome_presenter.rb
+++ b/app/presenters/outcome_presenter.rb
@@ -17,17 +17,6 @@ class OutcomePresenter < NodePresenter
     end
   end
 
-  def translate!(subkey)
-    output = super(subkey)
-    if output
-      output.gsub!(/\+\[data_partial:(\w+):(\w+)\]/) do |match|
-        render_data_partial($1, $2)
-      end
-    end
-
-    output
-  end
-
   def body(html: true)
     if body_erb_template_exists?
       render_erb_template
@@ -74,13 +63,6 @@ class OutcomePresenter < NodePresenter
 
   def erb_template_exists?
     File.exists?(erb_template_path)
-  end
-
-  def render_data_partial(partial, variable_name)
-    data = @state.send(variable_name.to_sym)
-
-    partial_path = ::SmartAnswer::FlowRegistry.instance.load_path.join("data_partials", "_#{partial}")
-    ApplicationController.new.render_to_string(file: partial_path.to_s, layout: false, locals: {variable_name.to_sym => data})
   end
 
   def render_erb_template

--- a/app/presenters/outcome_presenter.rb
+++ b/app/presenters/outcome_presenter.rb
@@ -10,7 +10,7 @@ class OutcomePresenter < NodePresenter
   end
 
   def title
-    if use_template? && title_erb_template_exists?
+    if title_erb_template_exists?
       render_erb_template
       title = @view.content_for(:title) || ''
       strip_leading_spaces(title.chomp)
@@ -29,7 +29,7 @@ class OutcomePresenter < NodePresenter
   end
 
   def body(html: true)
-    if use_template? && body_erb_template_exists?
+    if body_erb_template_exists?
       render_erb_template
       govspeak = @view.content_for(:body) || ''
       govspeak = strip_leading_spaces(govspeak.to_str)
@@ -38,7 +38,7 @@ class OutcomePresenter < NodePresenter
   end
 
   def next_steps(html: true)
-    if use_template? && next_steps_erb_template_exists?
+    if next_steps_erb_template_exists?
       render_erb_template
       govspeak = @view.content_for(:next_steps) || ''
       govspeak = strip_leading_spaces(govspeak.to_str)
@@ -74,10 +74,6 @@ class OutcomePresenter < NodePresenter
 
   def erb_template_exists?
     File.exists?(erb_template_path)
-  end
-
-  def use_template?
-    @node.use_template?
   end
 
   def render_data_partial(partial, variable_name)

--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -87,12 +87,11 @@ module SmartAnswer
     end
 
     def use_outcome_templates
-      @use_outcome_templates = true
+      # no-op
     end
 
     def outcome(name, options = {}, &block)
       modified_options = options.merge(
-        use_outcome_templates: @use_outcome_templates || options[:use_outcome_templates],
         flow_name: self.name
       )
       add_node Outcome.new(name, modified_options, &block)

--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -86,10 +86,6 @@ module SmartAnswer
       add_node Question::Checkbox.new(name, &block)
     end
 
-    def use_outcome_templates
-      # no-op
-    end
-
     def outcome(name, options = {}, &block)
       modified_options = options.merge(
         flow_name: self.name

--- a/lib/smart_answer/outcome.rb
+++ b/lib/smart_answer/outcome.rb
@@ -13,10 +13,6 @@ module SmartAnswer
       raise InvalidNode
     end
 
-    def use_template?
-      @options[:use_outcome_templates]
-    end
-
     def template_directory
       return unless @options[:flow_name]
       load_path = FlowRegistry.instance.load_path

--- a/lib/smart_answer_flows/README.md
+++ b/lib/smart_answer_flows/README.md
@@ -169,23 +169,9 @@ next_node_if(:something, can_has_cheesburger?)
 
 ### Outcome templates
 
-#### YAML
-
-The outcome templates live in the Smart Answer YAML file ("lib/smart_answer_flows/locales/en/<flow-name>.yml"). The template will often be fairly simple, relying on interpolating `PhraseList` strings that have been built up during the flow itself.
-
-YAML templates are used by default.
-
 #### ERB
 
-The ERB outcome templates live in `lib/smart_answer_flows/<flow-name>/<outcome-name>.txt.erb`.
-
-You can enable ERB templates per outcome, or for an entire flow.
-
-To enable per outcome, pass the `use_outcome_templates: true` option to the outcome node in the flow.
-
-To enable for the entire flow, call the `use_outcome_templates` method on the flow itself.
-
-You will have to remove the relevant parts of the flow's integration test, because the phrase list keys will no longer exist, so the `assert_phrase_list` method cannot be used. You may also want to remove the tests which assert against outcome nodes, because these are well covered in the regression tests.
+The ERB outcome templates live in `lib/smart_answer_flows/<flow-name>/<outcome-name>.govspeak.erb`.
 
 ##### Indentation
 

--- a/lib/smart_answer_flows/additional-commodity-code.rb
+++ b/lib/smart_answer_flows/additional-commodity-code.rb
@@ -164,8 +164,6 @@ module SmartAnswer
         next_node :commodity_code_result
       end
 
-      use_outcome_templates
-
       outcome :commodity_code_result do
         precalculate :calculator do
           Calculators::CommodityCodeCalculator.new(

--- a/lib/smart_answer_flows/am-i-getting-minimum-wage.rb
+++ b/lib/smart_answer_flows/am-i-getting-minimum-wage.rb
@@ -5,7 +5,6 @@ module SmartAnswer
       status :published
       satisfies_need "100145"
 
-      use_outcome_templates
       use_shared_logic "minimum_wage"
     end
   end

--- a/lib/smart_answer_flows/apply-tier-4-visa.rb
+++ b/lib/smart_answer_flows/apply-tier-4-visa.rb
@@ -49,8 +49,6 @@ module SmartAnswer
         next_node(:outcome)
       end
 
-      use_outcome_templates
-
       outcome :outcome
     end
   end

--- a/lib/smart_answer_flows/benefit-cap-calculator.rb
+++ b/lib/smart_answer_flows/benefit-cap-calculator.rb
@@ -319,8 +319,6 @@ module SmartAnswer
 
       ##OUTCOMES
 
-      use_outcome_templates
-
       ## Outcome 1
       outcome :outcome_not_affected_exemptions
 

--- a/lib/smart_answer_flows/calculate-agricultural-holiday-entitlement.rb
+++ b/lib/smart_answer_flows/calculate-agricultural-holiday-entitlement.rb
@@ -91,8 +91,6 @@ module SmartAnswer
         end
       end
 
-      use_outcome_templates
-
       outcome :done
     end
   end

--- a/lib/smart_answer_flows/calculate-employee-redundancy-pay.rb
+++ b/lib/smart_answer_flows/calculate-employee-redundancy-pay.rb
@@ -6,8 +6,6 @@ module SmartAnswer
       status :published
       satisfies_need "100138"
 
-      use_outcome_templates
-
       use_shared_logic "redundancy_pay"
     end
   end

--- a/lib/smart_answer_flows/calculate-married-couples-allowance.rb
+++ b/lib/smart_answer_flows/calculate-married-couples-allowance.rb
@@ -115,8 +115,6 @@ module SmartAnswer
         end
       end
 
-      use_outcome_templates
-
       outcome :husband_done do
         precalculate :allowance do
           age_related_allowance = age_related_allowance_chooser.get_age_related_allowance(birth_date)

--- a/lib/smart_answer_flows/calculate-state-pension.rb
+++ b/lib/smart_answer_flows/calculate-state-pension.rb
@@ -457,8 +457,6 @@ module SmartAnswer
         next_node :amount_result
       end
 
-      use_outcome_templates
-
       outcome :near_state_pension_age
 
       outcome :reached_state_pension_age

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -301,8 +301,6 @@ module SmartAnswer
         next_node(:not_entitled_3_days_not_paid)
       end
 
-      use_outcome_templates
-
       # Answer 1
       outcome :already_getting_maternity
 

--- a/lib/smart_answer_flows/calculate-your-child-maintenance.rb
+++ b/lib/smart_answer_flows/calculate-your-child-maintenance.rb
@@ -113,8 +113,6 @@ module SmartAnswer
         next_node :reduced_and_basic_rates_result
       end
 
-      use_outcome_templates
-
       outcome :nil_rate_result
 
       outcome :flat_rate_result do

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
@@ -181,8 +181,6 @@ module SmartAnswer
         next_node :shift_worker_done
       end
 
-      use_outcome_templates
-
       outcome :shift_worker_done do
         precalculate :calculator do
           Calculators::HolidayEntitlement.new(

--- a/lib/smart_answer_flows/calculate-your-redundancy-pay.rb
+++ b/lib/smart_answer_flows/calculate-your-redundancy-pay.rb
@@ -6,8 +6,6 @@ module SmartAnswer
       status :published
       satisfies_need "100135"
 
-      use_outcome_templates
-
       use_shared_logic "redundancy_pay"
     end
   end

--- a/lib/smart_answer_flows/check-uk-visa.rb
+++ b/lib/smart_answer_flows/check-uk-visa.rb
@@ -128,8 +128,6 @@ module SmartAnswer
         end
       end
 
-      use_outcome_templates
-
       outcome :outcome_no_visa_needed do
         precalculate :purpose_of_visit_answer do
           purpose_of_visit_answer

--- a/lib/smart_answer_flows/childcare-costs-for-tax-credits.rb
+++ b/lib/smart_answer_flows/childcare-costs-for-tax-credits.rb
@@ -219,7 +219,6 @@ module SmartAnswer
       end
 
       ### Outcomes
-      use_outcome_templates
 
       #O1
       outcome :call_helpline_detailed

--- a/lib/smart_answer_flows/energy-grants-calculator.rb
+++ b/lib/smart_answer_flows/energy-grants-calculator.rb
@@ -314,8 +314,6 @@ module SmartAnswer
         next_node(:outcome_bills_and_measures_on_benefits_not_eco_eligible)
       end
 
-      use_outcome_templates
-
       outcome :outcome_help_with_bills do
         precalculate :incomesupp_jobseekers_1 do
           incomesupp_jobseekers_1

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
@@ -113,8 +113,6 @@ module SmartAnswer
         next_node :late
       end
 
-      use_outcome_templates
-
       outcome :late do
         precalculate :calculator do
           Calculators::SelfAssessmentPenalties.new(

--- a/lib/smart_answer_flows/help-if-you-are-arrested-abroad.rb
+++ b/lib/smart_answer_flows/help-if-you-are-arrested-abroad.rb
@@ -88,8 +88,6 @@ module SmartAnswer
 
       end
 
-      use_outcome_templates
-
       outcome :answer_one_generic do
         precalculate :transfers_back_to_uk_treaty_change_countries do
           %w(austria belgium croatia denmark finland hungary italy latvia luxembourg malta netherlands slovakia)

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will.rb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will.rb
@@ -265,8 +265,6 @@ module SmartAnswer
         next_node_if(:outcome_62, responded_with('no'))
       end
 
-      use_outcome_templates
-
       outcome :outcome_1
       outcome :outcome_2
       outcome :outcome_3

--- a/lib/smart_answer_flows/legalisation-document-checker.rb
+++ b/lib/smart_answer_flows/legalisation-document-checker.rb
@@ -80,8 +80,6 @@ module SmartAnswer
 
       end
 
-      use_outcome_templates
-
       outcome :outcome_results do
         precalculate :data_query do
           SmartAnswer::Calculators::LegalisationDocumentsDataQuery.new

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -254,8 +254,6 @@ module SmartAnswer
         end
       end
 
-      use_outcome_templates
-
       outcome :outcome_ireland
 
       outcome :outcome_switzerland

--- a/lib/smart_answer_flows/maternity-paternity-calculator.rb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator.rb
@@ -13,8 +13,6 @@ module SmartAnswer
         option adoption: :taking_paternity_leave_for_adoption?
       end
 
-      use_outcome_templates
-
       use_shared_logic ("adoption-calculator")
       use_shared_logic ("paternity-calculator")
       use_shared_logic ("maternity-calculator")

--- a/lib/smart_answer_flows/minimum-wage-calculator-employers.rb
+++ b/lib/smart_answer_flows/minimum-wage-calculator-employers.rb
@@ -5,7 +5,6 @@ module SmartAnswer
       status :published
       satisfies_need "100145"
 
-      use_outcome_templates
       use_shared_logic "minimum_wage"
     end
   end

--- a/lib/smart_answer_flows/overseas-passports.rb
+++ b/lib/smart_answer_flows/overseas-passports.rb
@@ -148,8 +148,6 @@ module SmartAnswer
         end
       end
 
-      use_outcome_templates
-
       ## Online IPS Application Result
       outcome :ips_application_result_online do
         precalculate :birth_location do

--- a/lib/smart_answer_flows/pip-checker.rb
+++ b/lib/smart_answer_flows/pip-checker.rb
@@ -48,8 +48,6 @@ module SmartAnswer
         end
       end
 
-      use_outcome_templates
-
       outcome :result_1
       outcome :result_2
       outcome :result_3

--- a/lib/smart_answer_flows/plan-adoption-leave.rb
+++ b/lib/smart_answer_flows/plan-adoption-leave.rb
@@ -37,8 +37,6 @@ module SmartAnswer
         next_node :adoption_leave_details
       end
 
-      use_outcome_templates
-
       outcome :adoption_leave_details do
         precalculate :match_date_formatted do
           calculator.formatted_match_date

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -119,8 +119,6 @@ module SmartAnswer
 
       # Outcomes
 
-      use_outcome_templates
-
       outcome :north_korea_result do
         precalculate :reg_data_query do
           reg_data_query

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -107,8 +107,6 @@ module SmartAnswer
         next_node(:oru_result)
       end
 
-      use_outcome_templates
-
       outcome :commonwealth_result
       outcome :no_embassy_result
 

--- a/lib/smart_answer_flows/report-a-lost-or-stolen-passport.rb
+++ b/lib/smart_answer_flows/report-a-lost-or-stolen-passport.rb
@@ -39,8 +39,6 @@ module SmartAnswer
         next_node :contact_the_embassy
       end
 
-      use_outcome_templates
-
       outcome :contact_the_embassy
       outcome :contact_the_embassy_canada
       outcome :complete_LS01_form

--- a/lib/smart_answer_flows/simplified-expenses-checker.rb
+++ b/lib/smart_answer_flows/simplified-expenses-checker.rb
@@ -282,8 +282,6 @@ module SmartAnswer
         next_node :you_can_use_result
       end
 
-      use_outcome_templates
-
       outcome :you_cant_use_result
       outcome :you_can_use_result do
         precalculate :capital_allowance_claimed do

--- a/lib/smart_answer_flows/state-pension-through-partner.rb
+++ b/lib/smart_answer_flows/state-pension-through-partner.rb
@@ -116,8 +116,6 @@ module SmartAnswer
         end
       end
 
-      use_outcome_templates
-
       outcome :widow_and_old_pension_outcome
 
       outcome :current_rules_no_additional_pension_outcome

--- a/lib/smart_answer_flows/state-pension-topup.rb
+++ b/lib/smart_answer_flows/state-pension-topup.rb
@@ -56,8 +56,6 @@ module SmartAnswer
         next_node :outcome_topup_calculations
       end
 
-      use_outcome_templates
-
       #A1
       outcome :outcome_topup_calculations do
         precalculate :amounts_vs_ages do

--- a/lib/smart_answer_flows/student-finance-calculator.rb
+++ b/lib/smart_answer_flows/student-finance-calculator.rb
@@ -171,8 +171,6 @@ module SmartAnswer
 
       end
 
-      use_outcome_templates
-
       outcome :outcome_uk_full_time_students
 
       outcome :outcome_uk_all_students

--- a/lib/smart_answer_flows/student-finance-forms.rb
+++ b/lib/smart_answer_flows/student-finance-forms.rb
@@ -164,9 +164,6 @@ module SmartAnswer
         end
       end
 
-
-      use_outcome_templates
-
       outcome :outcome_ccg_1415
       outcome :outcome_ccg_1516
       outcome :outcome_ccg_expenses

--- a/lib/smart_answer_flows/towing-rules.rb
+++ b/lib/smart_answer_flows/towing-rules.rb
@@ -121,8 +121,6 @@ module SmartAnswer
         option "21-or-over" => :apply_for_provisional_bus #A40
       end
 
-      use_outcome_templates
-
       outcome :car_light_vehicle_entitlement # A3
       outcome :full_entitlement #A4
       outcome :limited_trailer_entitlement #A6

--- a/lib/smart_answer_flows/uk-benefits-abroad.rb
+++ b/lib/smart_answer_flows/uk-benefits-abroad.rb
@@ -384,8 +384,6 @@ module SmartAnswer
         option is_more_than_a_year: :is_more_than_a_year_outcome # A41 going_abroad
       end
 
-      use_outcome_templates
-
       outcome :pension_going_abroad_outcome # A2 going_abroad
       outcome :jsa_less_than_a_year_medical_outcome # A3 going_abroad
       outcome :jsa_less_than_a_year_other_outcome # A4 going_abroad

--- a/lib/smart_answer_flows/vat-payment-deadlines.rb
+++ b/lib/smart_answer_flows/vat-payment-deadlines.rb
@@ -37,8 +37,6 @@ module SmartAnswer
         end
       end
 
-      use_outcome_templates
-
       outcome :result_direct_debit do
         precalculate(:last_dd_setup_date) { last_payment_date }
         precalculate(:funds_taken) { funds_received_by }

--- a/test/data/additional-commodity-code-files.yml
+++ b/test/data/additional-commodity-code-files.yml
@@ -1,5 +1,5 @@
---- 
-lib/smart_answer_flows/additional-commodity-code.rb: 017c1faf3343f33c59cd24626823dcc8
+---
+lib/smart_answer_flows/additional-commodity-code.rb: 862223763eb34d7342d789ba2fa8cc27
 lib/smart_answer_flows/locales/en/additional-commodity-code.yml: 1bd6a7da656f81f10992dcbae147f9b5
 test/data/additional-commodity-code-questions-and-responses.yml: f2149cbfa6ec8c5ead572f0a89542a79
 test/data/additional-commodity-code-responses-and-expected-results.yml: 6ca51c22f472dbe159ac81f31006a7b1

--- a/test/data/am-i-getting-minimum-wage-files.yml
+++ b/test/data/am-i-getting-minimum-wage-files.yml
@@ -1,5 +1,5 @@
---- 
-lib/smart_answer_flows/am-i-getting-minimum-wage.rb: 840e98c92ccddb4145878d66c72f5568
+---
+lib/smart_answer_flows/am-i-getting-minimum-wage.rb: a5f9ccf8dfe0c6835ef605aa1c5cbacc
 lib/smart_answer_flows/locales/en/am-i-getting-minimum-wage.yml: 33712eff4fda6c7b7c44306f2f9491ec
 test/data/am-i-getting-minimum-wage-questions-and-responses.yml: 8d05a23bb72740b2d9c9f1196f212e0e
 test/data/am-i-getting-minimum-wage-responses-and-expected-results.yml: 4f24160d38e41983f72ce1352fad9702

--- a/test/data/apply-tier-4-visa-files.yml
+++ b/test/data/apply-tier-4-visa-files.yml
@@ -1,5 +1,5 @@
---- 
-lib/smart_answer_flows/apply-tier-4-visa.rb: 44ce7b4a25bb0877d3972fbe9ed94a16
+---
+lib/smart_answer_flows/apply-tier-4-visa.rb: b9905c4436e3599fcf87870f9144f1a3
 lib/smart_answer_flows/locales/en/apply-tier-4-visa.yml: 52618ea258e1dcddb758adc934a524aa
 test/data/apply-tier-4-visa-questions-and-responses.yml: fe87a99e4337e45586806181742f0b8f
 test/data/apply-tier-4-visa-responses-and-expected-results.yml: 339690f2a3125ef29d63f29a79ae1cba

--- a/test/data/benefit-cap-calculator-files.yml
+++ b/test/data/benefit-cap-calculator-files.yml
@@ -1,5 +1,5 @@
---- 
-lib/smart_answer_flows/benefit-cap-calculator.rb: e6c2e371f1696004c374e07d0460f796
+---
+lib/smart_answer_flows/benefit-cap-calculator.rb: 7ab5e7f7043eabc1b903a2e1729c679e
 lib/smart_answer_flows/locales/en/benefit-cap-calculator.yml: 667893b71dd8dc4bc1aa07222eafa491
 test/data/benefit-cap-calculator-questions-and-responses.yml: 460336f2cf1f2acc62729ef5d831f25e
 test/data/benefit-cap-calculator-responses-and-expected-results.yml: 19c0bc207cde0d94c76b769b0da5d0bd

--- a/test/data/calculate-agricultural-holiday-entitlement-files.yml
+++ b/test/data/calculate-agricultural-holiday-entitlement-files.yml
@@ -1,5 +1,5 @@
---- 
-lib/smart_answer_flows/calculate-agricultural-holiday-entitlement.rb: cad2ee34078244f2de3b67e25edbfed9
+---
+lib/smart_answer_flows/calculate-agricultural-holiday-entitlement.rb: bc27a9976a1016f5d7da30db9cd1f182
 lib/smart_answer_flows/locales/en/calculate-agricultural-holiday-entitlement.yml: 9e1ab7c08a790c98de7eae3b9ab0936b
 test/data/calculate-agricultural-holiday-entitlement-questions-and-responses.yml: 4b91e0ca75c21fa5d93abc1944bfa8d4
 test/data/calculate-agricultural-holiday-entitlement-responses-and-expected-results.yml: 686cb77b2a3737021c020e6b56c3e586

--- a/test/data/calculate-employee-redundancy-pay-files.yml
+++ b/test/data/calculate-employee-redundancy-pay-files.yml
@@ -1,5 +1,5 @@
---- 
-lib/smart_answer_flows/calculate-employee-redundancy-pay.rb: d57da7a7963cf21588bd0b0a66179575
+---
+lib/smart_answer_flows/calculate-employee-redundancy-pay.rb: f82afbba5721b039e19a4d8c5e253c3f
 lib/smart_answer_flows/locales/en/calculate-employee-redundancy-pay.yml: 28d8ce5c2b449a2d03c20b6b0a1a60f1
 test/data/calculate-employee-redundancy-pay-questions-and-responses.yml: dca676f9f9cd34571e4338b66d18bd89
 test/data/calculate-employee-redundancy-pay-responses-and-expected-results.yml: c2a4b09c482a4c3afdbedad7ce8089e0

--- a/test/data/calculate-married-couples-allowance-files.yml
+++ b/test/data/calculate-married-couples-allowance-files.yml
@@ -1,5 +1,5 @@
---- 
-lib/smart_answer_flows/calculate-married-couples-allowance.rb: 23ab1ba6758d3437b93f5352c1547632
+---
+lib/smart_answer_flows/calculate-married-couples-allowance.rb: c7e93d8d17bfa0f57793048c6a100ff0
 lib/smart_answer_flows/locales/en/calculate-married-couples-allowance.yml: a327a55a834e3f9344bebeafd12d7a95
 test/data/calculate-married-couples-allowance-questions-and-responses.yml: 1bbef5f2f30d470433bbb63f029881cd
 test/data/calculate-married-couples-allowance-responses-and-expected-results.yml: 3bb53e4211718b8b1b7dacfaa52f3f49

--- a/test/data/calculate-state-pension-files.yml
+++ b/test/data/calculate-state-pension-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/calculate-state-pension.rb: e0d85de87409ebc72db6dfc260ec0c35
+lib/smart_answer_flows/calculate-state-pension.rb: 66ee591c957c5fafd237307667283559
 lib/smart_answer_flows/locales/en/calculate-state-pension.yml: aaadd5749253fa1fea73f168e6783818
 test/data/calculate-state-pension-questions-and-responses.yml: 62d1841ee3292988bcec43d8bbf21ea7
 test/data/calculate-state-pension-responses-and-expected-results.yml: d467d2445671cb21151d59d9dd004d9f

--- a/test/data/calculate-statutory-sick-pay-files.yml
+++ b/test/data/calculate-statutory-sick-pay-files.yml
@@ -1,5 +1,5 @@
---- 
-lib/smart_answer_flows/calculate-statutory-sick-pay.rb: 9c1e703af03a20302cd8d5b626c97081
+---
+lib/smart_answer_flows/calculate-statutory-sick-pay.rb: 35b53e3c0307caa15921bb2b079a42cf
 lib/smart_answer_flows/locales/en/calculate-statutory-sick-pay.yml: 99127d932672eba7aef80e5aa6945e94
 test/data/calculate-statutory-sick-pay-questions-and-responses.yml: 225bf0303e9d1c7fa1a929c24b543db3
 test/data/calculate-statutory-sick-pay-responses-and-expected-results.yml: 171dcf9d94ad17c5c64d6e776c73c69b

--- a/test/data/calculate-your-child-maintenance-files.yml
+++ b/test/data/calculate-your-child-maintenance-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/calculate-your-child-maintenance.rb: d8cd1379b99c8b97cb7016d2cf5b3eab
+lib/smart_answer_flows/calculate-your-child-maintenance.rb: bebd85f1515ceccc756fdedc9aa4ae25
 lib/smart_answer_flows/locales/en/calculate-your-child-maintenance.yml: fd220c5c8edbafe63225f5cc043f69d3
 test/data/calculate-your-child-maintenance-questions-and-responses.yml: 5e6e6e5307c1d385da9abfeb18900c51
 test/data/calculate-your-child-maintenance-responses-and-expected-results.yml: 30457fdf39035ab0333e3e9ad9fedec9

--- a/test/data/calculate-your-holiday-entitlement-files.yml
+++ b/test/data/calculate-your-holiday-entitlement-files.yml
@@ -1,5 +1,5 @@
---- 
-lib/smart_answer_flows/calculate-your-holiday-entitlement.rb: dcef2ca2da1b85fafc3104cf67b87f19
+---
+lib/smart_answer_flows/calculate-your-holiday-entitlement.rb: 5965a557c8d504fae49f7381d687c856
 lib/smart_answer_flows/locales/en/calculate-your-holiday-entitlement.yml: c901649bd737ab8fcfeb29da464ac637
 test/data/calculate-your-holiday-entitlement-questions-and-responses.yml: a5d687911e6173e74f2b70af6a5ff7bd
 test/data/calculate-your-holiday-entitlement-responses-and-expected-results.yml: b7d4735ae33ef0dceeeb97c12019db84

--- a/test/data/calculate-your-redundancy-pay-files.yml
+++ b/test/data/calculate-your-redundancy-pay-files.yml
@@ -1,5 +1,5 @@
---- 
-lib/smart_answer_flows/calculate-your-redundancy-pay.rb: b6b4b001749728acd0c2345707c9c5cb
+---
+lib/smart_answer_flows/calculate-your-redundancy-pay.rb: 74b0bb1ff133a4691bd1b3cde434b6f7
 lib/smart_answer_flows/locales/en/calculate-your-redundancy-pay.yml: d9dc798455fc5e039abd10ad7135769a
 test/data/calculate-your-redundancy-pay-questions-and-responses.yml: dca676f9f9cd34571e4338b66d18bd89
 test/data/calculate-your-redundancy-pay-responses-and-expected-results.yml: c2a4b09c482a4c3afdbedad7ce8089e0

--- a/test/data/check-uk-visa-files.yml
+++ b/test/data/check-uk-visa-files.yml
@@ -1,5 +1,5 @@
---- 
-lib/smart_answer_flows/check-uk-visa.rb: dc1c01019af17dee7cbfef4f18e77b0a
+---
+lib/smart_answer_flows/check-uk-visa.rb: 28e40e3202a22eb1228a9af24da80988
 lib/smart_answer_flows/locales/en/check-uk-visa.yml: 7f441908f6c20b8e548e9a11ce8ade73
 test/data/check-uk-visa-questions-and-responses.yml: f3bbf465d62274d46769eee8fb99d9bc
 test/data/check-uk-visa-responses-and-expected-results.yml: 5efd380bd1adca1aad2506c003c44f05

--- a/test/data/childcare-costs-for-tax-credits-files.yml
+++ b/test/data/childcare-costs-for-tax-credits-files.yml
@@ -1,5 +1,5 @@
---- 
-lib/smart_answer_flows/childcare-costs-for-tax-credits.rb: 5a81da259c587f65355e4e9ce7e52eee
+---
+lib/smart_answer_flows/childcare-costs-for-tax-credits.rb: b29eb75294314e894fb4476ce6d80fee
 lib/smart_answer_flows/locales/en/childcare-costs-for-tax-credits.yml: 7199a8c4f6e40c21c5ff299f29937f62
 test/data/childcare-costs-for-tax-credits-questions-and-responses.yml: 136aea3591662aa753c3c630546e68ad
 test/data/childcare-costs-for-tax-credits-responses-and-expected-results.yml: 7d90f3446d1e2c9551d7d363fbc4d639

--- a/test/data/energy-grants-calculator-files.yml
+++ b/test/data/energy-grants-calculator-files.yml
@@ -1,5 +1,5 @@
---- 
-lib/smart_answer_flows/energy-grants-calculator.rb: c6272116ab0e682e9fcd28f0e22038bd
+---
+lib/smart_answer_flows/energy-grants-calculator.rb: 75aa3d3502ec972766cdc9c87dee2542
 lib/smart_answer_flows/locales/en/energy-grants-calculator.yml: 59762be041aa30702b4539c24246e41c
 test/data/energy-grants-calculator-questions-and-responses.yml: 9db51ef9a0c467a588f0416ef5cefff1
 test/data/energy-grants-calculator-responses-and-expected-results.yml: a74075e2ccb5343d91f87a15924e0f65

--- a/test/data/estimate-self-assessment-penalties-files.yml
+++ b/test/data/estimate-self-assessment-penalties-files.yml
@@ -1,5 +1,5 @@
---- 
-lib/smart_answer_flows/estimate-self-assessment-penalties.rb: cd353c7d2390d5e88c9d08e1b5a488d0
+---
+lib/smart_answer_flows/estimate-self-assessment-penalties.rb: c8ff21596090648a8762b962ab7754b6
 lib/smart_answer_flows/locales/en/estimate-self-assessment-penalties.yml: 2d15a489772e13429a7efdee5ef40e1a
 test/data/estimate-self-assessment-penalties-questions-and-responses.yml: 186d93854ea5dc9321408e14dcc8d61f
 test/data/estimate-self-assessment-penalties-responses-and-expected-results.yml: 07a0cd26b8c5e4b1fff6dfe51c20142e

--- a/test/data/help-if-you-are-arrested-abroad-files.yml
+++ b/test/data/help-if-you-are-arrested-abroad-files.yml
@@ -1,5 +1,5 @@
---- 
-lib/smart_answer_flows/help-if-you-are-arrested-abroad.rb: d132cd3bfcee17150a34bc556705b75c
+---
+lib/smart_answer_flows/help-if-you-are-arrested-abroad.rb: 98c42d92091f8df3c4f72dbfdbe45802
 lib/smart_answer_flows/locales/en/help-if-you-are-arrested-abroad.yml: 5583f9699ff484bfd4fc4ebe2a15f191
 test/data/help-if-you-are-arrested-abroad-questions-and-responses.yml: c007b0dd259d1c09ccc2dd3163fa1e56
 test/data/help-if-you-are-arrested-abroad-responses-and-expected-results.yml: 26a4d487258c3984a6cd73da22c2d8e6

--- a/test/data/inherits-someone-dies-without-will-files.yml
+++ b/test/data/inherits-someone-dies-without-will-files.yml
@@ -1,5 +1,5 @@
---- 
-lib/smart_answer_flows/inherits-someone-dies-without-will.rb: 0356c80fcc259a3cf882b7c90136906c
+---
+lib/smart_answer_flows/inherits-someone-dies-without-will.rb: 007d7e9809cdc82048e9b752a06464fe
 lib/smart_answer_flows/locales/en/inherits-someone-dies-without-will.yml: faf2edc7b65335d39b9771d179d279d8
 test/data/inherits-someone-dies-without-will-questions-and-responses.yml: e2e1ed6d7bb7c839f6ae34db9697dbbd
 test/data/inherits-someone-dies-without-will-responses-and-expected-results.yml: df21c3f65db333e619238f3baa3e9859

--- a/test/data/legalisation-document-checker-files.yml
+++ b/test/data/legalisation-document-checker-files.yml
@@ -1,5 +1,5 @@
---- 
-lib/smart_answer_flows/legalisation-document-checker.rb: 14b4efc9ab0774ae55ffe26ad65b5755
+---
+lib/smart_answer_flows/legalisation-document-checker.rb: 81ad2cd8f8ab034f29a9a74814c0a2b9
 lib/smart_answer_flows/locales/en/legalisation-document-checker.yml: 04490ae627332eeb5c83a769e10c6496
 test/data/legalisation-document-checker-questions-and-responses.yml: 37c99c68ba04e459447622b01938ce0b
 test/data/legalisation-document-checker-responses-and-expected-results.yml: a6de7673704ef7ff4348546128f52b75

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/marriage-abroad.rb: afc71eb8f329977cddd5d8595f1a48a1
+lib/smart_answer_flows/marriage-abroad.rb: 8f59a68b54e61811f256fee9006df45a
 lib/smart_answer_flows/locales/en/marriage-abroad.yml: 5839da4f9692ad08dae81297f3dbf197
 test/data/marriage-abroad-questions-and-responses.yml: eabbd09ca91fab72a9a520d1087fb35e
 test/data/marriage-abroad-responses-and-expected-results.yml: 74f923c5f929e369f4c9a9f0b47ffcc7

--- a/test/data/maternity-paternity-calculator-files.yml
+++ b/test/data/maternity-paternity-calculator-files.yml
@@ -1,5 +1,5 @@
---- 
-lib/smart_answer_flows/maternity-paternity-calculator.rb: 786d7f0e2058dd5a4b125094b4ff876e
+---
+lib/smart_answer_flows/maternity-paternity-calculator.rb: 685e6ad891cbcc7859d795b8e1ce3b81
 lib/smart_answer_flows/locales/en/maternity-paternity-calculator.yml: 1cd9c855b30fff4580fc2bbc5866fe83
 test/data/maternity-paternity-calculator-questions-and-responses.yml: 0907253765bf7e265a2399281f2b6cc5
 test/data/maternity-paternity-calculator-responses-and-expected-results.yml: 775834b47561e46bf1bb8f54dd197c60

--- a/test/data/minimum-wage-calculator-employers-files.yml
+++ b/test/data/minimum-wage-calculator-employers-files.yml
@@ -1,5 +1,5 @@
---- 
-lib/smart_answer_flows/minimum-wage-calculator-employers.rb: aa193c977054901f9db4dca7a7463f43
+---
+lib/smart_answer_flows/minimum-wage-calculator-employers.rb: 7d3535af37a25bb87337e8a118c3cf5f
 lib/smart_answer_flows/locales/en/minimum-wage-calculator-employers.yml: 1d69047c9eda71bf80fc761516b0e90e
 test/data/minimum-wage-calculator-employers-questions-and-responses.yml: 8d05a23bb72740b2d9c9f1196f212e0e
 test/data/minimum-wage-calculator-employers-responses-and-expected-results.yml: 4f24160d38e41983f72ce1352fad9702

--- a/test/data/overseas-passports-files.yml
+++ b/test/data/overseas-passports-files.yml
@@ -1,5 +1,5 @@
---- 
-lib/smart_answer_flows/overseas-passports.rb: a411122229c4205a3de5c9c9d850ad6b
+---
+lib/smart_answer_flows/overseas-passports.rb: d0ca6382bbe3570d952fc05c9d3bac0b
 lib/smart_answer_flows/locales/en/overseas-passports.yml: 818310a24be17db580977c560c009265
 test/data/overseas-passports-questions-and-responses.yml: dc6c103245cab8e2f33aee73d7c46556
 test/data/overseas-passports-responses-and-expected-results.yml: 13d8f1d2d9ac2d996e8f337702593417

--- a/test/data/pip-checker-files.yml
+++ b/test/data/pip-checker-files.yml
@@ -1,5 +1,5 @@
---- 
-lib/smart_answer_flows/pip-checker.rb: 51809f0bd466583cc045bd0cd5d7adaa
+---
+lib/smart_answer_flows/pip-checker.rb: 78c8062ff5b168f59fc4118a131907e0
 lib/smart_answer_flows/locales/en/pip-checker.yml: dbc19b1bdbf62c84bef9c4d48e98f213
 test/data/pip-checker-questions-and-responses.yml: b1d68ebfb76a9e2793705c55b82294f5
 test/data/pip-checker-responses-and-expected-results.yml: f0c8c243623cad06b9c65dbb504d5b4d

--- a/test/data/plan-adoption-leave-files.yml
+++ b/test/data/plan-adoption-leave-files.yml
@@ -1,5 +1,5 @@
---- 
-lib/smart_answer_flows/plan-adoption-leave.rb: b7e08de391492d2554121d8fb4712d53
+---
+lib/smart_answer_flows/plan-adoption-leave.rb: 3255e3c8c8704888f7993c87354be2ea
 lib/smart_answer_flows/locales/en/plan-adoption-leave.yml: 8c28c1f6a3946d3f57fc06538a72703b
 test/data/plan-adoption-leave-questions-and-responses.yml: 19cde22548bdc648de4a1616676283ae
 test/data/plan-adoption-leave-responses-and-expected-results.yml: 11998cff3f7d722bfb842851dde611b8

--- a/test/data/register-a-birth-files.yml
+++ b/test/data/register-a-birth-files.yml
@@ -1,5 +1,5 @@
---- 
-lib/smart_answer_flows/register-a-birth.rb: 52353ca3ef87fc5d76d027fdc36535c3
+---
+lib/smart_answer_flows/register-a-birth.rb: 7b842abccc1e27321268d3d79bbb7af0
 lib/smart_answer_flows/locales/en/register-a-birth.yml: 570b5821a64274d765cdf46d4d5b5b92
 test/data/register-a-birth-questions-and-responses.yml: d43385aee50bc3d3fa5550faf761a0ae
 test/data/register-a-birth-responses-and-expected-results.yml: c04b7ff4d2b3f05c04b4175fb5e50b2c

--- a/test/data/register-a-death-files.yml
+++ b/test/data/register-a-death-files.yml
@@ -1,5 +1,5 @@
---- 
-lib/smart_answer_flows/register-a-death.rb: 30b2a753ddfe6e22d0fc19841331b6da
+---
+lib/smart_answer_flows/register-a-death.rb: d18144dfb97bcbd600ef0433a56e512f
 lib/smart_answer_flows/locales/en/register-a-death.yml: 117a44ad76a2b05ed2a638e76b378640
 test/data/register-a-death-questions-and-responses.yml: 18aba16b4f569a17fbb81374dceaf265
 test/data/register-a-death-responses-and-expected-results.yml: 1d818139ced9c5e20262d144489bf090

--- a/test/data/report-a-lost-or-stolen-passport-files.yml
+++ b/test/data/report-a-lost-or-stolen-passport-files.yml
@@ -1,5 +1,5 @@
---- 
-lib/smart_answer_flows/report-a-lost-or-stolen-passport.rb: 0d35e8f5bb346d669c72cf61fbd97024
+---
+lib/smart_answer_flows/report-a-lost-or-stolen-passport.rb: 8313ba13aa54c9403dcceb8ba46abab2
 lib/smart_answer_flows/locales/en/report-a-lost-or-stolen-passport.yml: 08170c87d6f075fc0ca529dea22a430c
 test/data/report-a-lost-or-stolen-passport-questions-and-responses.yml: cb7d64407b737eeb4924389f3bd335c6
 test/data/report-a-lost-or-stolen-passport-responses-and-expected-results.yml: 2ef8837f76907e72aadb198636a62078

--- a/test/data/simplified-expenses-checker-files.yml
+++ b/test/data/simplified-expenses-checker-files.yml
@@ -1,5 +1,5 @@
---- 
-lib/smart_answer_flows/simplified-expenses-checker.rb: 6d5b95f38d2a001c6bf186acd3b49556
+---
+lib/smart_answer_flows/simplified-expenses-checker.rb: 4c48ace98519ddb46b2dd8c58bb5337a
 lib/smart_answer_flows/locales/en/simplified-expenses-checker.yml: d76eb23e44e50155626002c4242d43f7
 test/data/simplified-expenses-checker-questions-and-responses.yml: 6b1c358b3730897b6cbefa9477ada15b
 test/data/simplified-expenses-checker-responses-and-expected-results.yml: 983e72657f76697beafb2dcbe4018bee

--- a/test/data/state-pension-through-partner-files.yml
+++ b/test/data/state-pension-through-partner-files.yml
@@ -1,5 +1,5 @@
---- 
-lib/smart_answer_flows/state-pension-through-partner.rb: d5f74f7e01c2edfdbeda4f06b62afee9
+---
+lib/smart_answer_flows/state-pension-through-partner.rb: 91f52777732a5150028cb5006e54be12
 lib/smart_answer_flows/locales/en/state-pension-through-partner.yml: 593e67d24efb2ec7fca5925a7f07618f
 test/data/state-pension-through-partner-questions-and-responses.yml: 34f2b5f7ac286bb3eea690564339051b
 test/data/state-pension-through-partner-responses-and-expected-results.yml: 7886f7591361df671b51ad857265cf6a

--- a/test/data/state-pension-topup-files.yml
+++ b/test/data/state-pension-topup-files.yml
@@ -1,5 +1,5 @@
---- 
-lib/smart_answer_flows/state-pension-topup.rb: 787127f34774d5fffe01a76756d6c036
+---
+lib/smart_answer_flows/state-pension-topup.rb: 7d2c521d1096afeecaf8873f7f7acc27
 lib/smart_answer_flows/locales/en/state-pension-topup.yml: 43be8bb20be218e4a4f26970cf6411c6
 test/data/state-pension-topup-questions-and-responses.yml: d3997e715e206c38ea8a0783b07b2350
 test/data/state-pension-topup-responses-and-expected-results.yml: caa7a2bc7d84f16cf78583a97192e29b

--- a/test/data/student-finance-calculator-files.yml
+++ b/test/data/student-finance-calculator-files.yml
@@ -1,5 +1,5 @@
---- 
-lib/smart_answer_flows/student-finance-calculator.rb: 11a0a54f5635c6a438ee55e7206c7091
+---
+lib/smart_answer_flows/student-finance-calculator.rb: 50373e5766e6469df7110fde0fbcfc35
 lib/smart_answer_flows/locales/en/student-finance-calculator.yml: 6100f316b4a031ee1a3c46ff377c6ab6
 test/data/student-finance-calculator-questions-and-responses.yml: 7f7a6293dd5c37756c89ea6b075ffd45
 test/data/student-finance-calculator-responses-and-expected-results.yml: f4588ab6828397faa8f1fc4dce005398

--- a/test/data/student-finance-forms-files.yml
+++ b/test/data/student-finance-forms-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/student-finance-forms.rb: 8ee5bf5fc1ffb41c74bcef3972edd337
+lib/smart_answer_flows/student-finance-forms.rb: c8d2a9f40a8052633b021da6cd075c12
 lib/smart_answer_flows/locales/en/student-finance-forms.yml: 4af45b8e051978b737e78976edbbd826
 test/data/student-finance-forms-questions-and-responses.yml: ec2ad38a9df75dd2606b9f979afd5066
 test/data/student-finance-forms-responses-and-expected-results.yml: fb765941838abb1e05b2d874049c7db1

--- a/test/data/towing-rules-files.yml
+++ b/test/data/towing-rules-files.yml
@@ -1,5 +1,5 @@
---- 
-lib/smart_answer_flows/towing-rules.rb: 58086918ccaf3fbb6900cfa3c68c4d4c
+---
+lib/smart_answer_flows/towing-rules.rb: 76c99d0ebe9a26d686563ce4b9512a54
 lib/smart_answer_flows/locales/en/towing-rules.yml: 328d0b63a2a823181fa313815a40ee13
 test/data/towing-rules-questions-and-responses.yml: 09c8f43d5353fa6248658a27982ea5a2
 test/data/towing-rules-responses-and-expected-results.yml: ab907e6d438f7f2f6fc76bb1b219e6d7

--- a/test/data/uk-benefits-abroad-files.yml
+++ b/test/data/uk-benefits-abroad-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/uk-benefits-abroad.rb: c0ef16e74cd6f17c28bad828a1a4437d
+lib/smart_answer_flows/uk-benefits-abroad.rb: e0cc93a3362b014249d9e4b906d3f1b0
 lib/smart_answer_flows/locales/en/uk-benefits-abroad.yml: e9505d99568d8e4c79f30ba1a5fb8d12
 test/data/uk-benefits-abroad-questions-and-responses.yml: 17973c7c16f38d7988ff1a5b76d3261a
 test/data/uk-benefits-abroad-responses-and-expected-results.yml: 37bfb8e7982e15f0f907881bf1130ce3

--- a/test/data/vat-payment-deadlines-files.yml
+++ b/test/data/vat-payment-deadlines-files.yml
@@ -1,5 +1,5 @@
---- 
-lib/smart_answer_flows/vat-payment-deadlines.rb: 0b42593ff72d99cc3fb1c31d4851c5bb
+---
+lib/smart_answer_flows/vat-payment-deadlines.rb: 8ba554c733d8476deb567039620a5cda
 lib/smart_answer_flows/locales/en/vat-payment-deadlines.yml: 96a0aaa62f2db7169db4ed5f1caeff06
 test/data/vat-payment-deadlines-questions-and-responses.yml: a9c89cff2686881257fe52b750032268
 test/data/vat-payment-deadlines-responses-and-expected-results.yml: 88f5a54e78f8b5006265a8005cdd15fe

--- a/test/fixtures/smart_answer_flows/bridge-of-death.rb
+++ b/test/fixtures/smart_answer_flows/bridge-of-death.rb
@@ -34,8 +34,6 @@ module SmartAnswer
         option red: :done
       end
 
-      use_outcome_templates
-
       outcome :done
       outcome :auuuuuuuugh
     end

--- a/test/fixtures/smart_answer_flows/checkbox-sample.rb
+++ b/test/fixtures/smart_answer_flows/checkbox-sample.rb
@@ -26,8 +26,6 @@ module SmartAnswer
         end
       end
 
-      use_outcome_templates
-
       outcome :margherita
       outcome :on_its_way
       outcome :no_way

--- a/test/fixtures/smart_answer_flows/country-and-date-sample.rb
+++ b/test/fixtures/smart_answer_flows/country-and-date-sample.rb
@@ -26,8 +26,6 @@ module SmartAnswer
         next_node :ok
       end
 
-      use_outcome_templates
-
       outcome :ok
     end
   end

--- a/test/fixtures/smart_answer_flows/country-legacy-sample.rb
+++ b/test/fixtures/smart_answer_flows/country-legacy-sample.rb
@@ -14,8 +14,6 @@ module SmartAnswer
         next_node :ok
       end
 
-      use_outcome_templates
-
       outcome :ok
     end
   end

--- a/test/fixtures/smart_answer_flows/custom-errors-sample.rb
+++ b/test/fixtures/smart_answer_flows/custom-errors-sample.rb
@@ -11,8 +11,6 @@ module SmartAnswer
         end
       end
 
-      use_outcome_templates
-
       outcome :done
     end
   end

--- a/test/fixtures/smart_answer_flows/data-partial-sample.rb
+++ b/test/fixtures/smart_answer_flows/data-partial-sample.rb
@@ -9,8 +9,6 @@ module SmartAnswer
         option data_partial_with_array: :done_array
       end
 
-      use_outcome_templates
-
       outcome :done_scalar do
         precalculate :sample_data do
           {

--- a/test/fixtures/smart_answer_flows/money-and-salary-sample.rb
+++ b/test/fixtures/smart_answer_flows/money-and-salary-sample.rb
@@ -23,8 +23,6 @@ module SmartAnswer
         next_node :ok
       end
 
-      use_outcome_templates
-
       outcome :ok
     end
   end

--- a/test/fixtures/smart_answer_flows/precalculation-sample.rb
+++ b/test/fixtures/smart_answer_flows/precalculation-sample.rb
@@ -16,8 +16,6 @@ module SmartAnswer
         next_node :done
       end
 
-      use_outcome_templates
-
       outcome :done do
         precalculate :amount_of_wood do
           woodchuck_capacity.to_i * number_of_woodchucks.to_i

--- a/test/fixtures/smart_answer_flows/value-sample.rb
+++ b/test/fixtures/smart_answer_flows/value-sample.rb
@@ -10,8 +10,6 @@ module SmartAnswer
         next_node :outcome_with_template
       end
 
-      use_outcome_templates
-
       outcome :outcome_with_template
     end
   end

--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -24,8 +24,6 @@ class SmartAnswersControllerTest < ActionController::TestCase
         option no: :you_have_a_savoury_tooth
       end
 
-      use_outcome_templates
-
       outcome :you_have_a_savoury_tooth
       outcome :you_have_a_sweet_tooth
     end

--- a/test/unit/flow_test.rb
+++ b/test/unit/flow_test.rb
@@ -33,21 +33,6 @@ class FlowTest < ActiveSupport::TestCase
     assert flow.outcomes.first.template_directory.to_s.end_with?('flow-name')
   end
 
-  test "Can build single outcomes that use ERB templates" do
-    flow = SmartAnswer::Flow.new do
-      name 'flow-name'
-      outcome :outcome_with_erb_template, use_outcome_templates: true
-      outcome :outcome_without_erb_template, use_outcome_templates: false
-    end
-
-    assert_equal 2, flow.outcomes.size
-
-    assert_equal true, flow.outcomes.first.use_template?
-    assert flow.outcomes.first.template_directory.to_s.end_with?('flow-name')
-
-    assert_equal false, flow.outcomes.last.use_template?
-  end
-
   test "Can build multiple choice question nodes" do
     s = SmartAnswer::Flow.new do
       multiple_choice :do_you_like_chocolate? do

--- a/test/unit/flow_test.rb
+++ b/test/unit/flow_test.rb
@@ -24,7 +24,6 @@ class FlowTest < ActiveSupport::TestCase
   test "Can build outcomes where the whole flow uses ERB templates" do
     flow = SmartAnswer::Flow.new do
       name 'flow-name'
-      use_outcome_templates
       outcome :outcome_name
     end
 

--- a/test/unit/flow_test.rb
+++ b/test/unit/flow_test.rb
@@ -29,7 +29,6 @@ class FlowTest < ActiveSupport::TestCase
     end
 
     assert_equal 1, flow.outcomes.size
-    assert_equal true, flow.outcomes.first.use_template?
     assert flow.outcomes.first.template_directory.to_s.end_with?('flow-name')
   end
 

--- a/test/unit/node_presenter_test.rb
+++ b/test/unit/node_presenter_test.rb
@@ -181,13 +181,6 @@ module SmartAnswer
       assert presenter.has_title?
     end
 
-    test "Outcome has no title if using the OutcomePresenter" do
-      outcome = Outcome.new(:outcome_with_no_title)
-      presenter = OutcomePresenter.new("flow.test", outcome)
-
-      refute presenter.has_title?
-    end
-
     test "Node next_steps looked up from translation file, rendered as HTML using govspeak by default" do
       question = Question::Date.new(:example_question?)
       presenter = NodePresenter.new("flow.test", question)

--- a/test/unit/outcome_presenter_test.rb
+++ b/test/unit/outcome_presenter_test.rb
@@ -21,7 +21,7 @@ module SmartAnswer
     end
 
     test "#body returns nil when the erb template doesn't exist" do
-      outcome = Outcome.new('outcome-name', use_outcome_templates: true)
+      outcome = Outcome.new('outcome-name')
 
       options = { erb_template_directory: Pathname.new('/path/to/non-existent') }
       presenter = OutcomePresenter.new('i18n-prefix', outcome, state = nil, options)
@@ -30,7 +30,7 @@ module SmartAnswer
     end
 
     test '#body returns nil when content_for(:body) is missing' do
-      outcome = Outcome.new('outcome-name', use_outcome_templates: true)
+      outcome = Outcome.new('outcome-name')
 
       erb_template = ''
 
@@ -42,7 +42,7 @@ module SmartAnswer
     end
 
     test '#body returns a single newline when the template is empty' do
-      outcome = Outcome.new('outcome-name', use_outcome_templates: true)
+      outcome = Outcome.new('outcome-name')
 
       erb_template = content_for_body('')
 
@@ -54,7 +54,7 @@ module SmartAnswer
     end
 
     test "#body trims newlines by default" do
-      outcome = Outcome.new('outcome-name', use_outcome_templates: true)
+      outcome = Outcome.new('outcome-name')
 
       erb_template = content_for_body('<% if true %>
 Hello world
@@ -68,7 +68,7 @@ Hello world
     end
 
     test '#body strips spaces from the beginning of lines so that we can indent content in our content_for blocks' do
-      outcome = Outcome.new('outcome-name', use_outcome_templates: true)
+      outcome = Outcome.new('outcome-name')
 
       erb_template = content_for_body('  <% if true %>
     line 1
@@ -84,7 +84,7 @@ Hello world
     end
 
     test '#body makes the state variables available to the ERB template' do
-      outcome = Outcome.new('outcome-name', use_outcome_templates: true)
+      outcome = Outcome.new('outcome-name')
 
       erb_template = content_for_body('<%= state_variable %>')
 
@@ -97,7 +97,7 @@ Hello world
     end
 
     test "#body raises an exception if the ERB template references a non-existent state variable" do
-      outcome = Outcome.new('outcome-name', use_outcome_templates: true)
+      outcome = Outcome.new('outcome-name')
 
       erb_template = content_for_body('<%= non_existent_state_variable %>')
 
@@ -113,7 +113,7 @@ Hello world
     end
 
     test '#body makes the ActionView::Helpers::NumberHelper methods available to the ERB template' do
-      outcome = Outcome.new('outcome-name', use_outcome_templates: true)
+      outcome = Outcome.new('outcome-name')
 
       erb_template = content_for_body('<%= number_with_delimiter(123456789) %>')
 
@@ -125,7 +125,7 @@ Hello world
     end
 
     test '#body passes output of ERB template through Govspeak' do
-      outcome = Outcome.new('outcome-name', use_outcome_templates: true)
+      outcome = Outcome.new('outcome-name')
 
       erb_template = content_for_body('^information^')
 
@@ -138,7 +138,7 @@ Hello world
     end
 
     test '#body does not pass output of ERB template through Govspeak when HTML disabled' do
-      outcome = Outcome.new('outcome-name', use_outcome_templates: true)
+      outcome = Outcome.new('outcome-name')
 
       erb_template = content_for_body('^information^')
 
@@ -150,7 +150,7 @@ Hello world
     end
 
     test '#body returns the same content when called multiple times' do
-      outcome = Outcome.new('outcome-name', use_outcome_templates: true)
+      outcome = Outcome.new('outcome-name')
 
       erb_template = content_for_body('body-content')
 
@@ -163,7 +163,7 @@ Hello world
     end
 
     test "#title returns nil when the erb template doesn't exist" do
-      outcome = Outcome.new('outcome-name', use_outcome_templates: true)
+      outcome = Outcome.new('outcome-name')
 
       options = { erb_template_directory: Pathname.new('/path/to/non-existent') }
       presenter = OutcomePresenter.new('i18n-prefix', outcome, state = nil, options)
@@ -172,7 +172,7 @@ Hello world
     end
 
     test '#title returns nil when content_for(:title) is missing' do
-      outcome = Outcome.new('outcome-name', use_outcome_templates: true)
+      outcome = Outcome.new('outcome-name')
 
       erb_template = ''
 
@@ -184,7 +184,7 @@ Hello world
     end
 
     test '#title returns an empty string when the template is empty' do
-      outcome = Outcome.new('outcome-name', use_outcome_templates: true)
+      outcome = Outcome.new('outcome-name')
 
       erb_template = content_for_title('')
 
@@ -196,7 +196,7 @@ Hello world
     end
 
     test '#title trims a single newline from the end of the string' do
-      outcome = Outcome.new('outcome-name', use_outcome_templates: true)
+      outcome = Outcome.new('outcome-name')
 
       erb_template = content_for_title("title-text\n")
 
@@ -208,7 +208,7 @@ Hello world
     end
 
     test '#title strips spaces from the beginning of the line so that we can indent text within content_for blocks' do
-      outcome = Outcome.new('outcome-name', use_outcome_templates: true)
+      outcome = Outcome.new('outcome-name')
 
       erb_template = content_for_title('  indented-title-text')
 
@@ -220,7 +220,7 @@ Hello world
     end
 
     test '#title makes the state variables available to the ERB template' do
-      outcome = Outcome.new('outcome-name', use_outcome_templates: true)
+      outcome = Outcome.new('outcome-name')
 
       erb_template = content_for_title('<%= state_variable %>')
 
@@ -233,7 +233,7 @@ Hello world
     end
 
     test "#title raises an exception if the ERB template references a non-existent state variable" do
-      outcome = Outcome.new('outcome-name', use_outcome_templates: true)
+      outcome = Outcome.new('outcome-name')
 
       erb_template = content_for_title('<%= non_existent_state_variable %>')
 
@@ -249,7 +249,7 @@ Hello world
     end
 
     test '#title returns the same content when called multiple times' do
-      outcome = Outcome.new('outcome-name', use_outcome_templates: true)
+      outcome = Outcome.new('outcome-name')
 
       erb_template = content_for_title('title-content')
 
@@ -262,7 +262,7 @@ Hello world
     end
 
     test "#next_steps returns nil when the erb template doesn't exist" do
-      outcome = Outcome.new('outcome-name', use_outcome_templates: true)
+      outcome = Outcome.new('outcome-name')
 
       options = { erb_template_directory: Pathname.new('/path/to/non-existent') }
       presenter = OutcomePresenter.new('i18n-prefix', outcome, state = nil, options)
@@ -271,7 +271,7 @@ Hello world
     end
 
     test '#body returns nil when content_for(:next_steps) is missing' do
-      outcome = Outcome.new('outcome-name', use_outcome_templates: true)
+      outcome = Outcome.new('outcome-name')
 
       erb_template = ''
 
@@ -283,7 +283,7 @@ Hello world
     end
 
     test '#next_steps returns a single newline when the template is empty' do
-      outcome = Outcome.new('outcome-name', use_outcome_templates: true)
+      outcome = Outcome.new('outcome-name')
 
       erb_template = content_for_next_steps('')
 
@@ -295,7 +295,7 @@ Hello world
     end
 
     test "#next_steps trims newlines by default" do
-      outcome = Outcome.new('outcome-name', use_outcome_templates: true)
+      outcome = Outcome.new('outcome-name')
 
       erb_template = content_for_next_steps('<% if true %>
 Hello world
@@ -309,7 +309,7 @@ Hello world
     end
 
     test '#next_steps strips spaces from the beginning of the line so that we can indent text within content_for blocks' do
-      outcome = Outcome.new('outcome-name', use_outcome_templates: true)
+      outcome = Outcome.new('outcome-name')
 
       erb_template = content_for_next_steps('  indented-next-steps-text')
 
@@ -321,7 +321,7 @@ Hello world
     end
 
     test '#next_steps makes the state variables available to the ERB template' do
-      outcome = Outcome.new('outcome-name', use_outcome_templates: true)
+      outcome = Outcome.new('outcome-name')
 
       erb_template = content_for_next_steps('<%= state_variable %>')
 
@@ -334,7 +334,7 @@ Hello world
     end
 
     test "#next_steps raises an exception if the ERB template references a non-existent state variable" do
-      outcome = Outcome.new('outcome-name', use_outcome_templates: true)
+      outcome = Outcome.new('outcome-name')
 
       erb_template = content_for_next_steps('<%= non_existent_state_variable %>')
 
@@ -350,7 +350,7 @@ Hello world
     end
 
     test '#next_steps makes the ActionView::Helpers::NumberHelper methods available to the ERB template' do
-      outcome = Outcome.new('outcome-name', use_outcome_templates: true)
+      outcome = Outcome.new('outcome-name')
 
       erb_template = content_for_next_steps('<%= number_with_delimiter(123456789) %>')
 
@@ -362,7 +362,7 @@ Hello world
     end
 
     test '#next_steps passes output of ERB template through Govspeak' do
-      outcome = Outcome.new('outcome-name', use_outcome_templates: true)
+      outcome = Outcome.new('outcome-name')
 
       erb_template = content_for_next_steps('^information^')
 
@@ -375,7 +375,7 @@ Hello world
     end
 
     test '#next_steps does not pass output of ERB template through Govspeak when HTML disabled' do
-      outcome = Outcome.new('outcome-name', use_outcome_templates: true)
+      outcome = Outcome.new('outcome-name')
 
       erb_template = content_for_next_steps('^information^')
 
@@ -387,7 +387,7 @@ Hello world
     end
 
     test '#next_steps returns the same content when called multiple times' do
-      outcome = Outcome.new('outcome-name', use_outcome_templates: true)
+      outcome = Outcome.new('outcome-name')
 
       erb_template = content_for_next_steps('next-steps-content')
 

--- a/test/unit/outcome_presenter_test.rb
+++ b/test/unit/outcome_presenter_test.rb
@@ -149,14 +149,6 @@ Hello world
       end
     end
 
-    test '#body delegates to NodePresenter when not using outcome templates' do
-      outcome = Outcome.new('outcome-name', use_outcome_templates: false)
-      presenter = OutcomePresenter.new('i18n-prefix', outcome)
-
-      presenter.stubs(:translate_and_render).with('body', optionally(anything)).returns('node-presenter-body')
-      assert_equal 'node-presenter-body', presenter.body
-    end
-
     test '#body returns the same content when called multiple times' do
       outcome = Outcome.new('outcome-name', use_outcome_templates: true)
 

--- a/test/unit/outcome_presenter_test.rb
+++ b/test/unit/outcome_presenter_test.rb
@@ -256,14 +256,6 @@ Hello world
       end
     end
 
-    test '#title calls translate! to return the title when not using outcome templates' do
-      outcome = Outcome.new('outcome-name', use_outcome_templates: false)
-      presenter = OutcomePresenter.new('i18n-prefix', outcome)
-
-      presenter.stubs(:translate!).with('title').returns('outcome-presenter-title')
-      assert_equal 'outcome-presenter-title', presenter.title
-    end
-
     test '#title returns the same content when called multiple times' do
       outcome = Outcome.new('outcome-name', use_outcome_templates: true)
 

--- a/test/unit/outcome_presenter_test.rb
+++ b/test/unit/outcome_presenter_test.rb
@@ -386,14 +386,6 @@ Hello world
       end
     end
 
-    test '#next_steps delegates to NodePresenter when not using outcome templates' do
-      outcome = Outcome.new('outcome-name', use_outcome_templates: false)
-      presenter = OutcomePresenter.new('i18n-prefix', outcome)
-
-      presenter.stubs(:translate_and_render).with('next_steps', optionally(anything)).returns('node-presenter-body')
-      assert_equal 'node-presenter-body', presenter.next_steps
-    end
-
     test '#next_steps returns the same content when called multiple times' do
       outcome = Outcome.new('outcome-name', use_outcome_templates: true)
 

--- a/test/unit/outcome_test.rb
+++ b/test/unit/outcome_test.rb
@@ -2,18 +2,6 @@ require_relative '../test_helper'
 
 module SmartAnswer
   class OutcomeTest < ActiveSupport::TestCase
-    test '#use_template? returns nil by default' do
-      outcome = Outcome.new('outcome-name')
-      assert_equal nil, outcome.use_template?
-    end
-
-    test '#use_template? returns true if we supply the use_outcome_templates option' do
-      outcome_options = { use_outcome_templates: true }
-      outcome = Outcome.new('outcome-name', outcome_options)
-
-      assert_equal true, outcome.use_template?
-    end
-
     test '#template_directory returns nil by default' do
       outcome = Outcome.new('outcome-name')
       assert_equal nil, outcome.template_directory


### PR DESCRIPTION
__NOTE.__ This is based on #1894 so I'll want to make sure that's merged to master before this.

This removes the ability to render Outcomes using data stored in the YAML locale files.

This looks like a lot of commits but they're all really quite small; particularly the 35 commits that remove `use_outcome_templates` from each of the Smart Answer flows. I committed those separately so that I could commit the removal of that line and the change to the related checksum YAML file.