### PR TITLE
Extract OS marriage in Italy to its own outcome

### DIFF
--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -165,6 +165,10 @@ module SmartAnswer
           data_query.os_marriage_via_local_authorities?(ceremony_country)
         }
 
+        define_predicate(:marriage_in_italy) {
+          ceremony_country == 'italy'
+        }
+
         next_node_if(:outcome_brazil_not_living_in_the_uk, ceremony_in_brazil_not_resident_in_the_uk)
         next_node_if(:outcome_marriage_via_local_authorities, variable_matches(:ceremony_country, "netherlands"))
         next_node_if(:outcome_portugal, variable_matches(:ceremony_country, "portugal"))
@@ -176,6 +180,7 @@ module SmartAnswer
           next_node_if(:outcome_os_hong_kong, variable_matches(:ceremony_country, 'hong-kong'))
           next_node_if(:outcome_consular_cni_os_residing_in_third_country, consular_cni_residing_in_third_country)
           next_node_if(:outcome_consular_cni_os_residing_in_third_country, marriage_in_norway_third_country)
+          next_node_if(:outcome_os_italy, marriage_in_italy)
           next_node_if(:outcome_os_local_japan, os_marriage_with_local_in_japan)
           next_node_if(:outcome_os_colombia, variable_matches(:ceremony_country, "colombia"))
           next_node_if(:outcome_os_kosovo, variable_matches(:ceremony_country, "kosovo"))
@@ -300,6 +305,8 @@ module SmartAnswer
       outcome :outcome_os_commonwealth
 
       outcome :outcome_os_bot
+
+      outcome :outcome_os_italy
 
       outcome :outcome_consular_cni_os_residing_in_third_country do
         precalculate :data_query do

--- a/lib/smart_answer_flows/marriage-abroad/outcome_os_consular_cni.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcome_os_consular_cni.govspeak.erb
@@ -9,7 +9,7 @@
     ^You should [get legal advice](/government/publications/japan-list-of-lawyers) and check the [travel advice for Japan](/foreign-travel-advice/japan) before making any plans.^
 
   <% end %>
-  <% if %(japan italy).exclude?(ceremony_country) %>
+  <% if %(japan).exclude?(ceremony_country) %>
     <% if resident_of == 'uk' %>
       <% if data_query.dutch_caribbean_islands?(ceremony_country) %>
         <%= country_name_uppercase_prefix %> is one of the Dutch Caribbean islands.
@@ -47,7 +47,7 @@
 
     <% end %>
   <% end %>
-  <% if %(japan italy).exclude?(ceremony_country) %>
+  <% if %(japan).exclude?(ceremony_country) %>
 
     <% if resident_of == 'ceremony_country' %>
       <%= render partial: 'get_legal_advice.govspeak.erb' %>
@@ -58,10 +58,6 @@
                    ceremony_country: ceremony_country
                  } %>
     <% end %>
-  <% end %>
-  <% if ceremony_country == 'italy' %>
-    Contact the local comune (town hall) before making any plans to find out about local marriage laws, including what documents you’ll need.
-
   <% end %>
 
   <%= render partial: 'what_you_need_to_do.govspeak.erb' %>
@@ -91,30 +87,9 @@
 
     <%= render partial: 'you_will_be_asked_for_cni.govspeak.erb' %>
 
-  <% elsif ceremony_country != 'italy' && ceremony_not_germany_or_not_resident_other %>
+  <% elsif ceremony_not_germany_or_not_resident_other %>
     <%= render partial: 'you_will_be_asked_for_cni.govspeak.erb' %>
 
-  <% end %>
-  <% if ceremony_country == 'italy' %>
-    <% if resident_of == 'uk' %>
-      You’ll need to get a certificate of no impediment (CNI) from the authorities in the UK to prove you’re allowed to marry.
-
-    <% end %>
-    <% if resident_of == 'uk' && partner_nationality == 'partner_british' %>
-      ^Your partner will need to follow the same process to get their own CNI.^
-
-    <% end %>
-    <% if resident_of != 'uk' %>
-      You’ll be asked to provide a ‘Nulla Osta’ by the authorities in Italy. This is a certificate that proves you’re allowed to marry.
-
-      <%= render partial: 'contact_method.govspeak.erb',
-                 locals: {
-                   sex_of_your_partner: sex_of_your_partner,
-                   ceremony_country: ceremony_country,
-                   overseas_passports_embassies: overseas_passports_embassies,
-                   country_name_lowercase_prefix: country_name_lowercase_prefix
-                 } %>
-    <% end %>
   <% end %>
   <% if ceremony_country == 'denmark' %>
     ^You don’t need a CNI if you’re getting married in the main town hall in Copenhagen.^
