### PR TITLE
Enable regression tests for landing pages

### DIFF
--- a/app/controllers/smart_answers_controller.rb
+++ b/app/controllers/smart_answers_controller.rb
@@ -20,8 +20,10 @@ class SmartAnswersController < ApplicationController
           title: @presenter.current_node.title
         }
       }
-      if @presenter.finished? && !Rails.env.production?
-        format.text { render }
+      if !Rails.env.production? && @presenter.render_txt?
+        format.text {
+          render
+        }
       end
     end
 

--- a/app/presenters/smart_answer_presenter.rb
+++ b/app/presenters/smart_answer_presenter.rb
@@ -32,21 +32,22 @@ class SmartAnswerPresenter
     nil
   end
 
-  def markdown_for(key)
+  def markdown_for(key, html: true)
     markdown = lookup_translation(key)
-    markdown && GovspeakPresenter.new(markdown).html
+    return unless markdown
+    html ? GovspeakPresenter.new(markdown).html : markdown
   end
 
   def title
     lookup_translation(:title) || @flow.name.to_s.humanize
   end
 
-  def body
-    markdown_for('body')
+  def body(html: true)
+    markdown_for('body', html: html)
   end
 
-  def post_body
-    markdown_for('post_body')
+  def post_body(html: true)
+    markdown_for('post_body', html: html)
   end
 
   def has_body?
@@ -71,6 +72,10 @@ class SmartAnswerPresenter
 
   def finished?
     current_node.outcome?
+  end
+
+  def render_txt?
+    finished? || !started?
   end
 
   def current_state

--- a/app/views/smart_answers/show.text.erb
+++ b/app/views/smart_answers/show.text.erb
@@ -1,4 +1,10 @@
-<% if @presenter.finished? %>
+<% if !@presenter.started? %>
+<%= @presenter.title %>
+
+<%= @presenter.body(html: false) -%>
+
+<%= @presenter.post_body(html: false) -%>
+<% elsif @presenter.finished? %>
 <%= @presenter.current_node.title %>
 
 <%= @presenter.current_node.body(html: false) -%>

--- a/lib/smartdown_adapter/presenter.rb
+++ b/lib/smartdown_adapter/presenter.rb
@@ -103,6 +103,10 @@ module SmartdownAdapter
       smart_answer_path(url_hash)
     end
 
+    def render_txt?
+      false
+    end
+
     private
 
     def responses_from_request(request)

--- a/test/artefacts/additional-commodity-code/additional-commodity-code.txt
+++ b/test/artefacts/additional-commodity-code/additional-commodity-code.txt
@@ -1,0 +1,4 @@
+Look up Meursing code
+
+Use this tool to look up the additional code (Meursing code) for import or export of goods containing certain types of milk and sugars covered Regulation (EC) No. 1216/09.
+

--- a/test/artefacts/am-i-getting-minimum-wage/am-i-getting-minimum-wage.txt
+++ b/test/artefacts/am-i-getting-minimum-wage/am-i-getting-minimum-wage.txt
@@ -1,0 +1,4 @@
+National Minimum Wage calculator for workers
+
+Check if your pay matches the National Minimum Wage or if your employer owes you payments from past years.
+

--- a/test/artefacts/apply-tier-4-visa/apply-tier-4-visa.txt
+++ b/test/artefacts/apply-tier-4-visa/apply-tier-4-visa.txt
@@ -1,0 +1,9 @@
+Apply to extend or switch to a Tier 4 visa
+
+Apply to extend or switch to a Tier 4 visa.
+
+This applies to:
+
+* extending or switching to a [Tier 4 (General) student visa](/tier-4-general-visa)
+* extending or switching to a [Tier 4 (Child) student visa](/child-study-visa)
+

--- a/test/artefacts/benefit-cap-calculator/benefit-cap-calculator.txt
+++ b/test/artefacts/benefit-cap-calculator/benefit-cap-calculator.txt
@@ -1,0 +1,12 @@
+Benefit cap calculator
+
+There’s a limit on the total amount of benefits that most people aged 16 to 64 can get. This is called the [benefit cap](/benefit-cap).
+
+This calculator gives an estimate of how much your benefit might be capped.
+
+^You can't check if you're affected by the benefit cap if you're claiming [Universal Credit](/universal-credit).^
+
+You’ll need to know the amounts of each benefit you get to use the calculator and the number of people in your household.
+
+Your household includes you, your partner and any children that you’re responsible for and who live with you.
+

