### PR TITLE
Use GOVUK.analytics.trackEvent instead of ga function

### DIFF
--- a/app/views/smart_answers/_result.html.erb
+++ b/app/views/smart_answers/_result.html.erb
@@ -22,16 +22,14 @@
 </div>
 
 <script type="text/javascript">
-  var flowName = '<%= @name %>';
-  event = {
-    hitType: 'event',
-    eventCategory: 'Smart Answer',
-    eventAction: 'Completed',
-    eventLabel: flowName,
-    nonInteraction: 1,
-    page: document.location.pathname
-  };
-  if (typeof window.ga === "function") {
-    window.ga('send', event);
-  };
+  $(function() {
+    var flowName = '<%= @name %>';
+    var page = document.location.pathname;
+    var options = {
+      label: flowName,
+      nonInteraction: true,
+      page: page
+    };
+    GOVUK.analytics.trackEvent('Smart Answer', 'Completed', options);
+  });
 </script>


### PR DESCRIPTION
This replaces PR #1899.

Version 4.1.0 of the govuk_frontend_toolkit Gem introduced the ability to
specify the page when calling the `trackEvent` function.

The `GOVUK.analytics.trackEvent` function comes from the govuk_frontend_toolkit
Gem in Static. Static has been using version 4.1.0 of that Gem since 22nd
July[1] which means that we're safe to use the updated `trackEvent` function
too.

The use of `ga()` was introduced in ae2a25570d43e7686bc1ff625758273280f6bc72.
See that commit for more information about why recording the `page` is useful.

I've wrapped the call to `GOVUK.analytics.trackEvent()` in an anonymous
function to avoid polluting the global namespace. I'm executing this function
using jQuery's document ready[2] although I'm not entirely sure this adds much
over simply executing the anonymous function directly.

It's worth mentioning that the JavaScript in this _result partial is moved to
just before the closing `body` tag in the page that's rendered. It's moved by
the `Slimmer::Processors::TagMover` in the slimmer Gem.

I used the Google Analytics Debugger Chrome extension[3] to compare the events
being sent before and after this change:

== Before

Running command: ga("send", {hitType: "event", eventCategory: "Smart Answer",
eventAction: "Completed", eventLabel: "additional-commodity-code",
nonInteraction: 1, page: "/additional-commodity-code/y/75/5/85"})

== After

Running command: ga("send", {hitType: "event", eventCategory: "Smart Answer",
eventAction: "Completed", eventLabel: "additional-commodity-code",
nonInteraction: 1, page: "/additional-commodity-code/y/75/5/85"})

[1]: https://github.com/alphagov/static/pull/623
[2]: https://learn.jquery.com/using-jquery-core/document-ready/
[3]: https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna?hl=en
