### PR TITLE
Update opposite-sex marriage process in Indonesia

### DIFF
--- a/lib/smart_answer_flows/marriage-abroad/_contact_method.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/_contact_method.govspeak.erb
@@ -57,6 +57,10 @@
     [Make an appointment at the embassy in Budapest.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-budapest/notice-of-marriage-or-civil-partnership/slot_picker)
   <% when 'iceland' %>
     [Make an appointment at the embassy in Reykjavik.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-reykjavik/notice-of-marriage-or-civil-partnership/slot_picker)
+  <% when 'indonesia' %>
+    [Make an appointment at the embassy in Jakarta.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-jakarta/oaths-affirmations-and-affidavits/slot_picker)
+
+    [Make an appointment at the consulate in Bali.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-bali/oaths-affirmations-and-affidavits/slot_picker)
   <% when 'italy' %>
     [Make an appointment at the embassy in Rome.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rome/notice-of-marriage-or-civil-partnership/slot_picker)
   <% when 'kazakhstan' %>

--- a/lib/smart_answer_flows/marriage-abroad/outcome_os_indonesia.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcome_os_indonesia.govspeak.erb
@@ -4,14 +4,7 @@
 <% end %>
 
 <% content_for :body do %>
-  Make an appointment at the British Embassy in Jakarta to swear an affidavit (written statement of facts) that you’re free to marry.
-
-  Before the appointment you’ll need to pay a fee to the British Embassy in Jakarta. You can do this by credit card or in cash in the local currency. You also need to complete 2 copies of the [‘Affidavit for marriage’ form](/government/publications/marriage-in-indonesia).
-
-  Send one copy to the British Embassy in Jakarta by email or post. Take the other one with you when you go to your local appointment, along with your passport.
-
-  ^Allow the embassy at least 2 days to process your paperwork before turning up for your appointment.^
-
+  Make an appointment at the British embassy or consulate in Indonesia to swear an affirmation or affidavit (written statement of facts) that you’re free to marry.
 
   <%= render partial: 'contact_method.govspeak.erb',
              locals: {
@@ -21,10 +14,31 @@
                country_name_lowercase_prefix: country_name_lowercase_prefix
              } %>
 
-  <%= render partial: 'documents_for_divorced_or_widowed.govspeak.erb' %>
+  ^Contact the local civil registry office in Indonesia to find out when you need to swear your affirmation or affidavit.^
 
-  ^Your partner will need to get an affidavit as well.^
+  You need to complete 2 copies of the [affirmation (non religious) or affidavit (religious) of marriage form](/government/publications/marriage-in-indonesia).
+  Email one copy to the British embassy in Jakarta at least 2 days before your appointment. Take the other copy to your appointment.
 
+  $C
+  <consulate.jakarta@fco.gov.uk>
+  $C
+
+  You must pay a fee to the British embassy in Jakarta - email them to find out how to pay.
+
+  ^Your partner must get an affirmation or affidavit as well.^
+
+  ##What you need to take
+
+  You must take all of the following to your appointment:
+
+  - a copy of your affirmation or affidavit
+  <% if partner_nationality == 'partner_local' %>
+  - your passport and your partner’s passport or KTP (Indonesian identity card)
+  <% else %>
+  - your passport and your partner’s passport
+  <% end %>
+  - a [decree absolute or final order](/copy-decree-absolute-final-order) or [death certificate](/order-copy-birth-death-marriage-certificate/) (if you’ve been divorced or widowed)
+  - evidence if you’ve changed your name by deed poll
 
   <%= render partial: 'fee_table_45_70_55.govspeak.erb' %>
 <% end %>

--- a/test/artefacts/marriage-abroad/indonesia/ceremony_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/indonesia/ceremony_country/partner_british/opposite_sex.txt
@@ -1,48 +1,34 @@
 Marriage in Indonesia
 
 
-Make an appointment at the British Embassy in Jakarta to swear an affidavit (written statement of facts) that you’re free to marry.
+Make an appointment at the British embassy or consulate in Indonesia to swear an affirmation or affidavit (written statement of facts) that you’re free to marry.
 
-Before the appointment you’ll need to pay a fee to the British Embassy in Jakarta. You can do this by credit card or in cash in the local currency. You also need to complete 2 copies of the [‘Affidavit for marriage’ form](/government/publications/marriage-in-indonesia).
+[Make an appointment at the embassy in Jakarta.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-jakarta/oaths-affirmations-and-affidavits/slot_picker)
 