@@ -139,37 +114,6 @@
                } %>
     <% if cni_posted_after_14_days_countries.include?(ceremony_country) %>
       They’ll post your notice, and as long as nobody has registered an objection after 14 days, they’ll issue your CNI.
-
-    <% end %>
-    <% if ceremony_country == 'italy' %>
-      <% if partner_nationality == 'partner_british' %>
-        ###Getting a statutory declaration
-
-        While you’re waiting for your CNI, you and your partner will need to make a statutory declaration before a [solicitor or public notary](http://www.lawsociety.org.uk/find-a-solicitor/). The Italian authorities will need this in addition to your CNI. There’s a standard template in English and Italian that you can download and use.
-
-      <% else %>
-        ###Getting a statutory declaration
-
-        While you’re waiting for your CNI, you will need to make a statutory declaration before a [solicitor or public notary](http://www.lawsociety.org.uk/find-a-solicitor/). The Italian authorities will need this in addition to your CNI. There’s a standard template in English and Italian that you can download and use.
-
-
-      <% end %>
-      $D
-      [Download ‘Bilingual statutory declaration for marriage in Italy’ (PDF, 90KB)](/government/uploads/system/uploads/attachment_data/file/153753/bilingual-statutory-declaration.pdf)
-      $D
-
-
-      <% if partner_nationality != 'partner_british' %>
-
-        ^Your partner should check what they need to do with their own consulate.^
-
-      <% end %>
-
-      ###Legalisation and translation
-
-      You’ll need to get your statutory declaration and CNI ’[legalised](/get-document-legalised)’ (certified as genuine) by the Foreign & Commonwealth Office (FCO).
-
-      You’ll also need to get your CNI [translated](/government/publications/italy-list-of-translators-and-interpreters) and sworn before the Italian courts or an Italian Justice of the Peace.
 
     <% end %>
   <% end %>
@@ -207,14 +151,14 @@
 
       You should also check if it needs to be:
 
-    <% elsif %w(italy).exclude?(ceremony_country) %>
+    <% else %>
       <%= render partial: 'legisation_and_translation_intro_uk.govspeak.erb',
                  locals: {
                    country_name_lowercase_prefix: country_name_lowercase_prefix
                  } %>
 
     <% end %>
-    <% if %w(germany italy tunisia).exclude?(ceremony_country) %>
+    <% if %w(germany tunisia).exclude?(ceremony_country) %>
       <%= render partial: 'legalise_translate_and_check_with_authorities.govspeak.erb',
                  locals: {
                    country_name_lowercase_prefix: country_name_lowercase_prefix
@@ -234,7 +178,7 @@
       If you need a CNI, you must arrange this through the British Embassy in Costa Rica because there aren’t any British consular facilities in Nicaragua.
 
 
-    <% elsif %w(germany italy kazakhstan macedonia russia).exclude?(ceremony_country) %>
+    <% elsif %w(germany kazakhstan macedonia russia).exclude?(ceremony_country) %>
       To get a CNI, you must post notice of your intended marriage in <%= country_name_lowercase_prefix %>. You can do this at the British embassy or in front of a notary public.
 
 
@@ -270,7 +214,7 @@
 
 
     <% end %>
-    <% unless %w(germany italy japan).include?(ceremony_country) %>
+    <% unless %w(germany japan).include?(ceremony_country) %>
       <% if ceremony_country == 'macedonia' %>
         Contact a notary public or British Embassy in Macedonia to get advice:
 
@@ -292,15 +236,6 @@
                    } %>
       <% end %>
     <% end %>
-    <% if ceremony_country == 'italy' %>
-      To get a Nulla Osta, you’ll first need to give notice of your intended marriage at the British Embassy in Rome.
-
-      ###Applying for a Nulla Osta from the embassy
-
-      You’ll need to have been living in <%= country_name_lowercase_prefix %> for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday. You can then book an appointment at the British Embassy in Rome.
-
-
-    <% end %>
   <% end %>
   <% if resident_of != 'uk' && ceremony_country == 'egypt' %>
     <%= render partial: 'required_supporting_documents_egypt.govspeak.erb' %>
@@ -317,7 +252,7 @@
     <%= render partial: 'required_supporting_documents_philippines.govspeak.erb' %>
   <% elsif resident_of != 'uk' && ceremony_country == 'macao' %>
     <%= render partial: 'required_supporting_documents_macao.govspeak.erb' %>
-  <% elsif resident_of == 'ceremony_country' && %w(germany italy japan).exclude?(ceremony_country) %>
+  <% elsif resident_of == 'ceremony_country' && %w(germany japan).exclude?(ceremony_country) %>
     <% if birth_cert_inclusion && notary_public_inclusion %>
       You’ll need to provide supporting documents, including:
 
@@ -376,20 +311,6 @@
       - equivalent documents for your partner
 
     <% end %>
-    <% if ceremony_country == 'italy' %>
-      <% if partner_nationality == 'partner_british' %>
-        You and your partner will need to provide your passports and [full birth certificate](/order-copy-birth-death-marriage-certificate/) or [naturalisation certificate](/get-replacement-citizenship-certificate).
-
-      <% else %>
-        You’ll need to provide supporting documents, including:
-
-        - your passport
-        - your [full birth certificate](/order-copy-birth-death-marriage-certificate/) or [naturalisation certificate](/get-replacement-citizenship-certificate) which states both of your parents’ names
-        - proof of residence, such as a residence certificate - check with the <%= embassy_or_consulate_ceremony_country %> to find out what you need
-        - a copy of your partner’s identity document
-
-      <% end %>
-    <% end %>
   <% end %>
   <% if resident_of != 'uk' %>
     <% if ceremony_country == 'jordan' %>
@@ -407,19 +328,11 @@
     <% end %>
   <% end %>
   <% if resident_of != 'uk' %>
-    <% if ceremony_country == 'italy' && resident_of != 'uk' %>
-      You’ll also need to provide evidence of nationality or residence if the divorce or dissolution took place outside the UK. You’ll need to get it [translated](/government/publications/italy-list-of-translators-and-interpreters) if it’s not in English.
-
-
-    <% elsif %(germany).exclude?(ceremony_country) %>
+    <% if %(germany).exclude?(ceremony_country) %>
       ^You’ll also need to provide evidence of nationality or residence if the divorce or dissolution took place outside the UK. You’ll need to get it [legalised](/get-document-legalised) and [translated](/government/collections/list-of-lawyers) if it’s not in English.^
 
 
     <% end %>
-  <% end %>
-  <% if ceremony_country == 'italy' && resident_of != 'uk' %>
-    ^If you’re a woman you must wait 300 days after divorcing or the death of your husband before remarrying.^
-
   <% end %>
   <% if resident_of == 'ceremony_country' %>
     <% if ceremony_country == 'greece' %>
@@ -440,14 +353,14 @@
 
     <% end %>
   <% else %>
-    <% if sex_of_your_partner == 'same_sex' || no_document_download_link_if_os_resident_of_uk_countries.exclude?(ceremony_country) && (cni_notary_public_countries + %w(italy japan macedonia) - %w(greece tunisia)).include?(ceremony_country) %>
+    <% if sex_of_your_partner == 'same_sex' || no_document_download_link_if_os_resident_of_uk_countries.exclude?(ceremony_country) && (cni_notary_public_countries + %w(japan macedonia) - %w(greece tunisia)).include?(ceremony_country) %>
       <%= render partial: 'download_and_fill_notice_and_affidavit_but_not_sign.govspeak.erb' %>
 
     <% end %>
   <% end %>
   <% if resident_of == 'ceremony_country' %>
 
-    <% if partner_nationality == 'partner_british' && %w(italy germany finland).exclude?(ceremony_country) %>
+    <% if partner_nationality == 'partner_british' && %w(germany finland).exclude?(ceremony_country) %>
       ^Your partner will need to follow the same process and pay the fees to get their own CNI.^
     <% end %>
 
@@ -456,15 +369,6 @@
                  locals: {
                    embassy_or_consulate_ceremony_country: embassy_or_consulate_ceremony_country
                  } %>
-
-    <% elsif ceremony_country == 'italy' %>
-      ###What happens next
-
-      They’ll display your notice of marriage publicly for 7 days.
-
-      The British embassy will issue your CNI within 5 working days (as long as nobody has registered an objection). You can collect your CNI in person or have it delivered by post.
-
-      ^The embassy or consulate may charge a fee to return your documents to you.^
 
     <% elsif ceremony_country == 'greece' %>
       ###What happens next
@@ -512,7 +416,7 @@
                } %>
 
   <% end %>
-  <% if ceremony_country != 'italy' && resident_of == 'uk' && "partner_other" == partner_nationality && "finland" == ceremony_country %>
+  <% if resident_of == 'uk' && "partner_other" == partner_nationality && "finland" == ceremony_country %>
     <%= render partial: 'callout_partner_equivalent_document.govspeak.erb' %>
 
   <% end %>
@@ -520,7 +424,7 @@
   <% if ceremony_country != 'germany'  || (ceremony_country == 'germany' && resident_of == 'uk') %>
     <%= render partial: 'names_on_documents_must_match.govspeak.erb' %>
   <% end %>
-  <% if resident_of != 'uk' && %w(italy germany).exclude?(ceremony_country) %>
+  <% if resident_of != 'uk' && %w(germany).exclude?(ceremony_country) %>
     You should check if your CNI needs to be legalised (certified as genuine) by the local authorities in <%= country_name_lowercase_prefix %>.
 
 
@@ -534,44 +438,33 @@
     <%= render partial: 'partner_naturalisation_in_uk.govspeak.erb' %>
 
   <% end %>
-  <% unless ceremony_country == 'italy' && resident_of == 'uk' %>
-    <% if ceremony_country == 'croatia' && resident_of == 'ceremony_country' %>
-      ##Fees
+  <% if ceremony_country == 'croatia' && resident_of == 'ceremony_country' %>
+    ##Fees
 
-      Service | Fee
-      -|-
-      Receiving a notice of marriage | £65
-      Issuing a CNI, Nulla Osta or equivalent | £65
-      Issuing any other consular letter or certificate in English | £45
-      Issuing any other consular letter or certificate in any other language | £70
-      Administering an oath or making a declaration | £55
-      Issuing a certificate of custom and law | £65
+    Service | Fee
+    -|-
+    Receiving a notice of marriage | £65
+    Issuing a CNI, Nulla Osta or equivalent | £65
+    Issuing any other consular letter or certificate in English | £45
+    Issuing any other consular letter or certificate in any other language | £70
+    Administering an oath or making a declaration | £55
+    Issuing a certificate of custom and law | £65
 
 
-    <% elsif ceremony_country == 'italy' %>
-      ##Fees
+  <% else %>
+    <%= render partial: 'consular_cni_os_fees_incl_null_osta_oath_consular_letter.govspeak.erb' %>
 
-      Service | Fee
-      -|-
-      Receiving a notice of marriage | £65
-      Issuing a CNI, Nulla Osta or equivalent | £65
-
+  <% end %>
+  <% unless data_query.countries_without_consular_facilities?(ceremony_country) || ceremony_country == 'cote-d-ivoire' %>
+    <% if %w(kazakhstan kyrgyzstan).include?(ceremony_country) %>
+      You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Kazakhstan](/government/publications/kazakhstan-kyrgyzstan-consular-fees).
 
     <% else %>
