### PR TITLE
Update postcodes for PIP checker

### DIFF
--- a/lib/smart_answer_flows/pip-checker/_scheme_postcodes.govspeak.erb
+++ b/lib/smart_answer_flows/pip-checker/_scheme_postcodes.govspeak.erb
@@ -1,7 +1,7 @@
 
 ###Your DLA ends after September 2017 or your DLA award has no end date
 
-Some people will be invited to claim PIP from 13 July 2015 if you live in the following areas:
+Some people will be invited to claim PIP if you live in the following areas:
 
 - Blackburn (BB)
 - Bolton (BL)
@@ -13,12 +13,41 @@ Some people will be invited to claim PIP from 13 July 2015 if you live in the fo
 - Stoke-on-Trent (ST)
 - Warrington (WA)
 - Wigan (WN)
-
-On 17 August 2015 the scheme will be expanded to include postcodes beginning with:
-
 - Colchester (CO)
 - Liverpool (L)
 - Norwich (NR)
+
+On 1 September 2015 the scheme will be expanded to include postcodes beginning with:
+
+  - Cardiff (CF)
+  - Cambridge (CB)
+  - Chelmsford (CM)
+  - Romford (RM)
+  - Southend on Sea (SS)
+  - Bromley (BR)
+  - Canterbury (CT)
+  - Dartford (DA)
+  - Luton (LU)
+  - Portsmouth (PO)
+  - Reading (RG)
+  - Durham (DH)
+  - Huddersfield (HD)
+  - Halifax (HX)
+  - Crewe (CW)
+  - Blackpool (FY)
+  - Lancaster (LA)
+  - Stockport (SK)
+  - Southampton (SO)
+  - Bath (BA)
+  - Bournemouth (BH)
+  - Bristol (BS)
+  - Dorchester (DT)
+  - Gloucester (GL)
+  - Plymouth (PL)
+  - Salisbury (SP)
+  - Taunton (TA)
+  - Torquay (TQ)
+  - Truro (TR)
 
 This includes if you have an indefinite or long-term awards of DLA.
 

--- a/lib/smart_answer_flows/pip-checker/result_5.govspeak.erb
+++ b/lib/smart_answer_flows/pip-checker/result_5.govspeak.erb
@@ -18,7 +18,7 @@
 
   ###Your child's DLA ends after September 2017 or DLA awards with no end date
 
-  Some people will be invited to claim PIP from 13 July 2015 if you live in the following areas:
+  Some people will be invited to claim PIP if you live in the following areas:
 
   - Blackburn (BB)
   - Bolton (BL)
@@ -30,12 +30,42 @@
   - Stoke-on-Trent (ST)
   - Warrington (WA)
   - Wigan (WN)
-
-  On 17 August 2015 the scheme will be expanded to include postcodes beginning with:
-
   - Colchester (CO)
   - Liverpool (L)
   - Norwich (NR)
+  
+  On 1 September 2015 the scheme will be expanded to include postcodes beginning with:
+  
+  - Cardiff (CF)
+  - Cambridge (CB)
+  - Chelmsford (CM)
+  - Romford (RM)
+  - Southend on Sea (SS)
+  - Bromley (BR)
+  - Canterbury (CT)
+  - Dartford (DA)
+  - Luton (LU)
+  - Portsmouth (PO)
+  - Reading (RG)
+  - Durham (DH)
+  - Huddersfield (HD)
+  - Halifax (HX)
+  - Crewe (CW)
+  - Blackpool (FY)
+  - Lancaster (LA)
+  - Stockport (SK)
+  - Southampton (SO)
+  - Bath (BA)
+  - Bournemouth (BH)
+  - Bristol (BS)
+  - Dorchester (DT)
+  - Gloucester (GL)
+  - Plymouth (PL)
+  - Salisbury (SP)
+  - Taunton (TA)
+  - Torquay (TQ)
+  - Truro (TR)
+  
 
   This includes if your child has an indefinite or long-term awards of DLA.
 

--- a/test/artefacts/pip-checker/yes/1949-02-03.txt
+++ b/test/artefacts/pip-checker/yes/1949-02-03.txt
@@ -19,7 +19,7 @@ You'll also be invited to claim PIP if you tell the Department for Work and Pens
 
 ###Your DLA ends after September 2017 or your DLA award has no end date
 
-Some people will be invited to claim PIP from 13 July 2015 if you live in the following areas:
+Some people will be invited to claim PIP if you live in the following areas:
 
 - Blackburn (BB)
 - Bolton (BL)
@@ -31,12 +31,41 @@ Some people will be invited to claim PIP from 13 July 2015 if you live in the fo
 - Stoke-on-Trent (ST)
 - Warrington (WA)
 - Wigan (WN)