-Send one copy to the British Embassy in Jakarta by email or post. Take the other one with you when you go to your local appointment, along with your passport.
-
-^Allow the embassy at least 2 days to process your paperwork before turning up for your appointment.^
+[Make an appointment at the consulate in Bali.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-bali/oaths-affirmations-and-affidavits/slot_picker)
 
 
+^Contact the local civil registry office in Indonesia to find out when you need to swear your affirmation or affidavit.^
 
-
-$A
-British Embassy Jakarta
-British Embassy Jakarta
-Jl. MH Thamrin 75 Jakarta
-10310
-Indonesia
-$A
+You need to complete 2 copies of the [affirmation (non religious) or affidavit (religious) of marriage form](/government/publications/marriage-in-indonesia).
+Email one copy to the British embassy in Jakarta at least 2 days before your appointment. Take the other copy to your appointment.
 
 $C
-Telephone: (+62) (21) 2356 5200
-Fax: (+62) (21) 2356 5351
-Fax (Corporate Services): (+62) (21) 2356 5351 
-Fax (Media and Communications): (+62) (21) 2356 5336
-Fax (Political): (+62) (21) 2356 5293
-Fax (Defence): (+62) (21) 2356 5353
-
-Email: <Jakarta.mcs@fco.gov.uk>
-
+<consulate.jakarta@fco.gov.uk>
 $C
 
+You must pay a fee to the British embassy in Jakarta - email them to find out how to pay.
 
+^Your partner must get an affirmation or affidavit as well.^
 
-If you’ve been divorced or widowed, you’ll need to provide:
+##What you need to take
 
-- a [decree absolute or final order](/copy-decree-absolute-final-order) or [death certificate](/order-copy-birth-death-marriage-certificate/)
-- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [translated](/government/collections/list-of-lawyers) if it’s not in English
+You must take all of the following to your appointment:
+
+- a copy of your affirmation or affidavit
+- your passport and your partner’s passport
+- a [decree absolute or final order](/copy-decree-absolute-final-order) or [death certificate](/order-copy-birth-death-marriage-certificate/) (if you’ve been divorced or widowed)
 - evidence if you’ve changed your name by deed poll
-
-
-^Your partner will need to get an affidavit as well.^
-
 
 ##Fees
 

--- a/test/artefacts/marriage-abroad/indonesia/ceremony_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/indonesia/ceremony_country/partner_local/opposite_sex.txt
@@ -1,48 +1,34 @@
 Marriage in Indonesia
 
 
-Make an appointment at the British Embassy in Jakarta to swear an affidavit (written statement of facts) that you’re free to marry.
+Make an appointment at the British embassy or consulate in Indonesia to swear an affirmation or affidavit (written statement of facts) that you’re free to marry.
 
-Before the appointment you’ll need to pay a fee to the British Embassy in Jakarta. You can do this by credit card or in cash in the local currency. You also need to complete 2 copies of the [‘Affidavit for marriage’ form](/government/publications/marriage-in-indonesia).
+[Make an appointment at the embassy in Jakarta.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-jakarta/oaths-affirmations-and-affidavits/slot_picker)
 
-Send one copy to the British Embassy in Jakarta by email or post. Take the other one with you when you go to your local appointment, along with your passport.
-
-^Allow the embassy at least 2 days to process your paperwork before turning up for your appointment.^
+[Make an appointment at the consulate in Bali.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-bali/oaths-affirmations-and-affidavits/slot_picker)
 
 
+^Contact the local civil registry office in Indonesia to find out when you need to swear your affirmation or affidavit.^
 
-
-$A
-British Embassy Jakarta
-British Embassy Jakarta
-Jl. MH Thamrin 75 Jakarta
-10310
-Indonesia
-$A
+You need to complete 2 copies of the [affirmation (non religious) or affidavit (religious) of marriage form](/government/publications/marriage-in-indonesia).
+Email one copy to the British embassy in Jakarta at least 2 days before your appointment. Take the other copy to your appointment.
 
 $C
