### PR TITLE
Bump slimmer and explicitly set slimmer template

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem 'extlib', '0.9.16'
 if ENV['SLIMMER_DEV']
   gem 'slimmer', :path => '../slimmer'
 else
-  gem 'slimmer', '8.2.1'
+  gem 'slimmer', '9.0.0'
 end
 
 if ENV['GOVSPEAK_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -330,3 +330,6 @@ DEPENDENCIES
   uk_postcode (~> 1.0.1)
   unicorn (= 4.8.3)
   webmock (= 1.20.4)
+
+BUNDLED WITH
+   1.10.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,7 +236,7 @@ GEM
     simplecov-html (0.10.0)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    slimmer (8.2.1)
+    slimmer (9.0.0)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -321,7 +321,7 @@ DEPENDENCIES
   shoulda (~> 3.5.0)
   simplecov (~> 0.10.0)
   simplecov-rcov (~> 0.2.3)
-  slimmer (= 8.2.1)
+  slimmer (= 9.0.0)
   smartdown (~> 0.15.1)
   therubyracer (~> 0.12.1)
   tilt (= 1.4.1)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,11 +2,14 @@ require "slimmer/headers"
 
 class ApplicationController < ActionController::Base
   include Slimmer::Headers
+  include Slimmer::Template
   include Slimmer::SharedTemplates
   before_action :set_analytics_headers
 
   rescue_from GdsApi::TimedOutException, with: :error_503
   rescue_from ActionController::UnknownFormat, with: :error_404
+
+  slimmer_template 'wrapper'
 
 protected
 


### PR DESCRIPTION
The new version of slimmer changes the default template that gets used.
Bump slimmer to the newest version and ensure that the wrapper template
is still used.