### PR TITLE
Halve the time it takes to run regression tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,9 @@ Test a single Smartdown flow by running:
         $ RUN_REGRESSION_TESTS=<name-of-smart-answer> \
           ruby test/regression/smart_answers_regression_test.rb
 
+If you want individual tests to fail early when differences are detected, set `ASSERT_EACH_ARTEFACT=true`.
+Note that this more than doubles the time it takes to run regression tests.
+
 12. Commit the generated Govspeak files (in test/artefacts) to git.
 
 ## Making bigger changes

--- a/test/regression/smart_answers_regression_test.rb
+++ b/test/regression/smart_answers_regression_test.rb
@@ -108,7 +108,8 @@ class SmartAnswersRegressionTest < ActionController::TestCase
       should "render and save the landing page" do
         get :show, id: flow_name, format: 'txt'
 
-        assert_no_output_diff smart_answer_helper.save_output([flow_name], response)
+        artefact_path = smart_answer_helper.save_output([flow_name], response)
+        assert_no_output_diff artefact_path if ENV['ASSERT_EACH_ARTEFACT'].present?
       end
 
       responses_and_expected_results.each do |responses_and_expected_node|
@@ -119,7 +120,10 @@ class SmartAnswersRegressionTest < ActionController::TestCase
           should "render and save output for responses: #{responses.join(', ')}" do
             get :show, id: flow_name, started: 'y', responses: responses.join('/'), format: 'txt'
 
-            assert_no_output_diff smart_answer_helper.save_output(responses, response)
+            artefact_path = smart_answer_helper.save_output(responses, response)
+
+            # Enabling this more than doubles the time it takes to run regression tests
+            assert_no_output_diff artefact_path if ENV['ASSERT_EACH_ARTEFACT'].present?
           end
         end
       end


### PR DESCRIPTION
Shelling out and running git diff for each test artefact was consuming more than
half of the time to run regression tests. Avoiding that results in:
```
Before:
	marriage-abroad: 10:45
	register-a-birth: 3:53
After:
	marriage-abroad: 5:45
	register-a-birth: 1:34
```

I still left an option to enable early feedback by setting `EARLY_FEEDBACK=true`. I mostly hesitated to remove the diff completely because then regression tests would look very odd to someone unfamiliar with this performance issue :)