### PR TITLE
Allow exposing pages as govspeak based on an env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,34 @@ For more information, please go to the [Smartdown SmartAnswer README](lib/smartd
 Smart answers are by default expected to be in Ruby/YAML style.
 To transition a smart answer from Ruby/YML to Smartdown style, register it in the smartdown registry (`lib/smartdown/registry.rb`).
 
-## Debugging current state
+## Developing
+
+### Installing and running
+
+NB: this assumes you are running on the GOV.UK virtual machine, not your host.
+
+```bash
+  ./install # git fetch from each dependency dir and bundle install
+```
+
+Run using bowler on VM from cd /var/govuk/development:
+```
+bowl smartanswers
+```
+
+### Viewing a Smart Answer
+
+To view a smart answer locally if running using bowler http://smartanswers.dev.gov.uk/register-a-birth
+
+### Debugging current state
 
 If you have a URL of a Smart answer and want to debug the state of it i.e. to see PhraseList keys, saved inputs, the outcome name, append `debug=1` query parameter to the URL in development mode. This will render debug information on the Smart answer page.
 
-## Visualising a flow
+### Viewing a Smart Answer as Govspeak
+
+Seeing [Govspeak](https://github.com/alphagov/govspeak) markup of Smart Answer pages can be useful to content designers when preparing content change requests or developers inspecting generated Govspeak that later gets translated to HTML. This feature can be enabled by setting `EXPOSE_GOVSPEAK` to a non-empty value. It can be accessed by appending `.txt` to URLs (at the moment of writing this it's enabled for landing and outcome pages only).
+
+### Visualising a flow
 
 To see an interactive visualisation of a smart answer flow, append `/visualise` to the root of a smartanswer URL e.g. `http://smartanswers.dev.gov.uk/<my-flow>/visualise/`
 
@@ -44,23 +67,6 @@ To see a static visualisation of a smart answer flow, using Graphviz:
     $ open /tmp/marriage-abroad.png
 
 __NOTE.__ This assumes you already have Graphviz installed. You can install it using Homebrew on a Mac (`brew install graphviz`).
-
-## Installing and running
-
-NB: this assumes you are running on the GOV.UK virtual machine, not your host.
-
-```bash
-  ./install # git fetch from each dependency dir and bundle install
-```
-
-Run using bowler on VM from cd /var/govuk/development:
-```
-bowl smartanswers
-```
-
-## Viewing a Smart Answer
-
-To view a smart answer locally if running using bowler http://smartanswers.dev.gov.uk/register-a-birth
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If you have a URL of a Smart answer and want to debug the state of it i.e. to se
 
 ### Viewing a Smart Answer as Govspeak
 
-Seeing [Govspeak](https://github.com/alphagov/govspeak) markup of Smart Answer pages can be useful to content designers when preparing content change requests or developers inspecting generated Govspeak that later gets translated to HTML. This feature can be enabled by setting `EXPOSE_GOVSPEAK` to a non-empty value. It can be accessed by appending `.txt` to URLs (at the moment of writing this it's enabled for landing and outcome pages only).
+Seeing [Govspeak](https://github.com/alphagov/govspeak) markup of Smart Answer pages can be useful to content designers when preparing content change requests or developers inspecting generated Govspeak that later gets translated to HTML. This feature can be enabled by setting `EXPOSE_GOVSPEAK` to a non-empty value. It can be accessed by appending `.txt` to URLs (currently govspeak is available for landing and outcome pages, but not question pages).
 
 ### Visualising a flow
 

--- a/app/controllers/smart_answers_controller.rb
+++ b/app/controllers/smart_answers_controller.rb
@@ -63,7 +63,7 @@ private
   end
 
   def render_text?(presenter)
-    (!Rails.env.production? || ENV['EXPOSE_GOVSPEAK'].present?) && presenter.render_txt?
+    Rails.application.config.expose_govspeak && presenter.render_txt?
   end
 
   def with_format(format, &block)

--- a/app/controllers/smart_answers_controller.rb
+++ b/app/controllers/smart_answers_controller.rb
@@ -20,7 +20,7 @@ class SmartAnswersController < ApplicationController
           title: @presenter.current_node.title
         }
       }
-      if !Rails.env.production? && @presenter.render_txt?
+      if render_text?(@presenter)
         format.text {
           render
         }
@@ -51,7 +51,6 @@ class SmartAnswersController < ApplicationController
     end
   end
 
-
 private
 
   def debug?
@@ -61,6 +60,10 @@ private
 
   def json_request?
     request.format == Mime::JSON
+  end
+
+  def render_text?(presenter)
+    (!Rails.env.production? || ENV['EXPOSE_GOVSPEAK'].present?) && presenter.render_txt?
   end
 
   def with_format(format, &block)

--- a/config/initializers/expose_govspeak.rb
+++ b/config/initializers/expose_govspeak.rb
@@ -1,0 +1,5 @@
+if Rails.env.production?
+  SmartAnswers::Application.config.expose_govspeak = ENV['EXPOSE_GOVSPEAK'].present?
+else
+  SmartAnswers::Application.config.expose_govspeak = true
+end

--- a/startup_heroku.sh
+++ b/startup_heroku.sh
@@ -13,6 +13,7 @@ GOVUK_APP_DOMAIN=preview.alphagov.co.uk \
 PLEK_SERVICE_CONTENTAPI_URI=https://www.gov.uk/api \
 PLEK_SERVICE_STATIC_URI=https://assets-origin.preview.alphagov.co.uk \
 RUNNING_ON_HEROKU=true \
+EXPOSE_GOVSPEAK=true \
 ERRBIT_ENV=preview
 
 echo

--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -488,9 +488,9 @@ class SmartAnswersControllerTest < ActionController::TestCase
         assert_response :missing
       end
 
-      context "when in production environment" do
+      context "when Rails.application.config.expose_govspeak is not set" do
         setup do
-          Rails.env.stubs(:production?).returns(true)
+          Rails.application.config.stubs(:expose_govspeak).returns(false)
         end
 
         should "render not found" do


### PR DESCRIPTION
To simplify coordination of content change requests between content designers
and developers we're going to expose Smart Answer outcomes as govspeak by
appending `.txt` to Smart Answer outcome URLs. This will allow content designers
to copy, paste and modify (in their text editor) govspeak. Currently they are
'reverse-engineering' it from HTML outputs.

We do not want to expose this feature to the wide public, but we want to enable
it on preview. The main concerns for not exposing it in production are:

- a fear of needing to support it in a long term
- it is an internal 'tool' and it feels clunky to have it available in production

This also sets `EXPOSE_GOVSPEAK=true` on heroku instances and documents it in README.

NB.: I've submitted a PR to the private repo that sets this env variable to true on dev VMs and in the preview environment.