### PR TITLE
Add Rubocop to Jenkins

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ files relating to the regression tests e.g. file checksums, HTML artefacts, etc.
 
 ## Instructions
 
-1. Check out the branch from the forked repo onto your local machine. Note that `<github-username>` refers to the owner 
+1. Check out the branch from the forked repo onto your local machine. Note that `<github-username>` refers to the owner
 
         $ git remote add <owner-of-forked-repo> git@github.com:<owner-of-forked-repo>/smart-answers.git
         $ git fetch <owner-of-forked-repo>
@@ -230,3 +230,27 @@ files relating to the regression tests e.g. file checksums, HTML artefacts, etc.
 ## Issues/todos
 
 Please see the [github issues](https://github.com/alphagov/smart-answers/issues) page.
+
+## Rubocop
+
+We're using the govuk-lint Gem to include Rubocop and the GOV.UK styleguide rules in the project.
+
+### Jenkins
+
+We run Rubocop as part of the test suite executed on Jenkins (see jenkins.sh). Rubocop only tests for violations in files introduced in the branch being tested. This should prevent us from introducing new violations without us having to first fix all existing violations.
+
+### Running locally
+
+Testing for violations in the entire codebase:
+
+    $ govuk-lint-ruby
+
+Testing for violations in code committed locally that's not present in origin/master (useful to check code committed in a local branch):
+
+    $ govuk-lint-ruby --diff
+
+Testing for violations in code staged and committed locally that's not present in origin/master:
+
+    $ govuk-lint-ruby --diff --cached
+
+NOTE. This is mostly useful for Jenkins as we first merge, but don't commit, changes from master before running the test suite.

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -8,7 +8,7 @@ set -e
 git merge --no-commit origin/master || git merge --abort
 
 git clean -fdx
-bundle install --path "/home/jenkins/bundles/${JOB_NAME}" --deployment --without=development
+bundle install --path "/home/jenkins/bundles/${JOB_NAME}" --deployment
 export GOVUK_APP_DOMAIN=dev.gov.uk
 export GOVUK_ASSET_HOST=http://static.dev.gov.uk
 

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -15,6 +15,10 @@ export GOVUK_ASSET_HOST=http://static.dev.gov.uk
 export DISPLAY=:99
 
 if [ -z "$RUN_REGRESSION_TESTS" ]; then
+  bundle exec govuk-lint-ruby \
+    --diff --cached \
+    --format clang
+
   RAILS_ENV=test TEST_COVERAGE=true bundle exec rake test
 
   bundle exec rake assets:precompile


### PR DESCRIPTION
This branch adds Rubocop to our Jenkins test suite.

Rubocop is supplied by the govuk-lint Gem along with a set of rules that correspond to the GOV.UK styleguides.

Rubocop only checks for violations in the diff introduced in the current branch. This should help us avoid introducing new violations of the styleguide without first having to fix all existing violations.