--- a/test/artefacts/calculate-agricultural-holiday-entitlement/calculate-agricultural-holiday-entitlement.txt
+++ b/test/artefacts/calculate-agricultural-holiday-entitlement/calculate-agricultural-holiday-entitlement.txt
@@ -1,0 +1,7 @@
+Calculate your agricultural worker holiday entitlement
+
+Work out how much statutory holiday leave you're entitled to as an agricultural worker.
+
+Agricultural holiday entitlement is different in [Scotland](http://www.scotland.gov.uk/Publications/2012/10/7886/5){:rel="external"}
+and [Northern Ireland.](http://www.dardni.gov.uk/index/fisheries-farming-and-food/enforcement-awb/awb-current-terms-and-conditions-of-employment-wages-etc.htm){:rel="external"}
+

--- a/test/artefacts/calculate-employee-redundancy-pay/calculate-employee-redundancy-pay.txt
+++ b/test/artefacts/calculate-employee-redundancy-pay/calculate-employee-redundancy-pay.txt
@@ -1,0 +1,8 @@
+Calculate your employee's statutory redundancy pay
+
+Calculate an employee’s statutory redundancy pay.
+
+Redundancy payments are based on age, weekly pay and number of years in the job.
+
+Employees only qualify if they’ve worked at least 2 full years for you.
+

--- a/test/artefacts/calculate-married-couples-allowance/calculate-married-couples-allowance.txt
+++ b/test/artefacts/calculate-married-couples-allowance/calculate-married-couples-allowance.txt
@@ -1,0 +1,5 @@
+Calculate your Married Couple's Allowance
+
+
+You can use this calculator to work out if you qualify for Married Couple’s Allowance, and how much you might get. You need to be married or in a civil partnership to claim.
+

--- a/test/artefacts/calculate-state-pension/calculate-state-pension.txt
+++ b/test/artefacts/calculate-state-pension/calculate-state-pension.txt
@@ -1,0 +1,17 @@
+State Pension calculator
+
+Calculate when you’ll reach State Pension age or Pension Credit qualifying age and how much you may get in today’s money for your basic State Pension.
+
+%Get a [State Pension Statement](/state-pension-statement) instead of using this calculator if you're 55 or over and making a financial decision based on [the new pension options](https://www.pensionwise.gov.uk/).%
+
+##What you need to know:
+
+This calculator gives an estimate of your basic State pension and information about the [new State Pension](/new-state-pension) if you reach State Pension age on or after 6 April 2016.
+
+It doesn’t estimate any [Additional State Pension.](/additional-state-pension)
+
+You’ll be asked for the number of years you worked and paid National Insurance or got certain benefits. These are the years of your [National Insurance contributions](/national-insurance) that count towards your State Pension.
+
+Count tax years from 6 April to 5 April and don’t count any years twice (eg when you were working and getting benefits). Don’t count the current tax year.
+
+This calculator uses a simplified calculation based on the current law. It can’t take into account every circumstance that might affect you. Don't make future financial decisions based on its results.

--- a/test/artefacts/calculate-statutory-sick-pay/calculate-statutory-sick-pay.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/calculate-statutory-sick-pay.txt
@@ -1,0 +1,16 @@
+Calculate your employee's statutory sick pay
+
+Calculate Statutory Sick Pay (SSP) for your employee.
+
+##What you need to know
+
+You’re only responsible for paying SSP if:
+
+- you pay Class 1 National Insurance contributions for your employee (or would do if not for their age or their level of earnings)
+- your employee was sick for 4 or more days in a row (including non-working days)
+- your employee has told you they’re sick within your own time limit (or 7 days if you don’t have one)
+
+^ You can’t use the calculator for periods of sickness before 6 April 2011.^
+
+*[SSP]: Statutory Sick Pay
+

--- a/test/artefacts/calculate-your-child-maintenance/calculate-your-child-maintenance.txt
+++ b/test/artefacts/calculate-your-child-maintenance/calculate-your-child-maintenance.txt
@@ -1,0 +1,16 @@
+Child maintenance calculator
+
+Use the calculator to agree on a child maintenance amount if [you’re arranging it yourselves](/arranging-child-maintenance-yourself), or to get an idea of the statutory amount the government would work out for you (including collection and application fees).
+
+Don't use the calculator if you have a ['1993 scheme' or '2003 scheme' case](/how-child-maintenance-is-worked-out/child-maintenance-before-march-2003). These are managed by the Child Support Agency (CSA).
+
+##What you need to know:##
+
+- the calculator gives an estimate (it won't cover variations for exceptional circumstances)
+- you need information about your income
+- if you already have a case with the Child Support Agency (CSA) or the Child Maintenance Service and your circumstances have changed, [contact the office managing your case](/child-support-agency) - they’ll tell you if your child maintenance payments will change
+
+Check the [child maintenance rates](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance) before you use the calculator.
+
+*[CSA]: Child Support Agency
+

--- a/test/artefacts/calculate-your-holiday-entitlement/calculate-your-holiday-entitlement.txt
+++ b/test/artefacts/calculate-your-holiday-entitlement/calculate-your-holiday-entitlement.txt
@@ -1,0 +1,4 @@
+Calculate holiday entitlement
+
+Calculate statutory holiday entitlement in days or hours for a full leave year or work out holiday someone is entitled to when they start or leave a job part way through a leave year.
+

--- a/test/artefacts/calculate-your-redundancy-pay/calculate-your-redundancy-pay.txt
+++ b/test/artefacts/calculate-your-redundancy-pay/calculate-your-redundancy-pay.txt
@@ -1,0 +1,6 @@
+Calculate your statutory redundancy pay
+
+Calculate how much statutory redundancy you can get. It’s based on age, weekly pay and number of years in the job.
+
+You only qualify for statutory redundancy pay if you’ve worked for your employer for at least 2 years.
+

--- a/test/artefacts/check-uk-visa/check-uk-visa.txt
+++ b/test/artefacts/check-uk-visa/check-uk-visa.txt
@@ -1,0 +1,4 @@
+Check if you need a UK visa
+
+You may need a visa to come to the UK to visit, study or work.
+

--- a/test/artefacts/childcare-costs-for-tax-credits/childcare-costs-for-tax-credits.txt
+++ b/test/artefacts/childcare-costs-for-tax-credits/childcare-costs-for-tax-credits.txt
@@ -1,0 +1,21 @@
+Tax credits: working out your childcare costs
+
+You can claim extra tax credits to help with your childcare costs if you’re eligible. Use this tool to work out what childcare costs you should claim. You can make your claim 7 days before you start paying for childcare.
+
+If you already claim tax credits for childcare costs and your costs have changed, you can use this tool to work out if you need to report the change to the Tax Credit Office.
+
+^When calculating your childcare costs, you can only include costs you pay yourself. You may not receive the correct credits if you provide the wrong amount.^
+
+You cannot include the following in your childcare calculation:
+
+  - childcare payments from your employer - either in money or childcare vouchers
+
+  - childcare vouchers in return for a reduction in your pay - this is
+    called a 'salary sacrifice'
+
+  - childcare payments or grants from a government scheme, eg to help
+    you start work or because you are a student
+
+  - childcare costs paid for by an educational or local authority, eg
+    free early learning or nursery education
+

--- a/test/artefacts/energy-grants-calculator/energy-grants-calculator.txt
+++ b/test/artefacts/energy-grants-calculator/energy-grants-calculator.txt
@@ -1,0 +1,9 @@
+Find energy grants and ways to improve your energy efficiency
+
+You might be eligible for help with your energy bills or to make your home more energy efficient.
+
+To find out what energy saving improvements can help, you’ll need to know:
+
+- what kind of measures you already have (eg, insulation or double glazing)
+- a general idea of when your home was built
+

--- a/test/artefacts/estimate-self-assessment-penalties/estimate-self-assessment-penalties.txt
+++ b/test/artefacts/estimate-self-assessment-penalties/estimate-self-assessment-penalties.txt
@@ -1,0 +1,15 @@
+Estimate your penalty for late Self Assessment tax returns and payments
+
+Get an estimate of how much you’ll need to pay in penalties and interest if you’ve missed the deadline for:
+
+- sending your Self Assessment tax return
+- paying your Self Assessment tax bill
+
+^You can only calculate penalties for the current tax year.^
+
+This calculator doesn’t take account of any:
+
+- partial payments or penalty payments you’ve made towards your tax bill
+- outstanding interest or penalties for previous tax years
+- credit you have from previous tax years
+

--- a/test/artefacts/help-if-you-are-arrested-abroad/help-if-you-are-arrested-abroad.txt
+++ b/test/artefacts/help-if-you-are-arrested-abroad/help-if-you-are-arrested-abroad.txt
@@ -1,0 +1,3 @@
+Help if you're arrested abroad
+
+Find out what help you can get if you or someone you know is arrested abroad.

--- a/test/artefacts/inherits-someone-dies-without-will/inherits-someone-dies-without-will.txt
+++ b/test/artefacts/inherits-someone-dies-without-will/inherits-someone-dies-without-will.txt
@@ -1,0 +1,4 @@
+Intestacy - who inherits if someone dies without a will?
+
+Find out who is entitled to a share of someone’s money, property and possessions if they die without making a will.
+

--- a/test/artefacts/landlord-immigration-check/landlord-immigration-check.txt
+++ b/test/artefacts/landlord-immigration-check/landlord-immigration-check.txt
@@ -1,0 +1,11 @@
+Check if someone can rent your residential property
+
+Find out if someone can rent private residential property in the UK.
+
+This includes private residential properties for all people aged 18 or over (including house guests, lodgers and sub-tenants) who will use the property as their main home.
+
+You only have to do this check for new tenancies which started on or after 1 December 2014.
+
+If you’ve bought a property that is already occupied by tenants you should see if a check has been carried out. You’ll be responsible for carrying out [further checks on your tenants](/government/publications/right-to-rent-landlords-code-of-practice).
+
+^You can read more about the [right to rent documents](/government/publications/rules-and-acceptable-documents-right-to-rent-checks) if you can’t tell what kind of document your tenant is using to rent your property.^

--- a/test/artefacts/legalisation-document-checker/legalisation-document-checker.txt
+++ b/test/artefacts/legalisation-document-checker/legalisation-document-checker.txt
@@ -1,0 +1,6 @@
+Check if documents can be legalised
+
+You can get a UK public document ‘legalised’ - this means a signature, seal or stamp made by a UK public official on the document is confirmed as genuine by the UK government.
+
+Use this tool to check if your document can be legalised.
+

--- a/test/artefacts/marriage-abroad/marriage-abroad.txt
+++ b/test/artefacts/marriage-abroad/marriage-abroad.txt
@@ -1,0 +1,17 @@
+Getting married abroad
+
+Contact the local authorities in the country where you want to get married or enter into a civil partnership to find out what you need to do.
+
+Your marriage or civil partnership should be recognised in the UK if you follow the correct process according to local law - you won’t need to register it in the UK.
+
+You might be asked to get certain documents from the UK government if you’re a [British national](http://www.ukba.homeoffice.gov.uk/britishcitizenship/aboutcitizenship/). Use this tool to find out:
+
+- which documents you can get
+- how to apply for them
+
+There’s a separate guide if you want to [get married or enter into a civil partnership in the UK](/marriages-civil-partnerships).
+
+%If you’re living abroad and you want to get married in a different country, you’ll need to go to that country to post notice of your marriage. [Read the guidance on posting notice in a third country](/if-you-live-abroad-and-wish-to-marry-in-a-third-country).%
+
+*[GRO]:General Register Office
+

--- a/test/artefacts/maternity-paternity-calculator/maternity-paternity-calculator.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity-paternity-calculator.txt
@@ -1,0 +1,25 @@
+Maternity and paternity calculator for employers
+
+Calculate your employee’s:
+
++ statutory maternity pay (SMP), paternity pay, adoption pay
++ qualifying week
++ relevant employment period and average weekly earnings
++ leave period
+
+##What you need
+
+You need:
+
++ the baby’s due date
++ date of birth - for paternity
++ your employee’s salary details, eg weekly rates of pay
++ the dates for adoption, eg match date and date of placement
+
+
+You can’t use the calculator for:
+
++ births 15 weeks before the due date
++ [Additional paternity Leave or Pay](/additional-paternity-leave-pay-employees)
++ paternity leave or pay for [overseas adoptions](/paternity-leave-pay-employees)
++ [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide)

--- a/test/artefacts/minimum-wage-calculator-employers/minimum-wage-calculator-employers.txt
+++ b/test/artefacts/minimum-wage-calculator-employers/minimum-wage-calculator-employers.txt
@@ -1,0 +1,4 @@
+National Minimum Wage calculator for employers
+
+Check if you're paying a worker the National Minimum Wage or if you owe them payments from past years.
+

--- a/test/artefacts/overseas-passports/overseas-passports.txt
+++ b/test/artefacts/overseas-passports/overseas-passports.txt
@@ -1,0 +1,4 @@
+Overseas British passport applications
+
+Get the forms, prices and application details you need if you're a British national and you want to renew or apply for a British passport from overseas.
+

--- a/test/artefacts/pip-checker/pip-checker.txt
+++ b/test/artefacts/pip-checker/pip-checker.txt
@@ -1,0 +1,13 @@
+Check how Personal Independence Payment (PIP) affects you
+
+Personal Independence Payment (PIP) is replacing Disability Living Allowance (DLA) for people with a long-term health condition or disability aged 16 to 64.
+
+Use this tool to check:
+
+* if PIP affects you
+* when your Disability Living Allowance may be affected
+* when you can make a new claim for PIP
+
+*[PIP]: Personal Independence Payment
+*[DLA]: Disability Living Allowance
+

--- a/test/artefacts/plan-adoption-leave/plan-adoption-leave.txt
+++ b/test/artefacts/plan-adoption-leave/plan-adoption-leave.txt
@@ -1,0 +1,8 @@
+Plan your adoption leave
+
+Work out your Statutory Adoption Leave notice period, earliest start date and Ordinary and Additional Adoption Leave periods based on the match and placement dates for the child.
+
+##What you need to know
+
+You can’t use this tool if you’re [adopting from abroad](/adoption-leave) or taking [paternity leave for an adoption](/paternityleave).
+

--- a/test/artefacts/register-a-birth/register-a-birth.txt
+++ b/test/artefacts/register-a-birth/register-a-birth.txt
@@ -1,0 +1,15 @@
+Register a birth abroad
+
+$!You must register your child’s birth according to the regulations in the country where the child was born. They’ll give you a local birth certificate.$!
+
+This local birth certificate should be accepted in the UK, eg when you apply for a passport or register with a school or doctor. You might need to have it [translated and certified](https://www.gov.uk/certifying-a-document) if it isn’t in English.
+
+Once you’ve registered locally you may also be able to register the birth with the UK authorities. You can only do this if the child was born on or after 1 January 1983.
+
+You don’t need to register with the UK authorities but it means:
+
+- the birth will be recorded with the General Register Offices or at the National Records Office of Scotland
+- you can order a consular birth registration certificate
+
+^You can still [apply for a UK passport for your child](/apply-renew-passport) even if you don’t register the birth in the UK.^
+

--- a/test/artefacts/register-a-death/register-a-death.txt
+++ b/test/artefacts/register-a-death/register-a-death.txt
@@ -1,0 +1,13 @@
+Register a death
+
+Find out how to register a death in the UK or abroad.
+
+You need to read different information if:
+
+- the person [died in Scotland](http://www.nrscotland.gov.uk/registration/registering-a-death)
+- the person [died in Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/death-and-bereavement/death-and-bereavement-what-to-do-when-someone-dies/registering-a-death.htm)
+
+If the person died on a foreign ship or aircraft, you must register the death in the country the ship or aircraft is registered in.
+
+You can only register a death abroad if it happened on or after 1 January 1983.
+

--- a/test/artefacts/report-a-lost-or-stolen-passport/report-a-lost-or-stolen-passport.txt
+++ b/test/artefacts/report-a-lost-or-stolen-passport/report-a-lost-or-stolen-passport.txt
@@ -1,0 +1,8 @@
+Cancel a lost or stolen passport
+
+You must cancel a lost or stolen passport as soon as possible.
+
+This will reduce the risk of anyone else using your passport or your identity.
+
+You can report a lost or stolen passport for someone else if they can't do it themselves.
+

--- a/test/artefacts/simplified-expenses-checker/simplified-expenses-checker.txt
+++ b/test/artefacts/simplified-expenses-checker/simplified-expenses-checker.txt
@@ -1,0 +1,11 @@
+Check if simplified expenses works for your business
+
+If you are a sole trader or partnership there are now 2 ways you can calculate business expenses for vehicles, working from home, and living on your business premises. You can use [simplified expenses](/simpler-income-tax-simplified-expenses) or calculate your expenses by working out the actual costs.
+
+Use this checker to work out which method is best for you.
+
+## What you need to know:
+- you’ll be asked to make estimates about some of your business expenses - you don’t have to give accurate amounts
+- this checker doesn’t give exact figures to use in your tax return, it gives you an idea of which way of calculating your expenses might be best for you
+- limited companies aren’t eligible
+

--- a/test/artefacts/state-pension-through-partner/state-pension-through-partner.txt
+++ b/test/artefacts/state-pension-through-partner/state-pension-through-partner.txt
@@ -1,0 +1,9 @@
+Your partner’s National Insurance record and your State Pension
+
+The new State Pension will replace the current State Pension system (which includes [basic State Pension](/state-pension) and [Additional State Pension](/additional-state-pension)).
+
+The rules for how you can increase your State Pension and what you can inherit will be different depending on when you and your spouse or civil partner reach [State Pension age](/calculate-state-pension).
+
+
+You’ll need to know when both you and your spouse or civil partner reach State Pension age to use this tool.
+

--- a/test/artefacts/state-pension-topup/state-pension-topup.txt
+++ b/test/artefacts/state-pension-topup/state-pension-topup.txt
@@ -1,0 +1,27 @@
+State Pension top up calculator
+
+From 12 October 2015 to 5 April 2017 you’ll be able to make a ‘Class 3A voluntary contribution’ to top up your State Pension by up to £25 per week.
+
+Calculate how much you’ll need to contribute. You must be:
+
+- a man born before 6 April 1951
+- a woman born before 6 April 1953
+
+###What you need to know
+
+You can choose to top up your State Pension by between £1 and £25 per week. How much you’ll need to contribute depends on:
+
+- how much extra pension you want to get each week
+- how old you are when you make the contribution
+
+$E
+**Example**
+You are 68 years old in October 2015. You decide that you want to get an extra £5 per week (£260 a year) on top of your pension.
+
+The cost of an extra £1 per week for a 68 year old is £827, so you multiply £827 by 5.
+
+You’ll make a lump sum payment of £4,135.
+$E
+
+###Eligibility
+You must be entitled to the basic State Pension or Additional State Pension before 6 April 2016.

--- a/test/artefacts/student-finance-calculator/student-finance-calculator.txt
+++ b/test/artefacts/student-finance-calculator/student-finance-calculator.txt
@@ -1,0 +1,15 @@
+Student finance calculator
+
+This calculator is for students from England or the European Union (EU) starting a new course in the 2014 to 2015 or 2015 to 2016 academic year.
+
+Use the student finance calculator to estimate:
+
++ student loans
++ student grants
++ extra student funding, eg if you’re disabled or have children
+
+Your result will be more accurate if you know your annual household income (your parents’ or partner’s income plus your own).
+
+##Before you start
+
+You can’t use the calculator if you’re from [Scotland](http://www.saas.gov.uk/), [Wales](http://www.studentfinancewales.co.uk) or [Northern Ireland.](http://www.studentfinanceni.co.uk)

--- a/test/artefacts/student-finance-forms/student-finance-forms.txt
+++ b/test/artefacts/student-finance-forms/student-finance-forms.txt
@@ -1,0 +1,23 @@
+Student finance forms
+
+Download student finance forms and guidance notes for Student Finance England including:
+
++ forms PN1, PR1, PTL1, PFF2 and CYI
++ forms for parents
++ forms for EU students
+
+##Before you start
+
+The forms are different for students from [Scotland](http://www.saas.gov.uk), [Wales](http://www.studentfinancewales.co.uk) and [Northern Ireland](http://www.studentfinanceni.co.uk).
+
+For braille or alternative formats contact the helpline. If you email, include your contact details and the format you need.
+
+
+$C
+**Helpline - alternative formats only**
+
+0141 243 3686<br />
+<brailleandlargefonts@slc.co.uk>
+$C
+
+You can [call Student Finance England](https://www.gov.uk/contact-student-finance-england) if you want to [apply online](https://www.gov.uk/apply-online-for-student-finance) but you can't use a computer without help.

--- a/test/artefacts/towing-rules/towing-rules.txt
+++ b/test/artefacts/towing-rules/towing-rules.txt
@@ -1,0 +1,8 @@
+Towing: licence and age requirements
+
+Use this tool to find out if you’re old enough or have the right kind of licence to tow a trailer from different kinds of vehicle.
+
+This tool assumes that you already have the minimum of a full car driving licence (category B). You need a full car licence before being able to tow with any larger vehicle.
+
+^A full car licence already lets you tow trailers weighing no more than 750 kg. You can also tow heavier trailers with a car as long as the total weight of vehicle and trailer isn’t more than 3,500 kg.^
+

--- a/test/artefacts/uk-benefits-abroad/uk-benefits-abroad.txt
+++ b/test/artefacts/uk-benefits-abroad/uk-benefits-abroad.txt
@@ -1,0 +1,13 @@
+UK benefits if you're going or living abroad
+
+Find out which UK benefits you might be able to get while you're abroad and how to claim them.
+
+The UK has social security agreements with some countries that:
+
+- allow you to claim UK contribution-based benefits while you're there
+- mean that your National Insurance contributions can count towards your eligibility for that country's benefits
+
+It's easier to organise benefits before you leave.
+
+^You must meet the benefit's eligibility criteria to get it.^
+

--- a/test/artefacts/vat-payment-deadlines/vat-payment-deadlines.txt
+++ b/test/artefacts/vat-payment-deadlines/vat-payment-deadlines.txt
@@ -1,0 +1,7 @@
+VAT payment deadline calculator
+
+Work out the VAT payment deadline for your accounting period.
+
+You can't use this calculator if you make payments on account or use the annual
+accounting scheme.
+

--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -61,7 +61,7 @@ class SmartAnswersControllerTest < ActionController::TestCase
       assert_response :missing
     end
 
-    should "display landing page if no questions answered yet" do
+    should "display landing page in html if no questions answered yet" do
       get :show, id: 'sample'
       assert_select "h1", /#{@flow.name.to_s.humanize}/
     end
@@ -474,7 +474,12 @@ class SmartAnswersControllerTest < ActionController::TestCase
         assert_match /sweet-tooth-outcome-govspeak-next-steps/, response.body
       end
 
-      should "render not found for non-outcome node" do
+      should "render govspeak text for the landing page" do
+        get :show, id: 'sample', format: 'txt'
+        assert response.body.start_with?("Sample")
+      end
+
+      should "render not found for a question node" do
         document = stub('Govspeak::Document', to_html: 'html-output')
         Govspeak::Document.stubs(:new).returns(document)
 

--- a/test/regression/smart_answers_regression_test.rb
+++ b/test/regression/smart_answers_regression_test.rb
@@ -105,6 +105,12 @@ class SmartAnswersRegressionTest < ActionController::TestCase
         assert_equal true, unexercised_nodes.empty?, "Not all nodes are being exercised: #{unexercised_nodes.sort}"
       end
 
+      should "render and save the landing page" do
+        get :show, id: flow_name, format: 'txt'
+
+        assert_no_output_diff smart_answer_helper.save_output([flow_name], response)
+      end
+
       responses_and_expected_results.each do |responses_and_expected_node|
         responses    = responses_and_expected_node[:responses]
         outcome_node = responses_and_expected_node[:outcome_node]
@@ -113,10 +119,7 @@ class SmartAnswersRegressionTest < ActionController::TestCase
           should "render and save output for responses: #{responses.join(', ')}" do
             get :show, id: flow_name, started: 'y', responses: responses.join('/'), format: 'txt'
 
-            path_to_output = smart_answer_helper.save_output(responses, response)
-
-            diff_output = `git diff -- "#{path_to_output}"`
-            assert diff_output.blank?, diff_output
+            assert_no_output_diff smart_answer_helper.save_output(responses, response)
           end
         end
       end
@@ -129,6 +132,11 @@ class SmartAnswersRegressionTest < ActionController::TestCase
   end
 
   private
+
+  def assert_no_output_diff(path_to_output)
+    diff_output = `git diff -- "#{path_to_output}"`
+    assert diff_output.blank?, diff_output
+  end
 
   def setup_worldwide_locations
     location_slugs = YAML.load(read_fixture_file("worldwide_locations.yml"))


### PR DESCRIPTION
Allow rendering landing pages as govspeak

This is going to be useful when converting landing pages to erb. 
We'll want regression tests to ensure smooth transition to the new format, for which we'll need to render and save govspeak output of the landing pages the same way we currently do for outcomes.

I've added a sample of a generated landing page artefact, it has a title, body and post_body parts.
If you're happy with implementation and the `<flow_name>/landing_page.txt` naming convention I'll generate landing pages for each smart answer.

Edit: As voted by the majority, we've decided to go with the  `<flow_name>/<flow_name>.txt` naming convention