### PR TITLE
Simplify date question

### DIFF
--- a/app/views/smart_answers/_date_question.html.erb
+++ b/app/views/smart_answers/_date_question.html.erb
@@ -10,7 +10,7 @@
       <%= select_month default_for_date(prefill_value_for(question, number, :month)), prefix: response_prefix, prompt: '' %>
     </label>
   <% end %>
-  <% unless question.defaulted_year? %>
+  <% unless question.default_year %>
     <label for="<%=response_prefix%>_year">Year
       <%= select_year default_for_date(prefill_value_for(question, number, :year)), prefix: response_prefix, prompt: '', :start_year => question.start_date.year, :end_year => question.end_date.year %>
     </label>

--- a/app/views/smart_answers/_date_question.html.erb
+++ b/app/views/smart_answers/_date_question.html.erb
@@ -1,6 +1,6 @@
 <fieldset>
   <% response_prefix = number ? "response_#{number}" : "response" %>
-  <% unless question.defaulted_day? %>
+  <% unless question.default_day %>
     <label for="<%=response_prefix%>_day">Day
       <%= select_day default_for_date(prefill_value_for(question, number, :day)), prefix: response_prefix, :prompt => '' %>
     </label>

--- a/app/views/smart_answers/_date_question.html.erb
+++ b/app/views/smart_answers/_date_question.html.erb
@@ -5,7 +5,7 @@
       <%= select_day default_for_date(prefill_value_for(question, number, :day)), prefix: response_prefix, :prompt => '' %>
     </label>
   <% end %>
-  <% unless question.defaulted_month? %>
+  <% unless question.default_month %>
     <label for="<%=response_prefix%>_month">Month
       <%= select_month default_for_date(prefill_value_for(question, number, :month)), prefix: response_prefix, prompt: '' %>
     </label>

--- a/app/views/smart_answers/_date_question.html.erb
+++ b/app/views/smart_answers/_date_question.html.erb
@@ -2,17 +2,17 @@
   <% response_prefix = number ? "response_#{number}" : "response" %>
   <% unless question.defaulted_day? %>
     <label for="<%=response_prefix%>_day">Day
-      <%= select_day default_for_date(prefill_value_for(question, number, :day)) || question.default, prefix: response_prefix, :prompt => '' %>
+      <%= select_day default_for_date(prefill_value_for(question, number, :day)), prefix: response_prefix, :prompt => '' %>
     </label>
   <% end %>
   <% unless question.defaulted_month? %>
     <label for="<%=response_prefix%>_month">Month
-      <%= select_month default_for_date(prefill_value_for(question, number, :month)) || question.default, prefix: response_prefix, prompt: '' %>
+      <%= select_month default_for_date(prefill_value_for(question, number, :month)), prefix: response_prefix, prompt: '' %>
     </label>
   <% end %>
   <% unless question.defaulted_year? %>
     <label for="<%=response_prefix%>_year">Year
-      <%= select_year default_for_date(prefill_value_for(question, number, :year)) || question.default, prefix: response_prefix, prompt: '', :start_year => question.start_date.year, :end_year => question.end_date.year %>
+      <%= select_year default_for_date(prefill_value_for(question, number, :year)), prefix: response_prefix, prompt: '', :start_year => question.start_date.year, :end_year => question.end_date.year %>
     </label>
   <% end %>
 </fieldset>

--- a/lib/smart_answer/question/date.rb
+++ b/lib/smart_answer/question/date.rb
@@ -75,8 +75,12 @@ module SmartAnswer
           end
         validate_input(date) if @validate_in_range
         date
-      rescue
-        raise InvalidResponse, "Bad date: #{input.inspect}", caller
+      rescue ArgumentError => e
+        if e.message =~ /invalid date/
+          raise InvalidResponse, "Bad date: #{input.inspect}", caller
+        else
+          raise
+        end
       end
 
       def to_response(input)

--- a/lib/smart_answer/question/date.rb
+++ b/lib/smart_answer/question/date.rb
@@ -23,11 +23,9 @@ module SmartAnswer
         end
       end
 
-      def default_day(default_day = nil, &block)
+      def default_day(&block)
         if block_given?
           @default_day_func = block
-        elsif default_day
-          @default_day_func = lambda { default_day }
         else
           @default_day_func && @default_day_func.call
         end

--- a/lib/smart_answer/question/date.rb
+++ b/lib/smart_answer/question/date.rb
@@ -35,11 +35,9 @@ module SmartAnswer
         instance_variable_defined?(:@default_day_func)
       end
 
-      def default_month(default_month = nil, &block)
+      def default_month(&block)
         if block_given?
           @default_month_func = block