-
-On 17 August 2015 the scheme will be expanded to include postcodes beginning with:
-
 - Colchester (CO)
 - Liverpool (L)
 - Norwich (NR)
+
+On 1 September 2015 the scheme will be expanded to include postcodes beginning with:
+
+- Cardiff (CF)
+- Cambridge (CB)
+- Chelmsford (CM)
+- Romford (RM)
+- Southend on Sea (SS)
+- Bromley (BR)
+- Canterbury (CT)
+- Dartford (DA)
+- Luton (LU)
+- Portsmouth (PO)
+- Reading (RG)
+- Durham (DH)
+- Huddersfield (HD)
+- Halifax (HX)
+- Crewe (CW)
+- Blackpool (FY)
+- Lancaster (LA)
+- Stockport (SK)
+- Southampton (SO)
+- Bath (BA)
+- Bournemouth (BH)
+- Bristol (BS)
+- Dorchester (DT)
+- Gloucester (GL)
+- Plymouth (PL)
+- Salisbury (SP)
+- Taunton (TA)
+- Torquay (TQ)
+- Truro (TR)
 
 This includes if you have an indefinite or long-term awards of DLA.
 

--- a/test/artefacts/pip-checker/yes/1990-03-05.txt
+++ b/test/artefacts/pip-checker/yes/1990-03-05.txt
@@ -19,7 +19,7 @@ You'll also be invited to claim PIP if you tell the Department for Work and Pens
 
 ###Your DLA ends after September 2017 or your DLA award has no end date
 
-Some people will be invited to claim PIP from 13 July 2015 if you live in the following areas:
+Some people will be invited to claim PIP if you live in the following areas:
 
 - Blackburn (BB)
 - Bolton (BL)
@@ -31,12 +31,41 @@ Some people will be invited to claim PIP from 13 July 2015 if you live in the fo
 - Stoke-on-Trent (ST)
 - Warrington (WA)
 - Wigan (WN)
-
-On 17 August 2015 the scheme will be expanded to include postcodes beginning with:
-
 - Colchester (CO)
 - Liverpool (L)
 - Norwich (NR)
+
+On 1 September 2015 the scheme will be expanded to include postcodes beginning with:
+
+- Cardiff (CF)
+- Cambridge (CB)
+- Chelmsford (CM)
+- Romford (RM)
+- Southend on Sea (SS)
+- Bromley (BR)
+- Canterbury (CT)
+- Dartford (DA)
+- Luton (LU)
+- Portsmouth (PO)
+- Reading (RG)
+- Durham (DH)
+- Huddersfield (HD)
+- Halifax (HX)
+- Crewe (CW)
+- Blackpool (FY)
+- Lancaster (LA)
+- Stockport (SK)
+- Southampton (SO)
+- Bath (BA)
+- Bournemouth (BH)
+- Bristol (BS)
+- Dorchester (DT)
+- Gloucester (GL)
+- Plymouth (PL)
+- Salisbury (SP)
+- Taunton (TA)
+- Torquay (TQ)
+- Truro (TR)
 
 This includes if you have an indefinite or long-term awards of DLA.
 

--- a/test/artefacts/pip-checker/yes/1997-05-08.txt
+++ b/test/artefacts/pip-checker/yes/1997-05-08.txt
@@ -17,7 +17,7 @@ You'll also be invited to claim PIP if you tell the Department for Work and Pens
 
 ###Your DLA ends after September 2017 or your DLA award has no end date
 
-Some people will be invited to claim PIP from 13 July 2015 if you live in the following areas:
+Some people will be invited to claim PIP if you live in the following areas:
 
 - Blackburn (BB)
 - Bolton (BL)
@@ -29,12 +29,41 @@ Some people will be invited to claim PIP from 13 July 2015 if you live in the fo
 - Stoke-on-Trent (ST)
 - Warrington (WA)
 - Wigan (WN)
-
-On 17 August 2015 the scheme will be expanded to include postcodes beginning with:
-
 - Colchester (CO)
 - Liverpool (L)
 - Norwich (NR)
+
+On 1 September 2015 the scheme will be expanded to include postcodes beginning with:
+
+- Cardiff (CF)
+- Cambridge (CB)
+- Chelmsford (CM)
+- Romford (RM)
+- Southend on Sea (SS)
+- Bromley (BR)
+- Canterbury (CT)
+- Dartford (DA)
+- Luton (LU)
+- Portsmouth (PO)
+- Reading (RG)
+- Durham (DH)
+- Huddersfield (HD)
+- Halifax (HX)
+- Crewe (CW)
+- Blackpool (FY)
+- Lancaster (LA)
+- Stockport (SK)
+- Southampton (SO)
+- Bath (BA)
+- Bournemouth (BH)
+- Bristol (BS)
+- Dorchester (DT)
+- Gloucester (GL)
+- Plymouth (PL)
+- Salisbury (SP)
+- Taunton (TA)
+- Torquay (TQ)
+- Truro (TR)
 
 This includes if you have an indefinite or long-term awards of DLA.
 