-      <%= render partial: 'consular_cni_os_fees_incl_null_osta_oath_consular_letter.govspeak.erb' %>
-
-    <% end %>
-    <% unless data_query.countries_without_consular_facilities?(ceremony_country) || ceremony_country == 'cote-d-ivoire' %>
-      <% if %w(kazakhstan kyrgyzstan).include?(ceremony_country) %>
-        You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Kazakhstan](/government/publications/kazakhstan-kyrgyzstan-consular-fees).
-
-      <% else %>
-        <%= render partial: 'link_to_consular_fees.govspeak.erb',
-                   locals: {
-                     country_name_lowercase_prefix: country_name_lowercase_prefix,
-                     ceremony_country: ceremony_country
-                   } %>
-      <% end %>
+      <%= render partial: 'link_to_consular_fees.govspeak.erb',
+                 locals: {
+                   country_name_lowercase_prefix: country_name_lowercase_prefix,
+                   ceremony_country: ceremony_country
+                 } %>
     <% end %>
   <% end %>
   <% unless data_query.countries_without_consular_facilities?(ceremony_country) %>
@@ -597,7 +490,7 @@
     <% elsif ceremony_country == 'kuwait' %>
       You can pay by cash or credit card (except American Express), but not by personal cheque.
 
-    <% elsif %w(cote-d-ivoire burundi).exclude?(ceremony_country) && !(ceremony_country == 'italy' && resident_of == 'uk') %>
+    <% elsif %w(cote-d-ivoire burundi).exclude?(ceremony_country) %>
       <%= render partial: 'pay_by_cash_or_credit_card_no_cheque.govspeak.erb' %>
     <% end %>
   <% end %>