-Telephone: (+62) (21) 2356 5200
-Fax: (+62) (21) 2356 5351
-Fax (Corporate Services): (+62) (21) 2356 5351 
-Fax (Media and Communications): (+62) (21) 2356 5336
-Fax (Political): (+62) (21) 2356 5293
-Fax (Defence): (+62) (21) 2356 5353
-
-Email: <Jakarta.mcs@fco.gov.uk>
-
+<consulate.jakarta@fco.gov.uk>
 $C
 
+You must pay a fee to the British embassy in Jakarta - email them to find out how to pay.
 
+^Your partner must get an affirmation or affidavit as well.^
 
-If you’ve been divorced or widowed, you’ll need to provide:
+##What you need to take
 
-- a [decree absolute or final order](/copy-decree-absolute-final-order) or [death certificate](/order-copy-birth-death-marriage-certificate/)
-- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [translated](/government/collections/list-of-lawyers) if it’s not in English
+You must take all of the following to your appointment:
+
+- a copy of your affirmation or affidavit
+- your passport and your partner’s passport or KTP (Indonesian identity card)
+- a [decree absolute or final order](/copy-decree-absolute-final-order) or [death certificate](/order-copy-birth-death-marriage-certificate/) (if you’ve been divorced or widowed)
 - evidence if you’ve changed your name by deed poll
-
-
-^Your partner will need to get an affidavit as well.^
-
 
 ##Fees
 

--- a/test/artefacts/marriage-abroad/indonesia/ceremony_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/indonesia/ceremony_country/partner_other/opposite_sex.txt
@@ -1,48 +1,34 @@
 Marriage in Indonesia
 
 
-Make an appointment at the British Embassy in Jakarta to swear an affidavit (written statement of facts) that you’re free to marry.
+Make an appointment at the British embassy or consulate in Indonesia to swear an affirmation or affidavit (written statement of facts) that you’re free to marry.
 
-Before the appointment you’ll need to pay a fee to the British Embassy in Jakarta. You can do this by credit card or in cash in the local currency. You also need to complete 2 copies of the [‘Affidavit for marriage’ form](/government/publications/marriage-in-indonesia).
+[Make an appointment at the embassy in Jakarta.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-jakarta/oaths-affirmations-and-affidavits/slot_picker)
 
-Send one copy to the British Embassy in Jakarta by email or post. Take the other one with you when you go to your local appointment, along with your passport.
-
-^Allow the embassy at least 2 days to process your paperwork before turning up for your appointment.^
+[Make an appointment at the consulate in Bali.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-bali/oaths-affirmations-and-affidavits/slot_picker)
 
 
+^Contact the local civil registry office in Indonesia to find out when you need to swear your affirmation or affidavit.^
 
-
-$A
-British Embassy Jakarta
-British Embassy Jakarta
-Jl. MH Thamrin 75 Jakarta
-10310
-Indonesia
-$A
+You need to complete 2 copies of the [affirmation (non religious) or affidavit (religious) of marriage form](/government/publications/marriage-in-indonesia).
+Email one copy to the British embassy in Jakarta at least 2 days before your appointment. Take the other copy to your appointment.
 
 $C
-Telephone: (+62) (21) 2356 5200
-Fax: (+62) (21) 2356 5351
-Fax (Corporate Services): (+62) (21) 2356 5351 
-Fax (Media and Communications): (+62) (21) 2356 5336
-Fax (Political): (+62) (21) 2356 5293
-Fax (Defence): (+62) (21) 2356 5353
-
-Email: <Jakarta.mcs@fco.gov.uk>
-
+<consulate.jakarta@fco.gov.uk>
 $C
 
+You must pay a fee to the British embassy in Jakarta - email them to find out how to pay.
 
+^Your partner must get an affirmation or affidavit as well.^
 
-If you’ve been divorced or widowed, you’ll need to provide:
+##What you need to take
 
-- a [decree absolute or final order](/copy-decree-absolute-final-order) or [death certificate](/order-copy-birth-death-marriage-certificate/)
-- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [translated](/government/collections/list-of-lawyers) if it’s not in English
+You must take all of the following to your appointment:
+
+- a copy of your affirmation or affidavit
+- your passport and your partner’s passport
+- a [decree absolute or final order](/copy-decree-absolute-final-order) or [death certificate](/order-copy-birth-death-marriage-certificate/) (if you’ve been divorced or widowed)
 - evidence if you’ve changed your name by deed poll
-
-
-^Your partner will need to get an affidavit as well.^
-
 
 ##Fees
 

