### PR TITLE
Fix panopticon integration

### DIFF
--- a/app/presenters/flow_registration_presenter.rb
+++ b/app/presenters/flow_registration_presenter.rb
@@ -14,7 +14,7 @@ class FlowRegistrationPresenter
   end
 
   def title
-    lookup_translation("title") || @flow.name.to_s.humanize
+    start_node.title
   end
 
   def paths
@@ -26,14 +26,14 @@ class FlowRegistrationPresenter
   end
 
   def description
-    lookup_translation("meta.description")
+    start_node.meta_description
   end
 
   NODE_PRESENTER_METHODS = [:title, :body, :hint]
 
   def indexable_content
     HTMLEntities.new.decode(
-      text = @flow.nodes.inject([lookup_translation("body")]) { |acc, node|
+      text = @flow.nodes.inject([start_node.body]) { |acc, node|
         pres = NodePresenter.new(@i18n_prefix, node)
         acc.concat(NODE_PRESENTER_METHODS.map { |method|
           begin
@@ -53,9 +53,8 @@ class FlowRegistrationPresenter
 
 private
 
-  def lookup_translation(key)
-    I18n.translate!("#{@i18n_prefix}.#{key}")
-  rescue I18n::MissingTranslationData
-    nil
+  def start_node
+    node = SmartAnswer::Node.new(@flow, @flow.name.underscore.to_sym)
+    StartNodePresenter.new(@i18n_prefix, node)
   end
 end

--- a/test/fixtures/flow_registraion_presenter_sample/flow_sample.yml
+++ b/test/fixtures/flow_registraion_presenter_sample/flow_sample.yml
@@ -1,12 +1,6 @@
 en-GB:
   flow:
     flow-sample:
-      meta:
-        description: FLOW_DESCRIPTION
-      title:
-        FLOW_TITLE
-      body: |
-        FLOW_BODY
       hotter_or_colder?:
         title: NODE_1_TITLE
         body: NODE_1_BODY

--- a/test/fixtures/flow_registraion_presenter_sample/flow_sample_interpolation.yml
+++ b/test/fixtures/flow_registraion_presenter_sample/flow_sample_interpolation.yml
@@ -1,12 +1,6 @@
 en-GB:
   flow:
     flow-sample:
-      meta:
-        description: FLOW_DESCRIPTION
-      title:
-        FLOW_TITLE
-      body: |
-        FLOW_BODY
       hotter_or_colder?:
         title: NODE_1_TITLE
         body: NODE_1_BODY

--- a/test/fixtures/smart_answer_flows/flow-sample/flow_sample.govspeak.erb
+++ b/test/fixtures/smart_answer_flows/flow-sample/flow_sample.govspeak.erb
@@ -1,0 +1,11 @@
+<% content_for :title do %>
+  FLOW_TITLE
+<% end %>
+
+<% content_for :meta_description do %>
+  FLOW_DESCRIPTION
+<% end %>
+
+<% content_for :body do %>
+  FLOW_BODY
+<% end %>

--- a/test/unit/flow_registration_presenter_test.rb
+++ b/test/unit/flow_registration_presenter_test.rb
@@ -10,6 +10,10 @@ class FlowRegistrationPresenterTest < ActiveSupport::TestCase
       File.expand_path('../../fixtures/flow_registraion_presenter_sample/flow_sample.yml', __FILE__)
     I18n.config.load_path.unshift example_translation_file
     I18n.reload!
+
+    load_path = fixture_file('smart_answer_flows')
+    SmartAnswer::FlowRegistry.instance.stubs(:load_path).returns(load_path)
+
     @flow = SmartAnswer::FlowSampleFlow.build
     @presenter = FlowRegistrationPresenter.new(@flow)
   end
@@ -28,11 +32,6 @@ class FlowRegistrationPresenterTest < ActiveSupport::TestCase
   context "title" do
     should "should use the title translation" do
       assert_equal "FLOW_TITLE", @presenter.title
-    end
-
-    should "use the humanized flow name if no translation is available" do
-      I18n.stubs(:translate!).raises(I18n::MissingTranslationData.new(:en, "anything", {}))
-      assert_equal "Flow-sample", @presenter.title
     end
   end
 


### PR DESCRIPTION
As of 57493beeda38f35e3a9763bd3761ab3779f305fc Smart Answer titles and meta
descriptions are no longer stored in YAML files, however when flows are
registered with panopticon it is trying to look up those values in YAML
and falls back to humanised titles (that still have dashes in them) and empty
meta descriptions.

This change uses the new mechanism to fetch titles and meta descriptions from
ERB files. The fallback code for missing title has been removed, because
StartNodePresenter inherits NodePresenter#title that has this fallback
implemented.

I've noticed that there are more code that relies on titles and bodies being in YAML, but it's less important  e.g. [here](https://github.com/alphagov/smart-answers/blob/05f855cb21edd96637a25b89c4238f2fd3f9aef1/lib/graph_presenter.rb#L98), [here]( https://github.com/alphagov/smart-answers/blob/05f855cb21edd96637a25b89c4238f2fd3f9aef1/test/fixtures/graph_presenter_test/graph.yml#L7)

/cc @floehopper @alext 