--- a/lib/smart_answer_flows/marriage-abroad/outcome_os_italy.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcome_os_italy.govspeak.erb
@@ -1,0 +1,143 @@
+<% content_for :title do %>
+  Marriage in <%= country_name_lowercase_prefix %>
+<% end %>
+
+<% content_for :body do %>
+  Contact the local comune (town hall) before making any plans to find out about local marriage laws, including what documents you’ll need.
+
+  <%= render partial: 'what_you_need_to_do.govspeak.erb' %>
+
+  <% if resident_of == 'uk' %>
+    You’ll need to get a certificate of no impediment (CNI) from the authorities in the UK to prove you’re allowed to marry.
+
+    <% if partner_nationality == 'partner_british' %>
+      ^Your partner will need to follow the same process to get their own CNI.^
+    <% end %>
+  <% else %>
+    You’ll be asked to provide a ‘Nulla Osta’ by the authorities in Italy. This is a certificate that proves you’re allowed to marry.
+
+    <%= render partial: 'contact_method.govspeak.erb',
+               locals: {
+                 sex_of_your_partner: sex_of_your_partner,
+                 ceremony_country: ceremony_country,
+                 overseas_passports_embassies: overseas_passports_embassies,
+                 country_name_lowercase_prefix: country_name_lowercase_prefix
+               } %>
+  <% end %>
+  <% if resident_of == 'uk' %>
+    <%= render partial: 'cni_at_local_register_office.govspeak.erb' %>
+
+    <%= render partial: 'cni_issued_locally_validity.govspeak.erb',
+               locals: {
+                 country_name_lowercase_prefix: country_name_lowercase_prefix
+               } -%>
+
+    <% if partner_nationality == 'partner_british' %>
+      ###Getting a statutory declaration
+
+      While you’re waiting for your CNI, you and your partner will need to make a statutory declaration before a [solicitor or public notary](http://www.lawsociety.org.uk/find-a-solicitor/). The Italian authorities will need this in addition to your CNI. There’s a standard template in English and Italian that you can download and use.
+
+    <% else %>
+      ###Getting a statutory declaration
+
+      While you’re waiting for your CNI, you will need to make a statutory declaration before a [solicitor or public notary](http://www.lawsociety.org.uk/find-a-solicitor/). The Italian authorities will need this in addition to your CNI. There’s a standard template in English and Italian that you can download and use.
+
+
+    <% end %>
+    $D
+    [Download ‘Bilingual statutory declaration for marriage in Italy’ (PDF, 90KB)](/government/uploads/system/uploads/attachment_data/file/153753/bilingual-statutory-declaration.pdf)
+    $D
+
+
+    <% if partner_nationality != 'partner_british' %>
+
+      ^Your partner should check what they need to do with their own consulate.^
+
+    <% end %>
+
+    ###Legalisation and translation
+
+    You’ll need to get your statutory declaration and CNI ’[legalised](/get-document-legalised)’ (certified as genuine) by the Foreign & Commonwealth Office (FCO).
+
+    You’ll also need to get your CNI [translated](/government/publications/italy-list-of-translators-and-interpreters) and sworn before the Italian courts or an Italian Justice of the Peace.
+
+  <% end %>
+  <% if resident_of == 'ceremony_country' %>
+    To get a Nulla Osta, you’ll first need to give notice of your intended marriage at the British Embassy in Rome.
+
+    ###Applying for a Nulla Osta from the embassy
+
+    You’ll need to have been living in <%= country_name_lowercase_prefix %> for 3 full days before you can post notice, eg if you arrive in the country on Thursday, the earliest you can post notice is the following Monday. You can then book an appointment at the British Embassy in Rome.
+
+
+    <% if partner_nationality == 'partner_british' %>
+      You and your partner will need to provide your passports and [full birth certificate](/order-copy-birth-death-marriage-certificate/) or [naturalisation certificate](/get-replacement-citizenship-certificate).
+
+    <% else %>
+      You’ll need to provide supporting documents, including:
+
+      - your passport
+      - your [full birth certificate](/order-copy-birth-death-marriage-certificate/) or [naturalisation certificate](/get-replacement-citizenship-certificate) which states both of your parents’ names
+      - proof of residence, such as a residence certificate - check with the <%= embassy_or_consulate_ceremony_country %> to find out what you need
+      - a copy of your partner’s identity document
+
+    <% end %>
+  <% end %>
+  <% if resident_of != 'uk' %>
+    <%= render partial: 'consular_cni_os_not_uk_resident_ceremony_not_germany.govspeak.erb' %>
+
+    You’ll also need to provide evidence of nationality or residence if the divorce or dissolution took place outside the UK. You’ll need to get it [translated](/government/publications/italy-list-of-translators-and-interpreters) if it’s not in English.
+
+
+    ^If you’re a woman you must wait 300 days after divorcing or the death of your husband before remarrying.^
+
+  <% end %>
+  <% if resident_of == 'ceremony_country' %>
+    <%= render partial: 'download_and_fill_notice_and_affidavit_but_not_sign.govspeak.erb' %>
+
+
+
+    ###What happens next
+
+    They’ll display your notice of marriage publicly for 7 days.
+
+    The British embassy will issue your CNI within 5 working days (as long as nobody has registered an objection). You can collect your CNI in person or have it delivered by post.
+
+    ^The embassy or consulate may charge a fee to return your documents to you.^
+  <% end %>
+
+
+  <%= render partial: 'names_on_documents_must_match.govspeak.erb' -%>
+
+  <% if resident_of == 'ceremony_country' %>
+    ^You don't need to stay in the country while your notice is posted.^
+
+  <% end %>
+  <% if partner_nationality != 'partner_british' %>
+
+    <%= render partial: 'partner_naturalisation_in_uk.govspeak.erb' %>
+
+  <% end %>
+  <% if resident_of != 'uk' %>
+    ##Fees
+
+    Service | Fee
+    -|-
+    Receiving a notice of marriage | £65
+    Issuing a CNI, Nulla Osta or equivalent | £65
+
+
+    <%= render partial: 'link_to_consular_fees.govspeak.erb',
+               locals: {
+                 country_name_lowercase_prefix: country_name_lowercase_prefix,
+                 ceremony_country: ceremony_country
+               } %>
+
+    <%= render partial: 'pay_by_cash_or_credit_card_no_cheque.govspeak.erb' %>
+  <% end %>
+
+
+  *[CNI]:certificate of no impediment
+  *[GRO]:General Register Office
+  *[FCO]:Foreign &amp; Commonwealth Office
+<% end %>

--- a/test/artefacts/marriage-abroad/italy/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/italy/ceremony_country/partner_british/opposite_sex.txt
@@ -2,14 +2,12 @@ Marriage in Italy
 
 Contact the local comune (town hall) before making any plans to find out about local marriage laws, including what documents you’ll need.
 
-
 ##What you need to do
 
 
 You’ll be asked to provide a ‘Nulla Osta’ by the authorities in Italy. This is a certificate that proves you’re allowed to marry.
 
 [Make an appointment at the embassy in Rome.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rome/notice-of-marriage-or-civil-partnership/slot_picker)
-
 
 To get a Nulla Osta, you’ll first need to give notice of your intended marriage at the British Embassy in Rome.
 
@@ -71,6 +69,7 @@ You normally have to pay fees for consular services in the local currency - thes
 
 
 You can pay by cash or credit card, but not by personal cheque.
+
 
 
 *[CNI]:certificate of no impediment

--- a/test/artefacts/marriage-abroad/italy/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/italy/ceremony_country/partner_local/opposite_sex.txt
@@ -2,14 +2,12 @@ Marriage in Italy
 
 Contact the local comune (town hall) before making any plans to find out about local marriage laws, including what documents you’ll need.
 
-
 ##What you need to do
 
 
 You’ll be asked to provide a ‘Nulla Osta’ by the authorities in Italy. This is a certificate that proves you’re allowed to marry.
 
 [Make an appointment at the embassy in Rome.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rome/notice-of-marriage-or-civil-partnership/slot_picker)
-
 
 To get a Nulla Osta, you’ll first need to give notice of your intended marriage at the British Embassy in Rome.
 
@@ -82,6 +80,7 @@ You normally have to pay fees for consular services in the local currency - thes
 
 
 You can pay by cash or credit card, but not by personal cheque.
+
 
 
 *[CNI]:certificate of no impediment

--- a/test/artefacts/marriage-abroad/italy/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/italy/ceremony_country/partner_other/opposite_sex.txt
@@ -2,14 +2,12 @@ Marriage in Italy
 
 Contact the local comune (town hall) before making any plans to find out about local marriage laws, including what documents you’ll need.
 
-
 ##What you need to do
 
 
 You’ll be asked to provide a ‘Nulla Osta’ by the authorities in Italy. This is a certificate that proves you’re allowed to marry.
 
 [Make an appointment at the embassy in Rome.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rome/notice-of-marriage-or-civil-partnership/slot_picker)
-
 
 To get a Nulla Osta, you’ll first need to give notice of your intended marriage at the British Embassy in Rome.
 
@@ -82,6 +80,7 @@ You normally have to pay fees for consular services in the local currency - thes
 
 
 You can pay by cash or credit card, but not by personal cheque.
+
 
 
 *[CNI]:certificate of no impediment

--- a/test/artefacts/marriage-abroad/italy/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/italy/uk/partner_british/opposite_sex.txt
@@ -2,14 +2,12 @@ Marriage in Italy
 
 Contact the local comune (town hall) before making any plans to find out about local marriage laws, including what documents you’ll need.
 
-
 ##What you need to do
 
 
 You’ll need to get a certificate of no impediment (CNI) from the authorities in the UK to prove you’re allowed to marry.
 
 ^Your partner will need to follow the same process to get their own CNI.^
-
 You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.gro-scotland.gov.uk/files1/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
 

--- a/test/artefacts/marriage-abroad/italy/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/italy/uk/partner_local/opposite_sex.txt
@@ -2,7 +2,6 @@ Marriage in Italy
 
 Contact the local comune (town hall) before making any plans to find out about local marriage laws, including what documents you’ll need.
 
-
 ##What you need to do
 
 

--- a/test/artefacts/marriage-abroad/italy/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/italy/uk/partner_other/opposite_sex.txt
@@ -2,7 +2,6 @@ Marriage in Italy
 
 Contact the local comune (town hall) before making any plans to find out about local marriage laws, including what documents you’ll need.
 
-
 ##What you need to do
 
 

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -1,8 +1,8 @@
 ---
-lib/smart_answer_flows/marriage-abroad.rb: c509df582129a4bbba4f2f850d69c06c
+lib/smart_answer_flows/marriage-abroad.rb: 3d3c3dce01cb44ec4fb2f46808266bfe
 lib/smart_answer_flows/locales/en/marriage-abroad.yml: 164d2e20ece110c5f60744b483766e36
 test/data/marriage-abroad-questions-and-responses.yml: eabbd09ca91fab72a9a520d1087fb35e
-test/data/marriage-abroad-responses-and-expected-results.yml: 4744dcb2be7083fc17334bc2d8c9ae2a
+test/data/marriage-abroad-responses-and-expected-results.yml: 364c07a077f707fff8c408a888b67a7f
 lib/smart_answer_flows/marriage-abroad/_affirmation_os_translation_in_local_language_text.govspeak.erb: 2e6645f9114db57b0f081070d0473771
 lib/smart_answer_flows/marriage-abroad/_appointment_for_affidavit.govspeak.erb: c9714322b3c62e0a0ded981da6025b9d
 lib/smart_answer_flows/marriage-abroad/_appointment_for_affidavit_norway.govspeak.erb: de478bc6121e2e4c7f748a4e1831befb
@@ -84,10 +84,11 @@ lib/smart_answer_flows/marriage-abroad/outcome_os_affirmation.govspeak.erb: 6b33
 lib/smart_answer_flows/marriage-abroad/outcome_os_bot.govspeak.erb: 6265728604b85e2fd51b59b3823fe1aa
 lib/smart_answer_flows/marriage-abroad/outcome_os_colombia.govspeak.erb: 0278771b1619672cf187445c6cef00f4
 lib/smart_answer_flows/marriage-abroad/outcome_os_commonwealth.govspeak.erb: 34601719747aa693e793816036730450
-lib/smart_answer_flows/marriage-abroad/outcome_os_consular_cni.govspeak.erb: f04ea67d39d0b256d07f0e749a34bb90
+lib/smart_answer_flows/marriage-abroad/outcome_os_consular_cni.govspeak.erb: acfcd866e7e930c3c13795528712b86b
 lib/smart_answer_flows/marriage-abroad/outcome_os_france_or_fot.govspeak.erb: 7a5cb5ac119b7891858e415872d3e20e
 lib/smart_answer_flows/marriage-abroad/outcome_os_hong_kong.govspeak.erb: 9fad3bd3a55309f5a345b378b1bb8dd4
 lib/smart_answer_flows/marriage-abroad/outcome_os_indonesia.govspeak.erb: 36b4facf927967b5a52aae809e154f4b
+lib/smart_answer_flows/marriage-abroad/outcome_os_italy.govspeak.erb: 47789cf3e35e975a09a4db085376b211
 lib/smart_answer_flows/marriage-abroad/outcome_os_kosovo.govspeak.erb: 0f95fb2f76855f9394fe5ff6f539874c
 lib/smart_answer_flows/marriage-abroad/outcome_os_laos.govspeak.erb: 3df2462e6af37249dac29544a85c1a2f
 lib/smart_answer_flows/marriage-abroad/outcome_os_local_japan.govspeak.erb: d4d0357da97be8aff5d2e9826000e581

--- a/test/data/marriage-abroad-responses-and-expected-results.yml
+++ b/test/data/marriage-abroad-responses-and-expected-results.yml
@@ -9487,7 +9487,7 @@
   - uk
   - partner_british
   - opposite_sex
-  :next_node: :outcome_os_consular_cni
+  :next_node: :outcome_os_italy
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
@@ -9510,7 +9510,7 @@
   - uk
   - partner_local
   - opposite_sex
-  :next_node: :outcome_os_consular_cni
+  :next_node: :outcome_os_italy
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
@@ -9533,7 +9533,7 @@
   - uk
   - partner_other
   - opposite_sex
-  :next_node: :outcome_os_consular_cni
+  :next_node: :outcome_os_italy
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
@@ -9562,7 +9562,7 @@
   - ceremony_country
   - partner_british
   - opposite_sex
-  :next_node: :outcome_os_consular_cni
+  :next_node: :outcome_os_italy
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
@@ -9585,7 +9585,7 @@
   - ceremony_country
   - partner_local
   - opposite_sex
-  :next_node: :outcome_os_consular_cni
+  :next_node: :outcome_os_italy
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses:
@@ -9608,7 +9608,7 @@
   - ceremony_country
   - partner_other
   - opposite_sex
-  :next_node: :outcome_os_consular_cni
+  :next_node: :outcome_os_italy
   :outcome_node: true
 - :current_node: :partner_opposite_or_same_sex?
   :responses:

--- a/test/integration/smart_answer_flows/marriage_abroad_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_test.rb
@@ -390,7 +390,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
       add_response 'opposite_sex'
     end
     should "go to consular cni os outcome" do
-      assert_current_node :outcome_os_consular_cni
+      assert_current_node :outcome_os_italy
     end
   end
 
@@ -403,7 +403,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
       add_response 'opposite_sex'
     end
     should "go to consular cni os outcome" do
-      assert_current_node :outcome_os_consular_cni
+      assert_current_node :outcome_os_italy
     end
   end
 


### PR DESCRIPTION
This is up for discussion.

Opposite-sex marriages in Italy have plenty of exceptions. That means a lot of extra ifs in the generic CNI outcome. Splitting Italy out duplicates some of the CNI logic, but also removes those extra ifs in the already big CNI outcome. Similar thing has been done to other countries eg Spain.