### PR TITLE
Updated postcodes for PIP

### DIFF
--- a/lib/smart_answer_flows/pip-checker/result_5.govspeak.erb
+++ b/lib/smart_answer_flows/pip-checker/result_5.govspeak.erb
@@ -18,7 +18,7 @@
 
   ###Your child's DLA ends after September 2017 or DLA awards with no end date
 
-  Some people will be invited to claim PIP from 13 July 2015 if you live in the following areas:
+  Some people will be invited to claim PIP if you live in the following areas:
 
   - Blackburn (BB)
   - Bolton (BL)
@@ -30,12 +30,42 @@
   - Stoke-on-Trent (ST)
   - Warrington (WA)
   - Wigan (WN)
-
-  On 17 August 2015 the scheme will be expanded to include postcodes beginning with:
-
   - Colchester (CO)
   - Liverpool (L)
   - Norwich (NR)
+  
+  On 1 September 2015 the scheme will be expanded to include postcodes beginning with:
+  
+  - Cardiff (CF)
+  - Cambridge (CB)
+  - Chelmsford (CM)
+  - Romford (RM)
+  - Southend on Sea (SS)
+  - Bromley (BR)
+  - Canterbury (CT)
+  - Dartford (DA)
+  - Luton (LU)
+  - Portsmouth (PO)
+  - Reading (RG)
+  - Durham (DH)
+  - Huddersfield (HD)
+  - Halifax (HX)
+  - Crewe (CW)
+  - Blackpool (FY)
+  - Lancaster (LA)
+  - Stockport (SK)
+  - Southampton (SO)
+  - Bath (BA)
+  - Bournemouth (BH)
+  - Bristol (BS)
+  - Dorchester (DT)
+  - Gloucester (GL)
+  - Plymouth (PL)
+  - Salisbury (SP)
+  - Taunton (TA)
+  - Torquay (TQ)
+  - Truro (TR)
+  
 
   This includes if your child has an indefinite or long-term awards of DLA.
 


### PR DESCRIPTION
Amending this outcome: https://www.gov.uk/pip-checker/y/yes/2001-01-01

I've combined the 2 sets of postcodes that went live on 13 July and 17 August. And created a new list of postcodes to be includes from 1 September. 

Relates to ticket: https://govuk.zendesk.com/agent/tickets/1118011