### PR TITLE
Add a prisoners pack link for Haiti

### DIFF
--- a/lib/data/prisoner_packs.yml
+++ b/lib/data/prisoner_packs.yml
@@ -220,6 +220,7 @@
   pdf: /government/publications/guyana-prisoner-pack
   lawyer: /government/publications/guyana-list-of-lawyers-and-translators
 - slug: haiti
+  pdf: /government/publications/haiti-prisoner-pack-2015
 - slug: honduras
   pdf: /government/publications/honduras-prisoners-pack
 - slug: hong-kong

--- a/test/data/help-if-you-are-arrested-abroad-files.yml
+++ b/test/data/help-if-you-are-arrested-abroad-files.yml
@@ -9,4 +9,4 @@ lib/smart_answer_flows/help-if-you-are-arrested-abroad/answer_one_generic.govspe
 lib/smart_answer_flows/help-if-you-are-arrested-abroad/answer_three_syria.govspeak.erb: ccfffcc8d0153f222707e16b5f51a3e3
 lib/smart_answer_flows/help-if-you-are-arrested-abroad/answer_two_iran.govspeak.erb: 61fad6c7b114294027628e3064ced46d
 lib/smart_answer/calculators/arrested_abroad.rb: 86a082401f28942c9482c02ca9155eba
-lib/data/prisoner_packs.yml: 0d4f8ef1137b9fe8162cfed302874268
+lib/data/prisoner_packs.yml: 821fb0e9f893354f647d5b97453ce322


### PR DESCRIPTION
The FCO has prepared a prisoners pack pdf for Haiti. Make it downloadable.

<img width="701" alt="screenshot 2015-08-27 17 06 49" src="https://cloud.githubusercontent.com/assets/218239/9525844/0d8d977a-4cde-11e5-9a5f-5b2bb6799e91.png">