-        elsif default_month
-          @default_month_func = lambda { default_month }
         else
           @default_month_func && @default_month_func.call
         end

--- a/lib/smart_answer/question/date.rb
+++ b/lib/smart_answer/question/date.rb
@@ -47,10 +47,6 @@ module SmartAnswer
         end
       end
 
-      def defaulted_year?
-        instance_variable_defined?(:@default_year_func)
-      end
-
       def range
         @range ||= @from_func.present? and @to_func.present? ? @from_func.call..@to_func.call : false
       end
@@ -62,7 +58,7 @@ module SmartAnswer
            expected_keys = []
            expected_keys << :day unless default_day
            expected_keys << :month unless default_month
-           expected_keys << :year unless defaulted_year?
+           expected_keys << :year unless default_year
            expected_keys.each do |k|
              raise InvalidResponse, "Please enter a complete date", caller unless input[k].present?
            end

--- a/lib/smart_answer/question/date.rb
+++ b/lib/smart_answer/question/date.rb
@@ -27,16 +27,6 @@ module SmartAnswer
         end
       end
 
-      def default(default = nil, &block)
-        if block_given?
-          @default_func = block
-        elsif default
-          @default_func = lambda { default }
-        else
-          @default_func && @default_func.call
-        end
-      end
-
       def default_day(default_day = nil, &block)
         if block_given?
           @default_day_func = block

--- a/lib/smart_answer/question/date.rb
+++ b/lib/smart_answer/question/date.rb
@@ -39,10 +39,6 @@ module SmartAnswer
         end
       end
 
-      def defaulted_month?
-        instance_variable_defined?(:@default_month_func)
-      end
-
       def default_year(&block)
         if block_given?
           @default_year_func = block
@@ -65,7 +61,7 @@ module SmartAnswer
            input = input.symbolize_keys
            expected_keys = []
            expected_keys << :day unless default_day
-           expected_keys << :month unless defaulted_month?
+           expected_keys << :month unless default_month
            expected_keys << :year unless defaulted_year?
            expected_keys.each do |k|
              raise InvalidResponse, "Please enter a complete date", caller unless input[k].present?

--- a/lib/smart_answer/question/date.rb
+++ b/lib/smart_answer/question/date.rb
@@ -31,10 +31,6 @@ module SmartAnswer
         end
       end
 
-      def defaulted_day?
-        instance_variable_defined?(:@default_day_func)
-      end
-
       def default_month(&block)
         if block_given?
           @default_month_func = block
@@ -68,7 +64,7 @@ module SmartAnswer
           when Hash, ActiveSupport::HashWithIndifferentAccess
            input = input.symbolize_keys
            expected_keys = []
-           expected_keys << :day unless defaulted_day?
+           expected_keys << :day unless default_day
            expected_keys << :month unless defaulted_month?
            expected_keys << :year unless defaulted_year?
            expected_keys.each do |k|

--- a/lib/smart_answer/question/date.rb
+++ b/lib/smart_answer/question/date.rb
@@ -15,11 +15,9 @@ module SmartAnswer
         end
       end
 
-      def to(to = nil, &block)
+      def to(&block)
         if block_given?
           @to_func = block
-        elsif to
-          @to_func = lambda { to }
         else
           @to_func && @to_func.call
         end

--- a/lib/smart_answer/question/date.rb
+++ b/lib/smart_answer/question/date.rb
@@ -90,7 +90,7 @@ module SmartAnswer
           month: date.month,
           year: date.year
         }
-      rescue
+      rescue InvalidResponse
         nil
       end
 

--- a/lib/smart_answer/question/date.rb
+++ b/lib/smart_answer/question/date.rb
@@ -7,11 +7,9 @@ module SmartAnswer
         @validate_in_range = true
       end
 
-      def from(from = nil, &block)
+      def from(&block)
         if block_given?
           @from_func = block
-        elsif from
-          @from_func = lambda { from }
         else
           @from_func && @from_func.call
         end

--- a/lib/smart_answer/question/date.rb
+++ b/lib/smart_answer/question/date.rb
@@ -55,17 +55,13 @@ module SmartAnswer
         date = case input
           when Hash, ActiveSupport::HashWithIndifferentAccess
            input = input.symbolize_keys