--- a/test/artefacts/marriage-abroad/indonesia/third_country/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/indonesia/third_country/partner_british/opposite_sex.txt
@@ -1,48 +1,34 @@
 Marriage in Indonesia
 
 
-Make an appointment at the British Embassy in Jakarta to swear an affidavit (written statement of facts) that you’re free to marry.
+Make an appointment at the British embassy or consulate in Indonesia to swear an affirmation or affidavit (written statement of facts) that you’re free to marry.
 
-Before the appointment you’ll need to pay a fee to the British Embassy in Jakarta. You can do this by credit card or in cash in the local currency. You also need to complete 2 copies of the [‘Affidavit for marriage’ form](/government/publications/marriage-in-indonesia).
+[Make an appointment at the embassy in Jakarta.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-jakarta/oaths-affirmations-and-affidavits/slot_picker)
 
-Send one copy to the British Embassy in Jakarta by email or post. Take the other one with you when you go to your local appointment, along with your passport.
-
-^Allow the embassy at least 2 days to process your paperwork before turning up for your appointment.^
+[Make an appointment at the consulate in Bali.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-bali/oaths-affirmations-and-affidavits/slot_picker)
 
 
+^Contact the local civil registry office in Indonesia to find out when you need to swear your affirmation or affidavit.^
 
-
-$A
-British Embassy Jakarta
-British Embassy Jakarta
-Jl. MH Thamrin 75 Jakarta
-10310
-Indonesia
-$A
+You need to complete 2 copies of the [affirmation (non religious) or affidavit (religious) of marriage form](/government/publications/marriage-in-indonesia).
+Email one copy to the British embassy in Jakarta at least 2 days before your appointment. Take the other copy to your appointment.
 
 $C
-Telephone: (+62) (21) 2356 5200
-Fax: (+62) (21) 2356 5351
-Fax (Corporate Services): (+62) (21) 2356 5351 
-Fax (Media and Communications): (+62) (21) 2356 5336
-Fax (Political): (+62) (21) 2356 5293
-Fax (Defence): (+62) (21) 2356 5353
-
-Email: <Jakarta.mcs@fco.gov.uk>
-
+<consulate.jakarta@fco.gov.uk>
 $C
 
+You must pay a fee to the British embassy in Jakarta - email them to find out how to pay.
 
+^Your partner must get an affirmation or affidavit as well.^
 
-If you’ve been divorced or widowed, you’ll need to provide:
+##What you need to take
 
-- a [decree absolute or final order](/copy-decree-absolute-final-order) or [death certificate](/order-copy-birth-death-marriage-certificate/)
-- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [translated](/government/collections/list-of-lawyers) if it’s not in English
+You must take all of the following to your appointment:
+
+- a copy of your affirmation or affidavit
+- your passport and your partner’s passport
+- a [decree absolute or final order](/copy-decree-absolute-final-order) or [death certificate](/order-copy-birth-death-marriage-certificate/) (if you’ve been divorced or widowed)
 - evidence if you’ve changed your name by deed poll
-
-
-^Your partner will need to get an affidavit as well.^
-
 
 ##Fees
 

--- a/test/artefacts/marriage-abroad/indonesia/third_country/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/indonesia/third_country/partner_local/opposite_sex.txt
@@ -1,48 +1,34 @@
 Marriage in Indonesia
 
 
-Make an appointment at the British Embassy in Jakarta to swear an affidavit (written statement of facts) that you’re free to marry.
+Make an appointment at the British embassy or consulate in Indonesia to swear an affirmation or affidavit (written statement of facts) that you’re free to marry.
 
-Before the appointment you’ll need to pay a fee to the British Embassy in Jakarta. You can do this by credit card or in cash in the local currency. You also need to complete 2 copies of the [‘Affidavit for marriage’ form](/government/publications/marriage-in-indonesia).
+[Make an appointment at the embassy in Jakarta.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-jakarta/oaths-affirmations-and-affidavits/slot_picker)
 
-Send one copy to the British Embassy in Jakarta by email or post. Take the other one with you when you go to your local appointment, along with your passport.
-
-^Allow the embassy at least 2 days to process your paperwork before turning up for your appointment.^
+[Make an appointment at the consulate in Bali.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-bali/oaths-affirmations-and-affidavits/slot_picker)
 
 
+^Contact the local civil registry office in Indonesia to find out when you need to swear your affirmation or affidavit.^
 
