### PR TITLE
Updated postcodes for PIP

### DIFF
--- a/lib/smart_answer_flows/pip-checker/_scheme_postcodes.govspeak.erb
+++ b/lib/smart_answer_flows/pip-checker/_scheme_postcodes.govspeak.erb
@@ -1,7 +1,7 @@
 
 ###Your DLA ends after September 2017 or your DLA award has no end date
 
-Some people will be invited to claim PIP from 13 July 2015 if you live in the following areas:
+Some people will be invited to claim PIP if you live in the following areas:
 
 - Blackburn (BB)
 - Bolton (BL)
@@ -13,12 +13,41 @@ Some people will be invited to claim PIP from 13 July 2015 if you live in the fo
 - Stoke-on-Trent (ST)
 - Warrington (WA)
 - Wigan (WN)
-
-On 17 August 2015 the scheme will be expanded to include postcodes beginning with:
-
 - Colchester (CO)
 - Liverpool (L)
 - Norwich (NR)
+
+On 1 September 2015 the scheme will be expanded to include postcodes beginning with:
+
+  - Cardiff (CF)
+  - Cambridge (CB)
+  - Chelmsford (CM)
+  - Romford (RM)
+  - Southend on Sea (SS)
+  - Bromley (BR)
+  - Canterbury (CT)
+  - Dartford (DA)
+  - Luton (LU)
+  - Portsmouth (PO)
+  - Reading (RG)
+  - Durham (DH)
+  - Huddersfield (HD)
+  - Halifax (HX)
+  - Crewe (CW)
+  - Blackpool (FY)
+  - Lancaster (LA)
+  - Stockport (SK)
+  - Southampton (SO)
+  - Bath (BA)
+  - Bournemouth (BH)
+  - Bristol (BS)
+  - Dorchester (DT)
+  - Gloucester (GL)
+  - Plymouth (PL)
+  - Salisbury (SP)
+  - Taunton (TA)
+  - Torquay (TQ)
+  - Truro (TR)
 
 This includes if you have an indefinite or long-term awards of DLA.
 


### PR DESCRIPTION
Update to outcome: https://www.gov.uk/pip-checker/y/yes/1985-01-01

I've combined the 2 sets of postcodes that went live on 13 July and 17 August. And added a new list of postcodes to be included from 1 September.