-           expected_keys = []
-           expected_keys << :day unless default_day
-           expected_keys << :month unless default_month
-           expected_keys << :year unless default_year
-           expected_keys.each do |k|
-             raise InvalidResponse, "Please enter a complete date", caller unless input[k].present?
-           end
-           day = (default_day || input[:day]).to_i
-           month = (default_month || input[:month]).to_i
-           year = (default_year || input[:year]).to_i
-           ::Date.new(year, month, day)
+           year_month_and_day = [
+             default_year || input[:year],
+             default_month || input[:month],
+             default_day || input[:day],
+           ]
+           raise InvalidResponse unless year_month_and_day.all?(&:present?)
+           ::Date.new(*year_month_and_day.map(&:to_i))
           when String
            ::Date.parse(input)
           when ::Date

--- a/lib/smart_answer/question/date.rb
+++ b/lib/smart_answer/question/date.rb
@@ -48,7 +48,7 @@ module SmartAnswer
       end
 
       def range
-        @range ||= @from_func.present? and @to_func.present? ? @from_func.call..@to_func.call : false
+        @range ||= from && to ? from..to : false
       end
 
       def parse_input(input)

--- a/lib/smart_answer/question/date.rb
+++ b/lib/smart_answer/question/date.rb
@@ -47,11 +47,9 @@ module SmartAnswer
         instance_variable_defined?(:@default_month_func)
       end
 
-      def default_year(default_year = nil, &block)
+      def default_year(&block)
         if block_given?
           @default_year_func = block
-        elsif default_year
-          @default_year_func = lambda { default_year }
         else
           @default_year_func && @default_year_func.call
         end

--- a/lib/smart_answer_flows/vat-payment-deadlines.rb
+++ b/lib/smart_answer_flows/vat-payment-deadlines.rb
@@ -6,7 +6,7 @@ module SmartAnswer
       satisfies_need "100624"
 
       date_question :when_does_your_vat_accounting_period_end? do
-        default_day -1
+        default_day { -1 }
         next_node :how_do_you_want_to_pay?
 
         calculate :period_end_date do |response|

--- a/lib/smartdown_adapter/date_question_presenter.rb
+++ b/lib/smartdown_adapter/date_question_presenter.rb
@@ -11,7 +11,7 @@ module SmartdownAdapter
       false
     end
 
-    def defaulted_year?
+    def default_year
       false
     end
 

--- a/lib/smartdown_adapter/date_question_presenter.rb
+++ b/lib/smartdown_adapter/date_question_presenter.rb
@@ -3,7 +3,7 @@ module SmartdownAdapter
     #TODO: range should be specified in smartdown and taken from there
     #these are only defaults
     #in the future we will want to specify in smartdown start/end etc,,,
-    def defaulted_day?
+    def default_day
       false
     end
 

--- a/lib/smartdown_adapter/date_question_presenter.rb
+++ b/lib/smartdown_adapter/date_question_presenter.rb
@@ -7,7 +7,7 @@ module SmartdownAdapter
       false
     end
 
-    def defaulted_month?
+    def default_month
       false
     end
 

--- a/test/data/vat-payment-deadlines-files.yml
+++ b/test/data/vat-payment-deadlines-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer_flows/vat-payment-deadlines.rb: 759c32f1010e945789253197f21a359c
+lib/smart_answer_flows/vat-payment-deadlines.rb: 7764d8e7fd71a171157e8538cf5e360d
 lib/smart_answer_flows/locales/en/vat-payment-deadlines.yml: d961b540b085e5d42ad9b4d624d58be4
 test/data/vat-payment-deadlines-questions-and-responses.yml: a9c89cff2686881257fe52b750032268
 test/data/vat-payment-deadlines-responses-and-expected-results.yml: 88f5a54e78f8b5006265a8005cdd15fe

--- a/test/fixtures/smart_answer_flows/country-and-date-sample.rb
+++ b/test/fixtures/smart_answer_flows/country-and-date-sample.rb
@@ -11,7 +11,7 @@ module SmartAnswer
 
       date_question :what_date_did_you_move_there? do
         from { Date.parse('1900-01-01') }
-        to Date.today
+        to { Date.today }
 
         save_input_as :date_moved
         calculate :years_there do

--- a/test/fixtures/smart_answer_flows/country-and-date-sample.rb
+++ b/test/fixtures/smart_answer_flows/country-and-date-sample.rb
@@ -10,7 +10,7 @@ module SmartAnswer
       end
 
       date_question :what_date_did_you_move_there? do
-        from Date.parse('1900-01-01')
+        from { Date.parse('1900-01-01') }
         to Date.today
 
         save_input_as :date_moved

--- a/test/unit/date_question_test.rb
+++ b/test/unit/date_question_test.rb
@@ -90,7 +90,7 @@ module SmartAnswer
 
     test "define default year" do
       q = Question::Date.new(nil, :example) do
-        default_year 2013
+        default_year { 2013 }
       end
       assert_equal 2013, q.default_year
     end