-
-$A
-British Embassy Jakarta
-British Embassy Jakarta
-Jl. MH Thamrin 75 Jakarta
-10310
-Indonesia
-$A
+You need to complete 2 copies of the [affirmation (non religious) or affidavit (religious) of marriage form](/government/publications/marriage-in-indonesia).
+Email one copy to the British embassy in Jakarta at least 2 days before your appointment. Take the other copy to your appointment.
 
 $C
-Telephone: (+62) (21) 2356 5200
-Fax: (+62) (21) 2356 5351
-Fax (Corporate Services): (+62) (21) 2356 5351 
-Fax (Media and Communications): (+62) (21) 2356 5336
-Fax (Political): (+62) (21) 2356 5293
-Fax (Defence): (+62) (21) 2356 5353
-
-Email: <Jakarta.mcs@fco.gov.uk>
-
+<consulate.jakarta@fco.gov.uk>
 $C
 
+You must pay a fee to the British embassy in Jakarta - email them to find out how to pay.
 
+^Your partner must get an affirmation or affidavit as well.^
 
-If you’ve been divorced or widowed, you’ll need to provide:
+##What you need to take
 
-- a [decree absolute or final order](/copy-decree-absolute-final-order) or [death certificate](/order-copy-birth-death-marriage-certificate/)
-- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [translated](/government/collections/list-of-lawyers) if it’s not in English
+You must take all of the following to your appointment:
+
+- a copy of your affirmation or affidavit
+- your passport and your partner’s passport or KTP (Indonesian identity card)
+- a [decree absolute or final order](/copy-decree-absolute-final-order) or [death certificate](/order-copy-birth-death-marriage-certificate/) (if you’ve been divorced or widowed)
 - evidence if you’ve changed your name by deed poll
-
-
-^Your partner will need to get an affidavit as well.^
-
 
 ##Fees
 

--- a/test/artefacts/marriage-abroad/indonesia/third_country/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/indonesia/third_country/partner_other/opposite_sex.txt
@@ -1,48 +1,34 @@
 Marriage in Indonesia
 
 
-Make an appointment at the British Embassy in Jakarta to swear an affidavit (written statement of facts) that you’re free to marry.
+Make an appointment at the British embassy or consulate in Indonesia to swear an affirmation or affidavit (written statement of facts) that you’re free to marry.
 
-Before the appointment you’ll need to pay a fee to the British Embassy in Jakarta. You can do this by credit card or in cash in the local currency. You also need to complete 2 copies of the [‘Affidavit for marriage’ form](/government/publications/marriage-in-indonesia).
+[Make an appointment at the embassy in Jakarta.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-jakarta/oaths-affirmations-and-affidavits/slot_picker)
 
-Send one copy to the British Embassy in Jakarta by email or post. Take the other one with you when you go to your local appointment, along with your passport.
-
-^Allow the embassy at least 2 days to process your paperwork before turning up for your appointment.^
+[Make an appointment at the consulate in Bali.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-bali/oaths-affirmations-and-affidavits/slot_picker)
 
 
+^Contact the local civil registry office in Indonesia to find out when you need to swear your affirmation or affidavit.^
 
-
-$A
-British Embassy Jakarta
-British Embassy Jakarta
-Jl. MH Thamrin 75 Jakarta
-10310
-Indonesia
-$A
+You need to complete 2 copies of the [affirmation (non religious) or affidavit (religious) of marriage form](/government/publications/marriage-in-indonesia).
+Email one copy to the British embassy in Jakarta at least 2 days before your appointment. Take the other copy to your appointment.
 
 $C
-Telephone: (+62) (21) 2356 5200
-Fax: (+62) (21) 2356 5351
-Fax (Corporate Services): (+62) (21) 2356 5351 
-Fax (Media and Communications): (+62) (21) 2356 5336
-Fax (Political): (+62) (21) 2356 5293
-Fax (Defence): (+62) (21) 2356 5353
-
-Email: <Jakarta.mcs@fco.gov.uk>
-
+<consulate.jakarta@fco.gov.uk>
 $C
 
+You must pay a fee to the British embassy in Jakarta - email them to find out how to pay.
 
+^Your partner must get an affirmation or affidavit as well.^
 
-If you’ve been divorced or widowed, you’ll need to provide:
+##What you need to take
 
