### PR TITLE
[Don't merge. FC] Explicit Bus Pass age calculation

### DIFF
--- a/lib/data/state_pension_date_query.rb
+++ b/lib/data/state_pension_date_query.rb
@@ -12,7 +12,7 @@ class StatePensionDate < Struct.new(:gender, :start_date, :end_date, :pension_da
   end
 end
 
-class StatePensionQuery < Struct.new(:dob, :gender)
+class StatePensionDateQuery < Struct.new(:dob, :gender)
   def self.find(dob, gender)
     state_pension_query = new(dob, gender)
     state_pension_query.find_date

--- a/lib/data/state_pension_date_query.rb
+++ b/lib/data/state_pension_date_query.rb
@@ -80,6 +80,6 @@ class StatePensionDateQuery < Struct.new(:dob, :gender)
   end
 
   def pension_dates_static
-    pension_dates_static ||= YAML.load_file(Rails.root.join("lib", "data", "state_pension_dates.yml"))
+    YAML.load_file(Rails.root.join("lib", "data", "state_pension_dates.yml"))
   end
 end

--- a/lib/data/state_pension_date_query.rb
+++ b/lib/data/state_pension_date_query.rb
@@ -18,6 +18,16 @@ class StatePensionDateQuery < Struct.new(:dob, :gender)
     state_pension_query.find_date
   end
 
+  def self.pension_credit_date(dob)
+    # Pension credit age calculation for all genders is equivalent
+    # to the state pension date calculation for women
+    new(dob, :female).find_date
+  end
+
+  def self.bus_pass_qualification_date(dob)
+    pension_credit_date(dob)
+  end
+
   def find_date
     static_result = run(pension_dates_static)
     if static_result

--- a/lib/data/state_pension_date_query.rb
+++ b/lib/data/state_pension_date_query.rb
@@ -1,18 +1,18 @@
-class StatePensionDate < Struct.new(:gender, :start_date, :end_date, :pension_date)
+StatePensionDate = Struct.new(:gender, :start_date, :end_date, :pension_date) do
   def match?(dob, sex)
-    same_gender?(sex) and born_in_range?(dob)
+    same_gender?(sex) && born_in_range?(dob)
   end
 
   def same_gender?(sex)
-    gender == sex or :both == gender
+    gender == sex || :both == gender
   end
 
   def born_in_range?(dob)
-    dob >= start_date and dob <= end_date
+    dob >= start_date && dob <= end_date
   end
 end
 
-class StatePensionDateQuery < Struct.new(:dob, :gender)
+StatePensionDateQuery = Struct.new(:dob, :gender) do
   def self.find(dob, gender)
     state_pension_query = new(dob, gender)
     state_pension_query.find_date
@@ -48,14 +48,12 @@ class StatePensionDateQuery < Struct.new(:dob, :gender)
   # ActiveSupport will adjust the date, but the calculation
   # should adjust to the 1st March according to DWP rules.
   def adjust_when_dob_is_29february(date)
-    if leap_year_date?(dob) and !leap_year_date?(date)
-      date += 1
-    end
+    date += 1 if leap_year_date?(dob) && !leap_year_date?(date)
     date
   end
 
   def leap_year_date?(date)
-    date.month == 2 and date.day == 29
+    date.month == 2 && date.day == 29
   end
 
   def pension_dates_dynamic

--- a/lib/smart_answer/calculators/state_pension_amount_calculator.rb
+++ b/lib/smart_answer/calculators/state_pension_amount_calculator.rb
@@ -1,4 +1,4 @@
-require "data/state_pension_query"
+require "data/state_pension_date_query"
 
 module SmartAnswer::Calculators
   class StatePensionAmountCalculator
@@ -77,7 +77,7 @@ module SmartAnswer::Calculators
     end
 
     def state_pension_date(sp_gender = gender)
-      StatePensionQuery.find(dob, sp_gender)
+      StatePensionDateQuery.find(dob, sp_gender)
     end
 
     def state_pension_age

--- a/lib/smart_answer_flows/calculate-state-pension.rb
+++ b/lib/smart_answer_flows/calculate-state-pension.rb
@@ -8,7 +8,7 @@ module SmartAnswer
 
       # Q1
       multiple_choice :which_calculation? do
-        save_input_as :calculate_age_or_amount
+        save_input_as :relevant_calculation
 
         option :age
         option :amount
@@ -27,7 +27,7 @@ module SmartAnswer
         option :male
         option :female
 
-        next_node_if(:dob_age?, variable_matches(:calculate_age_or_amount, "age"))
+        next_node_if(:dob_age?, variable_matches(:relevant_calculation, "age"))
         next_node :dob_amount?
       end
 

--- a/lib/smart_answer_flows/calculate-state-pension.rb
+++ b/lib/smart_answer_flows/calculate-state-pension.rb
@@ -57,10 +57,8 @@ module SmartAnswer
           calculator.state_pension_date < Date.parse('6 April 2016')
         end
 
-        calculate :pension_credit_date do
-          # pension credit date calculation for all genders is equivalent
-          # to the state pension date age calculation for women
-          calculator.state_pension_date(:female).strftime("%-d %B %Y")
+        calculate :pension_credit_date do |response|
+          StatePensionDateQuery.bus_pass_qualification_date(response).strftime("%-d %B %Y")
         end
 
         calculate :formatted_state_pension_date do
@@ -97,9 +95,7 @@ module SmartAnswer
         validate { |response| response <= Date.today }
 
         calculate :qualifies_for_bus_pass_on do |response|
-          # Bus pass age calculation for all genders is equivalent
-          # to the state pension date calculation for women
-          StatePensionDateQuery.find(response, :female).strftime("%-d %B %Y")
+          StatePensionDateQuery.bus_pass_qualification_date(response).strftime("%-d %B %Y")
         end
 
         next_node(:bus_pass_age_result)

--- a/lib/smart_answer_flows/calculate-state-pension.rb
+++ b/lib/smart_answer_flows/calculate-state-pension.rb
@@ -1,4 +1,4 @@
-require "data/state_pension_query"
+require "data/state_pension_date_query"
 
 module SmartAnswer
   class CalculateStatePensionFlow < Flow
@@ -99,7 +99,7 @@ module SmartAnswer
         calculate :qualifies_for_bus_pass_on do |response|
           # Bus pass age calculation for all genders is equivalent
           # to the state pension date calculation for women
-          StatePensionQuery.find(response, :female).strftime("%-d %B %Y")
+          StatePensionDateQuery.find(response, :female).strftime("%-d %B %Y")
         end
 
         next_node(:bus_pass_age_result)

--- a/lib/smart_answer_flows/calculate-state-pension.rb
+++ b/lib/smart_answer_flows/calculate-state-pension.rb
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+require "data/state_pension_query"
+
 module SmartAnswer
   class CalculateStatePensionFlow < Flow
     def define
@@ -12,12 +13,19 @@ module SmartAnswer
 
         option :age
         option :amount
+        option :bus_pass
 
         calculate :weekly_state_pension_rate do
           SmartAnswer::Calculators::RatesQuery.new('state_pension').rates.weekly_rate
         end
 
-        next_node :gender?
+        next_node do |response|
+          if response == 'bus_pass'
+            :dob_bus_pass?
+          else
+            :gender?
+          end
+        end
       end
 
       # Q2
@@ -82,6 +90,19 @@ module SmartAnswer
         next_node_if(:too_young, under_20_years_old?)
         next_node_if(:near_state_pension_age, near_pension_date?)
         next_node(:age_result)
+      end
+
+      date_question :dob_bus_pass? do
+        date_of_birth_defaults
+        validate { |response| response <= Date.today }
+
+        calculate :qualifies_for_bus_pass_on do |response|
+          # Bus pass age calculation for all genders is equivalent
+          # to the state pension date calculation for women
+          StatePensionQuery.find(response, :female).strftime("%-d %B %Y")
+        end
+
+        next_node(:bus_pass_age_result)
       end
 
       # Q3:Amount
@@ -465,6 +486,7 @@ module SmartAnswer
       outcome :too_young
 
       outcome :age_result
+      outcome :bus_pass_age_result
       outcome :over55_result
 
       outcome :amount_result do

--- a/lib/smart_answer_flows/calculate-state-pension.rb
+++ b/lib/smart_answer_flows/calculate-state-pension.rb
@@ -50,6 +50,8 @@ module SmartAnswer
         end
 
         calculate :pension_credit_date do
+          # pension credit date calculation for all genders is equivalent
+          # to the state pension date age calculation for women
           calculator.state_pension_date(:female).strftime("%-d %B %Y")
         end
 

--- a/lib/smart_answer_flows/calculate-state-pension/_bus_pass_age.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-state-pension/_bus_pass_age.govspeak.erb
@@ -1,0 +1,8 @@
+The date you qualify for a bus pass depends on where you live:
+
+- on <%= qualifies_for_bus_pass_on %> in England
+- when you turn 60 years old in [Scotland](http://www.transportscotland.gov.uk/public-transport/concessionary-travel-people-aged-60-or-disability),[Wales](http://wales.gov.uk/topics/transport/public/concessionary/?lang=en),[Northern Ireland](http://www.nidirect.gov.uk/free-bus-travel-and-concessions)
+
+The dates may be different in some areas, check with your council when you can [apply for a bus pass](/apply-for-elderly-person-bus-pass).
+
+You can get an 60+ Oyster card from [Transport for London](https://www.tfl.gov.uk/fares-and-payments/adult-discounts-and-concessions/60-london-oyster?intcmp=1763) if you live in Greater London.

--- a/lib/smart_answer_flows/calculate-state-pension/age_result.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-state-pension/age_result.govspeak.erb
@@ -62,13 +62,5 @@
   <% end %>
 
   ##Bus pass
-  The date you qualify for a bus pass depends on where you live:
-
-  - on <%= pension_credit_date %> in England
-  - when you turn 60 years old in [Scotland](http://www.transportscotland.gov.uk/public-transport/concessionary-travel-people-aged-60-or-disability),[Wales](http://wales.gov.uk/topics/transport/public/concessionary/?lang=en),[Northern Ireland](http://www.nidirect.gov.uk/free-bus-travel-and-concessions)
-
-  The dates may be different in some areas, check with your council when you can [apply for a bus pass](/apply-for-elderly-person-bus-pass).
-  
-  You can get an 60+ Oyster card from [Transport for London](https://www.tfl.gov.uk/fares-and-payments/adult-discounts-and-concessions/60-london-oyster?intcmp=1763) if you live in Greater London.
-
+  <%= render partial: 'bus_pass_age.govspeak.erb', locals: { qualifies_for_bus_pass_on: pension_credit_date } %>
 <% end %>

--- a/lib/smart_answer_flows/calculate-state-pension/bus_pass_age_result.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-state-pension/bus_pass_age_result.govspeak.erb
@@ -1,0 +1,10 @@
+<% content_for :title do %>
+  Your bus pass age
+
+<% end %>
+
+<% content_for :body do %>
+  <%= render partial: 'bus_pass_age.govspeak.erb', locals: { qualifies_for_bus_pass_on: qualifies_for_bus_pass_on } %>
+
+  ^Your [State Pension age](/calculate-state-pension/y/age) may be different.^
+<% end %>

--- a/lib/smart_answer_flows/locales/en/calculate-state-pension.yml
+++ b/lib/smart_answer_flows/locales/en/calculate-state-pension.yml
@@ -13,8 +13,9 @@ en-GB:
       which_calculation?:
         title: What would you like to calculate?
         options:
-          age: State Pension age - including pension credit age and when you’ll get free bus travel
+          age: State Pension age - including pension credit age
           amount: Amount - estimate of your basic State Pension amount
+          bus_pass: Bus pass age - find out when you’ll get free bus travel
       ## Q2
       gender?:
         title: Are you a man or a woman?
@@ -27,6 +28,10 @@ en-GB:
         error_message: Enter your date of birth
       ## Q3:Amount
       dob_amount?:
+        title: What is your date of birth?
+        error_message: Enter your date of birth
+      ## Q3:Age
+      dob_bus_pass?:
         title: What is your date of birth?
         error_message: Enter your date of birth
       ## Q3a Amount

--- a/test/artefacts/calculate-state-pension/bus_pass/1956-05-31.txt
+++ b/test/artefacts/calculate-state-pension/bus_pass/1956-05-31.txt
@@ -1,0 +1,13 @@
+Your bus pass age
+
+The date you qualify for a bus pass depends on where you live:
+
+- on 31 May 2022 in England
+- when you turn 60 years old in [Scotland](http://www.transportscotland.gov.uk/public-transport/concessionary-travel-people-aged-60-or-disability),[Wales](http://wales.gov.uk/topics/transport/public/concessionary/?lang=en),[Northern Ireland](http://www.nidirect.gov.uk/free-bus-travel-and-concessions)
+
+The dates may be different in some areas, check with your council when you can [apply for a bus pass](/apply-for-elderly-person-bus-pass).
+
+You can get an 60+ Oyster card from [Transport for London](https://www.tfl.gov.uk/fares-and-payments/adult-discounts-and-concessions/60-london-oyster?intcmp=1763) if you live in Greater London.
+
+^Your [State Pension age](/calculate-state-pension/y/age) may be different.^
+

--- a/test/data/calculate-state-pension-files.yml
+++ b/test/data/calculate-state-pension-files.yml
@@ -1,16 +1,18 @@
 ---
-lib/smart_answer_flows/calculate-state-pension.rb: 66ee591c957c5fafd237307667283559
-lib/smart_answer_flows/locales/en/calculate-state-pension.yml: 39a367e32fd0a938a8721689f6fcc79e
-test/data/calculate-state-pension-questions-and-responses.yml: 62d1841ee3292988bcec43d8bbf21ea7
-test/data/calculate-state-pension-responses-and-expected-results.yml: d467d2445671cb21151d59d9dd004d9f
-lib/smart_answer_flows/calculate-state-pension/age_result.govspeak.erb: 09497f3940d7a32cc51d06a5964d005b
+lib/smart_answer_flows/calculate-state-pension.rb: 8ec36aa8f1d35942dfdfe2af8018a028
+lib/smart_answer_flows/locales/en/calculate-state-pension.yml: 80767794dcf1a1557b7d141cc66338bf
+test/data/calculate-state-pension-questions-and-responses.yml: 8fe4d28d6b90ff1030ed15470d5b458f
+test/data/calculate-state-pension-responses-and-expected-results.yml: 61e8ccba31841f6616cf8b26f3da6ff9
+lib/smart_answer_flows/calculate-state-pension/_bus_pass_age.govspeak.erb: 5f1f77ef0e25bd24b4b8c6b4e30d4e92
+lib/smart_answer_flows/calculate-state-pension/age_result.govspeak.erb: 8b5d360fd6ef72d4f53a2592d8d7671f
 lib/smart_answer_flows/calculate-state-pension/amount_result.govspeak.erb: b46187c00300132102d7e5c214385b0d
+lib/smart_answer_flows/calculate-state-pension/bus_pass_age_result.govspeak.erb: a7253ec4bc72d5ffec14e9b9b7ba2238
 lib/smart_answer_flows/calculate-state-pension/calculate_state_pension.govspeak.erb: bd56129956ea4963698db778f12267be
 lib/smart_answer_flows/calculate-state-pension/near_state_pension_age.govspeak.erb: 2cf95f1256106b0c55f9af59c8e9cce1
 lib/smart_answer_flows/calculate-state-pension/over55_result.govspeak.erb: a30aa788e427c1c77840642b9cd6a816
 lib/smart_answer_flows/calculate-state-pension/reached_state_pension_age.govspeak.erb: 5aa766ef2e882eccd23bcc8a281dfb4e
 lib/smart_answer_flows/calculate-state-pension/too_young.govspeak.erb: fbdfeb69f91ca8be0fb00c1e6f897f2b
-lib/smart_answer/calculators/state_pension_amount_calculator.rb: 0ac1ebedc93860a25cea6813f48a8963
+lib/smart_answer/calculators/state_pension_amount_calculator.rb: dc34ccef222287ea14e4c9c7af164a32
 lib/data/rates/state_pension.yml: 7e97e88500fb698038c49332b48b82bf
-lib/data/state_pension_query.rb: a6b0bf6e86b14f0cb8ad432836e46fe6
+lib/data/state_pension_date_query.rb: ddb745e6cfdfc199c5003e66d674b0f0
 lib/data/state_pension_dates.yml: da1bdee8a5b42c489b3966c43b625113

--- a/test/data/calculate-state-pension-questions-and-responses.yml
+++ b/test/data/calculate-state-pension-questions-and-responses.yml
@@ -2,6 +2,7 @@
 :which_calculation?:
 - age
 - amount
+- bus_pass
 :gender?:
 - male
 - female
@@ -22,6 +23,8 @@
 - 1991-08-12
 - 1992-04-06
 - 1993-04-06
+:dob_bus_pass?:
+- 1956-05-31
 :pay_reduced_ni_rate?:
 - "yes"
 - "no"

--- a/test/data/calculate-state-pension-responses-and-expected-results.yml
+++ b/test/data/calculate-state-pension-responses-and-expected-results.yml
@@ -3788,3 +3788,14 @@
   - '30'
   :next_node: :years_paid_ni?
   :outcome_node: false
+- :current_node: :which_calculation?
+  :responses:
+  - bus_pass
+  :next_node: :dob_bus_pass?
+  :outcome_node: false
+- :current_node: :dob_bus_pass?
+  :responses:
+  - bus_pass
+  - '1956-05-31'
+  :next_node: :bus_pass_age_result
+  :outcome_node: true

--- a/test/data/calculate-state-pension-responses-and-expected-results.yml
+++ b/test/data/calculate-state-pension-responses-and-expected-results.yml
@@ -1,3790 +1,3790 @@
---- 
+---
 - :current_node: :which_calculation?
-  :responses: 
+  :responses:
   - age
   :next_node: :gender?
   :outcome_node: false
 - :current_node: :gender?
-  :responses: 
+  :responses:
   - age
   - male
   :next_node: :dob_age?
   :outcome_node: false
 - :current_node: :dob_age?
-  :responses: 
+  :responses:
   - age
   - male
-  - "1950-02-01"
+  - '1950-02-01'
   :next_node: :near_state_pension_age
   :outcome_node: true
 - :current_node: :dob_age?
-  :responses: 
+  :responses:
   - age
   - male
-  - "1951-04-06"
+  - '1951-04-06'
   :next_node: :age_result
   :outcome_node: true
 - :current_node: :dob_age?
-  :responses: 
+  :responses:
   - age
   - male
-  - "1953-02-06"
+  - '1953-02-06'
   :next_node: :age_result
   :outcome_node: true
 - :current_node: :dob_age?
-  :responses: 
+  :responses:
   - age
   - male
-  - "1980-01-01"
+  - '1980-01-01'
   :next_node: :age_result
   :outcome_node: true
 - :current_node: :dob_age?
-  :responses: 
+  :responses:
   - age
   - male
-  - "2000-01-01"
+  - '2000-01-01'
   :next_node: :too_young
   :outcome_node: true
 - :current_node: :gender?
-  :responses: 
+  :responses:
   - age
   - female
   :next_node: :dob_age?
   :outcome_node: false
 - :current_node: :dob_age?
-  :responses: 
+  :responses:
   - age
   - female
-  - "1950-02-01"
+  - '1950-02-01'
   :next_node: :age_result
   :outcome_node: true
 - :current_node: :dob_age?
-  :responses: 
+  :responses:
   - age
   - female
-  - "1951-04-06"
+  - '1951-04-06'
   :next_node: :age_result
   :outcome_node: true
 - :current_node: :dob_age?
-  :responses: 
+  :responses:
   - age
   - female
-  - "1953-02-06"
+  - '1953-02-06'
   :next_node: :age_result
   :outcome_node: true
 - :current_node: :dob_age?
-  :responses: 
+  :responses:
   - age
   - female
-  - "1980-01-01"
+  - '1980-01-01'
   :next_node: :age_result
   :outcome_node: true
 - :current_node: :dob_age?
-  :responses: 
+  :responses:
   - age
   - female
-  - "2000-01-01"
+  - '2000-01-01'
   :next_node: :too_young
   :outcome_node: true
 - :current_node: :which_calculation?
-  :responses: 
+  :responses:
   - amount
   :next_node: :gender?
   :outcome_node: false
 - :current_node: :gender?
-  :responses: 
+  :responses:
   - amount
   - male
   :next_node: :dob_amount?
   :outcome_node: false
 - :current_node: :dob_amount?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-01-01"
+  - '1950-01-01'
   :next_node: :reached_state_pension_age
   :outcome_node: true
 - :current_node: :dob_amount?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
+  - '1950-02-01'
   :next_node: :years_paid_ni?
   :outcome_node: false
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "1"
+  - '1950-02-01'
+  - '1'
   :next_node: :years_of_jsa?
   :outcome_node: false
 - :current_node: :years_of_jsa?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "1"
-  - "1"
+  - '1950-02-01'
+  - '1'
+  - '1'
   :next_node: :received_child_benefit?
   :outcome_node: false
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "1"
-  - "1"
-  - "yes"
+  - '1950-02-01'
+  - '1'
+  - '1'
+  - 'yes'
   :next_node: :years_of_benefit?
   :outcome_node: false
 - :current_node: :years_of_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
+  - '1950-02-01'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
   :next_node: :years_of_caring?
   :outcome_node: false
 - :current_node: :years_of_caring?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
+  - '1950-02-01'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
   :next_node: :years_of_carers_allowance?
   :outcome_node: false
 - :current_node: :years_of_carers_allowance?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
+  - '1950-02-01'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
   :next_node: :years_of_work?
   :outcome_node: false
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
-  - "0"
+  - '1950-02-01'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
+  - '0'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
-  - "1"
+  - '1950-02-01'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
+  - '1'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
-  - "2"
+  - '1950-02-01'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
+  - '2'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "1"
-  - "1"
-  - "no"
+  - '1950-02-01'
+  - '1'
+  - '1'
+  - 'no'
   :next_node: :years_of_work?
   :outcome_node: false
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "1"
-  - "1"
-  - "no"
-  - "0"
+  - '1950-02-01'
+  - '1'
+  - '1'
+  - 'no'
+  - '0'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "1"
-  - "1"
-  - "no"
-  - "1"
+  - '1950-02-01'
+  - '1'
+  - '1'
+  - 'no'
+  - '1'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "1"
-  - "1"
-  - "no"
-  - "2"
+  - '1950-02-01'
+  - '1'
+  - '1'
+  - 'no'
+  - '2'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "11"
+  - '1950-02-01'
+  - '11'
   :next_node: :years_of_jsa?
   :outcome_node: false
 - :current_node: :years_of_jsa?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "11"
-  - "1"
+  - '1950-02-01'
+  - '11'
+  - '1'
   :next_node: :received_child_benefit?
   :outcome_node: false
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "11"
-  - "1"
-  - "yes"
+  - '1950-02-01'
+  - '11'
+  - '1'
+  - 'yes'
   :next_node: :years_of_benefit?
   :outcome_node: false
 - :current_node: :years_of_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "11"
-  - "1"
-  - "yes"
-  - "1"
+  - '1950-02-01'
+  - '11'
+  - '1'
+  - 'yes'
+  - '1'
   :next_node: :years_of_caring?
   :outcome_node: false
 - :current_node: :years_of_caring?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "11"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
+  - '1950-02-01'
+  - '11'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
   :next_node: :years_of_carers_allowance?
   :outcome_node: false
 - :current_node: :years_of_carers_allowance?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "11"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
+  - '1950-02-01'
+  - '11'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
   :next_node: :years_of_work?
   :outcome_node: false
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "11"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
-  - "0"
+  - '1950-02-01'
+  - '11'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
+  - '0'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "11"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
-  - "1"
+  - '1950-02-01'
+  - '11'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
+  - '1'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "11"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
-  - "2"
+  - '1950-02-01'
+  - '11'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
+  - '2'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "11"
-  - "1"
-  - "no"
+  - '1950-02-01'
+  - '11'
+  - '1'
+  - 'no'
   :next_node: :years_of_work?
   :outcome_node: false
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "11"
-  - "1"
-  - "no"
-  - "0"
+  - '1950-02-01'
+  - '11'
+  - '1'
+  - 'no'
+  - '0'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "11"
-  - "1"
-  - "no"
-  - "1"
+  - '1950-02-01'
+  - '11'
+  - '1'
+  - 'no'
+  - '1'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "11"
-  - "1"
-  - "no"
-  - "2"
+  - '1950-02-01'
+  - '11'
+  - '1'
+  - 'no'
+  - '2'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "23"
+  - '1950-02-01'
+  - '23'
   :next_node: :years_of_jsa?
   :outcome_node: false
 - :current_node: :years_of_jsa?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "23"
-  - "1"
+  - '1950-02-01'
+  - '23'
+  - '1'
   :next_node: :received_child_benefit?
   :outcome_node: false
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "23"
-  - "1"
-  - "yes"
+  - '1950-02-01'
+  - '23'
+  - '1'
+  - 'yes'
   :next_node: :years_of_benefit?
   :outcome_node: false
 - :current_node: :years_of_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "23"
-  - "1"
-  - "yes"
-  - "1"
+  - '1950-02-01'
+  - '23'
+  - '1'
+  - 'yes'
+  - '1'
   :next_node: :years_of_caring?
   :outcome_node: false
 - :current_node: :years_of_caring?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "23"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
+  - '1950-02-01'
+  - '23'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
   :next_node: :years_of_carers_allowance?
   :outcome_node: false
 - :current_node: :years_of_carers_allowance?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "23"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
+  - '1950-02-01'
+  - '23'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
   :next_node: :years_of_work?
   :outcome_node: false
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "23"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
-  - "0"
+  - '1950-02-01'
+  - '23'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
+  - '0'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "23"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
-  - "1"
+  - '1950-02-01'
+  - '23'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
+  - '1'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "23"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
-  - "2"
+  - '1950-02-01'
+  - '23'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
+  - '2'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "23"
-  - "1"
-  - "no"
+  - '1950-02-01'
+  - '23'
+  - '1'
+  - 'no'
   :next_node: :years_of_work?
   :outcome_node: false
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "23"
-  - "1"
-  - "no"
-  - "0"
+  - '1950-02-01'
+  - '23'
+  - '1'
+  - 'no'
+  - '0'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "23"
-  - "1"
-  - "no"
-  - "1"
+  - '1950-02-01'
+  - '23'
+  - '1'
+  - 'no'
+  - '1'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "23"
-  - "1"
-  - "no"
-  - "2"
+  - '1950-02-01'
+  - '23'
+  - '1'
+  - 'no'
+  - '2'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "27"
+  - '1950-02-01'
+  - '27'
   :next_node: :years_of_jsa?
   :outcome_node: false
 - :current_node: :years_of_jsa?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "27"
-  - "1"
+  - '1950-02-01'
+  - '27'
+  - '1'
   :next_node: :received_child_benefit?
   :outcome_node: false
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "27"
-  - "1"
-  - "yes"
+  - '1950-02-01'
+  - '27'
+  - '1'
+  - 'yes'
   :next_node: :years_of_benefit?
   :outcome_node: false
 - :current_node: :years_of_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "27"
-  - "1"
-  - "yes"
-  - "1"
+  - '1950-02-01'
+  - '27'
+  - '1'
+  - 'yes'
+  - '1'
   :next_node: :years_of_caring?
   :outcome_node: false
 - :current_node: :years_of_caring?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "27"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
+  - '1950-02-01'
+  - '27'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "27"
-  - "1"
-  - "no"
+  - '1950-02-01'
+  - '27'
+  - '1'
+  - 'no'
   :next_node: :years_of_work?
   :outcome_node: false
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "27"
-  - "1"
-  - "no"
-  - "0"
+  - '1950-02-01'
+  - '27'
+  - '1'
+  - 'no'
+  - '0'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "27"
-  - "1"
-  - "no"
-  - "1"
+  - '1950-02-01'
+  - '27'
+  - '1'
+  - 'no'
+  - '1'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "27"
-  - "1"
-  - "no"
-  - "2"
+  - '1950-02-01'
+  - '27'
+  - '1'
+  - 'no'
+  - '2'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1950-02-01"
-  - "30"
+  - '1950-02-01'
+  - '30'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :dob_amount?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
+  - '1951-01-01'
   :next_node: :years_paid_ni?
   :outcome_node: false
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "1"
+  - '1951-01-01'
+  - '1'
   :next_node: :years_of_jsa?
   :outcome_node: false
 - :current_node: :years_of_jsa?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "1"
-  - "1"
+  - '1951-01-01'
+  - '1'
+  - '1'
   :next_node: :received_child_benefit?
   :outcome_node: false
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "1"
-  - "1"
-  - "yes"
+  - '1951-01-01'
+  - '1'
+  - '1'
+  - 'yes'
   :next_node: :years_of_benefit?
   :outcome_node: false
 - :current_node: :years_of_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
+  - '1951-01-01'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
   :next_node: :years_of_caring?
   :outcome_node: false
 - :current_node: :years_of_caring?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
+  - '1951-01-01'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
   :next_node: :years_of_carers_allowance?
   :outcome_node: false
 - :current_node: :years_of_carers_allowance?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
+  - '1951-01-01'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
   :next_node: :years_of_work?
   :outcome_node: false
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
-  - "0"
+  - '1951-01-01'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
+  - '0'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
-  - "1"
+  - '1951-01-01'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
+  - '1'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
-  - "2"
+  - '1951-01-01'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
+  - '2'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "1"
-  - "1"
-  - "no"
+  - '1951-01-01'
+  - '1'
+  - '1'
+  - 'no'
   :next_node: :years_of_work?
   :outcome_node: false
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "1"
-  - "1"
-  - "no"
-  - "0"
+  - '1951-01-01'
+  - '1'
+  - '1'
+  - 'no'
+  - '0'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "1"
-  - "1"
-  - "no"
-  - "1"
+  - '1951-01-01'
+  - '1'
+  - '1'
+  - 'no'
+  - '1'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "1"
-  - "1"
-  - "no"
-  - "2"
+  - '1951-01-01'
+  - '1'
+  - '1'
+  - 'no'
+  - '2'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "11"
+  - '1951-01-01'
+  - '11'
   :next_node: :years_of_jsa?
   :outcome_node: false
 - :current_node: :years_of_jsa?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "11"
-  - "1"
+  - '1951-01-01'
+  - '11'
+  - '1'
   :next_node: :received_child_benefit?
   :outcome_node: false
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "11"
-  - "1"
-  - "yes"
+  - '1951-01-01'
+  - '11'
+  - '1'
+  - 'yes'
   :next_node: :years_of_benefit?
   :outcome_node: false
 - :current_node: :years_of_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "11"
-  - "1"
-  - "yes"
-  - "1"
+  - '1951-01-01'
+  - '11'
+  - '1'
+  - 'yes'
+  - '1'
   :next_node: :years_of_caring?
   :outcome_node: false
 - :current_node: :years_of_caring?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "11"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
+  - '1951-01-01'
+  - '11'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
   :next_node: :years_of_carers_allowance?
   :outcome_node: false
 - :current_node: :years_of_carers_allowance?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "11"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
+  - '1951-01-01'
+  - '11'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
   :next_node: :years_of_work?
   :outcome_node: false
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "11"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
-  - "0"
+  - '1951-01-01'
+  - '11'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
+  - '0'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "11"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
-  - "1"
+  - '1951-01-01'
+  - '11'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
+  - '1'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "11"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
-  - "2"
+  - '1951-01-01'
+  - '11'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
+  - '2'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "11"
-  - "1"
-  - "no"
+  - '1951-01-01'
+  - '11'
+  - '1'
+  - 'no'
   :next_node: :years_of_work?
   :outcome_node: false
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "11"
-  - "1"
-  - "no"
-  - "0"
+  - '1951-01-01'
+  - '11'
+  - '1'
+  - 'no'
+  - '0'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "11"
-  - "1"
-  - "no"
-  - "1"
+  - '1951-01-01'
+  - '11'
+  - '1'
+  - 'no'
+  - '1'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "11"
-  - "1"
-  - "no"
-  - "2"
+  - '1951-01-01'
+  - '11'
+  - '1'
+  - 'no'
+  - '2'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "23"
+  - '1951-01-01'
+  - '23'
   :next_node: :years_of_jsa?
   :outcome_node: false
 - :current_node: :years_of_jsa?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "23"
-  - "1"
+  - '1951-01-01'
+  - '23'
+  - '1'
   :next_node: :received_child_benefit?
   :outcome_node: false
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "23"
-  - "1"
-  - "yes"
+  - '1951-01-01'
+  - '23'
+  - '1'
+  - 'yes'
   :next_node: :years_of_benefit?
   :outcome_node: false
 - :current_node: :years_of_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "23"
-  - "1"
-  - "yes"
-  - "1"
+  - '1951-01-01'
+  - '23'
+  - '1'
+  - 'yes'
+  - '1'
   :next_node: :years_of_caring?
   :outcome_node: false
 - :current_node: :years_of_caring?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "23"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
+  - '1951-01-01'
+  - '23'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
   :next_node: :years_of_carers_allowance?
   :outcome_node: false
 - :current_node: :years_of_carers_allowance?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "23"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
+  - '1951-01-01'
+  - '23'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
   :next_node: :years_of_work?
   :outcome_node: false
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "23"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
-  - "0"
+  - '1951-01-01'
+  - '23'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
+  - '0'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "23"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
-  - "1"
+  - '1951-01-01'
+  - '23'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
+  - '1'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "23"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
-  - "2"
+  - '1951-01-01'
+  - '23'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
+  - '2'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "23"
-  - "1"
-  - "no"
+  - '1951-01-01'
+  - '23'
+  - '1'
+  - 'no'
   :next_node: :years_of_work?
   :outcome_node: false
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "23"
-  - "1"
-  - "no"
-  - "0"
+  - '1951-01-01'
+  - '23'
+  - '1'
+  - 'no'
+  - '0'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "23"
-  - "1"
-  - "no"
-  - "1"
+  - '1951-01-01'
+  - '23'
+  - '1'
+  - 'no'
+  - '1'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "23"
-  - "1"
-  - "no"
-  - "2"
+  - '1951-01-01'
+  - '23'
+  - '1'
+  - 'no'
+  - '2'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "27"
+  - '1951-01-01'
+  - '27'
   :next_node: :years_of_jsa?
   :outcome_node: false
 - :current_node: :years_of_jsa?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "27"
-  - "1"
+  - '1951-01-01'
+  - '27'
+  - '1'
   :next_node: :received_child_benefit?
   :outcome_node: false
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "27"
-  - "1"
-  - "yes"
+  - '1951-01-01'
+  - '27'
+  - '1'
+  - 'yes'
   :next_node: :years_of_benefit?
   :outcome_node: false
 - :current_node: :years_of_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "27"
-  - "1"
-  - "yes"
-  - "1"
+  - '1951-01-01'
+  - '27'
+  - '1'
+  - 'yes'
+  - '1'
   :next_node: :years_of_caring?
   :outcome_node: false
 - :current_node: :years_of_caring?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "27"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
+  - '1951-01-01'
+  - '27'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "27"
-  - "1"
-  - "no"
+  - '1951-01-01'
+  - '27'
+  - '1'
+  - 'no'
   :next_node: :years_of_work?
   :outcome_node: false
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "27"
-  - "1"
-  - "no"
-  - "0"
+  - '1951-01-01'
+  - '27'
+  - '1'
+  - 'no'
+  - '0'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "27"
-  - "1"
-  - "no"
-  - "1"
+  - '1951-01-01'
+  - '27'
+  - '1'
+  - 'no'
+  - '1'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "27"
-  - "1"
-  - "no"
-  - "2"
+  - '1951-01-01'
+  - '27'
+  - '1'
+  - 'no'
+  - '2'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-01-01"
-  - "30"
+  - '1951-01-01'
+  - '30'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :dob_amount?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1951-06-01"
+  - '1951-06-01'
   :next_node: :over55_result
   :outcome_node: true
 - :current_node: :dob_amount?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1952-02-29"
+  - '1952-02-29'
   :next_node: :over55_result
   :outcome_node: true
 - :current_node: :dob_amount?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1954-01-01"
+  - '1954-01-01'
   :next_node: :over55_result
   :outcome_node: true
 - :current_node: :dob_amount?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1961-04-04"
+  - '1961-04-04'
   :next_node: :years_paid_ni?
   :outcome_node: false
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1961-04-04"
-  - "1"
+  - '1961-04-04'
+  - '1'
   :next_node: :years_of_jsa?
   :outcome_node: false
 - :current_node: :years_of_jsa?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1961-04-04"
-  - "1"
-  - "1"
+  - '1961-04-04'
+  - '1'
+  - '1'
   :next_node: :received_child_benefit?
   :outcome_node: false
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1961-04-04"
-  - "1"
-  - "1"
-  - "yes"
+  - '1961-04-04'
+  - '1'
+  - '1'
+  - 'yes'
   :next_node: :years_of_benefit?
   :outcome_node: false
 - :current_node: :years_of_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1961-04-04"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
+  - '1961-04-04'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
   :next_node: :years_of_caring?
   :outcome_node: false
 - :current_node: :years_of_caring?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1961-04-04"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
+  - '1961-04-04'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
   :next_node: :years_of_carers_allowance?
   :outcome_node: false
 - :current_node: :years_of_carers_allowance?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1961-04-04"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
+  - '1961-04-04'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
   :next_node: :lived_or_worked_outside_uk?
   :outcome_node: false
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1961-04-04"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
-  - "yes"
+  - '1961-04-04'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
+  - 'yes'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1961-04-04"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
-  - "no"
+  - '1961-04-04'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
+  - 'no'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1961-04-04"
-  - "1"
-  - "1"
-  - "no"
+  - '1961-04-04'
+  - '1'
+  - '1'
+  - 'no'
   :next_node: :lived_or_worked_outside_uk?
   :outcome_node: false
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1961-04-04"
-  - "1"
-  - "1"
-  - "no"
-  - "yes"
+  - '1961-04-04'
+  - '1'
+  - '1'
+  - 'no'
+  - 'yes'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1961-04-04"
-  - "1"
-  - "1"
-  - "no"
-  - "no"
+  - '1961-04-04'
+  - '1'
+  - '1'
+  - 'no'
+  - 'no'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1961-04-04"
-  - "11"
+  - '1961-04-04'
+  - '11'
   :next_node: :years_of_jsa?
   :outcome_node: false
 - :current_node: :years_of_jsa?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1961-04-04"
-  - "11"
-  - "1"
+  - '1961-04-04'
+  - '11'
+  - '1'
   :next_node: :received_child_benefit?
   :outcome_node: false
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1961-04-04"
-  - "11"
-  - "1"
-  - "yes"
+  - '1961-04-04'
+  - '11'
+  - '1'
+  - 'yes'
   :next_node: :years_of_benefit?
   :outcome_node: false
 - :current_node: :years_of_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1961-04-04"
-  - "11"
-  - "1"
-  - "yes"
-  - "1"
+  - '1961-04-04'
+  - '11'
+  - '1'
+  - 'yes'
+  - '1'
   :next_node: :years_of_caring?
   :outcome_node: false
 - :current_node: :years_of_caring?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1961-04-04"
-  - "11"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
+  - '1961-04-04'
+  - '11'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
   :next_node: :years_of_carers_allowance?
   :outcome_node: false
 - :current_node: :years_of_carers_allowance?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1961-04-04"
-  - "11"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
+  - '1961-04-04'
+  - '11'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1961-04-04"
-  - "11"
-  - "1"
-  - "no"
+  - '1961-04-04'
+  - '11'
+  - '1'
+  - 'no'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1961-04-04"
-  - "23"
+  - '1961-04-04'
+  - '23'
   :next_node: :years_of_jsa?
   :outcome_node: false
 - :current_node: :years_of_jsa?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1961-04-04"
-  - "23"
-  - "1"
+  - '1961-04-04'
+  - '23'
+  - '1'
   :next_node: :received_child_benefit?
   :outcome_node: false
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1961-04-04"
-  - "23"
-  - "1"
-  - "yes"
+  - '1961-04-04'
+  - '23'
+  - '1'
+  - 'yes'
   :next_node: :years_of_benefit?
   :outcome_node: false
 - :current_node: :years_of_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1961-04-04"
-  - "23"
-  - "1"
-  - "yes"
-  - "1"
+  - '1961-04-04'
+  - '23'
+  - '1'
+  - 'yes'
+  - '1'
   :next_node: :years_of_caring?
   :outcome_node: false
 - :current_node: :years_of_caring?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1961-04-04"
-  - "23"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
+  - '1961-04-04'
+  - '23'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
   :next_node: :years_of_carers_allowance?
   :outcome_node: false
 - :current_node: :years_of_carers_allowance?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1961-04-04"
-  - "23"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
+  - '1961-04-04'
+  - '23'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1961-04-04"
-  - "23"
-  - "1"
-  - "no"
+  - '1961-04-04'
+  - '23'
+  - '1'
+  - 'no'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1961-04-04"
-  - "27"
+  - '1961-04-04'
+  - '27'
   :next_node: :years_of_jsa?
   :outcome_node: false
 - :current_node: :years_of_jsa?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1961-04-04"
-  - "27"
-  - "1"
+  - '1961-04-04'
+  - '27'
+  - '1'
   :next_node: :received_child_benefit?
   :outcome_node: false
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1961-04-04"
-  - "27"
-  - "1"
-  - "yes"
+  - '1961-04-04'
+  - '27'
+  - '1'
+  - 'yes'
   :next_node: :years_of_benefit?
   :outcome_node: false
 - :current_node: :years_of_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1961-04-04"
-  - "27"
-  - "1"
-  - "yes"
-  - "1"
+  - '1961-04-04'
+  - '27'
+  - '1'
+  - 'yes'
+  - '1'
   :next_node: :years_of_caring?
   :outcome_node: false
 - :current_node: :years_of_caring?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1961-04-04"
-  - "27"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
+  - '1961-04-04'
+  - '27'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
   :next_node: :years_of_carers_allowance?
   :outcome_node: false
 - :current_node: :years_of_carers_allowance?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1961-04-04"
-  - "27"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
+  - '1961-04-04'
+  - '27'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1961-04-04"
-  - "27"
-  - "1"
-  - "no"
+  - '1961-04-04'
+  - '27'
+  - '1'
+  - 'no'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1961-04-04"
-  - "30"
+  - '1961-04-04'
+  - '30'
   :next_node: :years_of_jsa?
   :outcome_node: false
 - :current_node: :years_of_jsa?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1961-04-04"
-  - "30"
-  - "1"
+  - '1961-04-04'
+  - '30'
+  - '1'
   :next_node: :received_child_benefit?
   :outcome_node: false
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1961-04-04"
-  - "30"
-  - "1"
-  - "yes"
+  - '1961-04-04'
+  - '30'
+  - '1'
+  - 'yes'
   :next_node: :years_of_benefit?
   :outcome_node: false
 - :current_node: :years_of_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1961-04-04"
-  - "30"
-  - "1"
-  - "yes"
-  - "1"
+  - '1961-04-04'
+  - '30'
+  - '1'
+  - 'yes'
+  - '1'
   :next_node: :years_of_caring?
   :outcome_node: false
 - :current_node: :years_of_caring?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1961-04-04"
-  - "30"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
+  - '1961-04-04'
+  - '30'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
   :next_node: :years_of_carers_allowance?
   :outcome_node: false
 - :current_node: :years_of_carers_allowance?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1961-04-04"
-  - "30"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
+  - '1961-04-04'
+  - '30'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1961-04-04"
-  - "30"
-  - "1"
-  - "no"
+  - '1961-04-04'
+  - '30'
+  - '1'
+  - 'no'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :dob_amount?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1991-08-12"
+  - '1991-08-12'
   :next_node: :years_paid_ni?
   :outcome_node: false
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1991-08-12"
-  - "1"
+  - '1991-08-12'
+  - '1'
   :next_node: :years_of_jsa?
   :outcome_node: false
 - :current_node: :years_of_jsa?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1991-08-12"
-  - "1"
-  - "1"
+  - '1991-08-12'
+  - '1'
+  - '1'
   :next_node: :received_child_benefit?
   :outcome_node: false
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1991-08-12"
-  - "1"
-  - "1"
-  - "yes"
+  - '1991-08-12'
+  - '1'
+  - '1'
+  - 'yes'
   :next_node: :years_of_benefit?
   :outcome_node: false
 - :current_node: :years_of_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1991-08-12"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
+  - '1991-08-12'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
   :next_node: :years_of_caring?
   :outcome_node: false
 - :current_node: :years_of_caring?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1991-08-12"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
+  - '1991-08-12'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1991-08-12"
-  - "1"
-  - "1"
-  - "no"
+  - '1991-08-12'
+  - '1'
+  - '1'
+  - 'no'
   :next_node: :lived_or_worked_outside_uk?
   :outcome_node: false
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1991-08-12"
-  - "1"
-  - "1"
-  - "no"
-  - "yes"
+  - '1991-08-12'
+  - '1'
+  - '1'
+  - 'no'
+  - 'yes'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1991-08-12"
-  - "1"
-  - "1"
-  - "no"
-  - "no"
+  - '1991-08-12'
+  - '1'
+  - '1'
+  - 'no'
+  - 'no'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1991-08-12"
-  - "11"
+  - '1991-08-12'
+  - '11'
   :next_node: :years_paid_ni?
   :outcome_node: false
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1991-08-12"
-  - "23"
+  - '1991-08-12'
+  - '23'
   :next_node: :years_paid_ni?
   :outcome_node: false
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1991-08-12"
-  - "27"
+  - '1991-08-12'
+  - '27'
   :next_node: :years_paid_ni?
   :outcome_node: false
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1991-08-12"
-  - "30"
+  - '1991-08-12'
+  - '30'
   :next_node: :years_paid_ni?
   :outcome_node: false
 - :current_node: :dob_amount?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1992-04-06"
+  - '1992-04-06'
   :next_node: :years_paid_ni?
   :outcome_node: false
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1992-04-06"
-  - "1"
+  - '1992-04-06'
+  - '1'
   :next_node: :years_of_jsa?
   :outcome_node: false
 - :current_node: :years_of_jsa?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1992-04-06"
-  - "1"
-  - "1"
+  - '1992-04-06'
+  - '1'
+  - '1'
   :next_node: :received_child_benefit?
   :outcome_node: false
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "yes"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'yes'
   :next_node: :years_of_benefit?
   :outcome_node: false
 - :current_node: :years_of_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
   :next_node: :years_of_work?
   :outcome_node: false
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "0"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '0'
   :next_node: :lived_or_worked_outside_uk?
   :outcome_node: false
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "0"
-  - "yes"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '0'
+  - 'yes'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "0"
-  - "no"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '0'
+  - 'no'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
   :next_node: :lived_or_worked_outside_uk?
   :outcome_node: false
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "yes"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - 'yes'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "no"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - 'no'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "2"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '2'
   :next_node: :lived_or_worked_outside_uk?
   :outcome_node: false
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "2"
-  - "yes"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '2'
+  - 'yes'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "2"
-  - "no"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '2'
+  - 'no'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "no"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'no'
   :next_node: :years_of_work?
   :outcome_node: false
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "no"
-  - "0"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'no'
+  - '0'
   :next_node: :lived_or_worked_outside_uk?
   :outcome_node: false
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "no"
-  - "0"
-  - "yes"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'no'
+  - '0'
+  - 'yes'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "no"
-  - "0"
-  - "no"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'no'
+  - '0'
+  - 'no'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "no"
-  - "1"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'no'
+  - '1'
   :next_node: :lived_or_worked_outside_uk?
   :outcome_node: false
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "no"
-  - "1"
-  - "yes"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'no'
+  - '1'
+  - 'yes'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "no"
-  - "1"
-  - "no"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'no'
+  - '1'
+  - 'no'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "no"
-  - "2"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'no'
+  - '2'
   :next_node: :lived_or_worked_outside_uk?
   :outcome_node: false
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "no"
-  - "2"
-  - "yes"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'no'
+  - '2'
+  - 'yes'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "no"
-  - "2"
-  - "no"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'no'
+  - '2'
+  - 'no'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1992-04-06"
-  - "11"
+  - '1992-04-06'
+  - '11'
   :next_node: :years_paid_ni?
   :outcome_node: false
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1992-04-06"
-  - "23"
+  - '1992-04-06'
+  - '23'
   :next_node: :years_paid_ni?
   :outcome_node: false
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1992-04-06"
-  - "27"
+  - '1992-04-06'
+  - '27'
   :next_node: :years_paid_ni?
   :outcome_node: false
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1992-04-06"
-  - "30"
+  - '1992-04-06'
+  - '30'
   :next_node: :years_paid_ni?
   :outcome_node: false
 - :current_node: :dob_amount?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1993-04-06"
+  - '1993-04-06'
   :next_node: :years_paid_ni?
   :outcome_node: false
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1993-04-06"
-  - "1"
+  - '1993-04-06'
+  - '1'
   :next_node: :years_of_jsa?
   :outcome_node: false
 - :current_node: :years_of_jsa?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1993-04-06"
-  - "1"
-  - "1"
+  - '1993-04-06'
+  - '1'
+  - '1'
   :next_node: :years_of_work?
   :outcome_node: false
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1993-04-06"
-  - "1"
-  - "1"
-  - "0"
+  - '1993-04-06'
+  - '1'
+  - '1'
+  - '0'
   :next_node: :lived_or_worked_outside_uk?
   :outcome_node: false
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1993-04-06"
-  - "1"
-  - "1"
-  - "0"
-  - "yes"
+  - '1993-04-06'
+  - '1'
+  - '1'
+  - '0'
+  - 'yes'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1993-04-06"
-  - "1"
-  - "1"
-  - "0"
-  - "no"
+  - '1993-04-06'
+  - '1'
+  - '1'
+  - '0'
+  - 'no'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1993-04-06"
-  - "1"
-  - "1"
-  - "1"
+  - '1993-04-06'
+  - '1'
+  - '1'
+  - '1'
   :next_node: :lived_or_worked_outside_uk?
   :outcome_node: false
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1993-04-06"
-  - "1"
-  - "1"
-  - "1"
-  - "yes"
+  - '1993-04-06'
+  - '1'
+  - '1'
+  - '1'
+  - 'yes'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1993-04-06"
-  - "1"
-  - "1"
-  - "1"
-  - "no"
+  - '1993-04-06'
+  - '1'
+  - '1'
+  - '1'
+  - 'no'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1993-04-06"
-  - "1"
-  - "1"
-  - "2"
+  - '1993-04-06'
+  - '1'
+  - '1'
+  - '2'
   :next_node: :lived_or_worked_outside_uk?
   :outcome_node: false
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1993-04-06"
-  - "1"
-  - "1"
-  - "2"
-  - "yes"
+  - '1993-04-06'
+  - '1'
+  - '1'
+  - '2'
+  - 'yes'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1993-04-06"
-  - "1"
-  - "1"
-  - "2"
-  - "no"
+  - '1993-04-06'
+  - '1'
+  - '1'
+  - '2'
+  - 'no'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1993-04-06"
-  - "11"
+  - '1993-04-06'
+  - '11'
   :next_node: :years_paid_ni?
   :outcome_node: false
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1993-04-06"
-  - "23"
+  - '1993-04-06'
+  - '23'
   :next_node: :years_paid_ni?
   :outcome_node: false
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1993-04-06"
-  - "27"
+  - '1993-04-06'
+  - '27'
   :next_node: :years_paid_ni?
   :outcome_node: false
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - male
-  - "1993-04-06"
-  - "30"
+  - '1993-04-06'
+  - '30'
   :next_node: :years_paid_ni?
   :outcome_node: false
 - :current_node: :gender?
-  :responses: 
+  :responses:
   - amount
   - female
   :next_node: :dob_amount?
   :outcome_node: false
 - :current_node: :dob_amount?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1950-01-01"
+  - '1950-01-01'
   :next_node: :reached_state_pension_age
   :outcome_node: true
 - :current_node: :dob_amount?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1950-02-01"
+  - '1950-02-01'
   :next_node: :reached_state_pension_age
   :outcome_node: true
 - :current_node: :dob_amount?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1951-01-01"
+  - '1951-01-01'
   :next_node: :reached_state_pension_age
   :outcome_node: true
 - :current_node: :dob_amount?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1951-06-01"
+  - '1951-06-01'
   :next_node: :reached_state_pension_age
   :outcome_node: true
 - :current_node: :dob_amount?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1952-02-29"
+  - '1952-02-29'
   :next_node: :reached_state_pension_age
   :outcome_node: true
 - :current_node: :dob_amount?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1954-01-01"
+  - '1954-01-01'
   :next_node: :over55_result
   :outcome_node: true
 - :current_node: :dob_amount?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
+  - '1961-04-04'
   :next_node: :pay_reduced_ni_rate?
   :outcome_node: false
 - :current_node: :pay_reduced_ni_rate?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "yes"
+  - '1961-04-04'
+  - 'yes'
   :next_node: :years_paid_ni?
   :outcome_node: false
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "yes"
-  - "1"
+  - '1961-04-04'
+  - 'yes'
+  - '1'
   :next_node: :years_of_jsa?
   :outcome_node: false
 - :current_node: :years_of_jsa?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "yes"
-  - "1"
-  - "1"
+  - '1961-04-04'
+  - 'yes'
+  - '1'
+  - '1'
   :next_node: :received_child_benefit?
   :outcome_node: false
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "yes"
-  - "1"
-  - "1"
-  - "yes"
+  - '1961-04-04'
+  - 'yes'
+  - '1'
+  - '1'
+  - 'yes'
   :next_node: :years_of_benefit?
   :outcome_node: false
 - :current_node: :years_of_benefit?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "yes"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
+  - '1961-04-04'
+  - 'yes'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
   :next_node: :years_of_caring?
   :outcome_node: false
 - :current_node: :years_of_caring?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "yes"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
+  - '1961-04-04'
+  - 'yes'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
   :next_node: :years_of_carers_allowance?
   :outcome_node: false
 - :current_node: :years_of_carers_allowance?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "yes"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
+  - '1961-04-04'
+  - 'yes'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
   :next_node: :lived_or_worked_outside_uk?
   :outcome_node: false
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "yes"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
-  - "yes"
+  - '1961-04-04'
+  - 'yes'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
+  - 'yes'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "yes"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
-  - "no"
+  - '1961-04-04'
+  - 'yes'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
+  - 'no'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "yes"
-  - "1"
-  - "1"
-  - "no"
+  - '1961-04-04'
+  - 'yes'
+  - '1'
+  - '1'
+  - 'no'
   :next_node: :lived_or_worked_outside_uk?
   :outcome_node: false
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "yes"
-  - "1"
-  - "1"
-  - "no"
-  - "yes"
+  - '1961-04-04'
+  - 'yes'
+  - '1'
+  - '1'
+  - 'no'
+  - 'yes'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "yes"
-  - "1"
-  - "1"
-  - "no"
-  - "no"
+  - '1961-04-04'
+  - 'yes'
+  - '1'
+  - '1'
+  - 'no'
+  - 'no'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "yes"
-  - "11"
+  - '1961-04-04'
+  - 'yes'
+  - '11'
   :next_node: :years_of_jsa?
   :outcome_node: false
 - :current_node: :years_of_jsa?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "yes"
-  - "11"
-  - "1"
+  - '1961-04-04'
+  - 'yes'
+  - '11'
+  - '1'
   :next_node: :received_child_benefit?
   :outcome_node: false
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "yes"
-  - "11"
-  - "1"
-  - "yes"
+  - '1961-04-04'
+  - 'yes'
+  - '11'
+  - '1'
+  - 'yes'
   :next_node: :years_of_benefit?
   :outcome_node: false
 - :current_node: :years_of_benefit?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "yes"
-  - "11"
-  - "1"
-  - "yes"
-  - "1"
+  - '1961-04-04'
+  - 'yes'
+  - '11'
+  - '1'
+  - 'yes'
+  - '1'
   :next_node: :years_of_caring?
   :outcome_node: false
 - :current_node: :years_of_caring?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "yes"
-  - "11"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
+  - '1961-04-04'
+  - 'yes'
+  - '11'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
   :next_node: :years_of_carers_allowance?
   :outcome_node: false
 - :current_node: :years_of_carers_allowance?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "yes"
-  - "11"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
+  - '1961-04-04'
+  - 'yes'
+  - '11'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "yes"
-  - "11"
-  - "1"
-  - "no"
+  - '1961-04-04'
+  - 'yes'
+  - '11'
+  - '1'
+  - 'no'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "yes"
-  - "23"
+  - '1961-04-04'
+  - 'yes'
+  - '23'
   :next_node: :years_of_jsa?
   :outcome_node: false
 - :current_node: :years_of_jsa?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "yes"
-  - "23"
-  - "1"
+  - '1961-04-04'
+  - 'yes'
+  - '23'
+  - '1'
   :next_node: :received_child_benefit?
   :outcome_node: false
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "yes"
-  - "23"
-  - "1"
-  - "yes"
+  - '1961-04-04'
+  - 'yes'
+  - '23'
+  - '1'
+  - 'yes'
   :next_node: :years_of_benefit?
   :outcome_node: false
 - :current_node: :years_of_benefit?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "yes"
-  - "23"
-  - "1"
-  - "yes"
-  - "1"
+  - '1961-04-04'
+  - 'yes'
+  - '23'
+  - '1'
+  - 'yes'
+  - '1'
   :next_node: :years_of_caring?
   :outcome_node: false
 - :current_node: :years_of_caring?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "yes"
-  - "23"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
+  - '1961-04-04'
+  - 'yes'
+  - '23'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
   :next_node: :years_of_carers_allowance?
   :outcome_node: false
 - :current_node: :years_of_carers_allowance?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "yes"
-  - "23"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
+  - '1961-04-04'
+  - 'yes'
+  - '23'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "yes"
-  - "23"
-  - "1"
-  - "no"
+  - '1961-04-04'
+  - 'yes'
+  - '23'
+  - '1'
+  - 'no'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "yes"
-  - "27"
+  - '1961-04-04'
+  - 'yes'
+  - '27'
   :next_node: :years_of_jsa?
   :outcome_node: false
 - :current_node: :years_of_jsa?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "yes"
-  - "27"
-  - "1"
+  - '1961-04-04'
+  - 'yes'
+  - '27'
+  - '1'
   :next_node: :received_child_benefit?
   :outcome_node: false
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "yes"
-  - "27"
-  - "1"
-  - "yes"
+  - '1961-04-04'
+  - 'yes'
+  - '27'
+  - '1'
+  - 'yes'
   :next_node: :years_of_benefit?
   :outcome_node: false
 - :current_node: :years_of_benefit?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "yes"
-  - "27"
-  - "1"
-  - "yes"
-  - "1"
+  - '1961-04-04'
+  - 'yes'
+  - '27'
+  - '1'
+  - 'yes'
+  - '1'
   :next_node: :years_of_caring?
   :outcome_node: false
 - :current_node: :years_of_caring?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "yes"
-  - "27"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
+  - '1961-04-04'
+  - 'yes'
+  - '27'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
   :next_node: :years_of_carers_allowance?
   :outcome_node: false
 - :current_node: :years_of_carers_allowance?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "yes"
-  - "27"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
+  - '1961-04-04'
+  - 'yes'
+  - '27'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "yes"
-  - "27"
-  - "1"
-  - "no"
+  - '1961-04-04'
+  - 'yes'
+  - '27'
+  - '1'
+  - 'no'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "yes"
-  - "30"
+  - '1961-04-04'
+  - 'yes'
+  - '30'
   :next_node: :years_of_jsa?
   :outcome_node: false
 - :current_node: :years_of_jsa?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "yes"
-  - "30"
-  - "1"
+  - '1961-04-04'
+  - 'yes'
+  - '30'
+  - '1'
   :next_node: :received_child_benefit?
   :outcome_node: false
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "yes"
-  - "30"
-  - "1"
-  - "yes"
+  - '1961-04-04'
+  - 'yes'
+  - '30'
+  - '1'
+  - 'yes'
   :next_node: :years_of_benefit?
   :outcome_node: false
 - :current_node: :years_of_benefit?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "yes"
-  - "30"
-  - "1"
-  - "yes"
-  - "1"
+  - '1961-04-04'
+  - 'yes'
+  - '30'
+  - '1'
+  - 'yes'
+  - '1'
   :next_node: :years_of_caring?
   :outcome_node: false
 - :current_node: :years_of_caring?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "yes"
-  - "30"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
+  - '1961-04-04'
+  - 'yes'
+  - '30'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
   :next_node: :years_of_carers_allowance?
   :outcome_node: false
 - :current_node: :years_of_carers_allowance?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "yes"
-  - "30"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
+  - '1961-04-04'
+  - 'yes'
+  - '30'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "yes"
-  - "30"
-  - "1"
-  - "no"
+  - '1961-04-04'
+  - 'yes'
+  - '30'
+  - '1'
+  - 'no'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :pay_reduced_ni_rate?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "no"
+  - '1961-04-04'
+  - 'no'
   :next_node: :years_paid_ni?
   :outcome_node: false
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "no"
-  - "1"
+  - '1961-04-04'
+  - 'no'
+  - '1'
   :next_node: :years_of_jsa?
   :outcome_node: false
 - :current_node: :years_of_jsa?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "no"
-  - "1"
-  - "1"
+  - '1961-04-04'
+  - 'no'
+  - '1'
+  - '1'
   :next_node: :received_child_benefit?
   :outcome_node: false
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "no"
-  - "1"
-  - "1"
-  - "yes"
+  - '1961-04-04'
+  - 'no'
+  - '1'
+  - '1'
+  - 'yes'
   :next_node: :years_of_benefit?
   :outcome_node: false
 - :current_node: :years_of_benefit?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "no"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
+  - '1961-04-04'
+  - 'no'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
   :next_node: :years_of_caring?
   :outcome_node: false
 - :current_node: :years_of_caring?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "no"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
+  - '1961-04-04'
+  - 'no'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
   :next_node: :years_of_carers_allowance?
   :outcome_node: false
 - :current_node: :years_of_carers_allowance?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "no"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
+  - '1961-04-04'
+  - 'no'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
   :next_node: :lived_or_worked_outside_uk?
   :outcome_node: false
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "no"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
-  - "yes"
+  - '1961-04-04'
+  - 'no'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
+  - 'yes'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "no"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
-  - "no"
+  - '1961-04-04'
+  - 'no'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
+  - 'no'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "no"
-  - "1"
-  - "1"
-  - "no"
+  - '1961-04-04'
+  - 'no'
+  - '1'
+  - '1'
+  - 'no'
   :next_node: :lived_or_worked_outside_uk?
   :outcome_node: false
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "no"
-  - "1"
-  - "1"
-  - "no"
-  - "yes"
+  - '1961-04-04'
+  - 'no'
+  - '1'
+  - '1'
+  - 'no'
+  - 'yes'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "no"
-  - "1"
-  - "1"
-  - "no"
-  - "no"
+  - '1961-04-04'
+  - 'no'
+  - '1'
+  - '1'
+  - 'no'
+  - 'no'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "no"
-  - "11"
+  - '1961-04-04'
+  - 'no'
+  - '11'
   :next_node: :years_of_jsa?
   :outcome_node: false
 - :current_node: :years_of_jsa?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "no"
-  - "11"
-  - "1"
+  - '1961-04-04'
+  - 'no'
+  - '11'
+  - '1'
   :next_node: :received_child_benefit?
   :outcome_node: false
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "no"
-  - "11"
-  - "1"
-  - "yes"
+  - '1961-04-04'
+  - 'no'
+  - '11'
+  - '1'
+  - 'yes'
   :next_node: :years_of_benefit?
   :outcome_node: false
 - :current_node: :years_of_benefit?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "no"
-  - "11"
-  - "1"
-  - "yes"
-  - "1"
+  - '1961-04-04'
+  - 'no'
+  - '11'
+  - '1'
+  - 'yes'
+  - '1'
   :next_node: :years_of_caring?
   :outcome_node: false
 - :current_node: :years_of_caring?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "no"
-  - "11"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
+  - '1961-04-04'
+  - 'no'
+  - '11'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
   :next_node: :years_of_carers_allowance?
   :outcome_node: false
 - :current_node: :years_of_carers_allowance?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "no"
-  - "11"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
+  - '1961-04-04'
+  - 'no'
+  - '11'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "no"
-  - "11"
-  - "1"
-  - "no"
+  - '1961-04-04'
+  - 'no'
+  - '11'
+  - '1'
+  - 'no'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "no"
-  - "23"
+  - '1961-04-04'
+  - 'no'
+  - '23'
   :next_node: :years_of_jsa?
   :outcome_node: false
 - :current_node: :years_of_jsa?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "no"
-  - "23"
-  - "1"
+  - '1961-04-04'
+  - 'no'
+  - '23'
+  - '1'
   :next_node: :received_child_benefit?
   :outcome_node: false
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "no"
-  - "23"
-  - "1"
-  - "yes"
+  - '1961-04-04'
+  - 'no'
+  - '23'
+  - '1'
+  - 'yes'
   :next_node: :years_of_benefit?
   :outcome_node: false
 - :current_node: :years_of_benefit?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "no"
-  - "23"
-  - "1"
-  - "yes"
-  - "1"
+  - '1961-04-04'
+  - 'no'
+  - '23'
+  - '1'
+  - 'yes'
+  - '1'
   :next_node: :years_of_caring?
   :outcome_node: false
 - :current_node: :years_of_caring?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "no"
-  - "23"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
+  - '1961-04-04'
+  - 'no'
+  - '23'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
   :next_node: :years_of_carers_allowance?
   :outcome_node: false
 - :current_node: :years_of_carers_allowance?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "no"
-  - "23"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
+  - '1961-04-04'
+  - 'no'
+  - '23'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "no"
-  - "23"
-  - "1"
-  - "no"
+  - '1961-04-04'
+  - 'no'
+  - '23'
+  - '1'
+  - 'no'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "no"
-  - "27"
+  - '1961-04-04'
+  - 'no'
+  - '27'
   :next_node: :years_of_jsa?
   :outcome_node: false
 - :current_node: :years_of_jsa?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "no"
-  - "27"
-  - "1"
+  - '1961-04-04'
+  - 'no'
+  - '27'
+  - '1'
   :next_node: :received_child_benefit?
   :outcome_node: false
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "no"
-  - "27"
-  - "1"
-  - "yes"
+  - '1961-04-04'
+  - 'no'
+  - '27'
+  - '1'
+  - 'yes'
   :next_node: :years_of_benefit?
   :outcome_node: false
 - :current_node: :years_of_benefit?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "no"
-  - "27"
-  - "1"
-  - "yes"
-  - "1"
+  - '1961-04-04'
+  - 'no'
+  - '27'
+  - '1'
+  - 'yes'
+  - '1'
   :next_node: :years_of_caring?
   :outcome_node: false
 - :current_node: :years_of_caring?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "no"
-  - "27"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
+  - '1961-04-04'
+  - 'no'
+  - '27'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
   :next_node: :years_of_carers_allowance?
   :outcome_node: false
 - :current_node: :years_of_carers_allowance?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "no"
-  - "27"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
+  - '1961-04-04'
+  - 'no'
+  - '27'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "no"
-  - "27"
-  - "1"
-  - "no"
+  - '1961-04-04'
+  - 'no'
+  - '27'
+  - '1'
+  - 'no'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "no"
-  - "30"
+  - '1961-04-04'
+  - 'no'
+  - '30'
   :next_node: :years_of_jsa?
   :outcome_node: false
 - :current_node: :years_of_jsa?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "no"
-  - "30"
-  - "1"
+  - '1961-04-04'
+  - 'no'
+  - '30'
+  - '1'
   :next_node: :received_child_benefit?
   :outcome_node: false
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "no"
-  - "30"
-  - "1"
-  - "yes"
+  - '1961-04-04'
+  - 'no'
+  - '30'
+  - '1'
+  - 'yes'
   :next_node: :years_of_benefit?
   :outcome_node: false
 - :current_node: :years_of_benefit?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "no"
-  - "30"
-  - "1"
-  - "yes"
-  - "1"
+  - '1961-04-04'
+  - 'no'
+  - '30'
+  - '1'
+  - 'yes'
+  - '1'
   :next_node: :years_of_caring?
   :outcome_node: false
 - :current_node: :years_of_caring?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "no"
-  - "30"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
+  - '1961-04-04'
+  - 'no'
+  - '30'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
   :next_node: :years_of_carers_allowance?
   :outcome_node: false
 - :current_node: :years_of_carers_allowance?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "no"
-  - "30"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "1"
+  - '1961-04-04'
+  - 'no'
+  - '30'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - '1'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1961-04-04"
-  - "no"
-  - "30"
-  - "1"
-  - "no"
+  - '1961-04-04'
+  - 'no'
+  - '30'
+  - '1'
+  - 'no'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :dob_amount?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1991-08-12"
+  - '1991-08-12'
   :next_node: :years_paid_ni?
   :outcome_node: false
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1991-08-12"
-  - "1"
+  - '1991-08-12'
+  - '1'
   :next_node: :years_of_jsa?
   :outcome_node: false
 - :current_node: :years_of_jsa?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1991-08-12"
-  - "1"
-  - "1"
+  - '1991-08-12'
+  - '1'
+  - '1'
   :next_node: :received_child_benefit?
   :outcome_node: false
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1991-08-12"
-  - "1"
-  - "1"
-  - "yes"
+  - '1991-08-12'
+  - '1'
+  - '1'
+  - 'yes'
   :next_node: :years_of_benefit?
   :outcome_node: false
 - :current_node: :years_of_benefit?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1991-08-12"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
+  - '1991-08-12'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
   :next_node: :years_of_caring?
   :outcome_node: false
 - :current_node: :years_of_caring?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1991-08-12"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
+  - '1991-08-12'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1991-08-12"
-  - "1"
-  - "1"
-  - "no"
+  - '1991-08-12'
+  - '1'
+  - '1'
+  - 'no'
   :next_node: :lived_or_worked_outside_uk?
   :outcome_node: false
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1991-08-12"
-  - "1"
-  - "1"
-  - "no"
-  - "yes"
+  - '1991-08-12'
+  - '1'
+  - '1'
+  - 'no'
+  - 'yes'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1991-08-12"
-  - "1"
-  - "1"
-  - "no"
-  - "no"
+  - '1991-08-12'
+  - '1'
+  - '1'
+  - 'no'
+  - 'no'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1991-08-12"
-  - "11"
+  - '1991-08-12'
+  - '11'
   :next_node: :years_paid_ni?
   :outcome_node: false
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1991-08-12"
-  - "23"
+  - '1991-08-12'
+  - '23'
   :next_node: :years_paid_ni?
   :outcome_node: false
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1991-08-12"
-  - "27"
+  - '1991-08-12'
+  - '27'
   :next_node: :years_paid_ni?
   :outcome_node: false
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1991-08-12"
-  - "30"
+  - '1991-08-12'
+  - '30'
   :next_node: :years_paid_ni?
   :outcome_node: false
 - :current_node: :dob_amount?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1992-04-06"
+  - '1992-04-06'
   :next_node: :years_paid_ni?
   :outcome_node: false
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1992-04-06"
-  - "1"
+  - '1992-04-06'
+  - '1'
   :next_node: :years_of_jsa?
   :outcome_node: false
 - :current_node: :years_of_jsa?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1992-04-06"
-  - "1"
-  - "1"
+  - '1992-04-06'
+  - '1'
+  - '1'
   :next_node: :received_child_benefit?
   :outcome_node: false
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "yes"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'yes'
   :next_node: :years_of_benefit?
   :outcome_node: false
 - :current_node: :years_of_benefit?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
   :next_node: :years_of_work?
   :outcome_node: false
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "0"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '0'
   :next_node: :lived_or_worked_outside_uk?
   :outcome_node: false
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "0"
-  - "yes"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '0'
+  - 'yes'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "0"
-  - "no"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '0'
+  - 'no'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
   :next_node: :lived_or_worked_outside_uk?
   :outcome_node: false
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "yes"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - 'yes'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "1"
-  - "no"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '1'
+  - 'no'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "2"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '2'
   :next_node: :lived_or_worked_outside_uk?
   :outcome_node: false
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "2"
-  - "yes"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '2'
+  - 'yes'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "yes"
-  - "1"
-  - "2"
-  - "no"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'yes'
+  - '1'
+  - '2'
+  - 'no'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :received_child_benefit?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "no"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'no'
   :next_node: :years_of_work?
   :outcome_node: false
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "no"
-  - "0"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'no'
+  - '0'
   :next_node: :lived_or_worked_outside_uk?
   :outcome_node: false
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "no"
-  - "0"
-  - "yes"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'no'
+  - '0'
+  - 'yes'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "no"
-  - "0"
-  - "no"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'no'
+  - '0'
+  - 'no'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "no"
-  - "1"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'no'
+  - '1'
   :next_node: :lived_or_worked_outside_uk?
   :outcome_node: false
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "no"
-  - "1"
-  - "yes"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'no'
+  - '1'
+  - 'yes'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "no"
-  - "1"
-  - "no"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'no'
+  - '1'
+  - 'no'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "no"
-  - "2"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'no'
+  - '2'
   :next_node: :lived_or_worked_outside_uk?
   :outcome_node: false
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "no"
-  - "2"
-  - "yes"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'no'
+  - '2'
+  - 'yes'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1992-04-06"
-  - "1"
-  - "1"
-  - "no"
-  - "2"
-  - "no"
+  - '1992-04-06'
+  - '1'
+  - '1'
+  - 'no'
+  - '2'
+  - 'no'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1992-04-06"
-  - "11"
+  - '1992-04-06'
+  - '11'
   :next_node: :years_paid_ni?
   :outcome_node: false
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1992-04-06"
-  - "23"
+  - '1992-04-06'
+  - '23'
   :next_node: :years_paid_ni?
   :outcome_node: false
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1992-04-06"
-  - "27"
+  - '1992-04-06'
+  - '27'
   :next_node: :years_paid_ni?
   :outcome_node: false
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1992-04-06"
-  - "30"
+  - '1992-04-06'
+  - '30'
   :next_node: :years_paid_ni?
   :outcome_node: false
 - :current_node: :dob_amount?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1993-04-06"
+  - '1993-04-06'
   :next_node: :years_paid_ni?
   :outcome_node: false
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1993-04-06"
-  - "1"
+  - '1993-04-06'
+  - '1'
   :next_node: :years_of_jsa?
   :outcome_node: false
 - :current_node: :years_of_jsa?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1993-04-06"
-  - "1"
-  - "1"
+  - '1993-04-06'
+  - '1'
+  - '1'
   :next_node: :years_of_work?
   :outcome_node: false
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1993-04-06"
-  - "1"
-  - "1"
-  - "0"
+  - '1993-04-06'
+  - '1'
+  - '1'
+  - '0'
   :next_node: :lived_or_worked_outside_uk?
   :outcome_node: false
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1993-04-06"
-  - "1"
-  - "1"
-  - "0"
-  - "yes"
+  - '1993-04-06'
+  - '1'
+  - '1'
+  - '0'
+  - 'yes'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1993-04-06"
-  - "1"
-  - "1"
-  - "0"
-  - "no"
+  - '1993-04-06'
+  - '1'
+  - '1'
+  - '0'
+  - 'no'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1993-04-06"
-  - "1"
-  - "1"
-  - "1"
+  - '1993-04-06'
+  - '1'
+  - '1'
+  - '1'
   :next_node: :lived_or_worked_outside_uk?
   :outcome_node: false
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1993-04-06"
-  - "1"
-  - "1"
-  - "1"
-  - "yes"
+  - '1993-04-06'
+  - '1'
+  - '1'
+  - '1'
+  - 'yes'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1993-04-06"
-  - "1"
-  - "1"
-  - "1"
-  - "no"
+  - '1993-04-06'
+  - '1'
+  - '1'
+  - '1'
+  - 'no'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_of_work?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1993-04-06"
-  - "1"
-  - "1"
-  - "2"
+  - '1993-04-06'
+  - '1'
+  - '1'
+  - '2'
   :next_node: :lived_or_worked_outside_uk?
   :outcome_node: false
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1993-04-06"
-  - "1"
-  - "1"
-  - "2"
-  - "yes"
+  - '1993-04-06'
+  - '1'
+  - '1'
+  - '2'
+  - 'yes'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :lived_or_worked_outside_uk?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1993-04-06"
-  - "1"
-  - "1"
-  - "2"
-  - "no"
+  - '1993-04-06'
+  - '1'
+  - '1'
+  - '2'
+  - 'no'
   :next_node: :amount_result
   :outcome_node: true
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1993-04-06"
-  - "11"
+  - '1993-04-06'
+  - '11'
   :next_node: :years_paid_ni?
   :outcome_node: false
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1993-04-06"
-  - "23"
+  - '1993-04-06'
+  - '23'
   :next_node: :years_paid_ni?
   :outcome_node: false
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1993-04-06"
-  - "27"
+  - '1993-04-06'
+  - '27'
   :next_node: :years_paid_ni?
   :outcome_node: false
 - :current_node: :years_paid_ni?
-  :responses: 
+  :responses:
   - amount
   - female
-  - "1993-04-06"
-  - "30"
+  - '1993-04-06'
+  - '30'
   :next_node: :years_paid_ni?
   :outcome_node: false

--- a/test/integration/smart_answer_flows/calculate_state_pension_test.rb
+++ b/test/integration/smart_answer_flows/calculate_state_pension_test.rb
@@ -730,6 +730,18 @@ class CalculateStatePensionTest < ActiveSupport::TestCase
         assert_current_node :over55_result
       end
     end
+  end
 
-  end #amount calculation
-end #ask which calculation
+  context "bus pass age" do
+    setup do
+      add_response :bus_pass
+    end
+
+    should "lead to bus_pass_age_result" do
+      assert_current_node :dob_bus_pass?
+      add_response '1956-05-31'
+      assert_current_node :bus_pass_age_result
+      assert_state_variable :qualifies_for_bus_pass_on, "31 May 2022"
+    end
+  end
+end

--- a/test/unit/state_pension_date_query_test.rb
+++ b/test/unit/state_pension_date_query_test.rb
@@ -1,0 +1,20 @@
+require_relative '../../lib/data/state_pension_date_query'
+require_relative '../test_helper'
+
+class StatePensionDateQueryTest < ActiveSupport::TestCase
+  test ".pension_credit_date initializes the class with the 'female' gender" do
+    today = Date.today
+    query_double = OpenStruct.new(find_date: :date)
+    StatePensionDateQuery.expects(:new).with(today, :female).returns(query_double)
+
+    StatePensionDateQuery.pension_credit_date(today)
+  end
+
+  test ".bus_pass_qualification_date initializes the class with the 'female' gender" do
+    today = Date.today
+    query_double = OpenStruct.new(find_date: :date)
+    StatePensionDateQuery.expects(:new).with(today, :female).returns(query_double)
+
+    StatePensionDateQuery.bus_pass_qualification_date(today)
+  end
+end


### PR DESCRIPTION
Currently state pension age outcomes from from gov.uk/calculate-state-pension show a paragraph
about bus pass eligibility age. However it is not very easy to find as it is
at the bottom and only one of many paragraphs. A lot of users find it confusing.

A lot of local council and other authority websites link to this calculator
for bus pass age calculation (that's why we rejected an idea of having a
completely separate calculator), therefore making this option explicit should
make it easier for users. The new outcome has only information about the bus
pass age and a link back to State Pension age calculation (ideally we'd link to
an outcome, but we don't know user's gender).

I opted in for some duplication to introduce a bus_pass_dob? question. I could
have reused age_dob? question, but inelegant hacks are needed to workaround the
fact that an instance of StatePensionAmountCalculator is initialized there
and it requires gender to be passed in.