### PR TITLE
Normalize responses to postcode_questions

### DIFF
--- a/lib/smart_answer/question/postcode.rb
+++ b/lib/smart_answer/question/postcode.rb
@@ -5,7 +5,7 @@ module SmartAnswer
         postcode = UKPostcode.new(raw_input)
         raise InvalidResponse, :error_postcode_invalid unless postcode.valid?
         raise InvalidResponse, :error_postcode_incomplete unless postcode.full?
-        postcode.to_s
+        postcode.normalize
       end
     end
   end

--- a/test/unit/postcode_question_test.rb
+++ b/test/unit/postcode_question_test.rb
@@ -15,6 +15,11 @@ module SmartAnswer
       assert_equal "W1A 2AB", new_state.my_postcode
     end
 
+    test "abnormal postcode" do
+      new_state = @question.transition(@initial_state, "w1A2ab")
+      assert_equal "W1A 2AB", new_state.my_postcode
+    end
+
     test "incomplete postcode" do
       e = assert_raises InvalidResponse do
         @question.transition(@initial_state, "W1A")


### PR DESCRIPTION
This feels like a nice thing to do and is built-in to the `uk_postcode` gem
that we're already using. What's more it means that URLs for the same postcode
in a different format are now the same.

Note that making the change here means that the postcode is displayed in the
normalized form in the responses to previous questions. Also when you click one
of the related "Change" links the postcode text field is pre-filled with the
normalized form of the original value.