-- a [decree absolute or final order](/copy-decree-absolute-final-order) or [death certificate](/order-copy-birth-death-marriage-certificate/)
-- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [translated](/government/collections/list-of-lawyers) if it’s not in English
+You must take all of the following to your appointment:
+
+- a copy of your affirmation or affidavit
+- your passport and your partner’s passport
+- a [decree absolute or final order](/copy-decree-absolute-final-order) or [death certificate](/order-copy-birth-death-marriage-certificate/) (if you’ve been divorced or widowed)
 - evidence if you’ve changed your name by deed poll
-
-
-^Your partner will need to get an affidavit as well.^
-
 
 ##Fees
 

--- a/test/artefacts/marriage-abroad/indonesia/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/indonesia/uk/partner_british/opposite_sex.txt
@@ -1,48 +1,34 @@
 Marriage in Indonesia
 
 
-Make an appointment at the British Embassy in Jakarta to swear an affidavit (written statement of facts) that you’re free to marry.
+Make an appointment at the British embassy or consulate in Indonesia to swear an affirmation or affidavit (written statement of facts) that you’re free to marry.
 
-Before the appointment you’ll need to pay a fee to the British Embassy in Jakarta. You can do this by credit card or in cash in the local currency. You also need to complete 2 copies of the [‘Affidavit for marriage’ form](/government/publications/marriage-in-indonesia).
+[Make an appointment at the embassy in Jakarta.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-jakarta/oaths-affirmations-and-affidavits/slot_picker)
 
-Send one copy to the British Embassy in Jakarta by email or post. Take the other one with you when you go to your local appointment, along with your passport.
-
-^Allow the embassy at least 2 days to process your paperwork before turning up for your appointment.^
+[Make an appointment at the consulate in Bali.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-bali/oaths-affirmations-and-affidavits/slot_picker)
 
 
+^Contact the local civil registry office in Indonesia to find out when you need to swear your affirmation or affidavit.^
 
-
-$A
-British Embassy Jakarta
-British Embassy Jakarta
-Jl. MH Thamrin 75 Jakarta
-10310
-Indonesia
-$A
+You need to complete 2 copies of the [affirmation (non religious) or affidavit (religious) of marriage form](/government/publications/marriage-in-indonesia).
+Email one copy to the British embassy in Jakarta at least 2 days before your appointment. Take the other copy to your appointment.
 
 $C
-Telephone: (+62) (21) 2356 5200
-Fax: (+62) (21) 2356 5351
-Fax (Corporate Services): (+62) (21) 2356 5351 
-Fax (Media and Communications): (+62) (21) 2356 5336
-Fax (Political): (+62) (21) 2356 5293
-Fax (Defence): (+62) (21) 2356 5353
-
-Email: <Jakarta.mcs@fco.gov.uk>
-
+<consulate.jakarta@fco.gov.uk>
 $C
 
+You must pay a fee to the British embassy in Jakarta - email them to find out how to pay.
 
+^Your partner must get an affirmation or affidavit as well.^
 
-If you’ve been divorced or widowed, you’ll need to provide:
+##What you need to take
 
-- a [decree absolute or final order](/copy-decree-absolute-final-order) or [death certificate](/order-copy-birth-death-marriage-certificate/)
-- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [translated](/government/collections/list-of-lawyers) if it’s not in English
+You must take all of the following to your appointment:
+
+- a copy of your affirmation or affidavit
+- your passport and your partner’s passport
+- a [decree absolute or final order](/copy-decree-absolute-final-order) or [death certificate](/order-copy-birth-death-marriage-certificate/) (if you’ve been divorced or widowed)
 - evidence if you’ve changed your name by deed poll
-
-
-^Your partner will need to get an affidavit as well.^
-
 
 ##Fees
 

--- a/test/artefacts/marriage-abroad/indonesia/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/indonesia/uk/partner_local/opposite_sex.txt
@@ -1,48 +1,34 @@
 Marriage in Indonesia
 
 
-Make an appointment at the British Embassy in Jakarta to swear an affidavit (written statement of facts) that you’re free to marry.
+Make an appointment at the British embassy or consulate in Indonesia to swear an affirmation or affidavit (written statement of facts) that you’re free to marry.
 