@@ -99,7 +99,7 @@ module SmartAnswer
       q = Question::Date.new(nil, :example) do
         default_day { 11 }
         default_month { 2 }
-        default_year 2013
+        default_year { 2013 }
         save_input_as :date
         next_node :done
       end

--- a/test/unit/date_question_test.rb
+++ b/test/unit/date_question_test.rb
@@ -107,10 +107,18 @@ module SmartAnswer
       assert_equal expected_hash, q.to_response('valid-date')
     end
 
-    test 'to_response returns nil if parse_input raises an exception' do
+    test 'to_response returns nil if parse_input raises an InvalidResponse exception' do
       q = Question::Date.new(nil, :example)
-      q.stubs(:parse_input).with('invalid-date').raises(StandardError)
+      q.stubs(:parse_input).with('invalid-date').raises(InvalidResponse)
       assert_equal nil, q.to_response('invalid-date')
+    end
+
+    test 'to_response raises the exception if parse_input raises anything other than an InvalidResponse exception' do
+      q = Question::Date.new(nil, :example)
+      q.stubs(:parse_input).with('anything').raises(StandardError)
+      assert_raises(StandardError) do
+        q.to_response('anything')
+      end
     end
 
     test "dates are parsed from Hash into Date before being saved" do

--- a/test/unit/date_question_test.rb
+++ b/test/unit/date_question_test.rb
@@ -76,7 +76,7 @@ module SmartAnswer
 
     test "define default day" do
       q = Question::Date.new(nil, :example) do
-        default_day 11
+        default_day { 11 }
       end
       assert_equal 11, q.default_day
     end
@@ -97,7 +97,7 @@ module SmartAnswer
 
     test "incomplete dates are accepted if appropriate defaults are defined" do
       q = Question::Date.new(nil, :example) do
-        default_day 11
+        default_day { 11 }
         default_month 2
         default_year 2013
         save_input_as :date
@@ -110,7 +110,7 @@ module SmartAnswer
 
     test "default the day to the last in the month of an incomplete date" do
       q = Question::Date.new(nil, :example) do
-        default_day -1
+        default_day { -1 }
         save_input_as :date
         next_node :done
       end

--- a/test/unit/date_question_test.rb
+++ b/test/unit/date_question_test.rb
@@ -98,6 +98,21 @@ module SmartAnswer
       end
     end
 
+    test 'to_response returns a hash of day, month and year representing the date returned from parse_input' do
+      valid_date = Date.parse('2015-02-01')
+      q = Question::Date.new(nil, :example)
+      q.stubs(:parse_input).with('valid-date').returns(valid_date)
+
+      expected_hash = {day: 1, month: 2, year: 2015}
+      assert_equal expected_hash, q.to_response('valid-date')
+    end
+
+    test 'to_response returns nil if parse_input raises an exception' do
+      q = Question::Date.new(nil, :example)
+      q.stubs(:parse_input).with('invalid-date').raises(StandardError)
+      assert_equal nil, q.to_response('invalid-date')
+    end
+
     test "dates are parsed from Hash into Date before being saved" do
       q = Question::Date.new(nil, :example) do
         save_input_as :date

--- a/test/unit/date_question_test.rb
+++ b/test/unit/date_question_test.rb
@@ -74,13 +74,6 @@ module SmartAnswer
       q.transition(@initial_state, '2011-01-02')
     end
 
-    test "define default date" do
-      q = Question::Date.new(nil, :example) do
-        default { Date.today }
-      end
-      assert_equal Date.today, q.default
-    end
-
     test "define default day" do
       q = Question::Date.new(nil, :example) do
         default_day 11

--- a/test/unit/date_question_test.rb
+++ b/test/unit/date_question_test.rb
@@ -9,6 +9,95 @@ module SmartAnswer
       @initial_state = State.new(:example)
     end
 
