### PR TITLE
Fix overseas passports in Saint Barthélemy

### DIFF
--- a/lib/data/passport_data.yml
+++ b/lib/data/passport_data.yml
@@ -1660,6 +1660,16 @@ rwanda:
   applying: 10 weeks
   replacing: 8 weeks
   optimistic_processing_time?: false
+saint-barthelemy:
+  type: ips_application_1
+  group: ips_documents_group_1
+  app_form: hmpo_2_application_form
+  online_application: true
+  renewing_new: 4 weeks
+  renewing_old: 6 weeks
+  applying: 6 weeks
+  replacing: 6 weeks
+  optimistic_processing_time?: true
 samoa:
   type: ips_application_1
   group: ips_documents_group_1

--- a/test/integration/smart_answer_flows/overseas_passports_test.rb
+++ b/test/integration/smart_answer_flows/overseas_passports_test.rb
@@ -9,7 +9,7 @@ class OverseasPassportsTest < ActiveSupport::TestCase
   include GdsApi::TestHelpers::Worldwide
 
   setup do
-    @location_slugs = %w(albania algeria afghanistan australia austria azerbaijan bahamas bangladesh benin british-indian-ocean-territory burma burundi cambodia cameroon china congo georgia greece haiti hong-kong india iran iraq ireland italy jamaica jordan kenya kyrgyzstan laos malta nepal nigeria pakistan pitcairn-island saudi-arabia syria south-africa spain sri-lanka st-helena-ascension-and-tristan-da-cunha st-maarten st-martin tajikistan tanzania timor-leste turkey turkmenistan ukraine united-kingdom united-arab-emirates usa uzbekistan yemen zimbabwe venezuela vietnam zambia)
+    @location_slugs = %w(albania algeria afghanistan australia austria azerbaijan bahamas bangladesh benin british-indian-ocean-territory burma burundi cambodia cameroon china congo georgia greece haiti hong-kong india iran iraq ireland italy jamaica jordan kenya kyrgyzstan laos malta nepal nigeria pakistan pitcairn-island saint-barthelemy saudi-arabia syria south-africa spain sri-lanka st-helena-ascension-and-tristan-da-cunha st-maarten st-martin tajikistan tanzania timor-leste turkey turkmenistan ukraine united-kingdom united-arab-emirates usa uzbekistan yemen zimbabwe venezuela vietnam zambia)
     worldwide_api_has_locations(@location_slugs)
     setup_for_testing_flow SmartAnswer::OverseasPassportsFlow
   end
@@ -1047,6 +1047,17 @@ class OverseasPassportsTest < ActiveSupport::TestCase
 
         assert_current_node :ips_application_result
       end
+    end
+  end
+
+  context "Saint Barthelemy" do
+    should "suggest to apply online" do
+      worldwide_api_has_no_organisations_for_location('saint-barthelemy')
+      add_response 'saint-barthelemy'
+      add_response 'renewing_new'
+      add_response 'adult'
+
+      assert_current_node :ips_application_result_online
     end
   end
 


### PR DESCRIPTION
FCO have confirmed the process is identical to St Martin (online application).
Copy configuration in passports-data.yml from st-martin.

### Some history

Saint Barthélemy was added to the WorldwideApi as per FCO request.
This caused it to show up in all Smart Answers' country question drop downs. Most of the Smart Answers, including overseas passports, did not have logic for Saint Barthélemy and were failing because of that.