-Before the appointment you’ll need to pay a fee to the British Embassy in Jakarta. You can do this by credit card or in cash in the local currency. You also need to complete 2 copies of the [‘Affidavit for marriage’ form](/government/publications/marriage-in-indonesia).
+[Make an appointment at the embassy in Jakarta.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-jakarta/oaths-affirmations-and-affidavits/slot_picker)
 
-Send one copy to the British Embassy in Jakarta by email or post. Take the other one with you when you go to your local appointment, along with your passport.
-
-^Allow the embassy at least 2 days to process your paperwork before turning up for your appointment.^
+[Make an appointment at the consulate in Bali.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-bali/oaths-affirmations-and-affidavits/slot_picker)
 
 
+^Contact the local civil registry office in Indonesia to find out when you need to swear your affirmation or affidavit.^
 
-
-$A
-British Embassy Jakarta
-British Embassy Jakarta
-Jl. MH Thamrin 75 Jakarta
-10310
-Indonesia
-$A
+You need to complete 2 copies of the [affirmation (non religious) or affidavit (religious) of marriage form](/government/publications/marriage-in-indonesia).
+Email one copy to the British embassy in Jakarta at least 2 days before your appointment. Take the other copy to your appointment.
 
 $C
-Telephone: (+62) (21) 2356 5200
-Fax: (+62) (21) 2356 5351
-Fax (Corporate Services): (+62) (21) 2356 5351 
-Fax (Media and Communications): (+62) (21) 2356 5336
-Fax (Political): (+62) (21) 2356 5293
-Fax (Defence): (+62) (21) 2356 5353
-
-Email: <Jakarta.mcs@fco.gov.uk>
-
+<consulate.jakarta@fco.gov.uk>
 $C
 
+You must pay a fee to the British embassy in Jakarta - email them to find out how to pay.
 
+^Your partner must get an affirmation or affidavit as well.^
 
-If you’ve been divorced or widowed, you’ll need to provide:
+##What you need to take
 
-- a [decree absolute or final order](/copy-decree-absolute-final-order) or [death certificate](/order-copy-birth-death-marriage-certificate/)
-- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [translated](/government/collections/list-of-lawyers) if it’s not in English
+You must take all of the following to your appointment:
+
+- a copy of your affirmation or affidavit
+- your passport and your partner’s passport or KTP (Indonesian identity card)
+- a [decree absolute or final order](/copy-decree-absolute-final-order) or [death certificate](/order-copy-birth-death-marriage-certificate/) (if you’ve been divorced or widowed)
 - evidence if you’ve changed your name by deed poll
-
-
-^Your partner will need to get an affidavit as well.^
-
 
 ##Fees
 

--- a/test/artefacts/marriage-abroad/indonesia/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/indonesia/uk/partner_other/opposite_sex.txt
@@ -1,48 +1,34 @@
 Marriage in Indonesia
 
 
-Make an appointment at the British Embassy in Jakarta to swear an affidavit (written statement of facts) that you’re free to marry.
+Make an appointment at the British embassy or consulate in Indonesia to swear an affirmation or affidavit (written statement of facts) that you’re free to marry.
 
-Before the appointment you’ll need to pay a fee to the British Embassy in Jakarta. You can do this by credit card or in cash in the local currency. You also need to complete 2 copies of the [‘Affidavit for marriage’ form](/government/publications/marriage-in-indonesia).
+[Make an appointment at the embassy in Jakarta.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-jakarta/oaths-affirmations-and-affidavits/slot_picker)
 
-Send one copy to the British Embassy in Jakarta by email or post. Take the other one with you when you go to your local appointment, along with your passport.
-
-^Allow the embassy at least 2 days to process your paperwork before turning up for your appointment.^
+[Make an appointment at the consulate in Bali.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-bali/oaths-affirmations-and-affidavits/slot_picker)
 
 
+^Contact the local civil registry office in Indonesia to find out when you need to swear your affirmation or affidavit.^
 
-
-$A
-British Embassy Jakarta
-British Embassy Jakarta
-Jl. MH Thamrin 75 Jakarta
-10310
-Indonesia
-$A
+You need to complete 2 copies of the [affirmation (non religious) or affidavit (religious) of marriage form](/government/publications/marriage-in-indonesia).
+Email one copy to the British embassy in Jakarta at least 2 days before your appointment. Take the other copy to your appointment.
 
 $C