+    context '#parse_input' do
+      setup do
+        @question = Question::Date.new(nil, :example)
+      end
+
+      context 'when supplied with a hash' do
+        should 'return a date representing the hash' do
+          date = @question.parse_input(day: 1, month: 2, year: 2015)
+          assert_equal Date.parse('2015-02-01'), date
+        end
+
+        should 'raise an InvalidResponse exception when the hash represents an invalid date' do
+          assert_raises(InvalidResponse) do
+            @question.parse_input(day: 32, month: 2, year: 2015)
+          end
+        end
+
+        context 'and the day is missing' do
+          should 'raise an InvalidResponse exception' do
+            assert_raises(InvalidResponse) do
+              @question.parse_input(day: nil, month: 2, year: 2015)
+            end
+          end
+
+          should 'return the date using the default day when specified' do
+            @question.default_day { 1 }
+            date = @question.parse_input(day: nil, month: 2, year: 2015)
+            assert_equal Date.parse('2015-02-01'), date
+          end
+        end
+
+        context 'and the month is missing' do
+          should 'raise an InvalidResponse exception' do
+            assert_raises(InvalidResponse) do
+              @question.parse_input(day: 1, month: nil, year: 2015)
+            end
+          end
+
+          should 'return the date using the default month when specified' do
+            @question.default_month { 2 }
+            date = @question.parse_input(day: 1, month: nil, year: 2015)
+            assert_equal Date.parse('2015-02-01'), date
+          end
+        end
+
+        context 'and the year is missing' do
+          should 'raise an InvalidResponse exception' do
+            assert_raises(InvalidResponse) do
+              @question.parse_input(day: 1, month: 2, year: nil)
+            end
+          end
+
+          should 'return the date using the default year when specified' do
+            @question.default_year { 2015 }
+            date = @question.parse_input(day: 1, month: 2, year: nil)
+            assert_equal Date.parse('2015-02-01'), date
+          end
+        end
+      end
+
+      context 'when supplied with a string' do
+        should 'return a date representing the string' do
+          date = @question.parse_input('2015-02-01')
+          assert_equal Date.parse('2015-02-01'), date
+        end
+
+        should 'raise an InvalidResponse exception when the string represents an invalid date' do
+          assert_raises(InvalidResponse) do
+            @question.parse_input('2015-02-32')
+          end
+        end
+      end
+
+      context 'when supplied with a date' do
+        should 'return the date' do
+          date = @question.parse_input(Date.parse('2015-02-01'))
+          assert_equal Date.parse('2015-02-01'), date
+        end
+      end
+
+      context 'when supplied with another object' do
+        should 'raise an InvalidResponse exception' do
+          assert_raises(InvalidResponse) do
+            @question.parse_input(Object.new)
+          end
+        end
+      end
+    end
+
     test "dates are parsed from Hash into Date before being saved" do
       q = Question::Date.new(nil, :example) do
         save_input_as :date

--- a/test/unit/date_question_test.rb
+++ b/test/unit/date_question_test.rb
@@ -30,6 +30,25 @@ module SmartAnswer
       end
     end
 
+    test 'range returns false when neither from nor to are set' do
+      q = Question::Date.new(nil, :question_name)
+      assert_equal false, q.range
+    end
+
+    test 'range returns false when only the from date is set' do
+      q = Question::Date.new(nil, :question_name) do
+        from { Date.today }
+      end
+      assert_equal false, q.range
+    end
+
+    test 'range returns false when only the to date is set' do
+      q = Question::Date.new(nil, :question_name) do
+        to { Date.today }
+      end
+      assert_equal false, q.range
+    end
+
     test "define allowable range of dates" do
       q = Question::Date.new(nil, :example) do
         save_input_as :date

--- a/test/unit/date_question_test.rb
+++ b/test/unit/date_question_test.rb
@@ -83,7 +83,7 @@ module SmartAnswer
 
     test "define default month" do
       q = Question::Date.new(nil, :example) do
-        default_month 2
+        default_month { 2 }
       end
       assert_equal 2, q.default_month
     end
@@ -98,7 +98,7 @@ module SmartAnswer
     test "incomplete dates are accepted if appropriate defaults are defined" do
       q = Question::Date.new(nil, :example) do
         default_day { 11 }
-        default_month 2
+        default_month { 2 }
         default_year 2013
         save_input_as :date
         next_node :done


### PR DESCRIPTION
This all came out of the work on the new HMRC Smart Answer (calculate-your-part-year-profits). I found the implementation of `Question::Date` to be somewhat more complicated than it needed to be. This pull request aims to simplify the class.

In summary, I've:

* Removed the unused `Question::Date#default` method.

* Simplified the implementations of `Question::Date#from`, `#to`, `#default_day`, `#default_month`, `#default_year` so that they can _only_ be set by providing a block rather than by providing a block or a value argument.

* Removed `Question::Date#defaulted_day?`, `#defaulted_month?` and `#defaulted_year?` and replaced their use with `Date#default_day`, `#default_month` and `#default_year`.

* DRYed up calls to the blocks stored in `@from_func` and `@to_func`.

* Restricted the type of exceptions we rescue in `Question::Date#parse_input` and `#to_response`. We were previously rescuing everything that inherits from `StandardError`, which isn't ideal as it means we might end up swallowing genuine exceptions.

* Simplified the implementation of `Question::Date#parse_input` when it's parsing a date supplied as a hash.