--- a/test/artefacts/pip-checker/yes/2000-04-05.txt
+++ b/test/artefacts/pip-checker/yes/2000-04-05.txt
@@ -19,7 +19,7 @@ Your child will also be invited to claim PIP if you tell the Department for Work
 
 ###Your child's DLA ends after September 2017 or DLA awards with no end date
 
-Some people will be invited to claim PIP from 13 July 2015 if you live in the following areas:
+Some people will be invited to claim PIP if you live in the following areas:
 
 - Blackburn (BB)
 - Bolton (BL)
@@ -31,12 +31,42 @@ Some people will be invited to claim PIP from 13 July 2015 if you live in the fo
 - Stoke-on-Trent (ST)
 - Warrington (WA)
 - Wigan (WN)
-
-On 17 August 2015 the scheme will be expanded to include postcodes beginning with:
-
 - Colchester (CO)
 - Liverpool (L)
 - Norwich (NR)
+
+On 1 September 2015 the scheme will be expanded to include postcodes beginning with:
+
+- Cardiff (CF)
+- Cambridge (CB)
+- Chelmsford (CM)
+- Romford (RM)
+- Southend on Sea (SS)
+- Bromley (BR)
+- Canterbury (CT)
+- Dartford (DA)
+- Luton (LU)
+- Portsmouth (PO)
+- Reading (RG)
+- Durham (DH)
+- Huddersfield (HD)
+- Halifax (HX)
+- Crewe (CW)
+- Blackpool (FY)
+- Lancaster (LA)
+- Stockport (SK)
+- Southampton (SO)
+- Bath (BA)
+- Bournemouth (BH)
+- Bristol (BS)
+- Dorchester (DT)
+- Gloucester (GL)
+- Plymouth (PL)
+- Salisbury (SP)
+- Taunton (TA)
+- Torquay (TQ)
+- Truro (TR)
+
 
 This includes if your child has an indefinite or long-term awards of DLA.
 

--- a/test/data/pip-checker-files.yml
+++ b/test/data/pip-checker-files.yml
@@ -3,12 +3,12 @@ lib/smart_answer_flows/pip-checker.rb: 78c8062ff5b168f59fc4118a131907e0
 lib/smart_answer_flows/locales/en/pip-checker.yml: dbc19b1bdbf62c84bef9c4d48e98f213
 test/data/pip-checker-questions-and-responses.yml: b1d68ebfb76a9e2793705c55b82294f5
 test/data/pip-checker-responses-and-expected-results.yml: f0c8c243623cad06b9c65dbb504d5b4d
-lib/smart_answer_flows/pip-checker/_scheme_postcodes.govspeak.erb: e4ba5cfca5b6244e6f829c625dd5a014
+lib/smart_answer_flows/pip-checker/_scheme_postcodes.govspeak.erb: c8c884fbd4111d7cc3b015cb2be57b5a
 lib/smart_answer_flows/pip-checker/result_1.govspeak.erb: 568421449aaa526bea0f3e7fe8ecce75
 lib/smart_answer_flows/pip-checker/result_2.govspeak.erb: 5d4e0e90e793c76e8f3c595096e84361
 lib/smart_answer_flows/pip-checker/result_3.govspeak.erb: 19846eb641a3c4c629fde6ff9d21d35e
 lib/smart_answer_flows/pip-checker/result_4.govspeak.erb: 713354f745ca78af34d2d76b7c36b280
-lib/smart_answer_flows/pip-checker/result_5.govspeak.erb: 4a187ff0b1443e0f8fdc22640b305057
+lib/smart_answer_flows/pip-checker/result_5.govspeak.erb: c3af7778e8d2a3f4c2f3a342eac77ce1
 lib/smart_answer_flows/pip-checker/result_6.govspeak.erb: 9e8654af8d344aace18e6b84f6751589
 lib/smart_answer_flows/pip-checker/result_7.govspeak.erb: e01d19d461ccf9e57b6fc0678d725882
 lib/smart_answer/calculators/pip_dates.rb: 773342998eae28adbbc7403a24e9548c


### PR DESCRIPTION
Needs to go live on on Wednesday 26th.

Updates to two outcomes:
https://www.gov.uk/pip-checker/y/yes/1985-01-01
https://www.gov.uk/pip-checker/y/yes/2001-01-01

Combines the 2 sets of postcodes that went live on 13 July and 17 August.
Adds a new list of postcodes to be included from 1 September.

Relates to ticket: https://govuk.zendesk.com/agent/tickets/1118011

Closes #1903 #1904