-Telephone: (+62) (21) 2356 5200
-Fax: (+62) (21) 2356 5351
-Fax (Corporate Services): (+62) (21) 2356 5351 
-Fax (Media and Communications): (+62) (21) 2356 5336
-Fax (Political): (+62) (21) 2356 5293
-Fax (Defence): (+62) (21) 2356 5353
-
-Email: <Jakarta.mcs@fco.gov.uk>
-
+<consulate.jakarta@fco.gov.uk>
 $C
 
+You must pay a fee to the British embassy in Jakarta - email them to find out how to pay.
 
+^Your partner must get an affirmation or affidavit as well.^
 
-If you’ve been divorced or widowed, you’ll need to provide:
+##What you need to take
 
-- a [decree absolute or final order](/copy-decree-absolute-final-order) or [death certificate](/order-copy-birth-death-marriage-certificate/)
-- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [translated](/government/collections/list-of-lawyers) if it’s not in English
+You must take all of the following to your appointment:
+
+- a copy of your affirmation or affidavit
+- your passport and your partner’s passport
+- a [decree absolute or final order](/copy-decree-absolute-final-order) or [death certificate](/order-copy-birth-death-marriage-certificate/) (if you’ve been divorced or widowed)
 - evidence if you’ve changed your name by deed poll
-
-
-^Your partner will need to get an affidavit as well.^
-
 
 ##Fees
 

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -21,7 +21,7 @@ lib/smart_answer_flows/marriage-abroad/_contact_local_authorities.govspeak.erb: 
 lib/smart_answer_flows/marriage-abroad/_contact_local_authorities_in_country_cp.govspeak.erb: 1a5916b89288b05d2a50542f0c1ac857
 lib/smart_answer_flows/marriage-abroad/_contact_local_authorities_in_country_marriage.govspeak.erb: 5e081167b2f93585e1b781eece504742
 lib/smart_answer_flows/marriage-abroad/_contact_local_authorities_in_greece.govspeak.erb: cac1fcbc77323dc53596ca6d3cf7bd84
-lib/smart_answer_flows/marriage-abroad/_contact_method.govspeak.erb: 34113c4257e145b9203716a261e7db28
+lib/smart_answer_flows/marriage-abroad/_contact_method.govspeak.erb: fecf8bdf60eae2de9958807574a5fcf9
 lib/smart_answer_flows/marriage-abroad/_contact_nearest_embassy_of_country.govspeak.erb: 196319d3632f94cfa087f191d887e36c
 lib/smart_answer_flows/marriage-abroad/_contact_to_make_appointment.govspeak.erb: a7e4a184e974b3989a697578277b3b7a
 lib/smart_answer_flows/marriage-abroad/_convert_cc_to_ss_marriage.govspeak.erb: 38e1be8bb7bdd80ef0c4c6c3af8f7f04
@@ -87,7 +87,7 @@ lib/smart_answer_flows/marriage-abroad/outcome_os_commonwealth.govspeak.erb: 346
 lib/smart_answer_flows/marriage-abroad/outcome_os_consular_cni.govspeak.erb: acfcd866e7e930c3c13795528712b86b
 lib/smart_answer_flows/marriage-abroad/outcome_os_france_or_fot.govspeak.erb: 7a5cb5ac119b7891858e415872d3e20e
 lib/smart_answer_flows/marriage-abroad/outcome_os_hong_kong.govspeak.erb: 9fad3bd3a55309f5a345b378b1bb8dd4
-lib/smart_answer_flows/marriage-abroad/outcome_os_indonesia.govspeak.erb: 36b4facf927967b5a52aae809e154f4b
+lib/smart_answer_flows/marriage-abroad/outcome_os_indonesia.govspeak.erb: abca5f7bf4a59d2dd97d57aee8c9adaf
 lib/smart_answer_flows/marriage-abroad/outcome_os_italy.govspeak.erb: 47789cf3e35e975a09a4db085376b211
 lib/smart_answer_flows/marriage-abroad/outcome_os_kosovo.govspeak.erb: 0f95fb2f76855f9394fe5ff6f539874c
 lib/smart_answer_flows/marriage-abroad/outcome_os_laos.govspeak.erb: 3df2462e6af37249dac29544a85c1a2f


### PR DESCRIPTION
Summary:
- users can now book appointments in Jakarta and Bali
- users can book appointments online (replaces embassy address)
- clarifications for swearing affirmation
- local partners can use KTP for identification